### PR TITLE
fix(privacy): persist analytics opt-in/out to consent service

### DIFF
--- a/app/(modals)/privacy.tsx
+++ b/app/(modals)/privacy.tsx
@@ -98,9 +98,15 @@ export default function PrivacySecurityModal() {
     Linking.openURL('https://formfactor.app/privacy');
   };
 
-  const handleToggleAnalytics = () => {
-    setAnalyticsEnabled(!analyticsEnabled);
-    toast.show(analyticsEnabled ? 'Analytics disabled' : 'Analytics enabled', { type: 'success' });
+  const handleToggleAnalytics = async (enabled: boolean) => {
+    try {
+      await updateConsent({ allowAnonymousTelemetry: enabled });
+      setAnalyticsEnabled(enabled);
+      toast.show(enabled ? 'Analytics enabled' : 'Analytics disabled', { type: 'success' });
+    } catch (error) {
+      warnWithTs('[privacy] Failed to update analytics consent', error);
+      toast.show('Could not update analytics preference', { type: 'error' });
+    }
   };
 
   const handleToggleVideoResearch = async (enabled: boolean) => {


### PR DESCRIPTION
## Summary
- Analytics toggle in Privacy & Security now persists to Supabase via `updateConsent()`
- Previously only flipped local state — preference was lost on app restart
- Telemetry checks (`shouldLogFrames`, `shouldLogFramesSync`) already read from the consent service, so this completes the data flow

Closes #42

## Test plan
- [x] Toggle analytics off in Privacy & Security — calls updateConsent({ allowAnonymousTelemetry: false })
- [x] Toggle back on — calls updateConsent and shows toast
- [x] Error handling — catches errors and shows error toast
- [ ] Restart app — verify analytics stays off (requires device test)