### PR TITLE
fix(hooks): add cleanup useEffect to useSpeechFeedback for timeout and Speech

### DIFF
--- a/hooks/use-speech-feedback.ts
+++ b/hooks/use-speech-feedback.ts
@@ -251,5 +251,13 @@ export function useSpeechFeedback({
     };
   }, [enabled, flushQueue, stop, ensureAudioMode, reportAsyncError]);
 
+  // Ensure cleanup on unmount regardless of enabled state
+  useEffect(() => {
+    return () => {
+      clearPendingTimeout();
+      Speech.stop();
+    };
+  }, [clearPendingTimeout]);
+
   return { speak, stop };
 }


### PR DESCRIPTION
## Summary
- Adds unmount-only `useEffect` cleanup to `useSpeechFeedback` hook
- Ensures `timeoutRef` is cleared and `Speech.stop()` is called on unmount regardless of `enabled` state
- Prevents memory leak if parent component unmounts without calling `stop()`

## Verification
- [x] Type check passes
- [x] All tests pass
- [x] No file overlap with other open PRs

Closes #235