### PR TITLE
fix(video): clean up storage files on failed database insert

### DIFF
--- a/lib/services/video-service.ts
+++ b/lib/services/video-service.ts
@@ -337,6 +337,20 @@ export async function uploadWorkoutVideo(opts: {
     .single();
 
   if (insertError) {
+    // Clean up uploaded storage files to avoid orphans
+    try {
+      await supabase.storage.from(VIDEO_BUCKET).remove([videoPath]);
+    } catch (cleanupErr) {
+      warnWithTs('[video-service] Failed to clean up orphaned video file', cleanupErr);
+    }
+    if (thumbnailPath) {
+      try {
+        const thumbBucket = usePrivateThumbnail ? VIDEO_BUCKET : THUMBNAIL_BUCKET;
+        await supabase.storage.from(thumbBucket).remove([thumbnailPath]);
+      } catch (cleanupErr) {
+        warnWithTs('[video-service] Failed to clean up orphaned thumbnail', cleanupErr);
+      }
+    }
     throw insertError;
   }
 


### PR DESCRIPTION
## Summary
- When video/thumbnail upload succeeds but database insert fails, now cleans up uploaded files from Supabase Storage
- Uses correct bucket logic (private vs public thumbnail bucket)
- Cleanup failures are logged as warnings but don't mask the original error

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #123