### PR TITLE
feat(auth): add account deletion flow

### DIFF
--- a/app/(modals)/privacy.tsx
+++ b/app/(modals)/privacy.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { BackHandler, View, Text, StyleSheet, TouchableOpacity, Switch, Linking, ActivityIndicator } from 'react-native';
+import { Alert, BackHandler, View, Text, StyleSheet, TouchableOpacity, Switch, Linking, ActivityIndicator } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/contexts/ToastContext';
 import { useSafeBack } from '@/hooks/use-safe-back';
@@ -30,13 +31,15 @@ const SettingItem = ({ icon, title, subtitle, onPress, rightElement }: SettingIt
 );
 
 export default function PrivacySecurityModal() {
-  const { user } = useAuth();
+  const { user, deleteAccount } = useAuth();
   const toast = useToast();
+  const router = useRouter();
   const safeBack = useSafeBack(['/(tabs)/profile', '/profile'], { alwaysReplace: true });
   const [analyticsEnabled, setAnalyticsEnabled] = useState(true);
   const [videoResearchEnabled, setVideoResearchEnabled] = useState(false);
   const [loadingExport, setLoadingExport] = useState(false);
   const [savingVideoConsent, setSavingVideoConsent] = useState(false);
+  const [deletingAccount, setDeletingAccount] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -112,6 +115,30 @@ export default function PrivacySecurityModal() {
     } finally {
       setSavingVideoConsent(false);
     }
+  };
+
+  const handleDeleteAccount = () => {
+    Alert.alert(
+      'Delete Account',
+      'This will permanently delete your account and all associated data. This action cannot be undone.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete My Account',
+          style: 'destructive',
+          onPress: async () => {
+            setDeletingAccount(true);
+            const { error } = await deleteAccount();
+            setDeletingAccount(false);
+            if (error) {
+              toast.show('Failed to delete account. Please try again.', { type: 'error' });
+              return;
+            }
+            router.replace('/(auth)/sign-in');
+          },
+        },
+      ],
+    );
   };
 
   return (
@@ -198,6 +225,26 @@ export default function PrivacySecurityModal() {
             subtitle="Manage devices logged into your account"
           />
         </View>
+
+        {/* Danger Zone */}
+        <Text style={styles.sectionTitle}>Danger Zone</Text>
+        <View style={[styles.card, styles.dangerCard]}>
+          <TouchableOpacity
+            style={styles.settingItem}
+            onPress={handleDeleteAccount}
+            disabled={deletingAccount}
+            activeOpacity={0.7}
+          >
+            <View style={[styles.settingIconContainer, styles.dangerIconContainer]}>
+              <Ionicons name="trash-outline" size={22} color="#FF4444" />
+            </View>
+            <View style={styles.settingTextContainer}>
+              <Text style={[styles.settingTitle, styles.dangerText]}>Delete Account</Text>
+              <Text style={styles.settingSubtitle}>Permanently delete your account and all data</Text>
+            </View>
+            {deletingAccount && <ActivityIndicator size="small" color="#FF4444" />}
+          </TouchableOpacity>
+        </View>
       </View>
     </View>
   );
@@ -283,5 +330,14 @@ const styles = StyleSheet.create({
     height: 1,
     backgroundColor: '#E5E7EB',
     marginLeft: 64,
+  },
+  dangerCard: {
+    borderColor: 'rgba(255, 68, 68, 0.3)',
+  },
+  dangerIconContainer: {
+    backgroundColor: 'rgba(255, 68, 68, 0.1)',
+  },
+  dangerText: {
+    color: '#FF4444',
   },
 });

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -77,6 +77,7 @@ type AuthContextType = {
   resetPassword: (email: string) => Promise<{ error?: AuthError }>;
   updateProfile: (updates: { fullName?: string }) => Promise<{ error?: AuthError | Error }>;
   signOut: () => Promise<{ error?: Error }>;
+  deleteAccount: () => Promise<{ error?: Error }>;
   handleAuthCallback: (url: string) => Promise<void>;
   clearError: () => void;
 };
@@ -435,6 +436,43 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, [clearSessionTimers, isMockUser, sessionManager, user]);
 
+  const deleteAccount = useCallback(async () => {
+    try {
+      console.log('[Auth] Deleting account');
+
+      const { data: { session: currentSession } } = await supabase.auth.getSession();
+      if (!currentSession) {
+        return { error: new Error('No active session') };
+      }
+
+      const { error: fnError } = await supabase.functions.invoke('delete-account', {
+        headers: { Authorization: `Bearer ${currentSession.access_token}` },
+      });
+
+      if (fnError) {
+        throw fnError;
+      }
+
+      // Clear local state after successful deletion
+      clearSessionTimers();
+      setUser(null);
+      setSession(null);
+      setError(null);
+      await sessionManager.clearSession();
+
+      return {};
+    } catch (error) {
+      console.error('[Auth] Error deleting account:', error);
+      const appErr = createError('auth', 'DELETE_ACCOUNT_FAILED', error instanceof Error ? error.message : 'Failed to delete account', {
+        retryable: false,
+        severity: 'error',
+        details: error,
+      });
+      logError(appErr, { feature: 'auth', location: 'deleteAccount' });
+      return { error: error as Error };
+    }
+  }, [clearSessionTimers, sessionManager]);
+
   const refreshSessionForTimeout = useCallback(async () => {
     const { data, error } = await supabase.auth.refreshSession();
 
@@ -725,6 +763,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     resetPassword,
     updateProfile,
     signOut,
+    deleteAccount,
     handleAuthCallback,
     clearError,
   };

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,51 @@
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.4?target=deno';
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+      },
+    });
+  }
+
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405 });
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: 'Missing authorization header' }), { status: 401 });
+  }
+
+  // Create a client with the user's JWT to verify identity
+  const userClient = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_ANON_KEY')!,
+    { global: { headers: { Authorization: authHeader } } },
+  );
+
+  const { data: { user }, error: userError } = await userClient.auth.getUser();
+  if (userError || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  // Use service role to delete the auth user (cascades to all user data)
+  const adminClient = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+  );
+
+  const { error: deleteError } = await adminClient.auth.admin.deleteUser(user.id);
+  if (deleteError) {
+    console.error('[delete-account] Failed to delete user:', deleteError);
+    return new Response(JSON.stringify({ error: 'Failed to delete account' }), { status: 500 });
+  }
+
+  console.log(`[delete-account] Deleted user ${user.id}`);
+  return new Response(JSON.stringify({ success: true }), { status: 200 });
+});


### PR DESCRIPTION
## Summary
- Add "Delete Account" option in Privacy & Security settings with confirmation dialog
- Add `deleteAccount` method to AuthContext that calls new Edge Function
- Add `delete-account` Supabase Edge Function using admin API to delete auth user
- All user data cascades automatically via `ON DELETE CASCADE` constraints

Closes #43

## Test plan
- [x] Verify "Delete Account" appears in Privacy & Security > Danger Zone
- [x] Verify confirmation dialog shows with destructive styling
- [x] Verify cancel dismisses dialog without action
- [x] Verify successful deletion clears local state and redirects to sign-in
- [x] Verify error toast shows if deletion fails
- [x] Deploy Edge Function to Supabase and test end-to-end