### PR TITLE
fix(healthkit): guard Math.max against invalid date values in predictions

### DIFF
--- a/lib/services/healthkit/weight-trends.ts
+++ b/lib/services/healthkit/weight-trends.ts
@@ -284,7 +284,11 @@ function generatePredictions(
 
   const regression = calculateLinearRegression(data);
   const predictions: WeightPrediction[] = [];
-  const lastDate = Math.max(...data.map(p => p.date));
+  const validDates = data.map(p => p.date).filter(d => Number.isFinite(d));
+  if (validDates.length === 0) {
+    return [];
+  }
+  const lastDate = Math.max(...validDates);
   const lastWeight = data[data.length - 1].value;
 
   for (let i = 1; i <= days; i++) {


### PR DESCRIPTION
## Summary
- Filter date values through `Number.isFinite()` before `Math.max()` in `generatePredictions()`
- Return empty array if no valid dates remain
- Prevents -Infinity from corrupting prediction timestamps

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #142