### PR TITLE
fix(sync): surface realtime errors and auto-resync on failure

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2477,7 +2477,7 @@
 
     "hyphenate-style-name": ["hyphenate-style-name@1.1.0", "", {}, "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="],
 
-    "ibm-cloud-sdk-core": ["ibm-cloud-sdk-core@5.4.9", "", { "dependencies": { "@types/debug": "^4.1.12", "@types/node": "^18.19.80", "@types/tough-cookie": "^4.0.0", "axios": "^1.13.5", "camelcase": "^6.3.0", "debug": "^4.3.4", "dotenv": "^16.4.5", "extend": "3.0.2", "file-type": "^21.3.2", "form-data": "^4.0.4", "isstream": "0.1.2", "jsonwebtoken": "^9.0.3", "load-esm": "^1.0.3", "mime-types": "2.1.35", "retry-axios": "^2.6.0", "tough-cookie": "^4.1.3" } }, "sha512-340fGcZEwUBdxBOPmn8V8fIiFRWF92yFqSFRNLwPQz4h+PS4jcAyd3JGqU6CpFqzUTt+PatVX/jHFwzUTVdmxQ=="],
+    "ibm-cloud-sdk-core": ["ibm-cloud-sdk-core@5.4.11", "", { "dependencies": { "@types/debug": "^4.1.12", "@types/node": "^18.19.80", "@types/tough-cookie": "^4.0.0", "axios": "1.15.0", "camelcase": "^6.3.0", "debug": "^4.3.4", "dotenv": "^16.4.5", "extend": "3.0.2", "file-type": "^21.3.2", "form-data": "^4.0.4", "isstream": "0.1.2", "jsonwebtoken": "^9.0.3", "load-esm": "^1.0.3", "mime-types": "2.1.35", "retry-axios": "^2.6.0", "tough-cookie": "^4.1.3" } }, "sha512-UYm6i3OCcQ1sBOVIJh0gcwCNltiGCf7QBCPaDtqCXuHIPbn8m9sKqVBqfrgFuQpenAak/Yv/450Vw+tC59XVIQ=="],
 
     "iceberg-js": ["iceberg-js@0.8.1", "", {}, "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="],
 

--- a/lib/services/database/generic-sync.ts
+++ b/lib/services/database/generic-sync.ts
@@ -380,12 +380,17 @@ export async function downloadTableFromSupabase(
 
 /**
  * Handle a realtime change event for a generic table.
+ *
+ * When the local DB operation fails the error is surfaced via `onError`
+ * so the caller (SyncService) can set its status to 'error' and schedule
+ * a full resync to recover the lost change.
  */
 export async function handleGenericRealtimeChange(
   config: SyncTableConfig,
   payload: GenericRealtimePayload,
   notifyCallback: () => void,
   scheduleConflictReconcile: (reason: string) => void,
+  onError?: (table: string, error: unknown) => void,
 ): Promise<void> {
   const label = config.supabaseTable;
 
@@ -419,7 +424,22 @@ export async function handleGenericRealtimeChange(
       notifyCallback();
     }
   } catch (error) {
-    errorWithTs(`[GenericSync] Error handling realtime ${label} change:`, error);
+    const appError = createError(
+      'sync',
+      'REALTIME_CHANGE_FAILED',
+      `Failed to apply realtime ${payload.eventType} for ${label}`,
+      {
+        details: { table: label, eventType: payload.eventType, error },
+        retryable: true,
+        severity: 'error',
+      },
+    );
+    logError(appError, {
+      feature: 'workouts',
+      location: 'generic-sync.handleGenericRealtimeChange',
+      meta: { table: label, eventType: payload.eventType },
+    });
+    onError?.(label, error);
   }
 }
 

--- a/lib/services/database/sync-service.ts
+++ b/lib/services/database/sync-service.ts
@@ -10,6 +10,7 @@ import {
   SyncTableName,
 } from './local-db';
 import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
+import { createError, logError } from '../ErrorHandler';
 import {
   syncAllWorkoutTablesToSupabase,
   downloadAllWorkoutTablesFromSupabase,
@@ -97,9 +98,11 @@ class SyncService {
     lastErrorAt: null,
   };
   private conflictSyncTimer: ReturnType<typeof setTimeout> | null = null;
+  private realtimeResyncTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly maxChannelRetries = 3;
   private readonly conflictReconcileDelayMs = 750;
   private readonly maxQueueRetries = 5;
+  private readonly realtimeResyncDelayMs = 2_000;
 
   private getErrorCode(error: unknown): string | undefined {
     if (error && typeof error === 'object' && 'code' in error) {
@@ -197,6 +200,38 @@ class SyncService {
         errorWithTs('[SyncService] Conflict reconcile sync failed:', { reason, error });
       });
     }, this.conflictReconcileDelayMs);
+  }
+
+  /**
+   * Called when a realtime change handler fails to apply a remote change
+   * to the local DB. Sets sync status to 'error' so the UI can indicate
+   * stale data and schedules a full download to recover the lost change.
+   */
+  private handleRealtimeError(table: string, error: unknown): void {
+    const message = error instanceof Error ? error.message : `Realtime ${table} change failed`;
+    this.setSyncStatus({
+      state: 'error',
+      lastError: message,
+      lastErrorAt: new Date().toISOString(),
+    });
+    this.scheduleResyncAfterRealtimeError(table);
+  }
+
+  /**
+   * Debounced full resync after a realtime handler error. Multiple
+   * errors within the delay window collapse into a single resync.
+   */
+  private scheduleResyncAfterRealtimeError(table: string): void {
+    if (this.realtimeResyncTimer) {
+      return;
+    }
+
+    this.realtimeResyncTimer = setTimeout(() => {
+      this.realtimeResyncTimer = null;
+      this.downloadFromSupabase().catch((resyncError) => {
+        errorWithTs('[SyncService] Resync after realtime error failed:', { table, resyncError });
+      });
+    }, this.realtimeResyncDelayMs);
   }
 
   private getRetryDelayMs(retryCount: number): number {
@@ -478,6 +513,7 @@ class SyncService {
                 payload,
                 () => this.notifySyncComplete(),
                 (reason: string) => this.scheduleConflictReconcile(reason),
+                (table: string, error: unknown) => this.handleRealtimeError(table, error),
               );
             }
           ),
@@ -539,7 +575,22 @@ class SyncService {
         this.notifySyncComplete();
       }
     } catch (error) {
-      errorWithTs('[SyncService] Error handling realtime food change:', error);
+      const appError = createError(
+        'sync',
+        'REALTIME_CHANGE_FAILED',
+        `Failed to apply realtime ${payload.eventType} for foods`,
+        {
+          details: { table: 'foods', eventType: payload.eventType, error },
+          retryable: true,
+          severity: 'error',
+        },
+      );
+      logError(appError, {
+        feature: 'app',
+        location: 'sync-service.handleRealtimeFoodChange',
+        meta: { table: 'foods', eventType: payload.eventType },
+      });
+      this.handleRealtimeError('foods', error);
     }
   }
 
@@ -591,7 +642,22 @@ class SyncService {
         this.notifySyncComplete();
       }
     } catch (error) {
-      errorWithTs('[SyncService] Error handling realtime workout change:', error);
+      const appError = createError(
+        'sync',
+        'REALTIME_CHANGE_FAILED',
+        `Failed to apply realtime ${payload.eventType} for workouts`,
+        {
+          details: { table: 'workouts', eventType: payload.eventType, error },
+          retryable: true,
+          severity: 'error',
+        },
+      );
+      logError(appError, {
+        feature: 'app',
+        location: 'sync-service.handleRealtimeWorkoutChange',
+        meta: { table: 'workouts', eventType: payload.eventType },
+      });
+      this.handleRealtimeError('workouts', error);
     }
   }
 
@@ -643,7 +709,22 @@ class SyncService {
         this.notifySyncComplete();
       }
     } catch (error) {
-      errorWithTs('[SyncService] Error handling realtime health metric change:', error);
+      const appError = createError(
+        'sync',
+        'REALTIME_CHANGE_FAILED',
+        `Failed to apply realtime ${payload.eventType} for health_metrics`,
+        {
+          details: { table: 'health_metrics', eventType: payload.eventType, error },
+          retryable: true,
+          severity: 'error',
+        },
+      );
+      logError(appError, {
+        feature: 'app',
+        location: 'sync-service.handleRealtimeHealthMetricChange',
+        meta: { table: 'health_metrics', eventType: payload.eventType },
+      });
+      this.handleRealtimeError('health_metrics', error);
     }
   }
 
