### PR TITLE
fix: normalize TestFlight app name to Form Factor

### DIFF
--- a/etc/app.config.js
+++ b/etc/app.config.js
@@ -26,7 +26,7 @@ const getAndroidPackage = () => {
 };
 
 const getAppName = () => {
-  return 'formfactoreas';
+  return 'Form Factor';
 };
 
 const getScheme = () => {
@@ -203,6 +203,7 @@ module.exports = function ({ config }) {
       bundleIdentifier: getUniqueIdentifier(),
       infoPlist: {
         ...mergedConfig.ios?.infoPlist,
+        CFBundleName: 'Form Factor',
         CFBundleDisplayName: 'Form Factor',
       },
     },


### PR DESCRIPTION
## Summary
- ensure Expo config `name` resolves to `Form Factor` instead of `formfactoreas`
- set `ios.infoPlist.CFBundleName` explicitly to `Form Factor`
- keep `CFBundleDisplayName` as `Form Factor`

## Why
TestFlight/iOS app naming should be consistently `Form Factor` across metadata fields we control from Expo config.
