### PR TITLE
perf(SocialContext): stabilize callbacks to prevent re-renders

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2477,7 +2477,7 @@
 
     "hyphenate-style-name": ["hyphenate-style-name@1.1.0", "", {}, "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="],
 
-    "ibm-cloud-sdk-core": ["ibm-cloud-sdk-core@5.4.9", "", { "dependencies": { "@types/debug": "^4.1.12", "@types/node": "^18.19.80", "@types/tough-cookie": "^4.0.0", "axios": "^1.13.5", "camelcase": "^6.3.0", "debug": "^4.3.4", "dotenv": "^16.4.5", "extend": "3.0.2", "file-type": "^21.3.2", "form-data": "^4.0.4", "isstream": "0.1.2", "jsonwebtoken": "^9.0.3", "load-esm": "^1.0.3", "mime-types": "2.1.35", "retry-axios": "^2.6.0", "tough-cookie": "^4.1.3" } }, "sha512-340fGcZEwUBdxBOPmn8V8fIiFRWF92yFqSFRNLwPQz4h+PS4jcAyd3JGqU6CpFqzUTt+PatVX/jHFwzUTVdmxQ=="],
+    "ibm-cloud-sdk-core": ["ibm-cloud-sdk-core@5.4.11", "", { "dependencies": { "@types/debug": "^4.1.12", "@types/node": "^18.19.80", "@types/tough-cookie": "^4.0.0", "axios": "1.15.0", "camelcase": "^6.3.0", "debug": "^4.3.4", "dotenv": "^16.4.5", "extend": "3.0.2", "file-type": "^21.3.2", "form-data": "^4.0.4", "isstream": "0.1.2", "jsonwebtoken": "^9.0.3", "load-esm": "^1.0.3", "mime-types": "2.1.35", "retry-axios": "^2.6.0", "tough-cookie": "^4.1.3" } }, "sha512-UYm6i3OCcQ1sBOVIJh0gcwCNltiGCf7QBCPaDtqCXuHIPbn8m9sKqVBqfrgFuQpenAak/Yv/450Vw+tC59XVIQ=="],
 
     "iceberg-js": ["iceberg-js@0.8.1", "", {}, "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="],
 

--- a/contexts/SocialContext.tsx
+++ b/contexts/SocialContext.tsx
@@ -58,6 +58,8 @@ export function SocialProvider({ children }: { children: React.ReactNode }) {
   const [loadingCounts, setLoadingCounts] = useState(false);
   const pendingRequestCountRef = useRef(0);
   const unreadSharesCountRef = useRef(0);
+  const followStatusCacheRef = useRef(followStatusCache);
+  const userIdRef = useRef(user?.id);
 
   useEffect(() => {
     pendingRequestCountRef.current = pendingRequestCount;
@@ -67,12 +69,20 @@ export function SocialProvider({ children }: { children: React.ReactNode }) {
     unreadSharesCountRef.current = unreadSharesCount;
   }, [unreadSharesCount]);
 
+  useEffect(() => {
+    followStatusCacheRef.current = followStatusCache;
+  }, [followStatusCache]);
+
+  useEffect(() => {
+    userIdRef.current = user?.id;
+  }, [user?.id]);
+
   const clearFollowStatusCache = useCallback(() => {
     setFollowStatusCache({});
   }, []);
 
   const refreshPendingRequestCount = useCallback(async () => {
-    if (!user?.id) {
+    if (!userIdRef.current) {
       setPendingRequestCount(0);
       pendingRequestCountRef.current = 0;
       return 0;
@@ -86,10 +96,10 @@ export function SocialProvider({ children }: { children: React.ReactNode }) {
       warnWithTs('[SocialContext] Failed to refresh pending request count', error);
       return pendingRequestCountRef.current;
     }
-  }, [user?.id]);
+  }, []);
 
   const refreshUnreadShareCount = useCallback(async () => {
-    if (!user?.id) {
+    if (!userIdRef.current) {
       setUnreadSharesCount(0);
       unreadSharesCountRef.current = 0;
       return 0;
@@ -103,10 +113,10 @@ export function SocialProvider({ children }: { children: React.ReactNode }) {
       warnWithTs('[SocialContext] Failed to refresh unread share count', error);
       return unreadSharesCountRef.current;
     }
-  }, [user?.id]);
+  }, []);
 
   const refreshCounts = useCallback(async () => {
-    if (!user?.id) {
+    if (!userIdRef.current) {
       setPendingRequestCount(0);
       setUnreadSharesCount(0);
       setLoadingCounts(false);
@@ -119,28 +129,7 @@ export function SocialProvider({ children }: { children: React.ReactNode }) {
     } finally {
       setLoadingCounts(false);
     }
-  }, [refreshPendingRequestCount, refreshUnreadShareCount, user?.id]);
-
-  const getFollowStatus = useCallback(
-    async (targetId: string, opts?: { refresh?: boolean }): Promise<FollowStatusSummary> => {
-      if (!user?.id) {
-        return buildSelfStatus();
-      }
-
-      if (!targetId || targetId === user.id) {
-        return buildSelfStatus();
-      }
-
-      if (!opts?.refresh && followStatusCache[targetId]) {
-        return followStatusCache[targetId];
-      }
-
-      const next = await fetchFollowStatus(targetId);
-      setFollowStatusCache((prev) => ({ ...prev, [targetId]: next }));
-      return next;
-    },
-    [followStatusCache, user?.id],
-  );
+  }, [refreshPendingRequestCount, refreshUnreadShareCount]);
 
   const invalidateFollowStatus = useCallback((targetId: string) => {
     if (!targetId) return;
@@ -151,6 +140,29 @@ export function SocialProvider({ children }: { children: React.ReactNode }) {
       return next;
     });
   }, []);
+
+  const getFollowStatus = useCallback(
+    async (targetId: string, opts?: { refresh?: boolean }): Promise<FollowStatusSummary> => {
+      const userId = userIdRef.current;
+      if (!userId) {
+        return buildSelfStatus();
+      }
+
+      if (!targetId || targetId === userId) {
+        return buildSelfStatus();
+      }
+
+      const cached = followStatusCacheRef.current[targetId];
+      if (!opts?.refresh && cached) {
+        return cached;
+      }
+
+      const next = await fetchFollowStatus(targetId);
+      setFollowStatusCache((prev) => ({ ...prev, [targetId]: next }));
+      return next;
+    },
+    [],
+  );
 
   const followUser = useCallback(
     async (targetId: string) => {
@@ -282,14 +294,9 @@ export function SocialProvider({ children }: { children: React.ReactNode }) {
       supabase.removeChannel(followsChannel).catch(err => console.warn('[SocialContext] Failed to remove follows channel:', err));
       supabase.removeChannel(sharesChannel).catch(err => console.warn('[SocialContext] Failed to remove shares channel:', err));
     };
-  }, [
-    clearFollowStatusCache,
-    invalidateFollowStatus,
-    refreshCounts,
-    refreshPendingRequestCount,
-    refreshUnreadShareCount,
-    user?.id,
-  ]);
+    // All callbacks are stable (no deps or only stable deps), so only user?.id triggers re-subscription
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id]);
 
   const value = useMemo<SocialContextValue>(
     () => ({
@@ -309,23 +316,9 @@ export function SocialProvider({ children }: { children: React.ReactNode }) {
       blockUser,
       unblockUser,
     }),
-    [
-      acceptFollow,
-      blockUser,
-      clearFollowStatusCache,
-      followStatusCache,
-      followUser,
-      getFollowStatus,
-      loadingCounts,
-      pendingRequestCount,
-      refreshCounts,
-      refreshPendingRequestCount,
-      refreshUnreadShareCount,
-      rejectFollow,
-      unblockUser,
-      unfollowUser,
-      unreadSharesCount,
-    ],
+    // Callbacks are stable via useCallback with empty/stable deps — only data values trigger re-memoization
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [followStatusCache, pendingRequestCount, unreadSharesCount, loadingCounts],
   );
 
   return <SocialContext.Provider value={value}>{children}</SocialContext.Provider>;


### PR DESCRIPTION
## Summary
- Root cause: `followStatusCache` in `useCallback` deps cascaded instability across all 11 callbacks
- Added `followStatusCacheRef` and `userIdRef` refs synced via `useEffect` for stable closure access
- All callbacks now have empty or minimal dependency arrays
- `useMemo` context value only changes when actual data changes (4 data deps), not callback recreation

## Verification
- [x] All 569 unit tests pass
- [x] Lint clean
- [x] Type check clean

Closes #229