### PR TITLE
fix(ux): add pull-to-refresh on social screens

### DIFF
--- a/app/(modals)/follow-requests.tsx
+++ b/app/(modals)/follow-requests.tsx
@@ -3,6 +3,7 @@ import {
   ActivityIndicator,
   FlatList,
   Image,
+  RefreshControl,
   SafeAreaView,
   StyleSheet,
   Text,
@@ -24,9 +25,14 @@ export default function FollowRequestsModal() {
   const [requests, setRequests] = useState<FollowRelationship[]>([]);
   const [loading, setLoading] = useState(true);
   const [actingKey, setActingKey] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
 
-  const load = useCallback(async () => {
-    setLoading(true);
+  const load = useCallback(async (options?: { showLoading?: boolean }) => {
+    const showLoading = options?.showLoading ?? true;
+    if (showLoading) {
+      setLoading(true);
+    }
+
     try {
       const rows = await getPendingRequests();
       setRequests(rows);
@@ -35,9 +41,20 @@ export default function FollowRequestsModal() {
       warnWithTs('[follow-requests] Failed to load requests', error);
       showToast('Unable to load follow requests.', { type: 'error' });
     } finally {
-      setLoading(false);
+      if (showLoading) {
+        setLoading(false);
+      }
     }
   }, [showToast, social]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await load({ showLoading: false });
+    } finally {
+      setRefreshing(false);
+    }
+  }, [load]);
 
   useEffect(() => {
     void load();
@@ -142,6 +159,14 @@ export default function FollowRequestsModal() {
           keyExtractor={(item) => `${item.follower_id}:${item.following_id}`}
           renderItem={renderItem}
           contentContainerStyle={styles.listContent}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              tintColor="#4C8CFF"
+              colors={['#4C8CFF']}
+            />
+          }
           ListEmptyComponent={
             <View style={styles.centerState}>
               <Text style={styles.mutedText}>No pending requests.</Text>

--- a/app/(modals)/followers.tsx
+++ b/app/(modals)/followers.tsx
@@ -3,6 +3,7 @@ import {
   ActivityIndicator,
   FlatList,
   Image,
+  RefreshControl,
   SafeAreaView,
   StyleSheet,
   Text,
@@ -33,10 +34,15 @@ export default function FollowersModal() {
   const [following, setFollowing] = useState<FollowRelationship[]>([]);
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (options?: { showLoading?: boolean }) => {
     if (!targetUserId) return;
-    setLoading(true);
+    const showLoading = options?.showLoading ?? true;
+    if (showLoading) {
+      setLoading(true);
+    }
+
     try {
       const [followerRows, followingRows] = await Promise.all([
         getFollowers(targetUserId),
@@ -48,9 +54,20 @@ export default function FollowersModal() {
       warnWithTs('[followers] Failed to load followers modal data', error);
       showToast('Unable to load followers right now.', { type: 'error' });
     } finally {
-      setLoading(false);
+      if (showLoading) {
+        setLoading(false);
+      }
     }
   }, [showToast, targetUserId]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await load({ showLoading: false });
+    } finally {
+      setRefreshing(false);
+    }
+  }, [load]);
 
   useEffect(() => {
     void load();
@@ -142,6 +159,14 @@ export default function FollowersModal() {
           keyExtractor={(item) => `${item.follower_id}:${item.following_id}`}
           renderItem={renderItem}
           contentContainerStyle={styles.listContent}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              tintColor="#4C8CFF"
+              colors={['#4C8CFF']}
+            />
+          }
           ListEmptyComponent={
             <View style={styles.centerState}>
               <Text style={styles.mutedText}>No {activeTab} yet.</Text>

--- a/app/(modals)/shared-inbox.tsx
+++ b/app/(modals)/shared-inbox.tsx
@@ -3,6 +3,7 @@ import {
   ActivityIndicator,
   FlatList,
   Image,
+  RefreshControl,
   SafeAreaView,
   StyleSheet,
   Text,
@@ -36,6 +37,7 @@ export default function SharedInboxModal() {
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
 
   const unreadCount = useMemo(
     () => rows.filter((row) => activeTab === 'inbox' && row.read_at == null).length,
@@ -43,7 +45,7 @@ export default function SharedInboxModal() {
   );
 
   const load = useCallback(
-    async (mode: 'reset' | 'more' = 'reset') => {
+    async (mode: 'reset' | 'more' = 'reset', options?: { showLoading?: boolean }) => {
       if (!user) {
         setError('You must be signed in to view shared videos.');
         setLoading(false);
@@ -51,8 +53,11 @@ export default function SharedInboxModal() {
       }
 
       const isReset = mode === 'reset';
+      const showLoading = options?.showLoading ?? true;
       if (isReset) {
-        setLoading(true);
+        if (showLoading) {
+          setLoading(true);
+        }
         setError(null);
       } else {
         if (!cursor || loadingMore) return;
@@ -78,7 +83,9 @@ export default function SharedInboxModal() {
         showToast(message, { type: 'error' });
       } finally {
         if (isReset) {
-          setLoading(false);
+          if (showLoading) {
+            setLoading(false);
+          }
         } else {
           setLoadingMore(false);
         }
@@ -87,9 +94,18 @@ export default function SharedInboxModal() {
     [user, activeTab, cursor, loadingMore, showToast],
   );
 
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await load('reset', { showLoading: false });
+    } finally {
+      setRefreshing(false);
+    }
+  }, [load]);
+
   useEffect(() => {
     void load('reset');
-  }, [activeTab, load]);
+  }, [load]);
 
   const renderRow = ({ item }: { item: VideoShareWithContext }) => {
     const counterparty = activeTab === 'inbox' ? item.sender_profile : item.recipient_profile;
@@ -171,6 +187,14 @@ export default function SharedInboxModal() {
           keyExtractor={(item) => item.id}
           renderItem={renderRow}
           contentContainerStyle={styles.listContent}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              tintColor="#4C8CFF"
+              colors={['#4C8CFF']}
+            />
+          }
           ListEmptyComponent={
             <View style={styles.centerState}>
               <Text style={styles.mutedText}>No shared videos yet.</Text>

--- a/app/(modals)/user-profile.tsx
+++ b/app/(modals)/user-profile.tsx
@@ -3,6 +3,7 @@ import {
   ActivityIndicator,
   FlatList,
   Image,
+  RefreshControl,
   SafeAreaView,
   StyleSheet,
   Text,
@@ -54,6 +55,7 @@ export default function UserProfileModal() {
   const [videos, setVideos] = useState<VideoWithUrls[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingFollowAction, setLoadingFollowAction] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
 
   const canViewVideos = useMemo(() => {
     if (!profile) return false;
@@ -62,9 +64,13 @@ export default function UserProfileModal() {
     return status.follows;
   }, [profile, status.follows, user?.id]);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (options?: { showLoading?: boolean }) => {
     if (!targetUserId) return;
-    setLoading(true);
+    const showLoading = options?.showLoading ?? true;
+    if (showLoading) {
+      setLoading(true);
+    }
+
     try {
       const [loadedProfile, loadedCounts, loadedStatus] = await Promise.all([
         getProfile(targetUserId),
@@ -86,9 +92,20 @@ export default function UserProfileModal() {
       warnWithTs('[user-profile] Failed to load profile modal data', error);
       showToast('Unable to load profile right now.', { type: 'error' });
     } finally {
-      setLoading(false);
+      if (showLoading) {
+        setLoading(false);
+      }
     }
   }, [showToast, social, targetUserId, user?.id]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await load({ showLoading: false });
+    } finally {
+      setRefreshing(false);
+    }
+  }, [load]);
 
   useEffect(() => {
     void load();
@@ -208,6 +225,14 @@ export default function UserProfileModal() {
           keyExtractor={(item) => item.id}
           renderItem={renderVideoItem}
           contentContainerStyle={styles.listContent}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              tintColor="#4C8CFF"
+              colors={['#4C8CFF']}
+            />
+          }
           ListHeaderComponent={
             <View style={styles.profileCard}>
               <View style={styles.profileTopRow}>


### PR DESCRIPTION
## Summary
- Add RefreshControl to user-profile, followers, follow-requests, and shared-inbox
- Uses brand accent color for refresh indicator
- Calls existing data loader on refresh

## Verification
- [x] lint passes
- [x] types pass

Closes #286