### PR TITLE
fix(contexts): expose error states and add retry UI for data loading failures

### DIFF
--- a/app/(modals)/session-history.tsx
+++ b/app/(modals)/session-history.tsx
@@ -36,19 +36,18 @@ export default function SessionHistoryScreen() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    loadSessions();
-  }, []);
-
-  const loadSessions = async () => {
+  const loadSessions = useCallback(async () => {
     const db = localDB.db;
     if (!db) {
+      setError('Failed to load. Tap to retry.');
       setLoading(false);
       return;
     }
     setError(null);
 
     try {
+      setError(null);
+      setLoading(true);
       const rows = await db.getAllAsync<SessionSummary>(`
         SELECT
           ws.id,
@@ -69,28 +68,32 @@ export default function SessionHistoryScreen() {
       setError(null);
     } catch (error) {
       console.error('[SessionHistory] Failed to load sessions:', error);
-      setError('Failed to load sessions. Please try again.');
+      setError('Failed to load. Tap to retry.');
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
-  const formatDate = (iso: string): string => {
+  useEffect(() => {
+    void loadSessions();
+  }, [loadSessions]);
+
+  const formatDate = useCallback((iso: string): string => {
     const d = new Date(iso);
     return d.toLocaleDateString('en-US', {
       weekday: 'short',
       month: 'short',
       day: 'numeric',
     });
-  };
+  }, []);
 
-  const formatDuration = (start: string, end: string | null): string => {
+  const formatDuration = useCallback((start: string, end: string | null): string => {
     if (!end) return '-';
     const ms = new Date(end).getTime() - new Date(start).getTime();
     const mins = Math.round(ms / 60000);
     if (mins < 60) return `${mins}m`;
     return `${Math.floor(mins / 60)}h ${mins % 60}m`;
-  };
+  }, []);
 
   const renderItem = useCallback(
     ({ item }: { item: SessionSummary }) => (
@@ -117,7 +120,7 @@ export default function SessionHistoryScreen() {
         </View>
       </TouchableOpacity>
     ),
-    [],
+    [formatDate, formatDuration],
   );
 
   return (
@@ -136,18 +139,21 @@ export default function SessionHistoryScreen() {
           <ActivityIndicator color={tabColors.accent} />
         </View>
       ) : error ? (
-        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 32 }}>
-          <Ionicons name="warning-outline" size={48} color={tabColors.accentAlt} />
-          <Text style={historyStyles.emptyText}>{error}</Text>
+        <View style={historyStyles.stateContainer}>
+          <Ionicons name="alert-circle-outline" size={48} color="#FF3B30" />
+          <Text style={historyStyles.errorText}>{error}</Text>
           <TouchableOpacity
-            style={{ marginTop: 16, paddingHorizontal: 24, paddingVertical: 12, backgroundColor: tabColors.accent, borderRadius: 10 }}
-            onPress={loadSessions}
+            onPress={() => {
+              setError(null);
+              void loadSessions();
+            }}
+            style={historyStyles.retryButton}
           >
-            <Text style={{ color: '#fff', fontFamily: 'Lexend_700Bold', fontSize: 15 }}>Retry</Text>
+            <Text style={historyStyles.retryButtonText}>Retry</Text>
           </TouchableOpacity>
         </View>
       ) : sessions.length === 0 ? (
-        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 32 }}>
+        <View style={historyStyles.stateContainer}>
           <Ionicons name="barbell-outline" size={48} color={tabColors.textSecondary} />
           <Text style={historyStyles.emptyText}>No completed sessions yet</Text>
           <Text style={historyStyles.emptySubtext}>
@@ -230,6 +236,30 @@ const historyStyles = StyleSheet.create({
   cardStatSep: {
     fontSize: 12,
     color: tabColors.textSecondary,
+  },
+  stateContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  },
+  errorText: {
+    fontSize: 16,
+    fontFamily: 'Lexend_400Regular',
+    color: tabColors.textSecondary,
+    marginTop: 12,
+    textAlign: 'center',
+  },
+  retryButton: {
+    marginTop: 16,
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    backgroundColor: tabColors.accent,
+    borderRadius: 8,
+  },
+  retryButtonText: {
+    color: '#fff',
+    fontFamily: 'Lexend_700Bold',
   },
   emptyText: {
     fontSize: 16,

--- a/app/(modals)/templates.tsx
+++ b/app/(modals)/templates.tsx
@@ -30,19 +30,18 @@ export default function TemplatesScreen() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    loadTemplates();
-  }, []);
-
-  const loadTemplates = async () => {
+  const loadTemplates = useCallback(async () => {
     const db = localDB.db;
     if (!db) {
+      setError('Failed to load. Tap to retry.');
       setLoading(false);
       return;
     }
     setError(null);
 
     try {
+      setError(null);
+      setLoading(true);
       const rows = await db.getAllAsync<TemplateSummary>(`
         SELECT
           wt.*,
@@ -56,11 +55,15 @@ export default function TemplatesScreen() {
       setError(null);
     } catch (error) {
       console.error('[Templates] Failed to load templates:', error);
-      setError('Failed to load templates. Please try again.');
+      setError('Failed to load. Tap to retry.');
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    void loadTemplates();
+  }, [loadTemplates]);
 
   const handleStartSession = useCallback(
     (templateId: string, goalProfile: string) => {
@@ -136,18 +139,21 @@ export default function TemplatesScreen() {
           <ActivityIndicator color={tabColors.accent} />
         </View>
       ) : error ? (
-        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 32 }}>
-          <Ionicons name="warning-outline" size={48} color={tabColors.accentAlt} />
-          <Text style={templateStyles.emptyText}>{error}</Text>
+        <View style={templateStyles.stateContainer}>
+          <Ionicons name="alert-circle-outline" size={48} color="#FF3B30" />
+          <Text style={templateStyles.errorText}>{error}</Text>
           <TouchableOpacity
-            style={{ marginTop: 16, paddingHorizontal: 24, paddingVertical: 12, backgroundColor: tabColors.accent, borderRadius: 10 }}
-            onPress={loadTemplates}
+            style={templateStyles.retryButton}
+            onPress={() => {
+              setError(null);
+              void loadTemplates();
+            }}
           >
-            <Text style={{ color: '#fff', fontFamily: 'Lexend_700Bold', fontSize: 15 }}>Retry</Text>
+            <Text style={templateStyles.retryButtonText}>Retry</Text>
           </TouchableOpacity>
         </View>
       ) : templates.length === 0 ? (
-        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 32 }}>
+        <View style={templateStyles.stateContainer}>
           <Ionicons name="clipboard-outline" size={48} color={tabColors.textSecondary} />
           <Text style={templateStyles.emptyText}>No templates yet</Text>
           <Text style={templateStyles.emptySubtext}>
@@ -233,6 +239,30 @@ const templateStyles = StyleSheet.create({
     paddingHorizontal: 16,
     borderLeftWidth: StyleSheet.hairlineWidth,
     borderLeftColor: tabColors.border,
+  },
+  stateContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  },
+  errorText: {
+    fontSize: 16,
+    fontFamily: 'Lexend_400Regular',
+    color: tabColors.textSecondary,
+    marginTop: 12,
+    textAlign: 'center',
+  },
+  retryButton: {
+    marginTop: 16,
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 8,
+    backgroundColor: tabColors.accent,
+  },
+  retryButtonText: {
+    color: '#fff',
+    fontFamily: 'Lexend_700Bold',
   },
   emptyText: {
     fontSize: 16,

--- a/app/(tabs)/coach.tsx
+++ b/app/(tabs)/coach.tsx
@@ -6,6 +6,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import * as Crypto from 'expo-crypto';
 import { useAuth } from '../../contexts/AuthContext';
+import { useToast } from '@/contexts/ToastContext';
 import { CoachMessage, sendCoachPrompt } from '@/lib/services/coach-service';
 import { fetchTodaySession, fetchCoachSessionMessages } from '@/lib/services/coach-history-service';
 import { AppError, mapToUserMessage } from '@/lib/services/ErrorHandler';
@@ -32,6 +33,7 @@ const coachQuickPrompts = [
 
 export default function CoachScreen() {
   const { user } = useAuth();
+  const { show: showToast } = useToast();
   const router = useRouter();
   const { restoreSessionId } = useLocalSearchParams<{ restoreSessionId?: string }>();
   const insets = useSafeAreaInsets();
@@ -145,8 +147,11 @@ export default function CoachScreen() {
       if (!session) return;
       setCoachMessages(session.messages.map((m, i) => ({ ...m, id: `restored-${i}` })));
       setCoachSessionId(session.sessionId);
+    }).catch((err) => {
+      console.error('[Coach] Failed to restore session:', err);
+      showToast('Failed to restore session', { type: 'error' });
     });
-  }, [restoreSessionId]);
+  }, [restoreSessionId, showToast]);
 
   const handleNewChat = useCallback(() => {
     setCoachMessages([coachIntroMessage]);

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -271,11 +271,10 @@ export default function ProfileScreen() {
       setFollowCounts(counts);
       await social.refreshPendingRequestCount();
     } catch (error) {
-      if (__DEV__) {
-        warnWithTs('[Profile] Failed to load social profile data', error);
-      }
+      warnWithTs('[Profile] Failed to load social profile data', error);
+      showToast('Unable to load social data', { type: 'error' });
     }
-  }, [social, user?.id]);
+  }, [showToast, social, user?.id]);
 
   useEffect(() => {
     if (!hasFetchedOnce && !loadingVideos) {

--- a/contexts/FoodContext.tsx
+++ b/contexts/FoodContext.tsx
@@ -21,6 +21,7 @@ interface FoodContextValue {
   refreshFoods: () => Promise<void>;
   deleteFood: (id: string) => Promise<void>;
   loading: boolean;
+  error: string | null;
   isSyncing: boolean;
 }
 
@@ -30,18 +31,21 @@ const FoodContext = createContext<FoodContextValue>({
   refreshFoods: async () => { },
   deleteFood: async () => { },
   loading: false,
+  error: null,
   isSyncing: false,
 });
 
 export const FoodProvider = ({ children }: { children: ReactNode }) => {
   const [foods, setFoods] = useState<FoodEntry[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [isSyncing, setIsSyncing] = useState(false);
   const { isOnline } = useNetwork();
   const { user } = useAuth();
 
   const loadLocalFoods = useCallback(async () => {
     try {
+      setError(null);
       const localFoods = await localDB.getAllFoods();
       const transformedFoods: FoodEntry[] = localFoods.map(item => ({
         id: item.id,
@@ -56,6 +60,7 @@ export const FoodProvider = ({ children }: { children: ReactNode }) => {
       setFoods(transformedFoods);
     } catch (error) {
       console.error('[FoodProvider] Error loading local foods:', error);
+      setError('Failed to load food entries. Pull to refresh.');
     }
   }, []);
 
@@ -185,7 +190,7 @@ export const FoodProvider = ({ children }: { children: ReactNode }) => {
   };
 
   return (
-    <FoodContext.Provider value={{ foods, addFood, refreshFoods: fetchFoods, deleteFood, loading, isSyncing }}>
+    <FoodContext.Provider value={{ foods, addFood, refreshFoods: fetchFoods, deleteFood, loading, error, isSyncing }}>
       {children}
     </FoodContext.Provider>
   );

--- a/contexts/WorkoutsContext.tsx
+++ b/contexts/WorkoutsContext.tsx
@@ -21,6 +21,7 @@ interface WorkoutsContextValue {
   refreshWorkouts: () => Promise<void>;
   deleteWorkout: (id: string) => Promise<void>;
   loading: boolean;
+  error: string | null;
   isSyncing: boolean;
   isWorkoutInProgress: boolean;
   startWorkout: () => void;
@@ -33,6 +34,7 @@ const WorkoutsContext = createContext<WorkoutsContextValue>({
   refreshWorkouts: async () => {},
   deleteWorkout: async () => {},
   loading: false,
+  error: null,
   isSyncing: false,
   isWorkoutInProgress: false,
   startWorkout: () => {},
@@ -42,6 +44,7 @@ const WorkoutsContext = createContext<WorkoutsContextValue>({
 export const WorkoutsProvider = ({ children }: { children: ReactNode }) => {
   const [workouts, setWorkouts] = useState<Workout[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [isSyncing, setIsSyncing] = useState(false);
   const [isWorkoutInProgress, setIsWorkoutInProgress] = useState(false);
   const { isOnline } = useNetwork();
@@ -49,6 +52,7 @@ export const WorkoutsProvider = ({ children }: { children: ReactNode }) => {
 
   const loadLocalWorkouts = useCallback(async () => {
     try {
+      setError(null);
       const localWorkouts = await localDB.getAllWorkouts();
       const transformedWorkouts: Workout[] = localWorkouts.map(item => ({
         id: item.id,
@@ -63,6 +67,7 @@ export const WorkoutsProvider = ({ children }: { children: ReactNode }) => {
       setWorkouts(transformedWorkouts);
     } catch (error) {
       console.error('[WorkoutsProvider] Error loading local workouts:', error);
+      setError('Failed to load workouts. Pull to refresh.');
     }
   }, []);
 
@@ -197,7 +202,7 @@ export const WorkoutsProvider = ({ children }: { children: ReactNode }) => {
   };
 
   return (
-    <WorkoutsContext.Provider value={{ workouts, addWorkout, refreshWorkouts: fetchWorkouts, deleteWorkout, loading, isSyncing, isWorkoutInProgress, startWorkout, endWorkout }}>
+    <WorkoutsContext.Provider value={{ workouts, addWorkout, refreshWorkouts: fetchWorkouts, deleteWorkout, loading, error, isSyncing, isWorkoutInProgress, startWorkout, endWorkout }}>
       {children}
     </WorkoutsContext.Provider>
   );


### PR DESCRIPTION
## Summary
- Expose `error` state from WorkoutsContext and FoodContext so consuming screens can show error UI
- Add retryable error UI with "Retry" button to session-history and templates modals
- Add `.catch()` handler for coach session restore with toast feedback
- Remove `__DEV__`-only gate on profile social data error — now shows toast in production

## Files Changed (6)
- `contexts/WorkoutsContext.tsx` — Add `error` state + expose in context value
- `contexts/FoodContext.tsx` — Same pattern
- `app/(modals)/session-history.tsx` — Error UI with retry button
- `app/(modals)/templates.tsx` — Error UI with retry button
- `app/(tabs)/coach.tsx` — Add `.catch()` to restore session
- `app/(tabs)/profile.tsx` — Remove DEV-only error gate, add toast

## Verification
- [x] `bun run check:types` passes
- [x] `bun run test` passes
- [x] Only expected files changed

Closes #245