### PR TITLE
fix(coach): sanitize user name before prompt interpolation

### DIFF
--- a/supabase/functions/coach/index.ts
+++ b/supabase/functions/coach/index.ts
@@ -66,10 +66,17 @@ function sanitizeMessages(messages: ChatMessage[] = []): ChatMessage[] {
     .slice(-MAX_MESSAGES);
 }
 
+/** Strip control chars, prompt delimiters, and cap length to prevent injection. */
+function sanitizeName(name: string): string {
+  return name.replace(/[^\w\s'-]/g, '').slice(0, 100).trim();
+}
+
 function buildPrompt(context?: CoachContext) {
   const focus = context?.focus || 'fitness_coach';
-  const userLine = context?.profile?.name
-    ? `You are coaching ${context.profile.name}.`
+  const rawName = context?.profile?.name;
+  const safeName = rawName ? sanitizeName(rawName) : '';
+  const userLine = safeName
+    ? `You are coaching ${safeName}.`
     : 'You are coaching the user.';
 
   return [


### PR DESCRIPTION
## Summary
- Added `sanitizeName()` function that strips non-word characters (except spaces, hyphens, apostrophes), caps at 100 chars
- Applied to profile name before system prompt interpolation
- Falls back to generic "the user" if sanitization produces empty string
- Prevents prompt injection via crafted user names

## Verification
- [x] Type check passes
- [x] Lint passes

**Note:** PR #194 also touches `coach/index.ts`. This PR should merge after #194.

Closes #193