### PR TITLE
fix(workouts): avoid blocking add flow on sync

### DIFF
--- a/contexts/WorkoutsContext.tsx
+++ b/contexts/WorkoutsContext.tsx
@@ -186,9 +186,10 @@ export const WorkoutsProvider = ({ children }: { children: ReactNode }) => {
       // Update UI immediately
       setWorkouts(prev => [newWorkout, ...prev]);
 
-      // Sync to Supabase if online
       if (isOnline) {
-        await syncService.syncToSupabase();
+        void syncService.syncToSupabase().catch((syncError) => {
+          console.error('[WorkoutsProvider] Background sync failed after add:', syncError);
+        });
       }
     } catch (error) {
       console.error('[WorkoutsProvider] Error adding workout:', error);


### PR DESCRIPTION
## Summary
- make `addWorkout` fire Supabase sync in the background instead of awaiting network completion
- keep local DB write + UI update immediate so the add-workout modal does not stay stuck on `Saving...`
- preserve error visibility by logging background sync failures