### PR TITLE
fix(watch-app): normalize watch target name for EAS build

### DIFF
--- a/targets/watch-app/expo-target.config.js
+++ b/targets/watch-app/expo-target.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   type: 'watch',
-  name: 'Form Factor Watch Watch App',
+  name: 'FormFactorWatchApp',
   displayName: 'Form Factor',
   bundleIdentifier: 'com.slenthekid.formfactoreas.watchkitapp',
   entitlements: {


### PR DESCRIPTION
- Touches: expo-target.config.js

- Outcome: Fixes EAS build error where target name mismatch prevented provisioning profile assignment

- Notes: Changed target name from 'Form Factor Watch Watch App' to 'FormFactorWatchApp' to match EAS's PascalCase expectation