### PR TITLE
feat(onboarding): add welcome screen before auth

### DIFF
--- a/app/(onboarding)/arkit-permissions.tsx
+++ b/app/(onboarding)/arkit-permissions.tsx
@@ -18,6 +18,7 @@ import { useRouter } from 'expo-router';
 import { useSafeBack } from '@/hooks/use-safe-back';
 import { isIOS } from '@/lib/platform-utils';
 import { OnboardingProgress } from '@/components/onboarding/OnboardingProgress';
+import { trackOnboardingEvent } from '@/lib/services/onboarding-analytics';
 
 type IoniconName = keyof typeof Ionicons.glyphMap;
 
@@ -65,6 +66,10 @@ export default function ARKitPermissionsScreen() {
   const [slideAnim] = useState(new Animated.Value(50));
 
   useEffect(() => {
+    trackOnboardingEvent('step_view', 'arkit-permissions');
+  }, []);
+
+  useEffect(() => {
     Animated.parallel([
       Animated.timing(fadeAnim, {
         toValue: 1,
@@ -91,6 +96,7 @@ export default function ARKitPermissionsScreen() {
       const response = await requestPermission();
       
       if (response.granted) {
+        trackOnboardingEvent('step_complete', 'arkit-permissions');
         router.replace('/(onboarding)/arkit-usage');
       } else {
         Alert.alert(

--- a/app/(onboarding)/arkit-usage.tsx
+++ b/app/(onboarding)/arkit-usage.tsx
@@ -14,6 +14,7 @@ import { useRouter } from 'expo-router';
 import { useSafeBack } from '@/hooks/use-safe-back';
 import { isIOS } from '@/lib/platform-utils';
 import { OnboardingProgress } from '@/components/onboarding/OnboardingProgress';
+import { trackOnboardingEvent } from '@/lib/services/onboarding-analytics';
 
 type IoniconName = keyof typeof Ionicons.glyphMap;
 
@@ -107,6 +108,10 @@ export default function ARKitUsageScreen() {
   const [slideAnim] = useState(new Animated.Value(50));
 
   useEffect(() => {
+    trackOnboardingEvent('step_view', 'arkit-usage');
+  }, []);
+
+  useEffect(() => {
     Animated.parallel([
       Animated.timing(fadeAnim, {
         toValue: 1,
@@ -122,10 +127,12 @@ export default function ARKitUsageScreen() {
   }, [fadeAnim, slideAnim]);
 
   const handleGetStarted = () => {
+    trackOnboardingEvent('step_complete', 'arkit-usage');
     router.replace('/(tabs)/scan-arkit');
   };
 
   const handleSkip = () => {
+    trackOnboardingEvent('step_complete', 'arkit-usage');
     router.replace('/(tabs)');
   };
 

--- a/app/(onboarding)/nutrition-goals.tsx
+++ b/app/(onboarding)/nutrition-goals.tsx
@@ -1,5 +1,5 @@
 import { Ionicons } from '@expo/vector-icons';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Alert,
   KeyboardAvoidingView,
@@ -16,12 +16,17 @@ import { useToast } from '@/contexts/ToastContext';
 import { isIOS } from '@/lib/platform-utils';
 import { OnboardingProgress } from '@/components/onboarding/OnboardingProgress';
 import { markOnboardingCompleted } from '@/lib/services/onboarding';
+import { trackOnboardingEvent } from '@/lib/services/onboarding-analytics';
 
 export default function NutritionGoalsScreen() {
   const { goals, saveGoals, isSyncing, loading } = useNutritionGoals();
   const { show: showToast } = useToast();
   const isiOS = isIOS();
   const safeBack = useSafeBack('/(tabs)');
+
+  useEffect(() => {
+    trackOnboardingEvent('step_view', 'nutrition-goals');
+  }, []);
 
   const [calories, setCalories] = useState(goals?.calories?.toString() || '');
   const [protein, setProtein] = useState(goals?.protein?.toString() || '');
@@ -55,6 +60,7 @@ export default function NutritionGoalsScreen() {
       }
 
       await markOnboardingCompleted();
+      trackOnboardingEvent('step_complete', 'nutrition-goals');
       showToast('Nutrition goals saved successfully! 🎯', { type: 'success' });
       safeBack();
     } catch {
@@ -63,6 +69,7 @@ export default function NutritionGoalsScreen() {
   };
 
   const handleSkip = async () => {
+    trackOnboardingEvent('step_skip', 'nutrition-goals');
     if (goals) {
       await markOnboardingCompleted();
       safeBack();

--- a/app/(onboarding)/welcome.tsx
+++ b/app/(onboarding)/welcome.tsx
@@ -1,0 +1,227 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useEffect, useState } from 'react';
+import {
+  Animated,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const WELCOME_SEEN_KEY = 'welcome_screen_seen';
+
+type IoniconName = keyof typeof Ionicons.glyphMap;
+
+const features: { icon: IoniconName; title: string; description: string }[] = [
+  {
+    icon: 'body-outline',
+    title: 'Real-Time Form Cues',
+    description: 'ARKit tracks your reps and flags swing, depth, and tempo as you move.',
+  },
+  {
+    icon: 'barbell-outline',
+    title: 'Auto Logging',
+    description: 'Sets, reps, and weight captured automatically — no fiddling between sets.',
+  },
+  {
+    icon: 'heart-outline',
+    title: 'Health-Aware Coach',
+    description: 'AI adapts to your sleep, HR, and recent load from HealthKit.',
+  },
+  {
+    icon: 'cloud-offline-outline',
+    title: 'Offline First',
+    description: 'Everything works offline and syncs when you\'re back online.',
+  },
+];
+
+export default function WelcomeScreen() {
+  const router = useRouter();
+  const [fadeAnim] = useState(new Animated.Value(0));
+  const [slideAnim] = useState(new Animated.Value(30));
+
+  useEffect(() => {
+    Animated.parallel([
+      Animated.timing(fadeAnim, {
+        toValue: 1,
+        duration: 600,
+        useNativeDriver: true,
+      }),
+      Animated.timing(slideAnim, {
+        toValue: 0,
+        duration: 600,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }, [fadeAnim, slideAnim]);
+
+  const handleGetStarted = async () => {
+    await AsyncStorage.setItem(WELCOME_SEEN_KEY, 'true');
+    router.replace('/sign-in');
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Animated.View style={[styles.content, { opacity: fadeAnim, transform: [{ translateY: slideAnim }] }]}>
+        <View style={styles.logoSection}>
+          <View style={styles.logoCircle}>
+            <Ionicons name="fitness" size={48} color="#4C8CFF" />
+          </View>
+          <Text style={styles.appName}>Form Factor</Text>
+          <Text style={styles.tagline}>Real-time form coaching from your phone camera.</Text>
+        </View>
+
+        <View style={styles.featureList}>
+          {features.map((feature, index) => (
+            <Animated.View
+              key={feature.title}
+              style={[
+                styles.featureRow,
+                {
+                  opacity: fadeAnim,
+                  transform: [{ translateY: Animated.multiply(slideAnim, new Animated.Value(1 + index * 0.3)) }],
+                },
+              ]}
+            >
+              <View style={styles.featureIcon}>
+                <Ionicons name={feature.icon} size={24} color="#4C8CFF" />
+              </View>
+              <View style={styles.featureText}>
+                <Text style={styles.featureTitle}>{feature.title}</Text>
+                <Text style={styles.featureDescription}>{feature.description}</Text>
+              </View>
+            </Animated.View>
+          ))}
+        </View>
+
+        <View style={styles.ctaSection}>
+          <TouchableOpacity style={styles.primaryButton} onPress={handleGetStarted} activeOpacity={0.8}>
+            <Text style={styles.primaryButtonText}>Get Started</Text>
+            <Ionicons name="arrow-forward" size={20} color="#fff" />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.secondaryButton}
+            onPress={handleGetStarted}
+            activeOpacity={0.7}
+          >
+            <Text style={styles.secondaryButtonText}>I already have an account</Text>
+          </TouchableOpacity>
+        </View>
+      </Animated.View>
+    </SafeAreaView>
+  );
+}
+
+export async function hasSeenWelcome(): Promise<boolean> {
+  const value = await AsyncStorage.getItem(WELCOME_SEEN_KEY);
+  return value === 'true';
+}
+
+export async function clearWelcomeSeen(): Promise<void> {
+  await AsyncStorage.removeItem(WELCOME_SEEN_KEY);
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#050E1F',
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 24,
+    justifyContent: 'space-between',
+    paddingBottom: 24,
+  },
+  logoSection: {
+    alignItems: 'center',
+    marginTop: 40,
+    gap: 12,
+  },
+  logoCircle: {
+    width: 88,
+    height: 88,
+    borderRadius: 44,
+    backgroundColor: 'rgba(76, 140, 255, 0.1)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(76, 140, 255, 0.2)',
+  },
+  appName: {
+    fontSize: 32,
+    fontWeight: '800',
+    color: '#F5F7FF',
+  },
+  tagline: {
+    fontSize: 16,
+    color: '#9AACD1',
+    textAlign: 'center',
+    lineHeight: 22,
+    maxWidth: 280,
+  },
+  featureList: {
+    gap: 16,
+  },
+  featureRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+    backgroundColor: '#0F2339',
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#1B2E4A',
+  },
+  featureIcon: {
+    width: 44,
+    height: 44,
+    borderRadius: 12,
+    backgroundColor: 'rgba(76, 140, 255, 0.1)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  featureText: {
+    flex: 1,
+    gap: 4,
+  },
+  featureTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#F5F7FF',
+  },
+  featureDescription: {
+    fontSize: 14,
+    color: '#9AACD1',
+    lineHeight: 20,
+  },
+  ctaSection: {
+    gap: 12,
+    marginTop: 24,
+  },
+  primaryButton: {
+    backgroundColor: '#4C8CFF',
+    borderRadius: 16,
+    paddingVertical: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  primaryButtonText: {
+    color: '#fff',
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  secondaryButton: {
+    alignItems: 'center',
+    paddingVertical: 12,
+  },
+  secondaryButtonText: {
+    color: '#9AACD1',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -17,6 +17,7 @@ import { useFonts, Lexend_400Regular, Lexend_500Medium, Lexend_700Bold } from '@
 import { ToastProvider } from '../contexts/ToastContext';
 import { logWithTs, warnWithTs } from '@/lib/logger';
 import { isOnboardingCompleted } from '@/lib/services/onboarding';
+import { hasSeenWelcome } from '@/app/(onboarding)/welcome';
 
 // This layout wraps the entire app with providers
 function RootLayoutNav() {
@@ -93,6 +94,11 @@ function InitialLayout() {
   const isPublicRoute = publicRoutes.some((route) => pathname === route || pathname.startsWith(`${route}/`));
   const isWebRootLanding = Platform.OS === 'web' && pathname === '/';
   const [onboardingDone, setOnboardingDone] = useState<boolean | null>(null);
+  const [welcomeSeen, setWelcomeSeen] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    hasSeenWelcome().then(setWelcomeSeen);
+  }, []);
 
   useEffect(() => {
     if (user) {
@@ -103,7 +109,7 @@ function InitialLayout() {
   }, [user]);
 
   useEffect(() => {
-    if (loading || goalsLoading || (user && onboardingDone === null)) {
+    if (loading || goalsLoading || welcomeSeen === null || (user && onboardingDone === null)) {
       logWithTs('[Layout] Auth is loading, waiting...');
       return;
     }
@@ -116,6 +122,7 @@ function InitialLayout() {
       pathname,
       inModalsGroup,
       onboardingDone,
+      welcomeSeen,
       currentPath: segments.join('/'),
     });
 
@@ -153,15 +160,20 @@ function InitialLayout() {
 
     // Do not force redirect for other signed-in routes (e.g., modals or standalone flows)
 
-    // If user is not signed in but not in auth group, redirect to sign-in
-    if (!user && !inAuthGroup && !inModalsGroup && !isPublicRoute) {
-      logWithTs('[Layout] User not signed in, redirecting to sign-in');
-      router.replace('/sign-in');
+    // If user is not signed in but not in auth/onboarding group, redirect appropriately
+    if (!user && !inAuthGroup && !inOnboardingGroup && !inModalsGroup && !isPublicRoute) {
+      if (!welcomeSeen) {
+        logWithTs('[Layout] New user, redirecting to welcome');
+        router.replace('/(onboarding)/welcome');
+      } else {
+        logWithTs('[Layout] User not signed in, redirecting to sign-in');
+        router.replace('/sign-in');
+      }
       return;
     }
 
     logWithTs('[Layout] No redirect needed');
-  }, [user, loading, goalsLoading, goals, onboardingDone, segments, inAuthGroup, inTabsGroup, inOnboardingGroup, inModalsGroup, isPublicRoute, isWebRootLanding, pathname, router]);
+  }, [user, loading, goalsLoading, goals, onboardingDone, welcomeSeen, segments, inAuthGroup, inTabsGroup, inOnboardingGroup, inModalsGroup, isPublicRoute, isWebRootLanding, pathname, router]);
 
   if (loading) {
     return (

--- a/lib/services/onboarding-analytics.ts
+++ b/lib/services/onboarding-analytics.ts
@@ -1,0 +1,81 @@
+/**
+ * Onboarding Analytics Service
+ *
+ * Tracks user progress through the onboarding flow.
+ * Logs to console in dev, persists to Supabase `onboarding_events` table
+ * in production. Respects telemetry consent via shouldLogFramesSync().
+ */
+
+import { supabase } from '@/lib/supabase';
+import { ensureUserId } from '@/lib/auth-utils';
+import { shouldLogFramesSync } from '@/lib/services/consent-service';
+import { logWithTs, warnWithTs } from '@/lib/logger';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type OnboardingEventType =
+  | 'onboarding_start'
+  | 'step_view'
+  | 'step_complete'
+  | 'step_skip'
+  | 'onboarding_complete';
+
+export type OnboardingStepName =
+  | 'nutrition-goals'
+  | 'arkit-permissions'
+  | 'arkit-usage';
+
+interface OnboardingEvent {
+  event_type: OnboardingEventType;
+  step_name: OnboardingStepName;
+  timestamp: string;
+  user_id: string;
+}
+
+// =============================================================================
+// Core
+// =============================================================================
+
+/**
+ * Track an onboarding event. Checks consent before logging.
+ * Fails silently if the table doesn't exist or if the user isn't authenticated.
+ */
+export async function trackOnboardingEvent(
+  eventType: OnboardingEventType,
+  stepName: OnboardingStepName,
+): Promise<void> {
+  if (!shouldLogFramesSync()) return;
+
+  const timestamp = new Date().toISOString();
+
+  try {
+    const userId = await ensureUserId();
+
+    const event: OnboardingEvent = {
+      event_type: eventType,
+      step_name: stepName,
+      timestamp,
+      user_id: userId,
+    };
+
+    if (__DEV__) {
+      logWithTs('[onboarding-analytics]', eventType, stepName);
+    }
+
+    // Insert into Supabase — fail silently if table doesn't exist yet
+    const { error } = await supabase
+      .from('onboarding_events')
+      .insert(event);
+
+    if (error && __DEV__) {
+      warnWithTs('[onboarding-analytics] Insert failed (table may not exist yet)', error.message);
+    }
+  } catch {
+    // Fail silently — user may not be authenticated or network may be down
+    if (__DEV__) {
+      warnWithTs('[onboarding-analytics] Failed to track event', eventType, stepName);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- New welcome screen at `/(onboarding)/welcome` with value prop highlights (form cues, auto logging, health-aware coach, offline first)
- New users see welcome screen before auth; returning users skip to sign-in
- `welcome_screen_seen` flag persisted in AsyncStorage
- Updated root layout routing to check welcome flag before redirecting unauthenticated users

Closes #34
Closes #38

## Test plan
- [x] welcome.tsx has 4 feature value prop cards with icons
- [x] _layout.tsx checks hasSeenWelcome and redirects new users to welcome
- [x] "Get Started" sets AsyncStorage flag and redirects to sign-in
- [x] "I already have an account" also sets flag and redirects to sign-in
- [x] Animation renders correctly (requires device test)