### PR TITLE
test(services): add unit tests for OAuthHandler, rest-timer, consent-service, coach-service

### DIFF
--- a/tests/unit/services/OAuthHandler.test.ts
+++ b/tests/unit/services/OAuthHandler.test.ts
@@ -1,0 +1,165 @@
+const mockCreateURL = jest.fn(() => 'formfactor://callback');
+const mockParse = jest.fn();
+const mockMaybeCompleteAuthSession = jest.fn();
+const mockOpenAuthSessionAsync = jest.fn();
+
+const mockSignInWithOAuth = jest.fn();
+const mockSetSession = jest.fn();
+const mockExchangeCodeForSession = jest.fn();
+
+jest.mock('expo-linking', () => ({
+  createURL: mockCreateURL,
+  parse: mockParse,
+}));
+
+jest.mock('expo-web-browser', () => ({
+  maybeCompleteAuthSession: (...args: unknown[]) => mockMaybeCompleteAuthSession(...args),
+  openAuthSessionAsync: (...args: unknown[]) => mockOpenAuthSessionAsync(...args),
+}));
+
+jest.mock('expo-crypto', () => ({
+  getRandomBytesAsync: jest.fn(),
+  digestStringAsync: jest.fn(),
+  CryptoDigestAlgorithm: { SHA256: 'SHA256' },
+}));
+
+jest.mock('@supabase/supabase-js', () => ({}));
+
+jest.mock('@/lib/logger', () => ({
+  logWithTs: jest.fn(),
+  warnWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+}));
+
+const mockSupabase = {
+  auth: {
+    signInWithOAuth: (...args: unknown[]) => mockSignInWithOAuth(...args),
+    setSession: (...args: unknown[]) => mockSetSession(...args),
+    exchangeCodeForSession: (...args: unknown[]) => mockExchangeCodeForSession(...args),
+  },
+};
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: mockSupabase,
+}));
+
+jest.mock('../../../lib/supabase', () => ({
+  supabase: mockSupabase,
+}));
+
+let OAuthHandler: typeof import('@/lib/services/OAuthHandler')['OAuthHandler'];
+
+describe('OAuthHandler', () => {
+  const validAccessToken = `header.${'a'.repeat(60)}.signature`;
+  const validRefreshToken = `refresh-${'b'.repeat(24)}`;
+  const session = {
+    access_token: validAccessToken,
+    refresh_token: validRefreshToken,
+    user: { id: 'user-1' },
+  };
+
+  beforeAll(async () => {
+    ({ OAuthHandler } = await import('@/lib/services/OAuthHandler'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateURL.mockReturnValue('formfactor://callback');
+    mockParse.mockReturnValue({ queryParams: {} });
+    mockSignInWithOAuth.mockResolvedValue({ data: { url: 'https://supabase.test/auth' }, error: null });
+    mockOpenAuthSessionAsync.mockResolvedValue({
+      type: 'success',
+      url: `formfactor://callback#access_token=${validAccessToken}&refresh_token=${validRefreshToken}`,
+    });
+    mockSetSession.mockResolvedValue({ data: { session }, error: null });
+    mockExchangeCodeForSession.mockResolvedValue({ data: { session }, error: null });
+  });
+
+  it('initiates Google OAuth successfully and returns the created session', async () => {
+    const handler = new OAuthHandler();
+
+    const result = await handler.initiateOAuth('google');
+
+    expect(mockSignInWithOAuth).toHaveBeenCalledWith({
+      provider: 'google',
+      options: {
+        redirectTo: 'formfactor://callback',
+        skipBrowserRedirect: true,
+      },
+    });
+    expect(mockOpenAuthSessionAsync).toHaveBeenCalledWith(
+      'https://supabase.test/auth',
+      'formfactor://callback'
+    );
+    expect(mockSetSession).toHaveBeenCalledWith({
+      access_token: validAccessToken,
+      refresh_token: validRefreshToken,
+    });
+    expect(result).toEqual({ success: true, session });
+  });
+
+  it('returns a cancellation error when the user cancels OAuth', async () => {
+    mockOpenAuthSessionAsync.mockResolvedValue({ type: 'cancel' });
+    const handler = new OAuthHandler();
+
+    const result = await handler.initiateOAuth('google');
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Sign-in was cancelled',
+    });
+    expect(mockSetSession).not.toHaveBeenCalled();
+    expect(mockExchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it('parses tokens from both hash fragments and query params', () => {
+    const handler = new OAuthHandler();
+
+    expect(
+      handler.parseTokensFromUrl(
+        `formfactor://callback#access_token=${validAccessToken}&refresh_token=${validRefreshToken}`
+      )
+    ).toEqual({ accessToken: validAccessToken, refreshToken: validRefreshToken });
+
+    expect(
+      handler.parseTokensFromUrl(
+        `formfactor://callback?accessToken=${validAccessToken}&refreshToken=${validRefreshToken}`
+      )
+    ).toEqual({ accessToken: validAccessToken, refreshToken: validRefreshToken });
+  });
+
+  it('validates short tokens as invalid and substantial tokens as valid', () => {
+    const handler = new OAuthHandler();
+    const validateTokens = (handler as unknown as {
+      validateTokens(tokens: { accessToken: string; refreshToken: string }): boolean;
+    }).validateTokens.bind(handler);
+
+    expect(
+      validateTokens({
+        accessToken: 'too-short',
+        refreshToken: 'also-too-short',
+      })
+    ).toBe(false);
+
+    expect(
+      validateTokens({
+        accessToken: validAccessToken,
+        refreshToken: validRefreshToken,
+      })
+    ).toBe(true);
+  });
+
+  it('handles a valid callback URL by creating a session from tokens', async () => {
+    const handler = new OAuthHandler();
+
+    const result = await handler.handleCallback(
+      `formfactor://callback#access_token=${validAccessToken}&refresh_token=${validRefreshToken}`
+    );
+
+    expect(result).toEqual(session);
+    expect(mockSetSession).toHaveBeenCalledWith({
+      access_token: validAccessToken,
+      refresh_token: validRefreshToken,
+    });
+  });
+});

--- a/tests/unit/services/coach-service.test.ts
+++ b/tests/unit/services/coach-service.test.ts
@@ -1,0 +1,132 @@
+const mockInvoke = jest.fn();
+const mockInsert = jest.fn();
+const mockFrom = jest.fn(() => ({
+  insert: mockInsert,
+}));
+const mockCreateError = jest.fn(
+  (
+    domain: string,
+    code: string,
+    message: string,
+    opts?: { details?: unknown; retryable?: boolean; severity?: string }
+  ) => ({
+    domain,
+    code,
+    message,
+    retryable: opts?.retryable ?? false,
+    severity: opts?.severity ?? 'error',
+    details: opts?.details,
+  })
+);
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    functions: {
+      invoke: mockInvoke,
+    },
+    from: mockFrom,
+  },
+}));
+
+jest.mock('@/lib/services/ErrorHandler', () => ({
+  createError: mockCreateError,
+}));
+
+jest.mock('../../../lib/services/ErrorHandler', () => ({
+  createError: mockCreateError,
+}));
+
+let sendCoachPrompt: typeof import('@/lib/services/coach-service')['sendCoachPrompt'];
+
+describe('coach-service', () => {
+  const baseMessages = [{ role: 'user' as const, content: 'How should I squat?' }];
+
+  beforeAll(async () => {
+    ({ sendCoachPrompt } = await import('@/lib/services/coach-service'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInvoke.mockResolvedValue({ data: { message: 'Keep your chest up.' }, error: null });
+    mockInsert.mockResolvedValue({ error: null });
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('classifies a 404 invoke failure as COACH_NOT_DEPLOYED', async () => {
+    mockInvoke.mockResolvedValue({ data: null, error: { message: '404 Not Found', status: 404 } });
+
+    await expect(sendCoachPrompt(baseMessages)).rejects.toMatchObject({
+      domain: 'validation',
+      code: 'COACH_NOT_DEPLOYED',
+      retryable: false,
+    });
+  });
+
+  it('classifies missing API key failures as COACH_NOT_CONFIGURED', async () => {
+    mockInvoke.mockResolvedValue({ data: null, error: { message: 'OPENAI_API_KEY is missing' } });
+
+    await expect(sendCoachPrompt(baseMessages)).rejects.toMatchObject({
+      domain: 'validation',
+      code: 'COACH_NOT_CONFIGURED',
+      retryable: false,
+    });
+  });
+
+  it('maps response error payloads to COACH_ERROR', async () => {
+    mockInvoke.mockResolvedValue({ data: { error: 'Inference failed' }, error: null });
+
+    await expect(sendCoachPrompt(baseMessages)).rejects.toMatchObject({
+      domain: 'network',
+      code: 'COACH_ERROR',
+      message: 'Inference failed',
+      retryable: true,
+    });
+  });
+
+  it('rejects empty coach responses as COACH_EMPTY_RESPONSE', async () => {
+    mockInvoke.mockResolvedValue({ data: { message: '   ' }, error: null });
+
+    await expect(sendCoachPrompt(baseMessages)).rejects.toMatchObject({
+      domain: 'validation',
+      code: 'COACH_EMPTY_RESPONSE',
+    });
+  });
+
+  it('persists conversations when profile and session context are present', async () => {
+    const messages = [
+      { role: 'system' as const, content: 'You are a coach.' },
+      { role: 'user' as const, content: 'How should I brace?' },
+      { role: 'assistant' as const, content: 'Breathe into your belly.' },
+      { role: 'user' as const, content: 'What about my knees?' },
+    ];
+
+    const result = await sendCoachPrompt(messages, {
+      profile: { id: 'user-123', name: 'Pat' },
+      focus: 'squat',
+      sessionId: 'session-9',
+    });
+    await Promise.resolve();
+
+    expect(result).toEqual({ role: 'assistant', content: 'Keep your chest up.' });
+    expect(mockFrom).toHaveBeenCalledWith('coach_conversations');
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-123',
+        session_id: 'session-9',
+        turn_index: 1,
+        user_message: 'What about my knees?',
+        assistant_message: 'Keep your chest up.',
+        input_messages: messages,
+        context: { focus: 'squat' },
+        metadata: expect.objectContaining({
+          model: 'gpt-5.4-mini',
+          timestamp: expect.any(String),
+        }),
+      })
+    );
+  });
+});

--- a/tests/unit/services/consent-service.test.ts
+++ b/tests/unit/services/consent-service.test.ts
@@ -1,0 +1,128 @@
+const mockEnsureUserId = jest.fn();
+const mockSingle = jest.fn();
+const mockUpsert = jest.fn();
+const mockEq = jest.fn(() => ({ single: mockSingle }));
+const mockSelect = jest.fn(() => ({ eq: mockEq }));
+const mockFrom = jest.fn((table: string) => {
+  if (table === 'user_telemetry_consent') {
+    return {
+      select: mockSelect,
+      upsert: mockUpsert,
+    };
+  }
+
+  return {
+    select: mockSelect,
+    upsert: mockUpsert,
+  };
+});
+
+jest.mock('@/lib/auth-utils', () => ({
+  ensureUserId: (...args: unknown[]) => mockEnsureUserId(...args),
+}));
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: mockFrom,
+  },
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logWithTs: jest.fn(),
+  warnWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+}));
+
+let consentService: typeof import('@/lib/services/consent-service');
+
+describe('consent-service', () => {
+  beforeAll(async () => {
+    (globalThis as { __DEV__?: boolean }).__DEV__ = false;
+    consentService = await import('@/lib/services/consent-service');
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consentService.invalidateConsentCache();
+    mockEnsureUserId.mockResolvedValue('user-123');
+    mockSingle.mockResolvedValue({
+      data: {
+        allow_anonymous_telemetry: false,
+        allow_video_upload: true,
+        allow_trainer_labeling: true,
+        allow_extended_retention: false,
+      },
+      error: null,
+    });
+    mockUpsert.mockResolvedValue({ error: null });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns cached consent within the TTL and refetches after expiry', async () => {
+    jest.spyOn(Date, 'now')
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_200)
+      .mockReturnValueOnce(301_500)
+      .mockReturnValueOnce(301_600);
+
+    const first = await consentService.getConsent();
+    const second = await consentService.getConsent();
+    const third = await consentService.getConsent();
+
+    expect(first).toEqual({
+      allowAnonymousTelemetry: false,
+      allowVideoUpload: true,
+      allowTrainerLabeling: true,
+      allowExtendedRetention: false,
+    });
+    expect(second).toEqual(first);
+    expect(third).toEqual(first);
+    expect(mockSingle).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns default consent when no row exists', async () => {
+    mockSingle.mockResolvedValue({
+      data: null,
+      error: { code: 'PGRST116', message: 'No rows found' },
+    });
+
+    await expect(consentService.getConsent()).resolves.toEqual({
+      allowAnonymousTelemetry: true,
+      allowVideoUpload: false,
+      allowTrainerLabeling: false,
+      allowExtendedRetention: false,
+    });
+  });
+
+  it('invalidates the cache when consent is updated', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(10_000);
+    await consentService.getConsent();
+    await consentService.updateConsent({ allowVideoUpload: false, allowExtendedRetention: true });
+    await consentService.getConsent();
+
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-123',
+        allow_video_upload: false,
+        allow_extended_retention: true,
+        updated_at: expect.any(String),
+      }),
+      { onConflict: 'user_id' }
+    );
+    expect(mockSingle).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses cached consent for synchronous permission checks and falls back to defaults without cache', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(20_000);
+    expect(consentService.shouldLogFramesSync()).toBe(true);
+    expect(consentService.shouldUploadVideoSync()).toBe(false);
+
+    await consentService.getConsent();
+
+    expect(consentService.shouldLogFramesSync()).toBe(false);
+    expect(consentService.shouldUploadVideoSync()).toBe(true);
+  });
+});

--- a/tests/unit/services/rest-timer.test.ts
+++ b/tests/unit/services/rest-timer.test.ts
@@ -14,12 +14,10 @@ jest.mock('@/lib/logger', () => ({
   warnWithTs: jest.fn(),
 }));
 
-let restTimer: typeof import('@/lib/services/rest-timer');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const restTimer = require('@/lib/services/rest-timer') as typeof import('@/lib/services/rest-timer');
 
 describe('rest-timer', () => {
-  beforeAll(async () => {
-    restTimer = await import('@/lib/services/rest-timer');
-  });
 
   beforeEach(async () => {
     jest.clearAllMocks();

--- a/tests/unit/services/rest-timer.test.ts
+++ b/tests/unit/services/rest-timer.test.ts
@@ -1,0 +1,127 @@
+const mockScheduleNotificationAsync = jest.fn();
+const mockCancelScheduledNotificationAsync = jest.fn();
+
+jest.mock('expo-notifications', () => ({
+  scheduleNotificationAsync: (...args: unknown[]) => mockScheduleNotificationAsync(...args),
+  cancelScheduledNotificationAsync: (...args: unknown[]) => mockCancelScheduledNotificationAsync(...args),
+  SchedulableTriggerInputTypes: {
+    TIME_INTERVAL: 'timeInterval',
+  },
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logWithTs: jest.fn(),
+  warnWithTs: jest.fn(),
+}));
+
+let restTimer: typeof import('@/lib/services/rest-timer');
+
+describe('rest-timer', () => {
+  beforeAll(async () => {
+    restTimer = await import('@/lib/services/rest-timer');
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-01-01T12:00:00.000Z').getTime());
+    mockScheduleNotificationAsync.mockResolvedValue('notif-1');
+    mockCancelScheduledNotificationAsync.mockResolvedValue(undefined);
+    await restTimer.cancelRestNotification();
+  });
+
+  afterEach(async () => {
+    await restTimer.cancelRestNotification();
+    jest.restoreAllMocks();
+  });
+
+  it('computes rest seconds from overrides, set types, goal profiles, and RPE modifiers', () => {
+    expect(
+      restTimer.computeRestSeconds({
+        goalProfile: 'strength',
+        isCompound: true,
+        setType: 'normal',
+        overrideSeconds: 95,
+      })
+    ).toBe(95);
+
+    expect(
+      restTimer.computeRestSeconds({
+        goalProfile: 'mixed',
+        isCompound: true,
+        setType: 'warmup',
+      })
+    ).toBe(60);
+
+    expect(
+      restTimer.computeRestSeconds({
+        goalProfile: 'mixed',
+        isCompound: false,
+        setType: 'dropset',
+      })
+    ).toBe(15);
+
+    expect(
+      restTimer.computeRestSeconds({
+        goalProfile: 'power',
+        isCompound: true,
+        setType: 'normal',
+        perceivedRpe: 8,
+      })
+    ).toBe(264);
+
+    expect(
+      restTimer.computeRestSeconds({
+        goalProfile: 'hypertrophy',
+        isCompound: false,
+        setType: 'failure',
+        perceivedRpe: 9,
+      })
+    ).toBe(140);
+  });
+
+  it('computes remaining seconds across active, expired, and future-start edge cases', () => {
+    expect(
+      restTimer.computeRemainingSeconds(new Date('2026-01-01T11:59:30.000Z'), 60)
+    ).toBe(30);
+
+    expect(
+      restTimer.computeRemainingSeconds('2026-01-01T11:58:00.000Z', 30)
+    ).toBe(0);
+
+    expect(
+      restTimer.computeRemainingSeconds('2026-01-01T12:00:10.000Z', 30)
+    ).toBe(40);
+  });
+
+  it('formats rest time as MM:SS', () => {
+    expect(restTimer.formatRestTime(5)).toBe('0:05');
+    expect(restTimer.formatRestTime(65)).toBe('1:05');
+    expect(restTimer.formatRestTime(600)).toBe('10:00');
+  });
+
+  it('schedules a rest notification with the next set details', async () => {
+    const result = await restTimer.scheduleRestNotification(90, 'Back Squat', 3);
+
+    expect(result).toBe('notif-1');
+    expect(mockScheduleNotificationAsync).toHaveBeenCalledWith({
+      content: {
+        title: 'Rest Complete',
+        body: 'Time for set 3 of Back Squat',
+        sound: 'default',
+        categoryIdentifier: 'rest_timer',
+      },
+      trigger: {
+        type: 'timeInterval',
+        seconds: 90,
+        repeats: false,
+      },
+    });
+  });
+
+  it('cancels the active rest notification', async () => {
+    await restTimer.scheduleRestNotification(45);
+    await restTimer.cancelRestNotification();
+
+    expect(mockCancelScheduledNotificationAsync).toHaveBeenCalledWith('notif-1');
+  });
+});


### PR DESCRIPTION
## Summary
Adds 552 lines of unit tests covering 4 critical services that had zero test coverage:

- **OAuthHandler** (#328): OAuth flow initiation, cancellation, token parsing, validation (165 lines)
- **rest-timer** (#329): Rest duration computation across goal profiles, set types, RPE modifiers, formatting (127 lines)
- **consent-service** (#332): Consent caching, TTL behavior, defaults on missing rows, sync permission checks (128 lines)
- **coach-service** (#333): Error classification (404, config error, empty response), conversation persistence (132 lines)

## Test Files
| File | Lines | Coverage |
|------|-------|----------|
| `tests/unit/services/OAuthHandler.test.ts` | 165 | Auth flow, token parsing, validation |
| `tests/unit/services/rest-timer.test.ts` | 127 | Rest computation, formatting |
| `tests/unit/services/consent-service.test.ts` | 128 | Caching, defaults, permissions |
| `tests/unit/services/coach-service.test.ts` | 132 | Error paths, persistence |

## Verification
- [x] All tests pass (`bun test`)
- [x] `bun run check:types` passes
- [x] `bun run lint` passes
- [x] No source files modified — test files only

Closes #328
Closes #329
Closes #332
Closes #333