### PR TITLE
fix(config): use literal runtimeVersion in dynamic config for OTA

### DIFF
--- a/etc/app.config.js
+++ b/etc/app.config.js
@@ -34,9 +34,7 @@ const getScheme = () => {
 };
 
 const baseConfig = {
-  runtimeVersion: {
-    policy: 'appVersion',
-  },
+  runtimeVersion: '1.0.0',
   updates: {
     enabled: false,
     fallbackToCacheTimeout: 0,


### PR DESCRIPTION
## Summary

Fixes the remaining OTA step failure. The previous fix (PR #241) only changed `etc/app.json` (static config), but `etc/app.config.js` (dynamic config) overrides it via `baseConfig.runtimeVersion` which still had `{"policy": "appVersion"}`.

This changes `runtimeVersion` to `"1.0.0"` in the dynamic config where `eas update` actually reads it.