### PR TITLE
fix(healthkit): prevent duplicate auto-sync with ref guard

### DIFF
--- a/contexts/HealthKitContext.tsx
+++ b/contexts/HealthKitContext.tsx
@@ -152,6 +152,7 @@ export function HealthKitProvider({ children }: { children: React.ReactNode }) {
   const watchContextSignatureRef = useRef<string | null>(null);
   const lastPermissionLogRef = useRef<boolean | null>(null);
   const autoRequestedRef = useRef<boolean>(false);
+  const hasTriggeredAutoSyncRef = useRef<boolean>(false);
   
   // Bulk sync state
   const [isSyncing, setIsSyncing] = useState<boolean>(false);
@@ -558,8 +559,9 @@ export function HealthKitProvider({ children }: { children: React.ReactNode }) {
         if (range.count > 0) {
           setHasSyncedBefore(true);
           console.log('[HealthKitContext] User has', range.count, 'days of synced data');
-        } else {
+        } else if (!hasTriggeredAutoSyncRef.current) {
           // Auto-trigger a 6-month historical sync for first-time users to populate trends
+          hasTriggeredAutoSyncRef.current = true;
           syncAllHistoricalData(180).catch((err) => {
             console.warn('[HealthKitContext] Auto historical sync failed', err);
           });


### PR DESCRIPTION
## Summary
- Added `hasTriggeredAutoSyncRef` to prevent circular dependency from triggering multiple 180-day bulk syncs
- Guard ensures `syncAllHistoricalData` only fires once for first-time users
- Prevents overwhelming HealthKit/Supabase with duplicate API calls

## Verification
- [x] Type check passes
- [x] Lint passes
- [x] No file overlap with other open PRs

Closes #204