### PR TITLE
fix(onboarding): separate completion flag from nutrition goals

### DIFF
--- a/app/(onboarding)/nutrition-goals.tsx
+++ b/app/(onboarding)/nutrition-goals.tsx
@@ -15,6 +15,7 @@ import { useNutritionGoals } from '@/contexts/NutritionGoalsContext';
 import { useToast } from '@/contexts/ToastContext';
 import { isIOS } from '@/lib/platform-utils';
 import { OnboardingProgress } from '@/components/onboarding/OnboardingProgress';
+import { markOnboardingCompleted } from '@/lib/services/onboarding';
 
 export default function NutritionGoalsScreen() {
   const { goals, saveGoals, isSyncing, loading } = useNutritionGoals();
@@ -53,6 +54,7 @@ export default function NutritionGoalsScreen() {
         return;
       }
 
+      await markOnboardingCompleted();
       showToast('Nutrition goals saved successfully! 🎯', { type: 'success' });
       safeBack();
     } catch {
@@ -62,6 +64,7 @@ export default function NutritionGoalsScreen() {
 
   const handleSkip = async () => {
     if (goals) {
+      await markOnboardingCompleted();
       safeBack();
       return;
     }
@@ -79,6 +82,7 @@ export default function NutritionGoalsScreen() {
         return;
       }
 
+      await markOnboardingCompleted();
       safeBack();
     } catch {
       Alert.alert('Error', 'Failed to save goals. Please try again.');

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,6 @@
 import './global.css';
 import { Slot, usePathname, useRouter, useSegments } from 'expo-router';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, View, Text as RNText, StyleSheet, Platform } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
@@ -16,6 +16,7 @@ import { SocialProvider } from '../contexts/SocialContext';
 import { useFonts, Lexend_400Regular, Lexend_500Medium, Lexend_700Bold } from '@expo-google-fonts/lexend';
 import { ToastProvider } from '../contexts/ToastContext';
 import { logWithTs, warnWithTs } from '@/lib/logger';
+import { isOnboardingCompleted } from '@/lib/services/onboarding';
 
 // This layout wraps the entire app with providers
 function RootLayoutNav() {
@@ -91,9 +92,18 @@ function InitialLayout() {
   const publicRoutes = ['/landing', '/reset-password'];
   const isPublicRoute = publicRoutes.some((route) => pathname === route || pathname.startsWith(`${route}/`));
   const isWebRootLanding = Platform.OS === 'web' && pathname === '/';
+  const [onboardingDone, setOnboardingDone] = useState<boolean | null>(null);
 
   useEffect(() => {
-    if (loading || goalsLoading) {
+    if (user) {
+      isOnboardingCompleted().then(setOnboardingDone);
+    } else {
+      setOnboardingDone(null);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (loading || goalsLoading || (user && onboardingDone === null)) {
       logWithTs('[Layout] Auth is loading, waiting...');
       return;
     }
@@ -105,6 +115,7 @@ function InitialLayout() {
       inTabsGroup,
       pathname,
       inModalsGroup,
+      onboardingDone,
       currentPath: segments.join('/'),
     });
 
@@ -114,14 +125,14 @@ function InitialLayout() {
       return;
     }
 
-    if (user && !goals && !inOnboardingGroup) {
-      logWithTs('[Layout] Missing nutrition goals, redirecting to onboarding');
+    if (user && !onboardingDone && !goals && !inOnboardingGroup) {
+      logWithTs('[Layout] Onboarding not completed, redirecting to onboarding');
       router.replace('/(onboarding)/nutrition-goals');
       return;
     }
 
-    if (user && goals && inOnboardingGroup) {
-      logWithTs('[Layout] Goals configured, redirecting to tabs');
+    if (user && (onboardingDone || goals) && inOnboardingGroup) {
+      logWithTs('[Layout] Onboarding done, redirecting to tabs');
       router.replace('/(tabs)');
       return;
     }
@@ -150,7 +161,7 @@ function InitialLayout() {
     }
 
     logWithTs('[Layout] No redirect needed');
-  }, [user, loading, goalsLoading, goals, segments, inAuthGroup, inTabsGroup, inOnboardingGroup, inModalsGroup, isPublicRoute, isWebRootLanding, pathname, router]);
+  }, [user, loading, goalsLoading, goals, onboardingDone, segments, inAuthGroup, inTabsGroup, inOnboardingGroup, inModalsGroup, isPublicRoute, isWebRootLanding, pathname, router]);
 
   if (loading) {
     return (

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 import { OAuthHandler } from '@/lib/services/OAuthHandler';
 import { createError, mapToUserMessage, logError } from '@/lib/services/ErrorHandler';
+import { clearOnboardingFlag } from '@/lib/services/onboarding';
 import { AuthError, Session, User } from '@supabase/supabase-js';
 import Constants from 'expo-constants';
 import * as Linking from 'expo-linking';
@@ -416,6 +417,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setSession(null);
       setError(null);
       await sessionManager.clearSession();
+      await clearOnboardingFlag();
 
       // Fire supabase sign-out but don't let it block the UI for long
       const result = await withTimeout(

--- a/lib/services/onboarding.ts
+++ b/lib/services/onboarding.ts
@@ -1,0 +1,16 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const ONBOARDING_KEY = 'onboarding_completed';
+
+export async function isOnboardingCompleted(): Promise<boolean> {
+  const value = await AsyncStorage.getItem(ONBOARDING_KEY);
+  return value === 'true';
+}
+
+export async function markOnboardingCompleted(): Promise<void> {
+  await AsyncStorage.setItem(ONBOARDING_KEY, 'true');
+}
+
+export async function clearOnboardingFlag(): Promise<void> {
+  await AsyncStorage.removeItem(ONBOARDING_KEY);
+}


### PR DESCRIPTION
## Summary
- Add `onboarding_completed` AsyncStorage flag independent of nutrition goals
- Users who clear/reset nutrition goals no longer get sent back to onboarding
- Flag is set when user saves or skips nutrition goals during onboarding
- Flag is cleared on sign-out so new accounts still see onboarding

Closes #32

## Test plan
- [x] New user sees onboarding nutrition goals screen after sign-up
- [x] After completing onboarding, clearing nutrition goals does NOT redirect to onboarding
- [x] "Skip for now" marks onboarding complete and navigates to tabs
- [x] Sign out + sign in as new user still shows onboarding
- [x] Existing users with goals are not affected (onboardingDone || goals passes)