### PR TITLE
fix(ci): use npm packager for expo action setup

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -121,6 +121,7 @@ jobs:
         with:
           expo-version: latest
           eas-version: latest
+          packager: npm
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Verify EAS configuration (iOS only)
@@ -167,6 +168,7 @@ jobs:
         with:
           expo-version: latest
           eas-version: latest
+          packager: npm
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Setup Supabase CLI
@@ -253,6 +255,7 @@ jobs:
         with:
           expo-version: latest
           eas-version: latest
+          packager: npm
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Setup Supabase CLI


### PR DESCRIPTION
## Summary
Harden Expo action setup by forcing npm as the package manager.

## Why
`main` run `21769778359` failed in `Deploy to Production -> Setup Expo` while installing `expo-cli` via Yarn with:
`https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz: Request failed "502 Bad Gateway"`

## Change
- Add `packager: npm` to all `expo/expo-github-action@v8` steps in CI workflow.

## Outcome
Expo action setup no longer depends on Yarn registry for CLI installation, reducing transient setup failures.
