### PR TITLE
fix(config): use literal runtimeVersion for bare workflow OTA compatibility

### DIFF
--- a/etc/app.json
+++ b/etc/app.json
@@ -1,8 +1,6 @@
 {
   "expo": {
-    "runtimeVersion": {
-      "policy": "appVersion"
-    },
+    "runtimeVersion": "1.0.0",
     "updates": {
       "enabled": false,
       "fallbackToCacheTimeout": 0


### PR DESCRIPTION
## Summary

Fixes the "Deploy OTA update" step failure in the iOS Release workflow. The `eas update` command rejects `runtimeVersion: {"policy": "appVersion"}` in bare workflow mode.

Changes `runtimeVersion` from a policy object to a literal `"1.0.0"` matching the app version, which is the required format for `eas update` in bare workflow.

## Context

After fixing the MediaPipe linker error in PR #240, the Build iOS step now passes but the workflow still fails at step 12 (Deploy OTA update) with:
```
CommandError: You're currently using the bare workflow, where runtime version policies are not supported.
```

This is a separate pre-existing issue that was masked by the build failure.