### PR TITLE
fix(ux): use dynamic unit labels and device locale for formatting

### DIFF
--- a/app/(modals)/workout-session.tsx
+++ b/app/(modals)/workout-session.tsx
@@ -207,7 +207,7 @@ export default function WorkoutSessionScreen() {
   // Date title
   // =========================================================================
   const dateTitle = activeSession
-    ? new Date(activeSession.started_at).toLocaleDateString('en-US', {
+    ? new Date(activeSession.started_at).toLocaleDateString(undefined, {
         month: 'short',
         day: 'numeric',
       })

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -3,6 +3,7 @@ import * as Haptics from 'expo-haptics';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
 import { DeleteAction } from '@/components';
+import { useUnits } from '@/contexts/UnitsContext';
 import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
 import React, { useCallback, useRef, useState } from 'react';
 import {
@@ -21,7 +22,7 @@ import { useWorkouts, type Workout } from '../../contexts/WorkoutsContext';
 import { useToast } from '../../contexts/ToastContext';
 import { styles } from '../../styles/tabs/_workouts.styles';
 
-const buildWorkoutShareMessage = (workout: Workout): string => {
+const buildWorkoutShareMessage = (workout: Workout, weightLabel: string): string => {
   const workoutDate = workout.date ? new Date(workout.date) : null;
   const lines: string[] = [
     `Workout: ${workout.exercise}`,
@@ -30,7 +31,7 @@ const buildWorkoutShareMessage = (workout: Workout): string => {
       : null,
     `Sets: ${workout.sets}`,
     typeof workout.reps === 'number' && workout.reps > 0 ? `Reps: ${workout.reps}` : null,
-    typeof workout.weight === 'number' && workout.weight > 0 ? `Weight: ${workout.weight} lbs` : null,
+    typeof workout.weight === 'number' && workout.weight > 0 ? `Weight: ${workout.weight} ${weightLabel}` : null,
     typeof workout.duration === 'number' && workout.duration > 0 ? `Duration: ${workout.duration} min` : null,
   ].filter((line): line is string => Boolean(line));
 
@@ -39,6 +40,7 @@ const buildWorkoutShareMessage = (workout: Workout): string => {
 
 export default function WorkoutsScreen() {
   const router = useRouter();
+  const { getWeightLabel } = useUnits();
   const { workouts, loading, refreshWorkouts, deleteWorkout } = useWorkouts();
   const { show: showToast } = useToast();
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -112,7 +114,7 @@ export default function WorkoutsScreen() {
   const handleShareWorkout = useCallback(
     async (workout: Workout) => {
       try {
-        const message = buildWorkoutShareMessage(workout);
+        const message = buildWorkoutShareMessage(workout, getWeightLabel());
         await Share.share({ message });
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
       } catch (error) {
@@ -120,7 +122,7 @@ export default function WorkoutsScreen() {
         showToast('Unable to share this workout right now.', { type: 'error' });
       }
     },
-    [showToast]
+    [getWeightLabel, showToast]
   );
 
   const renderItem = (info: { item: Workout }) => {
@@ -155,7 +157,7 @@ export default function WorkoutsScreen() {
               <View style={styles.cardDateContainer}>
                 <Ionicons name="time-outline" size={14} color="#8E8E93" />
                 <Text style={styles.cardDate}>
-                  {new Date(item.date).toLocaleDateString('en-US', {
+                  {new Date(item.date).toLocaleDateString(undefined, {
                     month: 'short',
                     day: 'numeric',
                   })}
@@ -179,7 +181,7 @@ export default function WorkoutsScreen() {
               {item.weight && (
                 <View style={styles.detailItem}>
                   <Text style={styles.detailValue}>{item.weight}</Text>
-                  <Text style={styles.detailLabel}>lbs</Text>
+                  <Text style={styles.detailLabel}>{getWeightLabel()}</Text>
                 </View>
               )}
               

--- a/components/workout/SessionMetaCard.tsx
+++ b/components/workout/SessionMetaCard.tsx
@@ -7,6 +7,7 @@
 import React, { useCallback } from 'react';
 import { View, Text, TextInput, TouchableOpacity } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useUnits } from '@/contexts/UnitsContext';
 import { sessionStyles as styles, colors } from '@/styles/workout-session.styles';
 import type { WorkoutSession } from '@/lib/types/workout-session';
 
@@ -17,7 +18,7 @@ interface SessionMetaCardProps {
 
 function formatDateTime(iso: string): string {
   const d = new Date(iso);
-  return d.toLocaleString('en-US', {
+  return d.toLocaleString(undefined, {
     weekday: 'short',
     month: 'short',
     day: 'numeric',
@@ -28,6 +29,8 @@ function formatDateTime(iso: string): string {
 }
 
 export default function SessionMetaCard({ session, onUpdateSession }: SessionMetaCardProps) {
+  const { getWeightLabel } = useUnits();
+
   const handleNameChange = useCallback(
     (text: string) => onUpdateSession({ name: text || null }),
     [onUpdateSession],
@@ -71,7 +74,7 @@ export default function SessionMetaCard({ session, onUpdateSession }: SessionMet
 
       {/* Bodyweight */}
       <View style={styles.metaRow}>
-        <Text style={styles.metaLabel}>Bodyweight (lb)</Text>
+        <Text style={styles.metaLabel}>{`Bodyweight (${getWeightLabel()})`}</Text>
         <TextInput
           style={styles.metaInput}
           value={session.bodyweight_lb != null ? String(session.bodyweight_lb) : ''}

--- a/lib/video-feed.ts
+++ b/lib/video-feed.ts
@@ -21,6 +21,17 @@ export type VideoFeedMetrics = {
   [key: string]: any;
 };
 
+type RelativeTimeUnit = 'second' | 'minute' | 'hour' | 'day';
+
+type RelativeTimeFormatter = {
+  format: (value: number, unit: RelativeTimeUnit) => string;
+};
+
+type RelativeTimeFormatConstructor = new (
+  locales?: string | string[],
+  options?: { numeric?: 'always' | 'auto' }
+) => RelativeTimeFormatter;
+
 const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
 
 const isFiniteNumber = (value: unknown): value is number =>
@@ -85,13 +96,18 @@ export const formatRelativeTime = (createdAt: string): string => {
   const timestamp = date.getTime();
   if (Number.isNaN(timestamp)) return '';
   const diffMs = Date.now() - timestamp;
+  const RelativeTimeFormat = (Intl as typeof Intl & {
+    RelativeTimeFormat?: RelativeTimeFormatConstructor;
+  }).RelativeTimeFormat;
+  const formatter = RelativeTimeFormat ? new RelativeTimeFormat(undefined, { numeric: 'auto' }) : null;
+  const diffSeconds = Math.floor(diffMs / 1000);
+  if (diffSeconds < 60 && formatter) return formatter.format(-diffSeconds, 'second');
   const diffMinutes = Math.floor(diffMs / 60000);
-  if (diffMinutes < 1) return 'Just now';
-  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  if (diffMinutes < 60 && formatter) return formatter.format(-diffMinutes, 'minute');
   const diffHours = Math.floor(diffMinutes / 60);
-  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffHours < 24 && formatter) return formatter.format(-diffHours, 'hour');
   const diffDays = Math.floor(diffHours / 24);
-  if (diffDays < 7) return `${diffDays}d ago`;
+  if (diffDays < 7 && formatter) return formatter.format(-diffDays, 'day');
   return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 };
 


### PR DESCRIPTION
## Summary
- Replace hardcoded "lb"/"lbs" with `getWeightLabel()` from UnitsContext
- Replace hardcoded `'en-US'` locale with `undefined` (device locale)
- Update `formatRelativeTime()` to use `Intl.RelativeTimeFormat` with fallback

## Files Changed (4)
- `components/workout/SessionMetaCard.tsx` — Dynamic weight label + device locale
- `app/(tabs)/workouts.tsx` — Dynamic unit in share text and detail labels
- `app/(modals)/workout-session.tsx` — Device locale for date formatting
- `lib/video-feed.ts` — Locale-aware relative time formatting

## Verification
- [x] Only expected files changed
- [x] No new dependencies added

Closes #254
Closes #263