### PR TITLE
fix: add CrashBoundary for ARKit camera and retry coach conversation persist

### DIFF
--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -38,6 +38,7 @@ import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
 import { BodyTracker, useBodyTracking, type JointAngles, type Joint2D, type MediaPipePose2D } from '@/lib/arkit/ARKitBodyTracker';
 import { usePremiumCueAudio } from '@/hooks/use-premium-cue-audio';
 import { audioSessionManager } from '@/lib/services/audio-session-manager';
+import { CrashBoundary } from '@/components/CrashBoundary';
 import { generateSessionId, logCueEvent, upsertSessionMetrics } from '@/lib/services/cue-logger';
 import { logPoseSample, flushPoseBuffer, resetFrameCounter } from '@/lib/services/pose-logger';
 import { RepIndexTracker } from '@/lib/services/rep-index-tracker';
@@ -2409,6 +2410,10 @@ export default function ScanARKitScreen() {
       : 0;
 
   return (
+    <CrashBoundary
+      fallbackTitle="Camera error"
+      fallbackMessage="The body tracking camera encountered a problem. Tap below to restart."
+    >
     <View style={styles.container}>
       <View style={[styles.topBar, { paddingTop: topBarOffset }]}>
         <View style={styles.topBarContent}>
@@ -2989,5 +2994,6 @@ export default function ScanARKitScreen() {
         </SafeAreaView>
       </Modal>
 </View>
+    </CrashBoundary>
   );
 }

--- a/components/CrashBoundary.tsx
+++ b/components/CrashBoundary.tsx
@@ -1,0 +1,70 @@
+import React, { Component, type ErrorInfo, type ReactNode } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { errorWithTs } from '@/lib/logger';
+
+interface Props {
+  children: ReactNode;
+  fallbackTitle?: string;
+  fallbackMessage?: string;
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class CrashBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    errorWithTs('[CrashBoundary] Component tree crashed', {
+      error: error.message,
+      stack: error.stack?.slice(0, 500),
+      componentStack: errorInfo.componentStack?.slice(0, 500),
+    });
+    this.props.onError?.(error, errorInfo);
+  }
+
+  private handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      const title = this.props.fallbackTitle ?? 'Something went wrong';
+      const message = this.props.fallbackMessage
+        ?? 'This feature encountered an error. Tap below to retry.';
+
+      return (
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', padding: 32, backgroundColor: '#0D1117' }}>
+          <Text style={{ color: '#E6EDF3', fontSize: 20, fontWeight: '600', marginBottom: 12, textAlign: 'center' }}>
+            {title}
+          </Text>
+          <Text style={{ color: '#8B949E', fontSize: 14, textAlign: 'center', marginBottom: 24, lineHeight: 20 }}>
+            {message}
+          </Text>
+          <TouchableOpacity
+            onPress={this.handleRetry}
+            accessibilityRole="button"
+            accessibilityLabel="Retry"
+            style={{
+              backgroundColor: '#4C8CFF',
+              paddingHorizontal: 24,
+              paddingVertical: 12,
+              borderRadius: 8,
+            }}
+          >
+            <Text style={{ color: '#fff', fontSize: 16, fontWeight: '600' }}>Try Again</Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/lib/services/coach-service.ts
+++ b/lib/services/coach-service.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase';
+import { errorWithTs, warnWithTs } from '@/lib/logger';
 import { createError } from './ErrorHandler';
 
 export type CoachRole = 'user' | 'assistant' | 'system';
@@ -102,7 +103,7 @@ export async function sendCoachPrompt(
 
     if (context?.profile?.id && context.sessionId) {
       const userTurns = messages.filter(m => m.role === 'user');
-      supabase.from('coach_conversations').insert({
+      const insertPayload = {
         user_id: context.profile.id,
         session_id: context.sessionId,
         turn_index: Math.max(0, userTurns.length - 1),
@@ -111,8 +112,15 @@ export async function sendCoachPrompt(
         input_messages: messages,
         context: { focus: context.focus },
         metadata: { model: 'gpt-5.4-mini', timestamp: new Date().toISOString() },
-      }).then(({ error: insertErr }) => {
-        if (insertErr) console.warn('[coach] Failed to persist conversation:', insertErr.message);
+      };
+      supabase.from('coach_conversations').insert(insertPayload).then(({ error: insertErr }) => {
+        if (!insertErr) return;
+        warnWithTs('[coach] Conversation persist failed, retrying once', insertErr.message);
+        supabase.from('coach_conversations').insert(insertPayload).then(({ error: retryErr }) => {
+          if (retryErr) {
+            errorWithTs('[coach] Conversation persist failed after retry', retryErr.message);
+          }
+        });
       });
     }
 


### PR DESCRIPTION
## Summary
- **CrashBoundary component**: New reusable React Error Boundary with retry button, dark theme styling, and structured error logging via `errorWithTs`
- **ARKit screen wrapped**: The 3000-line scan-arkit screen now catches camera/tracking crashes gracefully instead of killing the app
- **Coach service retry**: Conversation DB insert now retries once on failure with proper `warnWithTs`/`errorWithTs` logging instead of a silent `console.warn`

## Verification
- [x] Lint passes (0 errors)
- [x] Type check passes
- [x] No file overlap with PRs #359, #360, #361, #362, #363, #342

Closes #224
Closes #296