### PR TITLE
fix(ui): use state instead of ref for RefreshControl

### DIFF
--- a/app/(tabs)/food.tsx
+++ b/app/(tabs)/food.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'expo-router';
 import { DeleteAction } from '@/components';
 import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
 import { Swipeable } from 'react-native-gesture-handler';
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
@@ -49,7 +49,14 @@ export default function FoodScreen() {
   const router = useRouter();
   const { foods, deleteFood, refreshFoods, loading } = useFood();
   const { show: showToast } = useToast();
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const swipeableRefs = useRef<Map<string, Swipeable>>(new Map());
+
+  const onRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    await refreshFoods();
+    setIsRefreshing(false);
+  }, [refreshFoods]);
 
   const handleAddPress = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
@@ -215,8 +222,8 @@ export default function FoodScreen() {
           contentContainerStyle={styles.emptyState}
           refreshControl={
             <RefreshControl
-              refreshing={loading}
-              onRefresh={refreshFoods}
+              refreshing={isRefreshing}
+              onRefresh={onRefresh}
               tintColor="#007AFF"
               colors={['#007AFF']}
             />
@@ -244,8 +251,8 @@ export default function FoodScreen() {
           contentContainerStyle={styles.list}
           refreshControl={
             <RefreshControl
-              refreshing={loading}
-              onRefresh={refreshFoods}
+              refreshing={isRefreshing}
+              onRefresh={onRefresh}
               tintColor="#007AFF"
               colors={['#007AFF']}
             />

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
 import { DeleteAction } from '@/components';
 import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import {
     ActivityIndicator,
     FlatList,
@@ -40,13 +40,13 @@ export default function WorkoutsScreen() {
   const router = useRouter();
   const { workouts, loading, refreshWorkouts, deleteWorkout } = useWorkouts();
   const { show: showToast } = useToast();
-  const refreshing = useRef(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const swipeableRefs = useRef<Map<string, Swipeable>>(new Map());
 
   const onRefresh = useCallback(async () => {
-    refreshing.current = true;
+    setIsRefreshing(true);
     await refreshWorkouts();
-    refreshing.current = false;
+    setIsRefreshing(false);
   }, [refreshWorkouts]);
 
   const handleAddPress = () => {
@@ -221,7 +221,7 @@ export default function WorkoutsScreen() {
           contentContainerStyle={styles.emptyState}
           refreshControl={
             <RefreshControl
-              refreshing={refreshing.current}
+              refreshing={isRefreshing}
               onRefresh={onRefresh}
               tintColor="#007AFF"
               colors={['#007AFF']}
@@ -263,7 +263,7 @@ export default function WorkoutsScreen() {
           showsVerticalScrollIndicator={false}
           refreshControl={
             <RefreshControl
-              refreshing={refreshing.current}
+              refreshing={isRefreshing}
               onRefresh={onRefresh}
               tintColor="#007AFF"
               colors={['#007AFF']}


### PR DESCRIPTION
## Summary
- Replaced `useRef(false)` with `useState(false)` for refreshing flag in `workouts.tsx` and `food.tsx`
- RefreshControl now properly reflects pull-to-refresh state via React state instead of a non-reactive ref
- Added proper `onRefresh` callback in `food.tsx` (was previously using `loading` from context)

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #128