### PR TITLE
fix(workout): guard against empty values in wheel picker

### DIFF
--- a/app/(modals)/add-workout.tsx
+++ b/app/(modals)/add-workout.tsx
@@ -82,6 +82,7 @@ function WheelPicker({ label, values, selectedValue, onChange, accessibilityLabe
   }, [loopData, middleSegmentStart, selectedValue]);
 
   const handleMomentumEnd = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    if (values.length === 0) return;
     const offset = event.nativeEvent.contentOffset.y;
     const rawIndex = Math.round(offset / WHEEL_ITEM_HEIGHT);
     const safeIndex = ((rawIndex % values.length) + values.length) % values.length;


### PR DESCRIPTION
## Summary
- Added `if (values.length === 0) return` guard at top of `handleMomentumEnd`
- Prevents division by zero in modulo operation when wheel picker has no values

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #185