### PR TITLE
fix(tracking): sync phaseRef and repCountRef with React state

### DIFF
--- a/hooks/use-workout-controller.ts
+++ b/hooks/use-workout-controller.ts
@@ -8,7 +8,7 @@
  * in scan-arkit.tsx with a factory pattern that works with any workout definition.
  */
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Platform } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
@@ -173,6 +173,11 @@ export function useWorkoutController<TPhase extends string = string>(
   // Refs for tracking (avoid re-renders on every frame)
   const phaseRef = useRef<TPhase>(state.phase);
   const repCountRef = useRef<number>(0);
+
+  // Keep refs synchronized with React state
+  useEffect(() => { phaseRef.current = state.phase; }, [state.phase]);
+  useEffect(() => { repCountRef.current = state.repCount; }, [state.repCount]);
+
   const lastRepTimestampRef = useRef<number>(0);
   const recentRepDurationsRef = useRef<number[]>([]);
   const pendingPhaseRef = useRef<TPhase | null>(null);


### PR DESCRIPTION
## Summary
- Added two `useEffect` hooks to synchronize `phaseRef` and `repCountRef` with `state.phase` and `state.repCount`
- Prevents refs from drifting when state updates asynchronously
- Ensures `processFrame` always reads current values from refs

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #197