### PR TITLE
fix(tut): validate tempo string parts before array access

### DIFF
--- a/lib/services/tut-estimator.ts
+++ b/lib/services/tut-estimator.ts
@@ -44,7 +44,9 @@ export function parseTempo(tempo: string | null | undefined): TempoPhases | null
   if (!tempo) return null;
 
   const parts = tempo.split('-').map(Number);
-  if (parts.some(isNaN)) return null;
+
+  if (parts.length < 3 || parts.length > 4) return null;
+  if (parts.some((v) => !Number.isFinite(v) || v < 0)) return null;
 
   if (parts.length === 3) {
     return {


### PR DESCRIPTION
## Summary
- Added explicit length check (< 3 or > 4) before accessing split array indices
- Replaced `isNaN` with stricter `!Number.isFinite(v) || v < 0` validation
- Returns null for malformed tempo strings instead of producing NaN values

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #176