### PR TITLE
fix(tracking): fix indentation in scoring availability check

### DIFF
--- a/lib/tracking-quality/scoring.ts
+++ b/lib/tracking-quality/scoring.ts
@@ -137,16 +137,16 @@ function missingReasonForRequiredJoints(input: {
   for (const spec of input.required) {
     if (typeof spec === 'string') {
       const joint = getJointFrom(input.joints, spec);
-        if (jointVisibilityScore(joint, Number.POSITIVE_INFINITY) < minConfidence) {
-          missing.push(spec);
-        }
-        continue;
+      if (jointVisibilityScore(joint, Number.POSITIVE_INFINITY) < minConfidence) {
+        missing.push(spec);
       }
+      continue;
+    }
 
-      const best = visibilityScoreForSpec(input.joints, spec, Number.POSITIVE_INFINITY);
-      if (best < minConfidence) {
-        missing.push(`[${spec.join('|')}]`);
-      }
+    const best = visibilityScoreForSpec(input.joints, spec, Number.POSITIVE_INFINITY);
+    if (best < minConfidence) {
+      missing.push(`[${spec.join('|')}]`);
+    }
   }
 
   if (missing.length === 0) {


### PR DESCRIPTION
## Summary
- Fixed misleading indentation in `missingReasonForRequiredJoints()` where visual structure didn't match brace structure
- String-case inner checks now properly indented inside `if (typeof spec === 'string')` block
- Array-of-joints case properly indented at for-loop body level
- Control flow was accidentally correct but indentation was a maintenance hazard

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #170