### PR TITLE
ci(ci): add fallback for missing local IPA

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -262,16 +262,24 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
       - name: Build iOS production locally
-        run: eas build --platform ios --profile production --local --non-interactive
+        run: |
+          rm -rf build
+          eas build --platform ios --profile production --local --non-interactive --output build/production.ipa
 
       - name: Submit iOS production build
         run: |
-          IPA_PATH="$(ls -t build/*.ipa | head -n 1)"
-          if [ -z "$IPA_PATH" ]; then
-            echo "No .ipa found in build/. Local build may have failed."
-            exit 1
+          set -euo pipefail
+          find_ipa() {
+            ls -1t build/*.ipa build-*.ipa 2>/dev/null | head -n 1
+          }
+          IPA_PATH="$(find_ipa || true)"
+          if [ -n "$IPA_PATH" ]; then
+            echo "Submitting local IPA: $IPA_PATH"
+            eas submit --platform ios --profile production --path "$IPA_PATH" --non-interactive
+            exit 0
           fi
-          eas submit --platform ios --profile production --path "$IPA_PATH" --non-interactive
+          echo "No local IPA found; falling back to cloud build+submit" >&2
+          eas build --platform ios --profile production --auto-submit --non-interactive
 
       - name: Ensure hermesc is available
         run: |


### PR DESCRIPTION
- Touches: .github/workflows/ci-cd.yml

- Outcome: local build artifacts used when available, otherwise cloud build+submit runs

- Notes: fallback only triggers when the local IPA cannot be located