### PR TITLE
fix(auth): add explicit JSON.parse error handling in SessionManager

### DIFF
--- a/lib/services/SessionManager.ts
+++ b/lib/services/SessionManager.ts
@@ -70,7 +70,15 @@ export class SessionManager {
         return null;
       }
 
-      const parsedData: StoredSession = JSON.parse(storedData);
+      let parsedData: StoredSession;
+      try {
+        parsedData = JSON.parse(storedData);
+      } catch (parseError) {
+        errorWithTs('[SessionManager] Failed to parse stored session data — clearing corrupted session:', parseError);
+        await this.clearSession();
+        return null;
+      }
+
       const { session, timestamp, expiresAt } = parsedData;
 
       logWithTs('[SessionManager] Found stored session:', {


### PR DESCRIPTION
## Summary
- Wrapped `JSON.parse(storedData)` in explicit try-catch with descriptive error message
- On parse failure: logs "Failed to parse stored session data", clears corrupted session, returns null
- Provides clearer error context than the generic outer try-catch

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #178