### PR TITLE
fix(fqi): add finite checks to prevent NaN score propagation

### DIFF
--- a/lib/services/fqi-calculator.ts
+++ b/lib/services/fqi-calculator.ts
@@ -65,6 +65,15 @@ function calculateRomScore(
       const left = metric.extract(repAngles, 'left');
       const right = metric.extract(repAngles, 'right');
 
+      if (
+        !Number.isFinite(left.min) ||
+        !Number.isFinite(left.max) ||
+        !Number.isFinite(right.min) ||
+        !Number.isFinite(right.max)
+      ) {
+        continue;
+      }
+
       const avgMin = (left.min + right.min) / 2;
       const avgMax = (left.max + right.max) / 2;
       const actualRom = Math.abs(avgMax - avgMin);
@@ -148,6 +157,10 @@ function calculateDepthScore(
 
       const left = metric.extract(repAngles, 'left');
       const right = metric.extract(repAngles, 'right');
+
+      if (!Number.isFinite(left.min) || !Number.isFinite(right.min)) {
+        continue;
+      }
 
       const avgMin = (left.min + right.min) / 2;
       const deviation = Math.abs(avgMin - range.optimal);
@@ -284,6 +297,17 @@ export function calculateFqi(
   const faultContribution = (100 - totalPenalty) * weights.faults;
 
   const rawScore = romContribution + depthContribution + faultContribution;
+
+  // Guard against NaN propagation from upstream calculations
+  if (!Number.isFinite(rawScore)) {
+    return {
+      score: 0,
+      romScore: Number.isFinite(romScore) ? Math.round(romScore) : 0,
+      depthScore: Number.isFinite(depthScore) ? Math.round(depthScore) : 0,
+      faultPenalty: totalPenalty,
+      detectedFaults: faultIds,
+    };
+  }
 
   // Clamp to 0-100
   const score = Math.max(0, Math.min(100, Math.round(rawScore)));


### PR DESCRIPTION
## Summary
- Added `Number.isFinite()` checks on extracted angle values in `calculateRomScore` and `calculateDepthScore`
- Non-finite metrics are skipped instead of corrupting the score
- Final `calculateFqi` returns zeroed-out result if raw score is NaN/Infinity
- Prevents NaN from being stored in the database

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #158