### PR TITLE
feat(onboarding): add shared progress indicator component

### DIFF
--- a/app/(onboarding)/arkit-permissions.tsx
+++ b/app/(onboarding)/arkit-permissions.tsx
@@ -17,6 +17,7 @@ import { useCameraPermissions } from 'expo-camera';
 import { useRouter } from 'expo-router';
 import { useSafeBack } from '@/hooks/use-safe-back';
 import { isIOS } from '@/lib/platform-utils';
+import { OnboardingProgress } from '@/components/onboarding/OnboardingProgress';
 
 type IoniconName = keyof typeof Ionicons.glyphMap;
 
@@ -159,10 +160,7 @@ export default function ARKitPermissionsScreen() {
               <Ionicons name="arrow-back" size={24} color="#007AFF" />
             </TouchableOpacity>
             <Text style={styles.headerTitle}>Camera Access</Text>
-            <View style={styles.progressContainer}>
-              <View style={styles.progressDot} />
-              <View style={[styles.progressDot, styles.progressDotInactive]} />
-            </View>
+            <OnboardingProgress current={1} total={2} />
           </Animated.View>
 
           {/* Hero Section */}

--- a/app/(onboarding)/arkit-usage.tsx
+++ b/app/(onboarding)/arkit-usage.tsx
@@ -13,6 +13,7 @@ import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router';
 import { useSafeBack } from '@/hooks/use-safe-back';
 import { isIOS } from '@/lib/platform-utils';
+import { OnboardingProgress } from '@/components/onboarding/OnboardingProgress';
 
 type IoniconName = keyof typeof Ionicons.glyphMap;
 
@@ -205,10 +206,7 @@ export default function ARKitUsageScreen() {
               <Ionicons name="arrow-back" size={24} color="#007AFF" />
             </TouchableOpacity>
             <Text style={styles.headerTitle}>Get Started</Text>
-            <View style={styles.progressContainer}>
-              <View style={[styles.progressDot, styles.progressDotInactive]} />
-              <View style={styles.progressDot} />
-            </View>
+            <OnboardingProgress current={2} total={2} />
           </Animated.View>
 
           {/* Hero Section */}

--- a/app/(onboarding)/nutrition-goals.tsx
+++ b/app/(onboarding)/nutrition-goals.tsx
@@ -14,6 +14,7 @@ import { useSafeBack } from '@/hooks/use-safe-back';
 import { useNutritionGoals } from '@/contexts/NutritionGoalsContext';
 import { useToast } from '@/contexts/ToastContext';
 import { isIOS } from '@/lib/platform-utils';
+import { OnboardingProgress } from '@/components/onboarding/OnboardingProgress';
 
 export default function NutritionGoalsScreen() {
   const { goals, saveGoals, isSyncing, loading } = useNutritionGoals();
@@ -109,6 +110,8 @@ export default function NutritionGoalsScreen() {
           <Text style={styles.headerTitle}>Set Nutrition Goals</Text>
           <View style={styles.headerSpacer} />
         </View>
+
+        <OnboardingProgress current={1} total={1} />
 
         <View style={styles.card}>
           <View style={styles.iconContainer}>

--- a/components/onboarding/OnboardingProgress.tsx
+++ b/components/onboarding/OnboardingProgress.tsx
@@ -1,0 +1,48 @@
+import { StyleSheet, View } from 'react-native';
+
+interface OnboardingProgressProps {
+  current: number;
+  total: number;
+}
+
+export function OnboardingProgress({ current, total }: OnboardingProgressProps) {
+  return (
+    <View style={styles.container}>
+      {Array.from({ length: total }, (_, i) => (
+        <View
+          key={i}
+          style={[
+            styles.dot,
+            i + 1 === current && styles.dotActive,
+            i + 1 < current && styles.dotCompleted,
+          ]}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 12,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#1B2E4A',
+  },
+  dotActive: {
+    width: 24,
+    borderRadius: 4,
+    backgroundColor: '#4C8CFF',
+  },
+  dotCompleted: {
+    backgroundColor: '#4C8CFF',
+    opacity: 0.5,
+  },
+});


### PR DESCRIPTION
## Summary
- Add `OnboardingProgress` component with dot-style step indicator (active dot is elongated pill, completed dots are dimmed)
- Add to nutrition-goals screen (step 1/1)
- Replace inline progress dots in ARKit permissions (step 1/2) and usage (step 2/2) screens with shared component
- Skip/continue CTAs already exist on all screens (no changes needed there)

Closes #36

## Test plan
- [x] Verify progress dots appear on nutrition-goals onboarding screen
- [x] Verify ARKit permissions shows step 1/2 indicator
- [x] Verify ARKit usage shows step 2/2 indicator
- [x] Verify active dot is visually distinct (wider, solid blue)
- [x] Verify completed dots are dimmed