### PR TITLE
fix(security): add CSRF state validation, delete-account body validation, sync table allowlist

### DIFF
--- a/lib/services/OAuthHandler.ts
+++ b/lib/services/OAuthHandler.ts
@@ -1,8 +1,11 @@
 import { Session } from '@supabase/supabase-js';
+import * as Crypto from 'expo-crypto';
 import * as Linking from 'expo-linking';
 import * as WebBrowser from 'expo-web-browser';
 import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
 import { supabase } from '../supabase';
+
+let pendingOAuthState: string | null = null;
 
  // Ensure the auth session is correctly completed when returning to the app (iOS 11+)
  // This avoids lingering authentication sessions after the redirect back to the app.
@@ -43,16 +46,22 @@ export class OAuthHandler {
     try {
       logWithTs(`[OAuthHandler] Starting ${provider} OAuth flow`);
 
+      pendingOAuthState = Crypto.randomUUID();
+
       // Start the OAuth flow with Supabase
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider,
         options: {
+          queryParams: {
+            state: pendingOAuthState,
+          },
           redirectTo: this.redirectUrl,
           skipBrowserRedirect: true,
         },
       });
 
       if (error) {
+        pendingOAuthState = null;
         errorWithTs(`[OAuthHandler] Error starting ${provider} OAuth:`, error);
         return {
           success: false,
@@ -61,6 +70,7 @@ export class OAuthHandler {
       }
 
       if (!data.url) {
+        pendingOAuthState = null;
         errorWithTs(`[OAuthHandler] No OAuth URL returned from Supabase`);
         return {
           success: false,
@@ -96,6 +106,7 @@ export class OAuthHandler {
       }
 
       if (result.type === 'cancel') {
+        pendingOAuthState = null;
         logWithTs(`[OAuthHandler] User cancelled ${provider} OAuth`);
         return {
           success: false,
@@ -104,6 +115,7 @@ export class OAuthHandler {
       }
 
       if (result.type === 'dismiss') {
+        pendingOAuthState = null;
         logWithTs(`[OAuthHandler] ${provider} OAuth was dismissed`);
         return {
           success: false,
@@ -111,11 +123,13 @@ export class OAuthHandler {
         };
       }
 
+      pendingOAuthState = null;
       return {
         success: false,
         error: `Unexpected OAuth result: ${result.type}`,
       };
     } catch (error) {
+      pendingOAuthState = null;
       errorWithTs(`[OAuthHandler] Unexpected error in ${provider} OAuth:`, error);
       return {
         success: false,
@@ -130,6 +144,16 @@ export class OAuthHandler {
   async handleCallback(url: string): Promise<Session | null> {
     try {
       logWithTs('[OAuthHandler] Processing callback URL:', url);
+
+      const callbackState = this.parseStateFromUrl(url);
+      if (!callbackState || !pendingOAuthState || callbackState !== pendingOAuthState) {
+        errorWithTs('[OAuthHandler] OAuth state validation failed', {
+          hasPendingState: !!pendingOAuthState,
+          hasCallbackState: !!callbackState,
+          callbackStateMatches: callbackState === pendingOAuthState,
+        });
+        return null;
+      }
 
       // Parse tokens from the URL
       const tokens = this.parseTokensFromUrl(url);
@@ -184,6 +208,31 @@ export class OAuthHandler {
       return null;
     } catch (error) {
       errorWithTs('[OAuthHandler] Error handling callback:', error);
+      return null;
+    } finally {
+      pendingOAuthState = null;
+    }
+  }
+
+  private parseStateFromUrl(url: string): string | null {
+    try {
+      const hashMatch = url.match(/#(.+)/);
+      const queryMatch = url.match(/\?(.+?)(?:#|$)/);
+
+      if (hashMatch) {
+        const hashParams = new URLSearchParams(hashMatch[1]);
+        const hashState = hashParams.get('state');
+        if (hashState) return hashState;
+      }
+
+      if (queryMatch) {
+        const queryParams = new URLSearchParams(queryMatch[1]);
+        return queryParams.get('state');
+      }
+
+      return null;
+    } catch (error) {
+      errorWithTs('[OAuthHandler] Error parsing state from URL:', error);
       return null;
     }
   }

--- a/lib/services/database/generic-sync.ts
+++ b/lib/services/database/generic-sync.ts
@@ -7,6 +7,7 @@
  */
 
 import { RealtimePostgresChangesPayload } from '@supabase/supabase-js';
+import { createError, logError } from '../ErrorHandler';
 import { supabase } from '../../supabase';
 import { localDB } from './local-db';
 import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
@@ -54,6 +55,8 @@ export async function genericLocalUpsert(
   row: Record<string, unknown>,
   synced: number = 0,
 ): Promise<void> {
+  assertValidTableName(table);
+
   const db = localDB.db;
   if (!db) throw new Error('Database not initialized');
 
@@ -88,6 +91,8 @@ export async function genericGetUnsynced(
   table: string,
   supportsSoftDelete: boolean,
 ): Promise<Record<string, unknown>[]> {
+  assertValidTableName(table);
+
   const db = localDB.db;
   if (!db) throw new Error('Database not initialized');
 
@@ -127,6 +132,8 @@ export async function genericUpdateSyncStatus(
   id: string,
   synced: boolean,
 ): Promise<void> {
+  assertValidTableName(table);
+
   const db = localDB.db;
   if (!db) throw new Error('Database not initialized');
 
@@ -144,6 +151,8 @@ export async function genericSoftDelete(
   primaryKey: string,
   id: string,
 ): Promise<void> {
+  assertValidTableName(table);
+
   const db = localDB.db;
   if (!db) throw new Error('Database not initialized');
 
@@ -161,6 +170,8 @@ export async function genericHardDelete(
   primaryKey: string,
   id: string,
 ): Promise<void> {
+  assertValidTableName(table);
+
   const db = localDB.db;
   if (!db) throw new Error('Database not initialized');
 
@@ -608,6 +619,38 @@ export const WORKOUT_SYNC_CONFIGS: SyncTableConfig[] = [
     },
   },
 ];
+
+export const VALID_TABLE_NAMES = new Set(
+  WORKOUT_SYNC_CONFIGS.flatMap((config) => [config.localTable, config.supabaseTable]),
+);
+
+function assertValidTableName(table: string): void {
+  if (VALID_TABLE_NAMES.has(table)) {
+    return;
+  }
+
+  const appError = createError(
+    'sync',
+    'INVALID_SYNC_TABLE',
+    `Invalid sync table name "${table}". Expected one of: ${Array.from(VALID_TABLE_NAMES).sort().join(', ')}`,
+    {
+      details: {
+        table,
+        validTableNames: Array.from(VALID_TABLE_NAMES).sort(),
+      },
+      retryable: false,
+      severity: 'error',
+    },
+  );
+
+  logError(appError, {
+    feature: 'workouts',
+    location: 'generic-sync.assertValidTableName',
+    meta: { table },
+  });
+
+  throw new Error(appError.message);
+}
 
 /**
  * Run sync for all workout-related tables.

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,6 +1,10 @@
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.4?target=deno';
 
+interface DeleteAccountRequestBody {
+  confirm_delete?: boolean;
+}
+
 serve(async (req: Request) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, {
@@ -15,6 +19,21 @@ serve(async (req: Request) => {
 
   if (req.method !== 'POST') {
     return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405 });
+  }
+
+  let requestBody: DeleteAccountRequestBody;
+  try {
+    requestBody = await req.json() as DeleteAccountRequestBody;
+  } catch (error) {
+    console.error('[delete-account] Invalid JSON body:', error);
+    return new Response(JSON.stringify({ error: 'Invalid request body' }), { status: 400 });
+  }
+
+  if (requestBody.confirm_delete !== true) {
+    return new Response(
+      JSON.stringify({ error: 'Request body must include { confirm_delete: true }' }),
+      { status: 400 },
+    );
   }
 
   const authHeader = req.headers.get('Authorization');
@@ -63,6 +82,11 @@ serve(async (req: Request) => {
     return new Response(JSON.stringify({ error: 'Failed to delete account' }), { status: 500 });
   }
 
-  console.log(`[delete-account] Deleted user ${user.id}`);
+  console.log(
+    `[delete-account] Deletion event ${JSON.stringify({
+      timestamp: new Date().toISOString(),
+      user_id: user.id,
+    })}`,
+  );
   return new Response(JSON.stringify({ success: true }), { status: 200 });
 });


### PR DESCRIPTION
## Summary
- **OAuthHandler CSRF protection** (#312): Generate cryptographic `state` param during `initiateOAuth()`, validate in `handleCallback()`, reject mismatched/missing state
- **delete-account body validation** (#313): Require `{ confirm_delete: true }` in request body, structured audit log with timestamp + user_id
- **generic-sync table allowlist** (#314): `VALID_TABLE_NAMES` set derived from `WORKOUT_SYNC_CONFIGS`, `assertValidTableName()` guard at entry of all 5 public functions

## Changes
| File | Change |
|------|--------|
| `lib/services/OAuthHandler.ts` | CSRF state generation, URL parsing, validation |
| `supabase/functions/delete-account/index.ts` | Body parsing, confirm_delete check, audit log |
| `lib/services/database/generic-sync.ts` | Table name allowlist, assertValidTableName() |

## Verification
- [x] `bun run check:types` passes
- [x] `bun run lint` passes
- [x] LSP diagnostics clean on all 3 files
- [x] No file overlap with other open PRs

Closes #312
Closes #313
Closes #314