### PR TITLE
test(sync): add unit tests for sync service

### DIFF
--- a/tests/unit/services/sync-service.test.ts
+++ b/tests/unit/services/sync-service.test.ts
@@ -1,0 +1,655 @@
+/**
+ * Unit tests for SyncService — the offline-first sync engine.
+ *
+ * We test the exported singleton (`syncService`) by mocking its two main
+ * dependencies: the local SQLite database (`localDB`) and the Supabase
+ * client.  The generic-sync helpers are stubbed out so we can focus on
+ * the core queue-processing, concurrency-lock, retry, and status logic
+ * that lives inside sync-service.ts itself.
+ */
+
+// ---------------------------------------------------------------------------
+// Supabase mock — a chainable query builder using Proxy
+// ---------------------------------------------------------------------------
+
+let qbResolvedValue: { data?: unknown; error?: unknown } = { data: null, error: null };
+
+function createQueryBuilder() {
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_target, prop: string) {
+      if (prop === 'then') {
+        return (resolve: (v: unknown) => void) => resolve(qbResolvedValue);
+      }
+      return (..._args: unknown[]) => builder;
+    },
+  };
+  const builder = new Proxy({} as Record<string, unknown>, handler);
+  return builder;
+}
+
+const mockGetUser = jest.fn().mockResolvedValue({
+  data: { user: { id: 'user-123' } },
+});
+
+const mockFrom = jest.fn().mockImplementation(() => createQueryBuilder());
+
+const mockRemoveChannel = jest.fn().mockResolvedValue(undefined);
+
+// ---------------------------------------------------------------------------
+// jest.mock calls — hoisted above imports
+// ---------------------------------------------------------------------------
+
+jest.mock('@/lib/services/database/local-db', () => {
+  const methods = [
+    'getUnsyncedFoods', 'getUnsyncedWorkouts', 'getUnsyncedHealthMetrics',
+    'getUnsyncedNutritionGoals', 'getSyncQueue', 'countSyncQueueItems',
+    'removeSyncQueueItem', 'incrementSyncQueueRetry', 'cleanupSyncedDeletes',
+    'clearSyncQueue', 'addToSyncQueue',
+    'updateFoodSyncStatus', 'updateWorkoutSyncStatus',
+    'updateHealthMetricSyncStatus', 'updateNutritionGoalsSyncStatus',
+    'hardDeleteFood', 'hardDeleteWorkout', 'deleteHealthMetric', 'deleteNutritionGoals',
+    'getAllFoodsWithDeleted', 'getAllWorkoutsWithDeleted',
+    'insertFood', 'insertWorkout', 'updateFood', 'updateWorkout',
+    'getFoodById', 'getWorkoutById', 'getHealthMetricById', 'getNutritionGoalsById',
+    'getNutritionGoals', 'upsertNutritionGoals',
+    'insertHealthMetric', 'updateHealthMetric',
+  ];
+  const db: Record<string, jest.Mock> = {};
+  for (const m of methods) {
+    db[m] = jest.fn().mockResolvedValue(
+      m === 'countSyncQueueItems' ? 0 :
+      (m.startsWith('getUnsynced') || m === 'getSyncQueue' || m.startsWith('getAll') ? [] : undefined)
+    );
+  }
+  // Store on global so tests can access it
+  (global as any).__mockLocalDB = db;
+  return { localDB: db };
+});
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    auth: {
+      getUser: () => mockGetUser(),
+      getSession: jest.fn().mockResolvedValue({ data: { session: null } }),
+      onAuthStateChange: jest.fn(() => ({
+        data: { subscription: { unsubscribe: jest.fn() } },
+      })),
+    },
+    channel: jest.fn().mockReturnValue({
+      on: jest.fn().mockReturnThis(),
+      subscribe: jest.fn().mockReturnThis(),
+    }),
+    removeChannel: (...args: unknown[]) => mockRemoveChannel(...args),
+  },
+}));
+
+jest.mock('@/lib/services/database/generic-sync', () => ({
+  syncAllWorkoutTablesToSupabase: jest.fn().mockResolvedValue(undefined),
+  downloadAllWorkoutTablesFromSupabase: jest.fn().mockResolvedValue(undefined),
+  cleanupWorkoutSyncedDeletes: jest.fn().mockResolvedValue(undefined),
+  WORKOUT_SYNC_CONFIGS: [],
+  handleGenericRealtimeChange: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logWithTs: jest.fn(),
+  warnWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test
+// ---------------------------------------------------------------------------
+
+import { syncService } from '@/lib/services/database/sync-service';
+
+// Access the mock object created inside the factory
+const mockLocalDB = (global as any).__mockLocalDB as Record<string, jest.Mock>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetSyncService() {
+  (syncService as any).isSyncing = false;
+  (syncService as any).syncPromise = null;
+  (syncService as any).syncCallbacks = [];
+  (syncService as any).syncStatusCallbacks = [];
+  (syncService as any).syncStatus = {
+    state: 'idle',
+    queueSize: 0,
+    lastError: null,
+    lastErrorAt: null,
+  };
+  (syncService as any).foodChannel = null;
+  (syncService as any).workoutChannel = null;
+  (syncService as any).healthChannel = null;
+  (syncService as any).nutritionGoalsChannel = null;
+  (syncService as any).workoutSessionChannels = [];
+  if ((syncService as any).conflictSyncTimer) {
+    clearTimeout((syncService as any).conflictSyncTimer);
+    (syncService as any).conflictSyncTimer = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SyncService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetSyncService();
+    // Reset default query builder resolved value
+    qbResolvedValue = { data: null, error: null };
+    // Re-set default return values that clearAllMocks removed
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-123' } } });
+    mockFrom.mockImplementation(() => createQueryBuilder());
+    mockRemoveChannel.mockResolvedValue(undefined);
+    // Re-set localDB default returns
+    for (const m of Object.keys(mockLocalDB)) {
+      if (m === 'countSyncQueueItems') {
+        mockLocalDB[m].mockResolvedValue(0);
+      } else if (m.startsWith('getUnsynced') || m === 'getSyncQueue' || m.startsWith('getAll')) {
+        mockLocalDB[m].mockResolvedValue([]);
+      } else if (m.startsWith('get') || m === 'getNutritionGoals') {
+        mockLocalDB[m].mockResolvedValue(null);
+      } else {
+        mockLocalDB[m].mockResolvedValue(undefined);
+      }
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Singleton
+  // -----------------------------------------------------------------------
+  describe('singleton export', () => {
+    it('exports a stable reference', () => {
+      const ref1 = syncService;
+      const ref2 = require('@/lib/services/database/sync-service').syncService;
+      expect(ref1).toBe(ref2);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Sync status
+  // -----------------------------------------------------------------------
+  describe('getSyncStatus / onSyncStatusChange', () => {
+    it('returns idle status by default', () => {
+      const status = syncService.getSyncStatus();
+      expect(status.state).toBe('idle');
+      expect(status.queueSize).toBe(0);
+      expect(status.lastError).toBeNull();
+    });
+
+    it('notifies status subscribers immediately on registration', () => {
+      const cb = jest.fn();
+      syncService.onSyncStatusChange(cb);
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenCalledWith(expect.objectContaining({ state: 'idle' }));
+    });
+
+    it('unsubscribe function removes the callback', () => {
+      const cb = jest.fn();
+      const unsub = syncService.onSyncStatusChange(cb);
+      cb.mockClear();
+      unsub();
+      (syncService as any).setSyncStatus({ state: 'syncing' });
+      expect(cb).not.toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // onSyncComplete
+  // -----------------------------------------------------------------------
+  describe('onSyncComplete', () => {
+    it('notifies registered callbacks', () => {
+      const cb = jest.fn();
+      syncService.onSyncComplete(cb);
+      (syncService as any).notifySyncComplete();
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('unsubscribe removes the callback', () => {
+      const cb = jest.fn();
+      const unsub = syncService.onSyncComplete(cb);
+      unsub();
+      (syncService as any).notifySyncComplete();
+      expect(cb).not.toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // syncToSupabase — concurrency lock & basic flow
+  // -----------------------------------------------------------------------
+  describe('syncToSupabase', () => {
+    it('skips when already syncing (isSyncing lock)', async () => {
+      (syncService as any).isSyncing = true;
+      await syncService.syncToSupabase();
+      expect(mockGetUser).not.toHaveBeenCalled();
+    });
+
+    it('sets isSyncing during execution and resets after', async () => {
+      expect((syncService as any).isSyncing).toBe(false);
+      const promise = syncService.syncToSupabase();
+      expect((syncService as any).isSyncing).toBe(true);
+      await promise;
+      expect((syncService as any).isSyncing).toBe(false);
+    });
+
+    it('skips sync when no authenticated user', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      await syncService.syncToSupabase();
+      expect(mockLocalDB.getUnsyncedFoods).not.toHaveBeenCalled();
+    });
+
+    it('sets status to syncing then back to idle on success', async () => {
+      const statuses: string[] = [];
+      syncService.onSyncStatusChange((s) => statuses.push(s.state));
+      await syncService.syncToSupabase();
+      expect(statuses).toContain('syncing');
+      expect(statuses[statuses.length - 1]).toBe('idle');
+    });
+
+    it('sets status to error when getUser throws', async () => {
+      mockGetUser.mockRejectedValue(new Error('network down'));
+      await syncService.syncToSupabase();
+      const status = syncService.getSyncStatus();
+      expect(status.state).toBe('error');
+      expect(status.lastError).toBe('network down');
+    });
+
+    it('notifies sync complete on success', async () => {
+      const cb = jest.fn();
+      syncService.onSyncComplete(cb);
+      await syncService.syncToSupabase();
+      expect(cb).toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // processSyncQueue
+  // -----------------------------------------------------------------------
+  describe('processSyncQueue (via syncToSupabase)', () => {
+    it('removes items that hit max retries (5)', async () => {
+      mockLocalDB.getSyncQueue.mockResolvedValue([
+        {
+          id: 1,
+          table_name: 'foods',
+          operation: 'upsert',
+          record_id: 'food-1',
+          data: JSON.stringify({ id: 'food-1', name: 'Apple', calories: 95 }),
+          created_at: new Date().toISOString(),
+          retry_count: 5,
+          next_retry_at: null,
+        },
+      ]);
+
+      await syncService.syncToSupabase();
+
+      expect(mockLocalDB.removeSyncQueueItem).toHaveBeenCalledWith(1);
+    });
+
+    it('processes upsert queue items and removes on success', async () => {
+      mockLocalDB.getSyncQueue.mockResolvedValue([
+        {
+          id: 10,
+          table_name: 'foods',
+          operation: 'upsert',
+          record_id: 'food-abc',
+          data: JSON.stringify({ id: 'food-abc', name: 'Banana', calories: 105 }),
+          created_at: new Date().toISOString(),
+          retry_count: 0,
+          next_retry_at: null,
+        },
+      ]);
+
+      await syncService.syncToSupabase();
+
+      expect(mockLocalDB.removeSyncQueueItem).toHaveBeenCalledWith(10);
+      expect(mockLocalDB.updateFoodSyncStatus).toHaveBeenCalledWith('food-abc', true);
+    });
+
+    it('processes delete queue items', async () => {
+      mockLocalDB.getSyncQueue.mockResolvedValue([
+        {
+          id: 20,
+          table_name: 'workouts',
+          operation: 'delete',
+          record_id: 'workout-xyz',
+          data: null,
+          created_at: new Date().toISOString(),
+          retry_count: 0,
+          next_retry_at: null,
+        },
+      ]);
+
+      await syncService.syncToSupabase();
+
+      expect(mockLocalDB.removeSyncQueueItem).toHaveBeenCalledWith(20);
+      expect(mockLocalDB.updateWorkoutSyncStatus).toHaveBeenCalledWith('workout-xyz', true);
+    });
+
+    it('increments retry count on queue processing failure', async () => {
+      qbResolvedValue = { data: null, error: { message: 'timeout', code: '500' } };
+
+      mockLocalDB.getSyncQueue.mockResolvedValue([
+        {
+          id: 30,
+          table_name: 'foods',
+          operation: 'upsert',
+          record_id: 'food-fail',
+          data: JSON.stringify({ id: 'food-fail', name: 'Test', calories: 50 }),
+          created_at: new Date().toISOString(),
+          retry_count: 2,
+          next_retry_at: null,
+        },
+      ]);
+
+      await syncService.syncToSupabase();
+
+      expect(mockLocalDB.incrementSyncQueueRetry).toHaveBeenCalledWith(
+        30,
+        expect.any(String)
+      );
+    });
+
+    it('skips queue items whose next_retry_at is in the future', async () => {
+      const futureDate = new Date(Date.now() + 60_000).toISOString();
+
+      mockLocalDB.getSyncQueue.mockResolvedValue([
+        {
+          id: 40,
+          table_name: 'foods',
+          operation: 'upsert',
+          record_id: 'food-wait',
+          data: JSON.stringify({ id: 'food-wait', name: 'Waiting', calories: 10 }),
+          created_at: new Date().toISOString(),
+          retry_count: 1,
+          next_retry_at: futureDate,
+        },
+      ]);
+
+      await syncService.syncToSupabase();
+
+      expect(mockLocalDB.removeSyncQueueItem).not.toHaveBeenCalledWith(40);
+      expect(mockLocalDB.incrementSyncQueueRetry).not.toHaveBeenCalledWith(40, expect.anything());
+    });
+
+    it('handles corrupted JSON data gracefully (catches parse error)', async () => {
+      mockLocalDB.getSyncQueue.mockResolvedValue([
+        {
+          id: 50,
+          table_name: 'foods',
+          operation: 'upsert',
+          record_id: 'food-corrupt',
+          data: '{{not valid json',
+          created_at: new Date().toISOString(),
+          retry_count: 0,
+          next_retry_at: null,
+        },
+      ]);
+
+      await syncService.syncToSupabase();
+
+      expect(mockLocalDB.incrementSyncQueueRetry).toHaveBeenCalledWith(
+        50,
+        expect.any(String)
+      );
+    });
+
+    it('purges local record and removes queue item on RLS violation (42501)', async () => {
+      qbResolvedValue = { data: null, error: { message: 'RLS', code: '42501' } };
+
+      mockLocalDB.getSyncQueue.mockResolvedValue([
+        {
+          id: 60,
+          table_name: 'foods',
+          operation: 'upsert',
+          record_id: 'food-rls',
+          data: JSON.stringify({ id: 'food-rls', name: 'Forbidden', calories: 0 }),
+          created_at: new Date().toISOString(),
+          retry_count: 0,
+          next_retry_at: null,
+        },
+      ]);
+
+      await syncService.syncToSupabase();
+
+      expect(mockLocalDB.hardDeleteFood).toHaveBeenCalledWith('food-rls');
+      expect(mockLocalDB.removeSyncQueueItem).toHaveBeenCalledWith(60);
+    });
+
+    it('purges health metric on invalid UUID error (22P02)', async () => {
+      qbResolvedValue = { data: null, error: { message: 'invalid UUID', code: '22P02' } };
+
+      mockLocalDB.getSyncQueue.mockResolvedValue([
+        {
+          id: 70,
+          table_name: 'health_metrics',
+          operation: 'upsert',
+          record_id: 'bad-uuid',
+          data: JSON.stringify({ id: 'bad-uuid', summary_date: '2025-01-01' }),
+          created_at: new Date().toISOString(),
+          retry_count: 0,
+          next_retry_at: null,
+        },
+      ]);
+
+      await syncService.syncToSupabase();
+
+      expect(mockLocalDB.deleteHealthMetric).toHaveBeenCalledWith('bad-uuid');
+      expect(mockLocalDB.removeSyncQueueItem).toHaveBeenCalledWith(70);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // fullSync
+  // -----------------------------------------------------------------------
+  describe('fullSync', () => {
+    it('coalesces concurrent calls via syncPromise', async () => {
+      const p1 = syncService.fullSync();
+      const p2 = syncService.fullSync();
+      await Promise.all([p1, p2]);
+      expect((syncService as any).syncPromise).toBeNull();
+    });
+
+    it('clears syncPromise after completion', async () => {
+      await syncService.fullSync();
+      expect((syncService as any).syncPromise).toBeNull();
+    });
+
+    it('clears syncPromise even on error', async () => {
+      // Make getUser reject so both downloadFromSupabase and syncToSupabase fail
+      mockGetUser.mockRejectedValue(new Error('kaboom'));
+      await syncService.fullSync();
+      expect((syncService as any).syncPromise).toBeNull();
+      expect(syncService.getSyncStatus().state).toBe('error');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // clearSyncQueue
+  // -----------------------------------------------------------------------
+  describe('clearSyncQueue', () => {
+    it('delegates to localDB.clearSyncQueue and resets status', async () => {
+      (syncService as any).setSyncStatus({
+        state: 'error',
+        lastError: 'some error',
+        lastErrorAt: new Date().toISOString(),
+      });
+
+      await syncService.clearSyncQueue();
+
+      expect(mockLocalDB.clearSyncQueue).toHaveBeenCalled();
+      const status = syncService.getSyncStatus();
+      expect(status.state).toBe('idle');
+      expect(status.lastError).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Retry delay calculation
+  // -----------------------------------------------------------------------
+  describe('getRetryDelayMs', () => {
+    it('uses exponential backoff capped at 60s', () => {
+      const fn = (syncService as any).getRetryDelayMs.bind(syncService);
+      expect(fn(0)).toBe(1_000);
+      expect(fn(1)).toBe(2_000);
+      expect(fn(2)).toBe(4_000);
+      expect(fn(3)).toBe(8_000);
+      expect(fn(4)).toBe(16_000);
+      expect(fn(5)).toBe(32_000);
+      expect(fn(6)).toBe(60_000);
+      expect(fn(10)).toBe(60_000);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // isQueueItemReady
+  // -----------------------------------------------------------------------
+  describe('isQueueItemReady', () => {
+    const check = (item: Record<string, unknown>) =>
+      (syncService as any).isQueueItemReady.call(syncService, item);
+
+    it('returns true when next_retry_at is null', () => {
+      expect(check({ next_retry_at: null, created_at: new Date().toISOString() })).toBe(true);
+    });
+
+    it('returns true when next_retry_at is in the past', () => {
+      expect(check({
+        next_retry_at: new Date(Date.now() - 10_000).toISOString(),
+        created_at: new Date().toISOString(),
+      })).toBe(true);
+    });
+
+    it('returns false when next_retry_at is in the future', () => {
+      expect(check({
+        next_retry_at: new Date(Date.now() + 60_000).toISOString(),
+        created_at: new Date().toISOString(),
+      })).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Realtime cleanup
+  // -----------------------------------------------------------------------
+  describe('cleanupRealtimeSync', () => {
+    it('removes all channels and clears conflict timer', async () => {
+      (syncService as any).foodChannel = { id: 'food' };
+      (syncService as any).workoutChannel = { id: 'workout' };
+      (syncService as any).healthChannel = { id: 'health' };
+      (syncService as any).nutritionGoalsChannel = { id: 'nutrition' };
+      (syncService as any).workoutSessionChannels = [{ id: 'session1' }];
+      (syncService as any).conflictSyncTimer = setTimeout(() => {}, 10000);
+
+      await syncService.cleanupRealtimeSync();
+
+      expect(mockRemoveChannel).toHaveBeenCalledTimes(5);
+      expect((syncService as any).foodChannel).toBeNull();
+      expect((syncService as any).workoutChannel).toBeNull();
+      expect((syncService as any).healthChannel).toBeNull();
+      expect((syncService as any).nutritionGoalsChannel).toBeNull();
+      expect((syncService as any).workoutSessionChannels).toHaveLength(0);
+      expect((syncService as any).conflictSyncTimer).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error classification helpers
+  // -----------------------------------------------------------------------
+  describe('error classification', () => {
+    it('identifies RLS violations (42501)', () => {
+      const fn = (syncService as any).isRlsViolation.bind(syncService);
+      expect(fn({ code: '42501' })).toBe(true);
+      expect(fn({ code: '500' })).toBe(false);
+      expect(fn(null)).toBe(false);
+    });
+
+    it('identifies invalid UUID errors (22P02)', () => {
+      const fn = (syncService as any).isInvalidUuid.bind(syncService);
+      expect(fn({ code: '22P02' })).toBe(true);
+      expect(fn({ code: '42501' })).toBe(false);
+      expect(fn(null)).toBe(false);
+    });
+
+    it('identifies managed tables', () => {
+      const fn = (syncService as any).isManagedTable.bind(syncService);
+      expect(fn('foods')).toBe(true);
+      expect(fn('workouts')).toBe(true);
+      expect(fn('health_metrics')).toBe(true);
+      expect(fn('nutrition_goals')).toBe(true);
+      expect(fn('other_table')).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Food-specific sync
+  // -----------------------------------------------------------------------
+  describe('food sync to Supabase', () => {
+    it('syncs unsynced foods with upsert', async () => {
+      mockLocalDB.getUnsyncedFoods.mockResolvedValue([
+        {
+          id: 'food-1',
+          name: 'Apple',
+          calories: 95,
+          protein: 0.5,
+          carbs: 25,
+          fat: 0.3,
+          date: '2025-01-01T12:00:00Z',
+          synced: 0,
+          deleted: 0,
+          updated_at: '2025-01-01T12:00:00Z',
+        },
+      ]);
+
+      await syncService.syncToSupabase();
+
+      expect(mockLocalDB.updateFoodSyncStatus).toHaveBeenCalledWith('food-1', true);
+    });
+
+    it('handles deleted foods by calling supabase delete', async () => {
+      mockLocalDB.getUnsyncedFoods.mockResolvedValue([
+        {
+          id: 'food-del',
+          name: 'Deleted Food',
+          calories: 0,
+          date: '2025-01-01',
+          synced: 0,
+          deleted: 1,
+          updated_at: '2025-01-01T12:00:00Z',
+        },
+      ]);
+
+      await syncService.syncToSupabase();
+
+      expect(mockLocalDB.updateFoodSyncStatus).toHaveBeenCalledWith('food-del', true);
+    });
+
+    it('adds food to sync queue on non-RLS failure', async () => {
+      qbResolvedValue = { data: null, error: { message: 'server error', code: '500' } };
+
+      mockLocalDB.getUnsyncedFoods.mockResolvedValue([
+        {
+          id: 'food-retry',
+          name: 'Retry Food',
+          calories: 100,
+          date: '2025-01-01',
+          synced: 0,
+          deleted: 0,
+          updated_at: '2025-01-01T12:00:00Z',
+        },
+      ]);
+
+      await syncService.syncToSupabase();
+
+      expect(mockLocalDB.addToSyncQueue).toHaveBeenCalledWith(
+        'foods',
+        'upsert',
+        'food-retry',
+        expect.objectContaining({ name: 'Retry Food' })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added 35 unit tests for `sync-service.ts` across 10 describe blocks
- Coverage includes: singleton pattern, concurrency locking, sync queue processing, retry logic with exponential backoff, error classification (RLS violations, invalid UUIDs), corrupted JSON handling, realtime cleanup, food sync operations
- Uses Proxy-based Supabase query builder mock for arbitrary chain depths

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] All 35 tests pass
- [x] No file overlap with other open PRs

Closes #126