### PR TITLE
fix(tests): restore home feed tab spec after social context changes

### DIFF
--- a/tests/unit/screens/home-videos-feed-tabs.test.tsx
+++ b/tests/unit/screens/home-videos-feed-tabs.test.tsx
@@ -7,6 +7,10 @@ jest.mock('../../../contexts/AuthContext', () => ({
   useAuth: () => ({ user: null }),
 }));
 
+jest.mock('../../../contexts/SocialContext', () => ({
+  useSocial: () => ({ unreadSharesCount: 0 }),
+}));
+
 jest.mock('../../../contexts/ToastContext', () => ({
   useToast: () => ({ show: jest.fn() }),
 }));
@@ -72,14 +76,14 @@ describe('HomeScreen video feed', () => {
   it('does not render Following/Trending tabs', async () => {
     const { getByText, queryByText } = render(<HomeScreen />);
 
-    fireEvent.press(getByText('Videos'));
+    fireEvent.press(getByText('Feed'));
 
     expect(queryByText('Following')).toBeNull();
     expect(queryByText('Trending')).toBeNull();
 
     await waitFor(
       () => {
-        expect(getByText('No videos yet. Share a set to see it here.')).toBeTruthy();
+        expect(getByText('No posts in your social feed yet.')).toBeTruthy();
       },
       { timeout: 10000 }
     );


### PR DESCRIPTION
## Summary\n- mock  in  so  can render after social context integration\n- update tab assertion from  to current  label\n- update empty-state assertion to \n\n## Why\nThe CI run https://github.com/ThyDrSlen/form-factor/actions/runs/21814657175 failed because this test rendered  without a social context and asserted stale UI copy.\n\n## Validation\n- \n- 