### PR TITLE
fix(config): use valid Android package IDs for Expo manifest validation

### DIFF
--- a/etc/app.config.js
+++ b/etc/app.config.js
@@ -19,6 +19,12 @@ const getUniqueIdentifier = () => {
   return 'com.slenthekid.form-factor-eas';
 };
 
+const getAndroidPackage = () => {
+  if (IS_DEV) return 'com.slenthekid.formfactoreas.dev';
+  if (IS_PREVIEW) return 'com.slenthekid.formfactoreas.preview';
+  return 'com.slenthekid.formfactoreas';
+};
+
 const getAppName = () => {
   return 'formfactoreas';
 };
@@ -202,7 +208,7 @@ module.exports = function ({ config }) {
     },
     android: {
       ...mergedConfig.android,
-      package: getUniqueIdentifier(),
+      package: getAndroidPackage(),
     },
     extra: {
       ...mergedConfig.extra,


### PR DESCRIPTION
## Summary
Fix invalid Android package IDs in Expo config so OTA publish validation succeeds.

## Why
Even with `eas update --platform ios`, EAS validates manifest fields and was failing with:
`android/package should be a reverse DNS notation unique name`
(Request ID: `1398791a-2c48-4387-bf1b-3f3d6bb5c463`)

## Change
- Add `getAndroidPackage()` in `etc/app.config.js` with Android-safe IDs (no hyphens).
- Use `getAndroidPackage()` for `android.package`.
- Leave iOS bundle identifier logic untouched.

## Validation
- `APP_VARIANT=production` => `android.package=com.slenthekid.formfactoreas`
- `APP_VARIANT=development` => `android.package=com.slenthekid.formfactoreas.dev`
- `APP_VARIANT=preview` => `android.package=com.slenthekid.formfactoreas.preview`
