### PR TITLE
fix(auth): remove non-functional help button from sign-in

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -1,4 +1,3 @@
-import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
 import { Alert, Image, KeyboardAvoidingView, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
@@ -168,14 +167,11 @@ export default function SignInScreen() {
           keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={false}
         >
-          {/* Header with help button */}
+          {/* Header */}
           <View style={styles.header}>
             <Text style={styles.headerTitle}>
               Form Factor
             </Text>
-            <TouchableOpacity style={styles.helpButton}>
-              <Ionicons name="help-circle-outline" size={24} color="#8E8E93" />
-            </TouchableOpacity>
           </View>
 
           {/* Main card container */}
@@ -368,9 +364,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     marginBottom: 40,
-  },
-  helpButton: {
-    padding: 8,
   },
   card: {
     backgroundColor: '#0F2339',


### PR DESCRIPTION
## Summary
- Removes non-functional help button (no `onPress` handler) from sign-in screen
- Removes unused `Ionicons` import and `helpButton` style

## Verification
- [x] Type check passes
- [x] All tests pass
- [x] No file overlap with other open PRs

Closes #234