### PR TITLE
fix(ux): enable swipe-to-dismiss, add inline validation, add onboarding context

### DIFF
--- a/app/(modals)/_layout.tsx
+++ b/app/(modals)/_layout.tsx
@@ -16,6 +16,11 @@ export default function ModalsLayout() {
       <Stack.Screen name="follow-requests" options={{ presentation: 'modal' }} />
       <Stack.Screen name="user-profile" options={{ presentation: 'modal' }} />
       <Stack.Screen name="workout-insights" options={{ presentation: 'modal' }} />
+      <Stack.Screen name="help-support" options={{ presentation: 'modal', gestureEnabled: true }} />
+      <Stack.Screen name="notifications" options={{ presentation: 'modal', gestureEnabled: true }} />
+      <Stack.Screen name="about" options={{ presentation: 'modal', gestureEnabled: true }} />
+      <Stack.Screen name="privacy" options={{ presentation: 'modal', gestureEnabled: true }} />
+      <Stack.Screen name="video-comments" options={{ presentation: 'modal', gestureEnabled: true }} />
       <Stack.Screen
         name="workout-session"
         options={{
@@ -34,6 +39,7 @@ export default function ModalsLayout() {
         name="session-history"
         options={{
           presentation: 'modal',
+          gestureEnabled: true,
           contentStyle: { backgroundColor: '#050E1F' },
         }}
       />
@@ -41,6 +47,7 @@ export default function ModalsLayout() {
         name="coach-history"
         options={{
           presentation: 'modal',
+          gestureEnabled: true,
           contentStyle: { backgroundColor: '#050E1F' },
         }}
       />

--- a/app/(modals)/add-food.tsx
+++ b/app/(modals)/add-food.tsx
@@ -47,6 +47,7 @@ export default function AddFoodScreen() {
   });
   const [showPicker, setShowPicker] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
 
   const nameRef = React.useRef<TextInput>(null);
   const caloriesRef = React.useRef<TextInput>(null);
@@ -63,7 +64,7 @@ export default function AddFoodScreen() {
 
   function safeParseFloat(s: string): number | undefined {
     const n = parseFloat(s);
-    return Number.isFinite(n) ? n : undefined;
+    return isFinite(n) ? n : undefined;
   }
 
   function normalizeDecimal(value: string): string {
@@ -71,6 +72,43 @@ export default function AddFoodScreen() {
     const firstDot = cleaned.indexOf('.');
     if (firstDot === -1) return cleaned;
     return cleaned.slice(0, firstDot + 1) + cleaned.slice(firstDot + 1).replace(/\./g, '');
+  }
+
+  function setFieldError(field: 'name' | 'calories', message?: string) {
+    setErrors((prev: Record<string, string>) => {
+      if (!message) {
+        if (!prev[field]) return prev;
+        const next = { ...prev };
+        delete next[field];
+        return next;
+      }
+
+      if (prev[field] === message) return prev;
+      return { ...prev, [field]: message };
+    });
+  }
+
+  function validateName(value: string): boolean {
+    if (!value.trim()) {
+      setFieldError('name', 'Enter a food name');
+      return false;
+    }
+
+    setFieldError('name');
+    return true;
+  }
+
+  function validateCalories(value: string): boolean {
+    const trimmed = value.trim();
+    const parsed = parseFloat(trimmed);
+
+    if (!trimmed || isNaN(parsed) || parsed <= 0) {
+      setFieldError('calories', 'Enter calories greater than 0');
+      return false;
+    }
+
+    setFieldError('calories');
+    return true;
   }
 
   // Safe back: force replace to the Food tab to avoid any stack edge-cases
@@ -109,12 +147,15 @@ export default function AddFoodScreen() {
   }, [isDirty, navigation]);
 
   const onSave = async () => {
-    if (!name.trim()) {
+    const isNameValid = validateName(name);
+    const areCaloriesValid = validateCalories(calories);
+
+    if (!isNameValid) {
       Alert.alert('Error', 'Please enter a food name');
       return;
     }
 
-    if (!calories.trim() || parseFloat(calories) <= 0) {
+    if (!areCaloriesValid) {
       Alert.alert('Error', 'Please enter valid calories');
       return;
     }
@@ -181,9 +222,15 @@ export default function AddFoodScreen() {
           <View style={styles.inputContainer}>
             <Text style={styles.label}>Food Name *</Text>
             <TextInput
-              style={styles.input}
+              style={[styles.input, errors.name && styles.inputError]}
               value={name}
-              onChangeText={setName}
+              onChangeText={(value: string) => {
+                setName(value);
+                if (errors.name) {
+                  validateName(value);
+                }
+              }}
+              onBlur={() => validateName(name)}
               placeholder="e.g., Chicken Breast, Apple, Pasta"
               placeholderTextColor="#8CA5C6"
               editable={!saving}
@@ -192,14 +239,22 @@ export default function AddFoodScreen() {
               onSubmitEditing={() => caloriesRef.current?.focus()}
               blurOnSubmit={false}
             />
+            {errors.name ? <Text style={styles.errorText}>{errors.name}</Text> : null}
           </View>
 
           <View style={styles.inputContainer}>
             <Text style={styles.label}>Calories *</Text>
             <TextInput
-              style={styles.input}
+              style={[styles.input, errors.calories && styles.inputError]}
               value={calories}
-              onChangeText={(t) => setCalories(normalizeDecimal(t))}
+              onChangeText={(t: string) => {
+                const normalized = normalizeDecimal(t);
+                setCalories(normalized);
+                if (errors.calories) {
+                  validateCalories(normalized);
+                }
+              }}
+              onBlur={() => validateCalories(calories)}
               inputMode="decimal"
               keyboardType="decimal-pad"
               placeholder="e.g., 250"
@@ -211,6 +266,7 @@ export default function AddFoodScreen() {
               blurOnSubmit={false}
               inputAccessoryViewID={isiOS ? accessoryID : undefined}
             />
+            {errors.calories ? <Text style={styles.errorText}>{errors.calories}</Text> : null}
           </View>
 
           <View style={styles.row}>
@@ -219,7 +275,7 @@ export default function AddFoodScreen() {
               <TextInput
                 style={styles.input}
                 value={protein}
-                onChangeText={(t) => setProtein(normalizeDecimal(t))}
+                onChangeText={(t: string) => setProtein(normalizeDecimal(t))}
                 inputMode="decimal"
                 keyboardType="decimal-pad"
                 placeholder="Optional"
@@ -238,7 +294,7 @@ export default function AddFoodScreen() {
               <TextInput
                 style={styles.input}
                 value={carbs}
-                onChangeText={(t) => setCarbs(normalizeDecimal(t))}
+                onChangeText={(t: string) => setCarbs(normalizeDecimal(t))}
                 inputMode="decimal"
                 keyboardType="decimal-pad"
                 placeholder="Optional"
@@ -257,7 +313,7 @@ export default function AddFoodScreen() {
               <TextInput
                 style={styles.input}
                 value={fat}
-                onChangeText={(t) => setFat(normalizeDecimal(t))}
+                onChangeText={(t: string) => setFat(normalizeDecimal(t))}
                 inputMode="decimal"
                 keyboardType="decimal-pad"
                 placeholder="Optional"
@@ -399,6 +455,16 @@ const styles = StyleSheet.create({
     padding: 16,
     fontSize: 16,
     color: '#F5F7FF',
+  },
+  inputError: {
+    borderColor: '#FF6B6B',
+  },
+  errorText: {
+    color: '#FF8A8A',
+    fontSize: 12,
+    lineHeight: 16,
+    marginTop: 6,
+    marginLeft: 2,
   },
   accessoryContainer: {
     flexDirection: 'row',

--- a/app/(onboarding)/nutrition-goals.tsx
+++ b/app/(onboarding)/nutrition-goals.tsx
@@ -32,6 +32,7 @@ export default function NutritionGoalsScreen() {
   const [protein, setProtein] = useState(goals?.protein?.toString() || '');
   const [carbs, setCarbs] = useState(goals?.carbs?.toString() || '');
   const [fat, setFat] = useState(goals?.fat?.toString() || '');
+  const [errors, setErrors] = useState<Record<string, string>>({});
 
   function normalizeDecimal(value: string): string {
     const cleaned = value.replace(/[^0-9.]/g, '');
@@ -40,9 +41,80 @@ export default function NutritionGoalsScreen() {
     return cleaned.slice(0, firstDot + 1) + cleaned.slice(firstDot + 1).replace(/\./g, '');
   }
 
+  function setFieldError(field: string, message?: string) {
+    setErrors((prev: Record<string, string>) => {
+      if (!message) {
+        if (!prev[field]) return prev;
+        const next = { ...prev };
+        delete next[field];
+        return next;
+      }
+
+      if (prev[field] === message) return prev;
+      return { ...prev, [field]: message };
+    });
+  }
+
+  function getFieldError(field: 'calories' | 'protein' | 'carbs' | 'fat', value: string): string | undefined {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return field === 'calories' ? 'Enter a calorie goal between 500 and 10,000' : undefined;
+    }
+
+    const parsed = parseFloat(trimmed);
+    if (isNaN(parsed)) {
+      return field === 'calories'
+        ? 'Enter a calorie goal between 500 and 10,000'
+        : `Enter ${field} between 0 and 1,000 g`;
+    }
+
+    if (field === 'calories') {
+      return parsed < 500 || parsed > 10000 ? 'Enter a calorie goal between 500 and 10,000' : undefined;
+    }
+
+    return parsed < 0 || parsed > 1000 ? `Enter ${field} between 0 and 1,000 g` : undefined;
+  }
+
+  function validateField(field: 'calories' | 'protein' | 'carbs' | 'fat', value: string): boolean {
+    const message = getFieldError(field, value);
+    setFieldError(field, message);
+    return !message;
+  }
+
+  function validateForm(): boolean {
+    const validations = [
+      validateField('calories', calories),
+      validateField('protein', protein),
+      validateField('carbs', carbs),
+      validateField('fat', fat),
+    ];
+
+    return validations.every(Boolean);
+  }
+
+  function handleFieldChange(field: 'calories' | 'protein' | 'carbs' | 'fat', value: string) {
+    const normalized = normalizeDecimal(value);
+
+    if (field === 'calories') setCalories(normalized);
+    if (field === 'protein') setProtein(normalized);
+    if (field === 'carbs') setCarbs(normalized);
+    if (field === 'fat') setFat(normalized);
+
+    if (errors[field]) {
+      validateField(field, normalized);
+    }
+  }
+
   const handleSave = async () => {
-    if (!calories.trim() || parseFloat(calories) <= 0) {
-      Alert.alert('Error', 'Please enter valid calorie goal');
+    if (!validateForm()) {
+      const firstError =
+        getFieldError('calories', calories)
+        ?? getFieldError('protein', protein)
+        ?? getFieldError('carbs', carbs)
+        ?? getFieldError('fat', fat)
+        ?? 'Please enter valid nutrition goals';
+      Alert.alert('Error', firstError);
       return;
     }
 
@@ -137,61 +209,74 @@ export default function NutritionGoalsScreen() {
             Set your daily targets to track your progress. You can always update these later in your profile settings.
           </Text>
 
+          <Text style={styles.contextText}>
+            Nutrition goals help you compare what you eat against a daily target. Most people land around
+            1,500–3,000 calories, while macros often stay between 50–250g depending on goals.
+          </Text>
+
           <View style={styles.inputContainer}>
             <Text style={styles.label}>Daily Calories *</Text>
             <TextInput
-              style={styles.input}
+              style={[styles.input, errors.calories && styles.inputError]}
               value={calories}
-              onChangeText={(t) => setCalories(normalizeDecimal(t))}
+              onChangeText={(t: string) => handleFieldChange('calories', t)}
+              onBlur={() => validateField('calories', calories)}
               inputMode="decimal"
               keyboardType="decimal-pad"
               placeholder="e.g., 2000"
               placeholderTextColor="#8CA5C6"
               editable={!isSyncing}
             />
+            {errors.calories ? <Text style={styles.errorText}>{errors.calories}</Text> : null}
           </View>
 
           <View style={styles.row}>
             <View style={[styles.inputContainer, styles.thirdWidth]}>
               <Text style={styles.label}>Protein (g)</Text>
               <TextInput
-                style={styles.input}
+                style={[styles.input, errors.protein && styles.inputError]}
                 value={protein}
-                onChangeText={(t) => setProtein(normalizeDecimal(t))}
+                onChangeText={(t: string) => handleFieldChange('protein', t)}
+                onBlur={() => validateField('protein', protein)}
                 inputMode="decimal"
                 keyboardType="decimal-pad"
                 placeholder="Optional"
                 placeholderTextColor="#8CA5C6"
                 editable={!isSyncing}
               />
+              {errors.protein ? <Text style={styles.errorText}>{errors.protein}</Text> : null}
             </View>
 
             <View style={[styles.inputContainer, styles.thirdWidth]}>
               <Text style={styles.label}>Carbs (g)</Text>
               <TextInput
-                style={styles.input}
+                style={[styles.input, errors.carbs && styles.inputError]}
                 value={carbs}
-                onChangeText={(t) => setCarbs(normalizeDecimal(t))}
+                onChangeText={(t: string) => handleFieldChange('carbs', t)}
+                onBlur={() => validateField('carbs', carbs)}
                 inputMode="decimal"
                 keyboardType="decimal-pad"
                 placeholder="Optional"
                 placeholderTextColor="#8CA5C6"
                 editable={!isSyncing}
               />
+              {errors.carbs ? <Text style={styles.errorText}>{errors.carbs}</Text> : null}
             </View>
 
             <View style={[styles.inputContainer, styles.thirdWidth]}>
               <Text style={styles.label}>Fat (g)</Text>
               <TextInput
-                style={styles.input}
+                style={[styles.input, errors.fat && styles.inputError]}
                 value={fat}
-                onChangeText={(t) => setFat(normalizeDecimal(t))}
+                onChangeText={(t: string) => handleFieldChange('fat', t)}
+                onBlur={() => validateField('fat', fat)}
                 inputMode="decimal"
                 keyboardType="decimal-pad"
                 placeholder="Optional"
                 placeholderTextColor="#8CA5C6"
                 editable={!isSyncing}
               />
+              {errors.fat ? <Text style={styles.errorText}>{errors.fat}</Text> : null}
             </View>
           </View>
 
@@ -287,8 +372,15 @@ const styles = StyleSheet.create({
     color: '#9AACD1',
     fontSize: 14,
     textAlign: 'center',
-    marginBottom: 24,
+    marginBottom: 12,
     lineHeight: 20,
+  },
+  contextText: {
+    color: '#C6D4EE',
+    fontSize: 13,
+    lineHeight: 19,
+    textAlign: 'center',
+    marginBottom: 24,
   },
   inputContainer: {
     marginBottom: 16,
@@ -308,6 +400,16 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     fontSize: 16,
     color: '#F5F7FF',
+  },
+  inputError: {
+    borderColor: '#FF6B6B',
+  },
+  errorText: {
+    color: '#FF8A8A',
+    fontSize: 12,
+    marginTop: 6,
+    marginLeft: 2,
+    lineHeight: 16,
   },
   row: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- Enable swipe-to-dismiss on view-only modals (help-support, notifications, coach-history, session-history)
- Keep fullScreenModal for workout-session and template-builder (unsaved state)
- Add `onBlur` inline validation to nutrition goals and add-food forms
- Add explanatory context text to nutrition goals onboarding screen

## Files Changed (3)
- `app/(modals)/_layout.tsx` — gestureEnabled on view-only modals
- `app/(modals)/add-food.tsx` — Inline validation on blur
- `app/(onboarding)/nutrition-goals.tsx` — Inline validation + context text

## ⚠️ Merge Order Note
This PR and #279 (`fix/248-266-form-persistence-polish`) both touch `add-food.tsx`. **Merge this PR first**, then rebase #279.

## Verification
- [x] LSP diagnostics clean
- [x] Only expected files changed

Closes #256
Closes #257
Closes #258