### PR TITLE
fix(tracking): guard processFrame during workout transition

### DIFF
--- a/hooks/use-workout-controller.ts
+++ b/hooks/use-workout-controller.ts
@@ -178,6 +178,7 @@ export function useWorkoutController<TPhase extends string = string>(
   const pendingPhaseRef = useRef<TPhase | null>(null);
   const pendingPhaseSinceRef = useRef<number>(0);
   const isInActiveRepRef = useRef<boolean>(false);
+  const transitioningRef = useRef<boolean>(false);
 
   // Rep tracking data
   const repTrackingRef = useRef<RepTrackingData>({
@@ -387,6 +388,8 @@ export function useWorkoutController<TPhase extends string = string>(
       joints?: Map<string, { x: number; y: number; isTracked: boolean; confidence?: number }>,
       context?: { trackingQuality?: number; shadowMeanAbsDelta?: number | null }
     ) => {
+      if (transitioningRef.current) return;
+
       const workoutDef = workoutDefRef.current;
       if (!workoutDef) return;
 
@@ -551,9 +554,11 @@ export function useWorkoutController<TPhase extends string = string>(
   }, []);
 
   const setWorkout = useCallback((workoutId: DetectionMode) => {
+    transitioningRef.current = true;
     workoutIdRef.current = workoutId;
     workoutDefRef.current = getWorkoutById(workoutId);
     reset();
+    transitioningRef.current = false;
   }, [reset]);
 
   const getWorkoutDefinition = useCallback(() => {


### PR DESCRIPTION
## Summary
- Added `transitioningRef` flag to prevent `processFrame` from running during workout switches
- `setWorkout` sets flag before updating refs, clears after `reset()` completes
- `processFrame` returns early when transitioning, preventing definition/state mismatch

## Verification
- [x] Type check passes
- [x] Lint passes

**Note:** PR #199 also touches `use-workout-controller.ts`. This PR should merge after #199.

Closes #198