### PR TITLE
fix(sync): wrap JSON.parse in generic-sync payload transformation

### DIFF
--- a/lib/services/database/generic-sync.ts
+++ b/lib/services/database/generic-sync.ts
@@ -577,7 +577,20 @@ export const WORKOUT_SYNC_CONFIGS: SyncTableConfig[] = [
       for (const col of workoutSessionEventColumns) {
         if (col === 'payload') {
           // payload is stored as JSON string locally, but jsonb on Supabase
-          remote[col] = typeof row[col] === 'string' ? JSON.parse(row[col] as string) : row[col];
+          if (typeof row[col] === 'string') {
+            try {
+              remote[col] = JSON.parse(row[col] as string);
+            } catch {
+              warnWithTs(
+                `[generic-sync] Failed to parse JSON for column "${col}"` +
+                  (row.id ? ` (row id: ${row.id})` : '') +
+                  `, falling back to raw value`,
+              );
+              remote[col] = row[col];
+            }
+          } else {
+            remote[col] = row[col];
+          }
         } else if (col in row) {
           remote[col] = row[col];
         }


### PR DESCRIPTION
## Summary
- Wrapped `JSON.parse(row[col])` in try-catch during sync payload transformation
- On parse failure: logs warning with column name and row ID, falls back to raw value
- Prevents corrupted payloads from breaking the entire sync pipeline

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #175