### PR TITLE
fix(sync): wrap JSON.parse in sync queue with try-catch

### DIFF
--- a/lib/services/database/sync-service.ts
+++ b/lib/services/database/sync-service.ts
@@ -973,7 +973,17 @@ class SyncService {
 
         let data: Record<string, unknown> = {};
         if (item.data) {
-          const parsed = JSON.parse(item.data);
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(item.data);
+          } catch {
+            warnWithTs(
+              `[SyncService] Corrupted JSON in sync queue item ${item.id} ` +
+                `(table: ${item.table_name}, op: ${item.operation}), removing`
+            );
+            await localDB.removeSyncQueueItem(item.id);
+            continue;
+          }
           if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
             data = parsed as Record<string, unknown>;
           }


### PR DESCRIPTION
## Summary
- Wraps `JSON.parse(item.data)` in sync queue processing with try-catch
- On parse failure: logs warning with item context (ID, table, operation), removes corrupted item, continues processing
- Prevents a single corrupted queue entry from halting all sync operations

## Verification
- [x] Type check passes
- [x] Lint passes
- [ ] No file overlap with other open PRs

Closes #121