### PR TITLE
fix(security): resolve tar advisory blocking CI security scan

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -123,7 +123,7 @@
     "node-forge": "^1.3.2",
     "qs": "6.14.1",
     "react-server-dom-webpack": "19.2.3",
-    "tar": "7.5.8",
+    "tar": "7.5.10",
   },
   "packages": {
     "@0no-co/graphql.web": ["@0no-co/graphql.web@1.2.0", "", { "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0" }, "optionalPeers": ["graphql"] }, "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw=="],
@@ -2308,7 +2308,7 @@
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
-    "tar": ["tar@7.5.8", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-SYkBtK99u0yXa+IWL0JRzzcl7RxNpvX/U08Z+8DKnysfno7M+uExnTZH8K+VGgShf2qFPKtbNr9QBl8n7WBP6Q=="],
+    "tar": ["tar@7.5.10", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw=="],
 
     "temp-dir": ["temp-dir@2.0.0", "", {}, "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg=="],
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "node-forge": "^1.3.2",
     "react-server-dom-webpack": "19.2.3",
     "qs": "6.14.1",
-    "tar": "7.5.8",
+    "tar": "7.5.10",
     "minimatch": "10.2.3"
   },
   "expo": {


### PR DESCRIPTION
## Summary
- fixes the failing `Security Scan` job on `main` by bumping the pinned `tar` resolution from `7.5.8` to `7.5.10`
- addresses advisory `GHSA-qffp-2rhf-9h96` reported by `bun audit` via `workspace:arkit-body-tracker -> expo`
- updates `bun.lock` to lock the fixed transitive version so CI and local audit results are consistent

## Validation
- `bun install --frozen-lockfile --backend=copyfile`
- `bun audit --audit-level=moderate --ignore=GHSA-2g4f-4pwh-qvx6`
- `bun run check:types`