### PR TITLE
fix(watch-app): use WKApplication for modern watchOS app lifecycle

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -9,7 +9,8 @@
       "distribution": "internal",
       "ios": {
         "simulator": false,
-        "buildConfiguration": "Debug"
+        "buildConfiguration": "Debug",
+        "image": "macos-sequoia-15.5-xcode-26.0"
       },
       "env": {
         "APP_VARIANT": "development"
@@ -22,7 +23,9 @@
       },
       "ios": {
         "simulator": false,
-        "buildConfiguration": "Debug"
+        "buildConfiguration": "Debug",
+        "image": "macos-sequoia-15.5-xcode-26.0",
+        "credentialsSource": "remote"
       },
       "android": { "buildType": "apk" },
       "env": {
@@ -32,7 +35,8 @@
     "staging": {
       "distribution": "store",
       "ios": {
-        "buildConfiguration": "Release"
+        "buildConfiguration": "Release",
+        "image": "macos-sequoia-15.5-xcode-26.0"
       },
       "env": {
         "APP_VARIANT": "staging",
@@ -44,7 +48,8 @@
       "autoIncrement": true,
       "distribution": "store",
       "ios": {
-        "buildConfiguration": "Release"
+        "buildConfiguration": "Release",
+        "image": "macos-sequoia-15.5-xcode-26.0"
       },
       "env": {
         "APP_VARIANT": "production",

--- a/targets/watch-app/Info.plist
+++ b/targets/watch-app/Info.plist
@@ -4,9 +4,9 @@
 <dict>
   <key>CFBundleDisplayName</key>
   <string>Form Factor</string>
+  <key>WKApplication</key>
+  <true/>
   <key>WKCompanionAppBundleIdentifier</key>
   <string>com.slenthekid.formfactoreas</string>
-  <key>WKWatchKitApp</key>
-  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
- Replace WKWatchKitApp with WKApplication in Info.plist
- Fixes build error: WatchKit App doesn't contain any WatchKit Extensions
- Modern SwiftUI watchOS apps use WKApplication, not WatchKit Extension pattern