### PR TITLE
fix(food): validate macro inputs to prevent NaN in database

### DIFF
--- a/app/(modals)/add-food.tsx
+++ b/app/(modals)/add-food.tsx
@@ -47,6 +47,11 @@ export default function AddFoodScreen() {
   const fatRef = React.useRef<TextInput>(null);
   const accessoryID = 'decimalAccessory';
 
+  function safeParseFloat(s: string): number | undefined {
+    const n = parseFloat(s);
+    return Number.isFinite(n) ? n : undefined;
+  }
+
   function normalizeDecimal(value: string): string {
     const cleaned = value.replace(/[^0-9.]/g, '');
     const firstDot = cleaned.indexOf('.');
@@ -75,9 +80,9 @@ export default function AddFoodScreen() {
         id,
         name: name.trim(),
         calories: parseFloat(calories),
-        protein: protein.trim() ? parseFloat(protein) : undefined,
-        carbs: carbs.trim() ? parseFloat(carbs) : undefined,
-        fat: fat.trim() ? parseFloat(fat) : undefined,
+        protein: protein.trim() ? safeParseFloat(protein) : undefined,
+        carbs: carbs.trim() ? safeParseFloat(carbs) : undefined,
+        fat: fat.trim() ? safeParseFloat(fat) : undefined,
         date: date.toISOString(),
       };
 


### PR DESCRIPTION
## Summary
- Added `safeParseFloat` helper using `Number.isFinite()` guard
- Returns `undefined` instead of NaN for non-numeric macro inputs
- Applied to protein, carbs, and fat parsing in add-food modal

## Verification
- [x] Type check passes
- [x] Lint passes

**Note:** PR #187 also touches `add-food.tsx`. This PR should merge after #187.

Closes #186