### PR TITLE
perf(contexts): memoize context values to prevent cascading re-renders

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -4,7 +4,7 @@ import { clearOnboardingFlag } from '@/lib/services/onboarding';
 import { AuthError, Session, User } from '@supabase/supabase-js';
 import Constants from 'expo-constants';
 import * as Linking from 'expo-linking';
-import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Alert } from 'react-native';
 import { SessionManager } from '@/lib/services/SessionManager';
 import { supabase } from '@/lib/supabase';
@@ -750,25 +750,46 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
-  const value = {
-    user,
-    session,
-    loading,
-    isSigningIn,
-    isMockUser,
-    error,
-    signInWithGoogle,
-    signInWithApple,
-    signInWithEmail,
-    signInWithMagicLink,
-    signUpWithEmail,
-    resetPassword,
-    updateProfile,
-    signOut,
-    deleteAccount,
-    handleAuthCallback,
-    clearError,
-  };
+  const value = useMemo(
+    () => ({
+      user,
+      session,
+      loading,
+      isSigningIn,
+      isMockUser,
+      error,
+      signInWithGoogle,
+      signInWithApple,
+      signInWithEmail,
+      signInWithMagicLink,
+      signUpWithEmail,
+      resetPassword,
+      updateProfile,
+      signOut,
+      deleteAccount,
+      handleAuthCallback,
+      clearError,
+    }),
+    [
+      user,
+      session,
+      loading,
+      isSigningIn,
+      isMockUser,
+      error,
+      signInWithGoogle,
+      signInWithApple,
+      signInWithEmail,
+      signInWithMagicLink,
+      signUpWithEmail,
+      resetPassword,
+      updateProfile,
+      signOut,
+      deleteAccount,
+      handleAuthCallback,
+      clearError,
+    ],
+  );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };

--- a/contexts/FoodContext.tsx
+++ b/contexts/FoodContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactNode, useCallback, useContext, useEffect, useState } from 'react';
+import React, { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import * as Crypto from 'expo-crypto';
 import { localDB } from '../lib/services/database/local-db';
 import { syncService } from '../lib/services/database/sync-service';
@@ -126,14 +126,14 @@ export const FoodProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [isOnline, performSync]);
 
-  const fetchFoods = async () => {
+  const fetchFoods = useCallback(async () => {
     await loadLocalFoods();
     if (isOnline) {
       await performSync();
     }
-  };
+  }, [isOnline, loadLocalFoods, performSync]);
 
