### PR TITLE
fix(speech): reset isSpeakingRef on audio mode error

### DIFF
--- a/hooks/use-speech-feedback.ts
+++ b/hooks/use-speech-feedback.ts
@@ -140,7 +140,14 @@ export function useSpeechFeedback({
       return;
     }
 
-    await ensureAudioMode();
+    try {
+      await ensureAudioMode();
+    } catch (error) {
+      isSpeakingRef.current = false;
+      reportAsyncError('SPEECH_AUDIO_MODE_FAILED', 'Audio mode configuration failed, skipping cue', error);
+      onEvent?.({ cue: next, action: 'dropped', reason: 'audio_mode_error' });
+      return;
+    }
 
     isSpeakingRef.current = true;
     lastPhraseRef.current = next;


### PR DESCRIPTION
## Summary
- Wrapped `ensureAudioMode()` in try/catch within `flushQueue`
- On error: keeps `isSpeakingRef.current = false`, logs via `reportAsyncError`, fires `onEvent` with `audio_mode_error` reason
- Prevents speech queue from getting permanently stuck after audio configuration failures

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #145