### PR TITLE
feat(healthkit): expand health metrics and permissions

### DIFF
--- a/components/health-kit/healthkit-guidance.ts
+++ b/components/health-kit/healthkit-guidance.ts
@@ -38,7 +38,7 @@ export function getHealthKitGuidance({ status, isLoading }: GuidanceInput): Heal
     return {
       shouldRenderCard: true,
       headline: 'Connect to Apple Health',
-      description: 'Enable Health permissions to sync steps, heart rate, and other activity metrics.',
+      description: 'Enable Health permissions to sync steps, heart rate (resting and variability), VO2 Max, sleep, respiratory rate, walking HR, and your sex/age for recovery-aware insights.',
       primaryCtaLabel: 'Enable Health Access',
       primaryDisabled: isLoading,
       showSettingsShortcut: false,
@@ -67,7 +67,7 @@ export function getHealthKitGuidance({ status, isLoading }: GuidanceInput): Heal
   const hasPromptedBefore = Boolean(status.lastCheckedAt);
   const description = hasPromptedBefore
     ? 'Health permissions are currently disabled. Re-enable access so we can display your latest metrics.'
-    : 'Enable Health permissions to start syncing steps, workouts, and heart data from Apple Health.';
+    : 'Enable Health permissions to start syncing steps, workouts, heart, sleep, respiratory rate, and recovery signals (including sex and age) from Apple Health.';
 
   const footnote = hasPromptedBefore
     ? 'After enabling in Settings, return to the app and your metrics will refresh automatically.'

--- a/etc/app.config.js
+++ b/etc/app.config.js
@@ -39,7 +39,7 @@ const baseConfig = {
     [
       'react-native-health',
       {
-        healthSharePermission: 'We read your step count and heart rate to display insights on your dashboard.',
+        healthSharePermission: 'We read steps, heart rate (including resting and variability), VO2 Max, sleep, respiratory rate, walking HR, cardio metrics, and sex/birth year to surface recovery and training insights.',
         healthUpdatePermission: 'We write selected health metrics only when you explicitly enable it.',
         isClinicalDataEnabled: true,
         healthClinicalDescription: 'We access clinical health records (e.g., labs and immunizations) to enhance your health insights.',
@@ -81,10 +81,10 @@ const baseConfig = {
     bundleIdentifier: 'com.slenthekid.formfactoreas',
     supportsTablet: true,
     icon: './assets/images/ff-logo.png',
-    buildNumber: '2',
+    // buildNumber is managed remotely via appVersionSource: "remote" in eas.json
     appleTeamId: 'NCTLNFGC6G',
     infoPlist: {
-      NSHealthShareUsageDescription: 'This app reads your health data to show activity insights.',
+      NSHealthShareUsageDescription: 'This app reads steps, heart rate (resting and variability), VO2 Max, sleep, respiratory rate, walking HR, cardio metrics, and sex/birth year to tailor recovery and training insights.',
       NSHealthUpdateUsageDescription: 'This app writes health data to record your activity.',
       NSCameraUsageDescription: 'We need camera access to scan your form and provide skeleton tracking.',
       NSMicrophoneUsageDescription: 'Optional: for recording workout videos',

--- a/etc/app.json
+++ b/etc/app.json
@@ -22,7 +22,7 @@
       [
         "react-native-health",
         {
-          "healthSharePermission": "We read your step count and heart rate to display insights on your dashboard.",
+          "healthSharePermission": "We read steps, heart rate (including resting and variability), VO2 Max, sleep, respiratory rate, walking HR, cardio metrics, and sex/birth year to surface recovery and training insights.",
           "healthUpdatePermission": "We write selected health metrics only when you explicitly enable it.",
           "isClinicalDataEnabled": true,
           "healthClinicalDescription": "We access clinical health records (e.g., labs and immunizations) to enhance your health insights."
@@ -72,7 +72,7 @@
       "buildNumber": "1",
       "appleTeamId": "NCTLNFGC6G",
       "infoPlist": {
-        "NSHealthShareUsageDescription": "This app reads your health data to show activity insights.",
+        "NSHealthShareUsageDescription": "This app reads steps, heart rate (resting and variability), VO2 Max, sleep, respiratory rate, walking HR, cardio metrics, and sex/birth year to tailor recovery and training insights.",
         "NSHealthUpdateUsageDescription": "This app writes health data to record your activity.",
         "NSCameraUsageDescription": "We need camera access to scan your form and provide skeleton tracking.",
         "NSMicrophoneUsageDescription": "Optional: for recording workout videos",

--- a/lib/services/healthkit/health-permissions.ts
+++ b/lib/services/healthkit/health-permissions.ts
@@ -25,6 +25,18 @@ function toApplePermissions(types: HealthDataType[]): AppleHealthPermission[] {
     bodyMass: Permissions.BodyMass,
     height: Permissions.Height,
     workouts: Permissions.Workout,
+    biologicalSex: Permissions.BiologicalSex,
+    dateOfBirth: Permissions.DateOfBirth,
+    respiratoryRate: Permissions.RespiratoryRate,
+    walkingHeartRateAverage: Permissions.WalkingHeartRateAverage,
+    distanceWalkingRunning: Permissions.DistanceWalkingRunning,
+    distanceCycling: Permissions.DistanceCycling,
+    distanceSwimming: Permissions.DistanceSwimming,
+    workoutRoute: Permissions.WorkoutRoute,
+    restingHeartRate: Permissions.RestingHeartRate,
+    heartRateVariability: Permissions.HeartRateVariability,
+    vo2Max: Permissions.Vo2Max,
+    sleepAnalysis: Permissions.SleepAnalysis,
   };
 
   const uniqueTypes = Array.from(new Set(types));

--- a/lib/services/healthkit/health-types.ts
+++ b/lib/services/healthkit/health-types.ts
@@ -13,7 +13,19 @@ export type HealthDataType =
   | 'stepCount'
   | 'bodyMass'
   | 'height'
-  | 'workouts';
+  | 'workouts'
+  | 'biologicalSex'
+  | 'dateOfBirth'
+  | 'respiratoryRate'
+  | 'walkingHeartRateAverage'
+  | 'distanceWalkingRunning'
+  | 'distanceCycling'
+  | 'distanceSwimming'
+  | 'workoutRoute'
+  | 'restingHeartRate'
+  | 'heartRateVariability'
+  | 'vo2Max'
+  | 'sleepAnalysis';
 
 export interface HealthPermissionStatus {
   isAvailable: boolean;

--- a/lib/shims/expo-health.ts
+++ b/lib/shims/expo-health.ts
@@ -9,6 +9,18 @@ export enum HealthDataType {
   BODY_MASS = 'bodyMass',
   HEIGHT = 'height',
   WORKOUTS = 'workouts',
+  BIOLOGICAL_SEX = 'biologicalSex',
+  DATE_OF_BIRTH = 'dateOfBirth',
+  RESPIRATORY_RATE = 'respiratoryRate',
+  WALKING_HEART_RATE_AVERAGE = 'walkingHeartRateAverage',
+  DISTANCE_WALKING_RUNNING = 'distanceWalkingRunning',
+  DISTANCE_CYCLING = 'distanceCycling',
+  DISTANCE_SWIMMING = 'distanceSwimming',
+  WORKOUT_ROUTE = 'workoutRoute',
+  RESTING_HEART_RATE = 'restingHeartRate',
+  HEART_RATE_VARIABILITY = 'heartRateVariability',
+  VO2_MAX = 'vo2Max',
+  SLEEP_ANALYSIS = 'sleepAnalysis',
 }
 
 export type PermissionSet = {

--- a/modules/arkit-body-tracker/arkit-body-tracker.podspec
+++ b/modules/arkit-body-tracker/arkit-body-tracker.podspec
@@ -18,8 +18,7 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
-    'SWIFT_COMPILATION_MODE' => 'wholemodule',
-    'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES'
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
   }
 
   s.dependency 'ExpoModulesCore'

--- a/types/expo-health.d.ts
+++ b/types/expo-health.d.ts
@@ -7,6 +7,18 @@ declare module 'expo-health' {
     BODY_MASS = 'bodyMass',
     HEIGHT = 'height',
     WORKOUTS = 'workouts',
+    BIOLOGICAL_SEX = 'biologicalSex',
+    DATE_OF_BIRTH = 'dateOfBirth',
+    RESPIRATORY_RATE = 'respiratoryRate',
+    WALKING_HEART_RATE_AVERAGE = 'walkingHeartRateAverage',
+    DISTANCE_WALKING_RUNNING = 'distanceWalkingRunning',
+    DISTANCE_CYCLING = 'distanceCycling',
+    DISTANCE_SWIMMING = 'distanceSwimming',
+    WORKOUT_ROUTE = 'workoutRoute',
+    RESTING_HEART_RATE = 'restingHeartRate',
+    HEART_RATE_VARIABILITY = 'heartRateVariability',
+    VO2_MAX = 'vo2Max',
+    SLEEP_ANALYSIS = 'sleepAnalysis',
   }
 
   export type PermissionSet = {


### PR DESCRIPTION
- Touches: HealthKitProvider, health-metrics, expo-health types

- Outcome: Request broader HealthKit permissions, ingest respiratory/HR/energy/distance history, and expose sex/age for richer insights with updated guidance copy.

- Notes: Removed BUILD_LIBRARY_FOR_DISTRIBUTION from ARKit podspec; build number managed remotely in app.config.js.