-  const deleteFood = async (id: string) => {
+  const deleteFood = useCallback(async (id: string) => {
     try {
       console.log('[FoodProvider] Deleting food:', id);
       
@@ -150,9 +150,9 @@ export const FoodProvider = ({ children }: { children: ReactNode }) => {
     } catch (err) {
       console.error('[FoodProvider] Error deleting food:', err);
     }
-  };
+  }, [isOnline]);
 
-  const addFood = async (food: FoodEntry) => {
+  const addFood = useCallback(async (food: FoodEntry) => {
     try {
       console.log('[FoodProvider] Adding food:', food);
 
@@ -182,10 +182,15 @@ export const FoodProvider = ({ children }: { children: ReactNode }) => {
       console.error('[FoodProvider] Error adding food:', error);
       throw error;
     }
-  };
+  }, [isOnline]);
+
+  const value = useMemo(
+    () => ({ foods, addFood, refreshFoods: fetchFoods, deleteFood, loading, isSyncing }),
+    [foods, addFood, fetchFoods, deleteFood, loading, isSyncing],
+  );
 
   return (
-    <FoodContext.Provider value={{ foods, addFood, refreshFoods: fetchFoods, deleteFood, loading, isSyncing }}>
+    <FoodContext.Provider value={value}>
       {children}
     </FoodContext.Provider>
   );

--- a/contexts/NetworkContext.tsx
+++ b/contexts/NetworkContext.tsx
@@ -1,5 +1,5 @@
 import * as Network from 'expo-network';
-import React, { createContext, ReactNode, useContext, useEffect, useState } from 'react';
+import React, { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
 
 interface NetworkContextValue {
   isOnline: boolean;
@@ -48,8 +48,13 @@ export const NetworkProvider = ({ children }: { children: ReactNode }) => {
     return () => clearInterval(interval);
   }, []);
 
+  const value = useMemo(
+    () => ({ isOnline, isConnected, networkType }),
+    [isOnline, isConnected, networkType],
+  );
+
   return (
-    <NetworkContext.Provider value={{ isOnline, isConnected, networkType }}>
+    <NetworkContext.Provider value={value}>
       {children}
     </NetworkContext.Provider>
   );

--- a/contexts/ToastContext.tsx
+++ b/contexts/ToastContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, Platform, StyleSheet, Text, View } from 'react-native';
 
 type ToastType = 'info' | 'success' | 'error';
@@ -68,8 +68,10 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
+  const value = useMemo(() => ({ show }), [show]);
+
   return (
-    <ToastContext.Provider value={{ show }}>
+    <ToastContext.Provider value={value}>
       {children}
       {toast ? (
         <Animated.View

--- a/contexts/UnitsContext.tsx
+++ b/contexts/UnitsContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 type WeightUnit = 'kg' | 'lbs';
@@ -26,25 +26,34 @@ export function UnitsProvider({ children }: { children: React.ReactNode }) {
     });
   }, []);
 
-  const toggleWeightUnit = async () => {
+  const toggleWeightUnit = useCallback(async () => {
     const newUnit: WeightUnit = weightUnit === 'kg' ? 'lbs' : 'kg';
     setWeightUnit(newUnit);
     await AsyncStorage.setItem(WEIGHT_UNIT_KEY, newUnit);
-  };
+  }, [weightUnit]);
 
-  const convertWeight = (kg: number): number => {
-    if (weightUnit === 'lbs') {
-      return kg * 2.20462;
-    }
-    return kg;
-  };
+  const convertWeight = useCallback(
+    (kg: number): number => {
+      if (weightUnit === 'lbs') {
+        return kg * 2.20462;
+      }
+      return kg;
+    },
+    [weightUnit],
+  );
 
-  const getWeightLabel = (): string => {
-    return weightUnit === 'kg' ? 'kg' : 'lbs';
-  };
+  const getWeightLabel = useCallback(
+    (): string => (weightUnit === 'kg' ? 'kg' : 'lbs'),
+    [weightUnit],
+  );
+
+  const value = useMemo(
+    () => ({ weightUnit, toggleWeightUnit, convertWeight, getWeightLabel }),
+    [weightUnit, toggleWeightUnit, convertWeight, getWeightLabel],
+  );
 
   return (
-    <UnitsContext.Provider value={{ weightUnit, toggleWeightUnit, convertWeight, getWeightLabel }}>
+    <UnitsContext.Provider value={value}>
       {children}
     </UnitsContext.Provider>
   );

--- a/contexts/WorkoutsContext.tsx
+++ b/contexts/WorkoutsContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactNode, useCallback, useContext, useEffect, useState } from 'react';
+import React, { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import * as Crypto from 'expo-crypto';
 import { localDB } from '../lib/services/database/local-db';
 import { syncService } from '../lib/services/database/sync-service';
@@ -133,17 +133,17 @@ export const WorkoutsProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [isOnline, performSync]);
 
-  const fetchWorkouts = async () => {
+  const fetchWorkouts = useCallback(async () => {
     await loadLocalWorkouts();
     if (isOnline) {
       await performSync();
     }
-  };
+  }, [isOnline, loadLocalWorkouts, performSync]);
 
-  const startWorkout = () => setIsWorkoutInProgress(true);
-  const endWorkout = () => setIsWorkoutInProgress(false);
+  const startWorkout = useCallback(() => setIsWorkoutInProgress(true), []);
+  const endWorkout = useCallback(() => setIsWorkoutInProgress(false), []);
 
-  const deleteWorkout = async (id: string) => {
+  const deleteWorkout = useCallback(async (id: string) => {
     try {
       console.log('[WorkoutsProvider] Deleting workout:', id);
       
@@ -161,9 +161,9 @@ export const WorkoutsProvider = ({ children }: { children: ReactNode }) => {
     } catch (err) {
       console.error('[WorkoutsProvider] Error deleting workout:', err);
     }
-  };
+  }, [isOnline]);
 
-  const addWorkout = async (workout: Workout) => {
+  const addWorkout = useCallback(async (workout: Workout) => {
     try {
       console.log('[WorkoutsProvider] Adding workout:', workout);
 
@@ -194,10 +194,25 @@ export const WorkoutsProvider = ({ children }: { children: ReactNode }) => {
       console.error('[WorkoutsProvider] Error adding workout:', error);
       throw error;
     }
-  };
+  }, [isOnline]);
+
+  const value = useMemo(
+    () => ({
+      workouts,
+      addWorkout,
+      refreshWorkouts: fetchWorkouts,
+      deleteWorkout,
+      loading,
+      isSyncing,
+      isWorkoutInProgress,
+      startWorkout,
+      endWorkout,
+    }),
+    [workouts, addWorkout, fetchWorkouts, deleteWorkout, loading, isSyncing, isWorkoutInProgress, startWorkout, endWorkout],
+  );
 
   return (
-    <WorkoutsContext.Provider value={{ workouts, addWorkout, refreshWorkouts: fetchWorkouts, deleteWorkout, loading, isSyncing, isWorkoutInProgress, startWorkout, endWorkout }}>
+    <WorkoutsContext.Provider value={value}>
       {children}
     </WorkoutsContext.Provider>
   );


### PR DESCRIPTION
## Summary
- Wrap context values in `useMemo` and non-stable functions in `useCallback` across 6 context providers
- **Affected:** AuthContext, WorkoutsContext, FoodContext, NetworkContext, ToastContext, UnitsContext
- Follows the pattern already established by SocialContext (which correctly uses `useMemo`)

## Problem
All 6 context providers created new object references on every render. Since these are deeply nested providers (see `app/_layout.tsx` nesting order), any state change in an outer provider caused ALL inner providers and their consumers to re-render — even when the actual data hadn't changed.

## Changes
- **NetworkContext**: Added `useMemo` for value (3 primitive deps)
- **ToastContext**: Added `useMemo` for value (`show` is already `useCallback`)
- **UnitsContext**: Wrapped `toggleWeightUnit`, `convertWeight`, `getWeightLabel` in `useCallback`, then `useMemo` for value
- **AuthContext**: Added `useMemo` for value (all callbacks already `useCallback`)
- **WorkoutsContext**: Wrapped `fetchWorkouts`, `addWorkout`, `deleteWorkout`, `startWorkout`, `endWorkout` in `useCallback`, then `useMemo` for value
- **FoodContext**: Same pattern as WorkoutsContext

## Verification
- [x] `bun run check:types` passes
- [x] `bun run lint` passes
- [x] No file overlap with other open PRs

Closes #315