### PR TITLE
fix(consent): invalidate cache before upsert to prevent stale reads

### DIFF
--- a/lib/services/consent-service.ts
+++ b/lib/services/consent-service.ts
@@ -102,6 +102,10 @@ export async function updateConsent(consent: Partial<TelemetryConsent>): Promise
       updateData.allow_extended_retention = consent.allowExtendedRetention;
     }
 
+    // Invalidate cache before upsert to prevent stale reads during concurrent access
+    cachedConsent = null;
+    cacheExpiry = 0;
+
     const { error } = await supabase
       .from('user_telemetry_consent')
       .upsert(updateData, { onConflict: 'user_id' });
@@ -109,10 +113,6 @@ export async function updateConsent(consent: Partial<TelemetryConsent>): Promise
     if (error) {
       throw error;
     }
-
-    // Invalidate cache
-    cachedConsent = null;
-    cacheExpiry = 0;
 
     if (__DEV__) {
       logWithTs('[consent-service] Consent updated', consent);


### PR DESCRIPTION
## Summary
- Moved cache invalidation before the Supabase upsert call (optimistic invalidation)
- Concurrent reads during async update now correctly miss the cache and fetch fresh data
- Prevents stale consent values from being returned during updates

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #156