### PR TITLE
perf(db): add composite indexes on workout_session_sets completed_at

### DIFF
--- a/supabase/migrations/031_add_workout_session_sets_indexes.sql
+++ b/supabase/migrations/031_add_workout_session_sets_indexes.sql
@@ -1,0 +1,6 @@
+-- Add indexes for workout session history queries
+CREATE INDEX IF NOT EXISTS idx_wss_completed_at
+  ON workout_session_sets (completed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_wss_session_completed
+  ON workout_session_sets (session_exercise_id, completed_at DESC);


### PR DESCRIPTION
## Summary
- New migration `031_add_workout_session_sets_indexes.sql`
- Adds `idx_wss_completed_at` (completed_at DESC) for history queries
- Adds `idx_wss_session_completed` (session_exercise_id, completed_at DESC) for session-scoped lookups
- Uses `IF NOT EXISTS` for idempotency

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #203