### PR TITLE
fix(food): await addFood call in add-food modal

### DIFF
--- a/app/(modals)/add-food.tsx
+++ b/app/(modals)/add-food.tsx
@@ -82,7 +82,7 @@ export default function AddFoodScreen() {
       };
 
       logWithTs('Saving food:', foodEntry);
-      addFood(foodEntry);
+      await addFood(foodEntry);
 
       // Haptic feedback
       if (isiOS) {


### PR DESCRIPTION
## Summary
- Added `await` before `addFood(foodEntry)` call
- Ensures errors are properly caught by surrounding try-catch
- Prevents success toast/navigation from firing before operation completes

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #183