### PR TITLE
fix(arkit-body-tracker): add XCFramework search paths to fix MediaPipe linker error

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -56,5 +56,25 @@ target 'formfactoreas' do
       :mac_catalyst_enabled => false,
       :ccache_enabled => ccache_enabled?(podfile_properties),
     )
+
+    # Fix MediaPipe XCFramework search paths (CocoaPods #9623).
+    # The [CP] Copy XCFrameworks phase copies the xcframeworks to
+    # PODS_XCFRAMEWORKS_BUILD_DIR, but the linker sometimes can't find them
+    # because FRAMEWORK_SEARCH_PATHS doesn't include those directories.
+    mediapipe_pods = ['MediaPipeTasksCommon', 'MediaPipeTasksVision']
+    xcf_paths = mediapipe_pods.map { |p| "\"${PODS_XCFRAMEWORKS_BUILD_DIR}/#{p}\"" }.join(' ')
+
+    installer.pods_project.targets.each do |target|
+      next unless target.name.start_with?('arkit-body-tracker') ||
+                  target.name.start_with?('Pods-formfactoreas')
+      target.build_configurations.each do |build_config|
+        ['FRAMEWORK_SEARCH_PATHS', 'LIBRARY_SEARCH_PATHS'].each do |key|
+          existing = build_config.build_settings[key] || '$(inherited)'
+          unless existing.include?('PODS_XCFRAMEWORKS_BUILD_DIR')
+            build_config.build_settings[key] = "$(inherited) #{xcf_paths}"
+          end
+        end
+      end
+    end
   end
 end

--- a/modules/arkit-body-tracker/arkit-body-tracker.podspec
+++ b/modules/arkit-body-tracker/arkit-body-tracker.podspec
@@ -18,7 +18,16 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
-    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+    'SWIFT_COMPILATION_MODE' => 'wholemodule',
+    'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PODS_XCFRAMEWORKS_BUILD_DIR)/MediaPipeTasksCommon" "$(PODS_XCFRAMEWORKS_BUILD_DIR)/MediaPipeTasksVision"',
+    'LIBRARY_SEARCH_PATHS' => '$(inherited) "$(PODS_XCFRAMEWORKS_BUILD_DIR)/MediaPipeTasksCommon" "$(PODS_XCFRAMEWORKS_BUILD_DIR)/MediaPipeTasksVision"',
+  }
+
+  # Propagate framework search paths to the main app target so the linker
+  # can find the MediaPipe xcframeworks at link time (CocoaPods #9623).
+  s.user_target_xcconfig = {
+    'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PODS_XCFRAMEWORKS_BUILD_DIR)/MediaPipeTasksCommon" "$(PODS_XCFRAMEWORKS_BUILD_DIR)/MediaPipeTasksVision"',
+    'LIBRARY_SEARCH_PATHS' => '$(inherited) "$(PODS_XCFRAMEWORKS_BUILD_DIR)/MediaPipeTasksCommon" "$(PODS_XCFRAMEWORKS_BUILD_DIR)/MediaPipeTasksVision"',
   }
 
   s.dependency 'ExpoModulesCore'


### PR DESCRIPTION
## Summary

Fixes the `ld: library 'MediaPipeTasksCommon' not found` linker error that has been failing the iOS Release workflow (runs [23399302628](https://github.com/ThyDrSlen/form-factor/actions/runs/23399302628), [23398414842](https://github.com/ThyDrSlen/form-factor/actions/runs/23398414842)).

## Root Cause

CocoaPods does not correctly propagate `FRAMEWORK_SEARCH_PATHS` for XCFramework dependencies to the main app target ([CocoaPods #9623](https://github.com/CocoaPods/CocoaPods/issues/9623)). The `[CP] Copy XCFrameworks` phase copies MediaPipeTasksCommon/Vision to `PODS_XCFRAMEWORKS_BUILD_DIR`, but the FormFactor target's linker doesn't have that directory in its search paths.

## Changes

- **`modules/arkit-body-tracker/arkit-body-tracker.podspec`**: Added `FRAMEWORK_SEARCH_PATHS` and `LIBRARY_SEARCH_PATHS` pointing to `PODS_XCFRAMEWORKS_BUILD_DIR` in both `pod_target_xcconfig` (for the pod itself) and `user_target_xcconfig` (propagates to the main app target)
- **`ios/Podfile`**: Added `post_install` hook that ensures the arkit-body-tracker pod target and the aggregate Pods target have the MediaPipe xcframework directories in their search paths (belt-and-suspenders)

## Testing

- Lint + type-check pass locally
- All unit tests pass
- The actual fix validates at EAS build time (native iOS linker)