@@ -682,7 +763,22 @@ class SyncService {
         this.notifySyncComplete();
       }
     } catch (error) {
-      errorWithTs('[SyncService] Error handling realtime nutrition goals change:', error);
+      const appError = createError(
+        'sync',
+        'REALTIME_CHANGE_FAILED',
+        `Failed to apply realtime ${payload.eventType} for nutrition_goals`,
+        {
+          details: { table: 'nutrition_goals', eventType: payload.eventType, error },
+          retryable: true,
+          severity: 'error',
+        },
+      );
+      logError(appError, {
+        feature: 'app',
+        location: 'sync-service.handleRealtimeNutritionGoalsChange',
+        meta: { table: 'nutrition_goals', eventType: payload.eventType },
+      });
+      this.handleRealtimeError('nutrition_goals', error);
     }
   }
 
@@ -693,6 +789,11 @@ class SyncService {
     if (this.conflictSyncTimer) {
       clearTimeout(this.conflictSyncTimer);
       this.conflictSyncTimer = null;
+    }
+
+    if (this.realtimeResyncTimer) {
+      clearTimeout(this.realtimeResyncTimer);
+      this.realtimeResyncTimer = null;
     }
 
     if (this.foodChannel) {

--- a/tests/unit/services/sync-service.test.ts
+++ b/tests/unit/services/sync-service.test.ts
@@ -98,6 +98,17 @@ jest.mock('@/lib/logger', () => ({
   errorWithTs: jest.fn(),
 }));
 
+jest.mock('@/lib/services/ErrorHandler', () => ({
+  createError: jest.fn((_domain: string, _code: string, message: string) => ({
+    domain: _domain,
+    code: _code,
+    message,
+    retryable: true,
+    severity: 'error',
+  })),
+  logError: jest.fn(),
+}));
+
 // ---------------------------------------------------------------------------
 // Import under test
 // ---------------------------------------------------------------------------
@@ -129,6 +140,10 @@ function resetSyncService() {
   if ((syncService as any).conflictSyncTimer) {
     clearTimeout((syncService as any).conflictSyncTimer);
     (syncService as any).conflictSyncTimer = null;
+  }
+  if ((syncService as any).realtimeResyncTimer) {
+    clearTimeout((syncService as any).realtimeResyncTimer);
+    (syncService as any).realtimeResyncTimer = null;
   }
 }
 
@@ -654,6 +669,146 @@ describe('SyncService', () => {
         'food-retry',
         expect.objectContaining({ name: 'Retry Food' })
       );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Realtime error handling (#225)
+  // -----------------------------------------------------------------------
+  describe('handleRealtimeError', () => {
+    it('sets sync status to error with the failure message', () => {
+      const fn = (syncService as any).handleRealtimeError.bind(syncService);
+      fn('foods', new Error('DB write failed'));
+
+      const status = syncService.getSyncStatus();
+      expect(status.state).toBe('error');
+      expect(status.lastError).toBe('DB write failed');
+      expect(status.lastErrorAt).toBeTruthy();
+    });
+
+    it('uses a generic message for non-Error values', () => {
+      const fn = (syncService as any).handleRealtimeError.bind(syncService);
+      fn('workouts', 'string error');
+
+      const status = syncService.getSyncStatus();
+      expect(status.state).toBe('error');
+      expect(status.lastError).toBe('Realtime workouts change failed');
+    });
+
+    it('schedules a resync via realtimeResyncTimer', () => {
+      const fn = (syncService as any).handleRealtimeError.bind(syncService);
+      fn('foods', new Error('write failed'));
+
+      // A resync timer should be pending
+      expect((syncService as any).realtimeResyncTimer).not.toBeNull();
+    });
+
+    it('debounces multiple errors into a single resync', () => {
+      jest.useFakeTimers();
+      try {
+        const fn = (syncService as any).handleRealtimeError.bind(syncService);
+        fn('foods', new Error('error 1'));
+        const timer1 = (syncService as any).realtimeResyncTimer;
+
+        fn('workouts', new Error('error 2'));
+        const timer2 = (syncService as any).realtimeResyncTimer;
+
+        // Same timer — second call was debounced
+        expect(timer1).toBe(timer2);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
+  describe('realtime food change error handling', () => {
+    it('sets sync status to error when local DB write fails', async () => {
+      const { createError: mockCreateError, logError: mockLogError } =
+        require('@/lib/services/ErrorHandler');
+
+      mockLocalDB.getFoodById.mockRejectedValue(new Error('SQLite full'));
+
+      const handler = (syncService as any).handleRealtimeFoodChange.bind(syncService);
+      await handler({
+        eventType: 'INSERT',
+        new: { id: 'food-rt-1', name: 'Apple', calories: 95 },
+        old: {},
+      });
+
+      const status = syncService.getSyncStatus();
+      expect(status.state).toBe('error');
+      expect(status.lastError).toBe('SQLite full');
+
+      expect(mockCreateError).toHaveBeenCalledWith(
+        'sync',
+        'REALTIME_CHANGE_FAILED',
+        expect.stringContaining('foods'),
+        expect.objectContaining({ retryable: true }),
+      );
+      expect(mockLogError).toHaveBeenCalled();
+    });
+  });
+
+  describe('realtime workout change error handling', () => {
+    it('sets sync status to error when local DB write fails', async () => {
+      mockLocalDB.getWorkoutById.mockRejectedValue(new Error('disk error'));
+
+      const handler = (syncService as any).handleRealtimeWorkoutChange.bind(syncService);
+      await handler({
+        eventType: 'UPDATE',
+        new: { id: 'workout-rt-1', exercise: 'Bench Press', sets: 3 },
+        old: {},
+      });
+
+      const status = syncService.getSyncStatus();
+      expect(status.state).toBe('error');
+      expect(status.lastError).toBe('disk error');
+    });
+  });
+
+  describe('realtime health metric change error handling', () => {
+    it('sets sync status to error when local DB write fails', async () => {
+      mockLocalDB.getHealthMetricById.mockRejectedValue(new Error('constraint violation'));
+
+      const handler = (syncService as any).handleRealtimeHealthMetricChange.bind(syncService);
+      await handler({
+        eventType: 'INSERT',
+        new: { id: 'hm-1', user_id: 'u-1', summary_date: '2025-01-01' },
+        old: {},
+      });
+
+      const status = syncService.getSyncStatus();
+      expect(status.state).toBe('error');
+      expect(status.lastError).toBe('constraint violation');
+    });
+  });
+
+  describe('realtime nutrition goals change error handling', () => {
+    it('sets sync status to error when local DB write fails', async () => {
+      mockLocalDB.getNutritionGoalsById.mockRejectedValue(new Error('table locked'));
+
+      const handler = (syncService as any).handleRealtimeNutritionGoalsChange.bind(syncService);
+      await handler({
+        eventType: 'INSERT',
+        new: { id: 'ng-1', user_id: 'u-1', calories_goal: 2000, protein_goal: 150, carbs_goal: 200, fat_goal: 60 },
+        old: {},
+      });
+
+      const status = syncService.getSyncStatus();
+      expect(status.state).toBe('error');
+      expect(status.lastError).toBe('table locked');
+    });
+  });
+
+  describe('cleanupRealtimeSync clears resync timer', () => {
+    it('clears the realtimeResyncTimer', async () => {
+      // Set up a pending resync timer
+      (syncService as any).realtimeResyncTimer = setTimeout(() => {}, 10000);
+      expect((syncService as any).realtimeResyncTimer).not.toBeNull();
+
+      await syncService.cleanupRealtimeSync();
+
+      expect((syncService as any).realtimeResyncTimer).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary
- All 5 realtime change handlers previously swallowed errors silently, permanently losing remote changes
- Added structured error handling with `createError`/`logError` from ErrorHandler
- New `handleRealtimeError` sets sync status to `'error'` with message/timestamp for UI indication
- Auto-recovery via debounced `downloadFromSupabase()` call (2s delay) after realtime failures
- Cleanup of resync timer in `cleanupRealtimeSync`

## Verification
- [x] 9 new tests covering error propagation, status setting, timer debouncing, and all 4 domain handlers
- [x] All 44 tests pass (35 existing + 9 new)
- [x] Lint clean
- [x] Type check clean

Closes #225