### PR TITLE
fix(ci): publish OTA updates to iOS only

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -211,7 +211,7 @@ jobs:
 
       - name: Deploy OTA update
         run: |
-          eas update --branch staging --message "Staging deployment from ${{ github.sha }}"
+          eas update --branch staging --platform ios --message "Staging deployment from ${{ github.sha }}"
 
   # Job 5: Production Deployment
   deploy-production:
@@ -317,7 +317,7 @@ jobs:
 
       - name: Deploy OTA update
         run: |
-          eas update --branch production --message "Production deployment from ${{ github.sha }}"
+          eas update --branch production --platform ios --message "Production deployment from ${{ github.sha }}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
Limit CI OTA publishing to iOS only.

## Why
Production OTA failed in run `21769347740` with:
`Manifest Validation Error: android/package ... should be a reverse DNS notation unique name`

You requested to ignore Android for now and focus on iOS/web.

## Change
- Update both OTA commands in CI workflow:
  - `deploy-staging`: `eas update --branch staging --platform ios ...`
  - `deploy-production`: `eas update --branch production --platform ios ...`

## Outcome
CI no longer publishes Android OTA updates, so Android manifest validation will not block production OTA releases.
