### PR TITLE
fix(arkit-body-tracker): declare MediaPipeTasksCommon dependency explicitly

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,6 +1,7 @@
 PODS:
   - arkit-body-tracker (1.0.0):
     - ExpoModulesCore
+    - MediaPipeTasksCommon
     - MediaPipeTasksVision
   - EXApplication (7.0.8):
     - ExpoModulesCore

--- a/modules/arkit-body-tracker/arkit-body-tracker.podspec
+++ b/modules/arkit-body-tracker/arkit-body-tracker.podspec
@@ -23,6 +23,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'ExpoModulesCore'
   s.dependency 'MediaPipeTasksVision'
+  s.dependency 'MediaPipeTasksCommon'
 
   # iOS frameworks required for ARKit body tracking
   s.frameworks = 'ARKit', 'RealityKit', 'AVFoundation', 'UIKit'


### PR DESCRIPTION
## Summary

Fixes EAS iOS production build failure: `ld: library 'MediaPipeTasksCommon' not found`

The `arkit-body-tracker` podspec depends on `MediaPipeTasksVision` which transitively pulls in `MediaPipeTasksCommon`. In clean EAS build environments, the transitive xcframework dependency doesn't propagate its framework search paths correctly, causing the linker to fail.

**Fix:** Add `MediaPipeTasksCommon` as an explicit dependency in the podspec so CocoaPods generates the correct linker flags directly.

**Diff:** 2 lines added across 2 files. Zero risk to existing functionality.