### PR TITLE
fix(ux): add error states, accessibility labels, empty states, progress jank fix

### DIFF
--- a/app/(modals)/coach-history.tsx
+++ b/app/(modals)/coach-history.tsx
@@ -85,6 +85,7 @@ export default function CoachHistoryScreen() {
   const [loadingMore, setLoadingMore] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [cursor, setCursor] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const loadSessions = useCallback(
     async (mode: 'reset' | 'more') => {
@@ -96,6 +97,7 @@ export default function CoachHistoryScreen() {
       const isReset = mode === 'reset';
       if (isReset) {
         setLoading(true);
+        setError(null);
       } else {
         if (!cursor || loadingMore) return;
         setLoadingMore(true);
@@ -115,6 +117,11 @@ export default function CoachHistoryScreen() {
         }
       } catch (err) {
         console.warn('[coach-history] Failed to load sessions:', err);
+        if (isReset) {
+          setSessions([]);
+          setCursor(null);
+          setError('Unable to load your coach history right now.');
+        }
       } finally {
         if (isReset) {
           setLoading(false);
@@ -127,13 +134,12 @@ export default function CoachHistoryScreen() {
     [user, cursor, loadingMore],
   );
 
-  useEffect(() => {
-    void loadSessions('reset');
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   const handleRefresh = useCallback(() => {
     setRefreshing(true);
+    void loadSessions('reset');
+  }, [loadSessions]);
+
+  useEffect(() => {
     void loadSessions('reset');
   }, [loadSessions]);
 
@@ -210,6 +216,22 @@ export default function CoachHistoryScreen() {
       {loading && !refreshing ? (
         <View style={styles.loadingContainer}>
           <ActivityIndicator color={tabColors.accent} />
+        </View>
+      ) : error ? (
+        <View style={styles.emptyContainer}>
+          <Ionicons
+            name="alert-circle-outline"
+            size={64}
+            color={tabColors.textSecondary}
+          />
+          <Text style={styles.emptyTitle}>Couldn&apos;t Load History</Text>
+          <Text style={styles.emptySubtitle}>{error}</Text>
+          <TouchableOpacity
+            style={styles.loadMoreButton}
+            onPress={() => void loadSessions('reset')}
+          >
+            <Text style={styles.loadMoreText}>Try again</Text>
+          </TouchableOpacity>
         </View>
       ) : (
         <FlatList

--- a/app/(modals)/followers.tsx
+++ b/app/(modals)/followers.tsx
@@ -69,6 +69,25 @@ export default function FollowersModal() {
     });
   }, [rows, search]);
 
+  const emptyMessage = useMemo(() => {
+    const trimmed = search.trim();
+    if (trimmed.length > 0) {
+      return `No results for '${trimmed}'`;
+    }
+
+    return activeTab === 'followers' ? 'No followers yet.' : 'Not following anyone yet.';
+  }, [activeTab, search]);
+
+  const emptySubtext = useMemo(() => {
+    if (search.trim().length > 0) {
+      return 'Try a different name or username.';
+    }
+
+    return activeTab === 'followers'
+      ? 'When people follow this account, they will appear here.'
+      : 'Accounts followed by this user will appear here.';
+  }, [activeTab, search]);
+
   const renderItem = ({ item }: { item: FollowRelationship }) => {
     const profile = item.profile;
     const displayName = profile?.display_name || profile?.username || 'User';
@@ -78,6 +97,9 @@ export default function FollowersModal() {
         style={styles.row}
         onPress={() => profile?.user_id && router.push(`/(modals)/user-profile?userId=${profile.user_id}`)}
         activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel={`Open ${displayName}'s profile`}
+        accessibilityHint="Navigates to this user profile"
       >
         {profile?.avatar_url ? (
           <Image source={{ uri: profile.avatar_url }} style={styles.avatar} />
@@ -90,7 +112,7 @@ export default function FollowersModal() {
           <Text style={styles.rowName}>{displayName}</Text>
           {profile?.username ? <Text style={styles.rowMeta}>@{profile.username}</Text> : null}
         </View>
-        <Ionicons name="chevron-forward" size={18} color="#6781A6" />
+        <Ionicons name="chevron-forward" size={18} color="#6781A6" accessible={false} />
       </TouchableOpacity>
     );
   };
@@ -159,7 +181,8 @@ export default function FollowersModal() {
             keyboardShouldPersistTaps="handled"
             ListEmptyComponent={
               <View style={styles.centerState}>
-                <Text style={styles.mutedText}>No {activeTab} yet.</Text>
+                <Text style={styles.mutedText}>{emptyMessage}</Text>
+                <Text style={styles.mutedText}>{emptySubtext}</Text>
               </View>
             }
           />

--- a/app/(modals)/user-profile.tsx
+++ b/app/(modals)/user-profile.tsx
@@ -159,8 +159,16 @@ export default function UserProfileModal() {
         <TouchableOpacity
           style={styles.videoAction}
           onPress={() => router.push(`/(modals)/video-comments?videoId=${item.id}&returnTo=videos`)}
+          accessibilityRole="button"
+          accessibilityLabel={`Open comments for ${exercise} video`}
+          accessibilityHint="Opens the comments for this shared workout video"
         >
-          <Ionicons name="chatbubble-ellipses-outline" size={17} color="#9AACD1" />
+          <Ionicons
+            name="chatbubble-ellipses-outline"
+            size={17}
+            color="#9AACD1"
+            accessible={false}
+          />
         </TouchableOpacity>
       </View>
     );
@@ -226,6 +234,13 @@ export default function UserProfileModal() {
                     style={[styles.followButton, (status.follows || status.requested) && styles.followButtonMuted]}
                     onPress={handleFollowAction}
                     disabled={loadingFollowAction}
+                    accessibilityRole="button"
+                    accessibilityLabel={`${followButtonLabel} ${displayName}`}
+                    accessibilityHint={
+                      status.follows || status.requested
+                        ? 'Double tap to remove this follow relationship'
+                        : 'Double tap to follow this profile'
+                    }
                   >
                     {loadingFollowAction ? (
                       <ActivityIndicator color="#0F2339" size="small" />
@@ -244,6 +259,9 @@ export default function UserProfileModal() {
                 <TouchableOpacity
                   style={styles.countPill}
                   onPress={() => router.push(`/(modals)/followers?userId=${profile.user_id}&tab=followers`)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`${counts.followers} followers`}
+                  accessibilityHint="Opens the followers list"
                 >
                   <Text style={styles.countValue}>{counts.followers}</Text>
                   <Text style={styles.countLabel}>Followers</Text>
@@ -251,6 +269,9 @@ export default function UserProfileModal() {
                 <TouchableOpacity
                   style={styles.countPill}
                   onPress={() => router.push(`/(modals)/followers?userId=${profile.user_id}&tab=following`)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`${counts.following} following`}
+                  accessibilityHint="Opens the following list"
                 >
                   <Text style={styles.countValue}>{counts.following}</Text>
                   <Text style={styles.countLabel}>Following</Text>
@@ -259,7 +280,7 @@ export default function UserProfileModal() {
 
               {profile.is_private && !status.follows && !status.is_self ? (
                 <View style={styles.privateCard}>
-                  <Ionicons name="lock-closed" size={16} color="#9AACD1" />
+                  <Ionicons name="lock-closed" size={16} color="#9AACD1" accessible={false} />
                   <Text style={styles.privateText}>This account is private.</Text>
                 </View>
               ) : null}

--- a/app/(tabs)/food.tsx
+++ b/app/(tabs)/food.tsx
@@ -117,11 +117,13 @@ export default function FoodScreen() {
 
   const renderRightActions = (id: string, name: string) => (
     <TouchableOpacity
+      accessibilityLabel={`Delete ${name}`}
+      accessibilityHint="Removes this meal from your log"
       accessibilityRole="button"
       onPress={() => confirmDeleteFood(id, name)}
       style={styles.swipeDelete}
     >
-      <Ionicons name="trash-outline" size={20} color="#fff" />
+      <Ionicons name="trash-outline" size={20} color="#fff" accessible={false} />
       <Text style={styles.swipeDeleteText}>Delete</Text>
     </TouchableOpacity>
   );
@@ -137,6 +139,8 @@ export default function FoodScreen() {
     >
       <TouchableOpacity 
         activeOpacity={0.9}
+        accessibilityLabel={`${item.name} meal`}
+        accessibilityHint="Swipe left to reveal delete actions"
         onPress={() => {
           Haptics.selectionAsync();
           // Navigate to food detail

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -236,7 +236,12 @@ const FeedVideoPlayer = ({ uri, thumbnailUrl, overlaySummary, overlayTime }: Fee
           <View style={styles.videoControlsRow}>
             <TouchableOpacity
               style={styles.videoProgressTrack}
-              onLayout={(event) => setProgressWidth(event.nativeEvent.layout.width)}
+              onLayout={(event) => {
+                const width = event.nativeEvent.layout.width;
+                if (width !== progressWidth) {
+                  setProgressWidth(width);
+                }
+              }}
               onPress={handleSeek}
               activeOpacity={0.85}
               accessibilityLabel="Seek video"

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -191,7 +191,12 @@ const FeedVideoPlayer = ({ uri, thumbnailUrl, overlaySummary, overlayTime }: Fee
         <View style={feedStyles.videoControlsRow}>
           <TouchableOpacity
             style={feedStyles.videoProgressTrack}
-            onLayout={(event) => setProgressWidth(event.nativeEvent.layout.width)}
+            onLayout={(event) => {
+              const width = event.nativeEvent.layout.width;
+              if (width !== progressWidth) {
+                setProgressWidth(width);
+              }
+            }}
             onPress={handleSeek}
             activeOpacity={0.85}
           >

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -100,11 +100,13 @@ export default function WorkoutsScreen() {
 
   const renderRightActions = (id: string, title: string) => (
     <TouchableOpacity
+      accessibilityLabel={`Delete ${title}`}
+      accessibilityHint="Removes this workout from your history"
       accessibilityRole="button"
       onPress={() => confirmDeleteWorkout(id, title)}
       style={styles.swipeDelete}
     >
-      <Ionicons name="trash-outline" size={20} color="#fff" />
+      <Ionicons name="trash-outline" size={20} color="#fff" accessible={false} />
       <Text style={styles.swipeDeleteText}>Delete</Text>
     </TouchableOpacity>
   );
@@ -137,6 +139,8 @@ export default function WorkoutsScreen() {
         <View style={styles.card}>
           <TouchableOpacity 
             activeOpacity={0.9}
+            accessibilityLabel={`${item.exercise} workout`}
+            accessibilityHint="Swipe left to reveal delete actions"
             onPress={() => {
               Haptics.selectionAsync();
               // Navigate to workout detail


### PR DESCRIPTION
## Summary
- **Coach history error state** (#323): Error view with retry button when sessions fail to load
- **Swipe accessibility** (#325): Added accessibilityLabel/Hint to swipeable rows and delete buttons in workouts/food
- **Video progress jank** (#326): Guard `setProgressWidth` to only update when value changes, preventing unnecessary re-renders
- **Followers empty state** (#327): ListEmptyComponent with search-specific and generic empty messaging
- **Accessibility labels** (#334): Added role, label, hint to interactive items in followers and user-profile modals

## Changes
| File | Change |
|------|--------|
| `app/(modals)/coach-history.tsx` | Error state + retry UI |
| `app/(tabs)/workouts.tsx` | Swipe a11y labels |
| `app/(tabs)/food.tsx` | Swipe a11y labels |
| `app/(tabs)/index.tsx` | Progress width guard |
| `app/(tabs)/profile.tsx` | Progress width guard |
| `app/(modals)/followers.tsx` | Empty state + a11y labels |
| `app/(modals)/user-profile.tsx` | A11y labels on interactive items |

## Verification
- [x] `bun run check:types` passes
- [x] `bun run lint` passes
- [x] LSP diagnostics clean
- [x] No file overlap with other open PRs

Closes #323
Closes #325
Closes #326
Closes #327
Closes #334