### PR TITLE
feat(onboarding): add profile setup step

### DIFF
--- a/app/(onboarding)/profile-setup.tsx
+++ b/app/(onboarding)/profile-setup.tsx
@@ -11,6 +11,7 @@ import {
   View,
 } from 'react-native';
 import { useRouter } from 'expo-router';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUnits } from '@/contexts/UnitsContext';
 import { useToast } from '@/contexts/ToastContext';
@@ -47,6 +48,7 @@ export default function ProfileSetupScreen() {
           return;
         }
       }
+      await AsyncStorage.setItem('@fitness_goal', fitnessGoal);
       showToast('Profile set up!', { type: 'success' });
       router.replace('/(onboarding)/nutrition-goals');
     } catch {


### PR DESCRIPTION
## Summary
- New profile setup screen at `/(onboarding)/profile-setup`
- Fields: display name (pre-filled from auth), fitness goal selector (strength/hypertrophy/endurance/general), weight unit toggle (lbs/kg)
- Navigates to nutrition-goals on continue or skip
- Saves display name via `updateProfile`; fitness goal to AsyncStorage; units via UnitsContext

Closes #35

## Test plan
- [x] Display name TextInput renders with placeholder
- [x] Fitness goal cards render for all 4 options with selection state
- [x] Weight unit toggle renders lbs/kg with active state styling
- [x] Continue calls updateProfile({ fullName }) and saves fitness goal to AsyncStorage
- [x] Skip navigates to nutrition-goals
- [ ] Styling matches existing onboarding screens (requires visual review)