### PR TITLE
fix(tracking): use low confidence default for undefined occlusion values

### DIFF
--- a/lib/tracking-quality/occlusion.ts
+++ b/lib/tracking-quality/occlusion.ts
@@ -81,7 +81,7 @@ export class OcclusionHoldManager {
       }
 
       held.missingFrames += 1;
-      const base = typeof held.lastGood.confidence === 'number' ? clamp01(held.lastGood.confidence) : 1;
+      const base = typeof held.lastGood.confidence === 'number' ? clamp01(held.lastGood.confidence) : CONFIDENCE_TIER_THRESHOLDS.low;
       const decayed = this.decayConfidence(base, held.missingFrames);
       output.set(key, {
         x: held.lastGood.x,
@@ -123,7 +123,7 @@ export class OcclusionHoldManager {
       }
 
       held.missingFrames += 1;
-      const base = typeof held.lastGood.confidence === 'number' ? clamp01(held.lastGood.confidence) : 1;
+      const base = typeof held.lastGood.confidence === 'number' ? clamp01(held.lastGood.confidence) : CONFIDENCE_TIER_THRESHOLDS.low;
       const decayed = this.decayConfidence(base, held.missingFrames);
       output[key] = {
         x: held.lastGood.x,


### PR DESCRIPTION
## Summary
- Changed confidence fallback from `1.0` to `CONFIDENCE_TIER_THRESHOLDS.low` (0.3) on lines 84 and 126
- Uses existing constant already imported in the file
- Prevents artificially high confidence from masking occlusion during decay calculations

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #169