### PR TITLE
fix(auth,coach): add catch handlers to promise chains

### DIFF
--- a/app/(tabs)/coach.tsx
+++ b/app/(tabs)/coach.tsx
@@ -91,9 +91,14 @@ export default function CoachScreen() {
   // Check if user has seen coach welcome on first visit
   React.useEffect(() => {
     const checkWelcomeSeen = async () => {
-      const seen = await AsyncStorage.getItem(COACH_WELCOME_SEEN_KEY);
-      if (!seen && coachMessages.length === 1) {
-        setShowCoachWelcome(true);
+      try {
+        const seen = await AsyncStorage.getItem(COACH_WELCOME_SEEN_KEY);
+        if (!seen && coachMessages.length === 1) {
+          setShowCoachWelcome(true);
+        }
+      } catch (err) {
+        console.error('[Coach] Failed to check welcome seen status:', err);
+        // Default to not showing welcome on error
       }
     };
     checkWelcomeSeen();

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -96,7 +96,12 @@ function InitialLayout() {
 
   useEffect(() => {
     if (user) {
-      isOnboardingCompleted().then(setOnboardingDone);
+      isOnboardingCompleted()
+        .then(setOnboardingDone)
+        .catch((err) => {
+          console.error('[Layout] Failed to check onboarding status:', err);
+          setOnboardingDone(false);
+        });
     } else {
       setOnboardingDone(null);
     }


### PR DESCRIPTION
## Summary
- Added `.catch()` to `isOnboardingCompleted().then(setOnboardingDone)` in `app/_layout.tsx` — falls back to `false` on error
- Wrapped `AsyncStorage.getItem` in `coach.tsx` `checkWelcomeSeen` with try/catch — defaults to not showing welcome card on error
- Prevents unhandled promise rejections that crash in dev and silently fail in prod

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #119