### PR TITLE
fix(nav): unify auth route paths

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -531,7 +531,7 @@ export default function ProfileScreen() {
           onPress: async () => {
             try {
               await signOut();
-              router.replace('/(auth)/sign-in');
+              router.replace('/sign-in');
             } catch (error) {
               errorWithTs('Error signing out:', error);
             }

--- a/app/@types/types.d.ts
+++ b/app/@types/types.d.ts
@@ -4,9 +4,9 @@ declare module 'expo-router' {
   // Extend the Link component props to include our routes
   export interface LinkProps extends Omit<OriginalLinkProps, 'href'> {
     href: 
-      | '/(auth)/sign-in'
-      | '/(auth)/sign-up'
-      | '/(auth)/forgot-password'
+      | '/sign-in'
+      | '/sign-up'
+      | '/forgot-password'
       | '/reset-password'
       | `/${string}`;
   }
@@ -14,9 +14,9 @@ declare module 'expo-router' {
   // Extend the router to include our routes
   export function useRouter(): {
     push: (path: 
-      | '/(auth)/sign-in'
-      | '/(auth)/sign-up'
-      | '/(auth)/forgot-password'
+      | '/sign-in'
+      | '/sign-up'
+      | '/forgot-password'
       | '/reset-password'
       | `/${string}`) => void;
     back: () => void;


### PR DESCRIPTION
## Summary
- Update `profile.tsx` sign-out redirect from `/(auth)/sign-in` to `/sign-in`
- Update route type definitions in `types.d.ts` to use `/sign-in`, `/sign-up`, `/forgot-password` instead of `/(auth)/` prefixed paths
- Expo Router groups like `(auth)` don't appear in the URL path, so `/(auth)/sign-in` was incorrect

Closes #31

## Test plan
- [ ] Verify sign-out from profile redirects to sign-in screen
- [ ] Verify all auth navigation links work (sign-in, sign-up, forgot-password)
- [ ] Verify deep linking to `/sign-in` works