### PR TITLE
fix(auth): validate OAuth tokens before session creation

### DIFF
--- a/lib/services/OAuthHandler.ts
+++ b/lib/services/OAuthHandler.ts
@@ -135,8 +135,14 @@ export class OAuthHandler {
       const tokens = this.parseTokensFromUrl(url);
       
       if (tokens) {
-        logWithTs('[OAuthHandler] Found tokens in URL, setting session');
-        
+        // Validate token format before attempting session creation
+        if (!this.validateTokens(tokens)) {
+          errorWithTs('[OAuthHandler] Token validation failed — tokens appear malformed');
+          return null;
+        }
+
+        logWithTs('[OAuthHandler] Tokens validated, setting session');
+
         // Set session using the extracted tokens
         const { data, error } = await supabase.auth.setSession({
           access_token: tokens.accessToken,


### PR DESCRIPTION
## Summary
- Calls existing `validateTokens()` method in `handleCallback()` before passing tokens to `supabase.auth.setSession()`
- If validation fails (empty tokens, access token < 50 chars, refresh token < 20 chars), returns `null` instead of creating an invalid session
- Prevents malformed/corrupted OAuth tokens from creating broken sessions

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #120