### PR TITLE
fix(tracking): guard against null baselineGap in rep detector

### DIFF
--- a/lib/tracking-quality/rep-detector.ts
+++ b/lib/tracking-quality/rep-detector.ts
@@ -169,17 +169,18 @@ export class RepDetectorPullup {
     }
 
     const visible = areRequiredJointsVisible(joints, REQUIRED_JOINTS, this.options.minJointConfidence);
-    const gap = visible ? computeShoulderHandGap(joints) : null;
-    if (!visible || gap === null) {
+    const rawGap = visible ? computeShoulderHandGap(joints) : null;
+    if (!visible || rawGap === null || !Number.isFinite(rawGap)) {
       this.freezeOrTimeout();
       return;
     }
+    const gap = rawGap;
 
     if (this.baselineGap === null) {
       this.baselineGap = gap;
     }
 
-    const delta = this.baselineGap === null ? 0 : gap - this.baselineGap;
+    const delta = gap - this.baselineGap;
     const avgElbow = (input.angles.leftElbow + input.angles.rightElbow) / 2;
 
     if (


### PR DESCRIPTION
## Summary
- Added `Number.isFinite(rawGap)` validation before using computed shoulder-hand gap
- Prevents NaN propagation when gap computation yields non-finite values
- Ensures baselineGap is always assigned before delta calculation

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #168