### PR TITLE
fix(sync): show toast on background sync failures in WorkoutsContext and FoodContext

### DIFF
--- a/contexts/FoodContext.tsx
+++ b/contexts/FoodContext.tsx
@@ -4,6 +4,7 @@ import { localDB } from '../lib/services/database/local-db';
 import { syncService } from '../lib/services/database/sync-service';
 import { useNetwork } from './NetworkContext';
 import { useAuth } from './AuthContext';
+import { useToast } from './ToastContext';
 
 export interface FoodEntry {
   id: string;
@@ -42,6 +43,7 @@ export const FoodProvider = ({ children }: { children: ReactNode }) => {
   const [isSyncing, setIsSyncing] = useState(false);
   const { isOnline } = useNetwork();
   const { user } = useAuth();
+  const { show: showToast } = useToast();
 
   const loadLocalFoods = useCallback(async () => {
     try {
@@ -150,7 +152,10 @@ export const FoodProvider = ({ children }: { children: ReactNode }) => {
 
       // Sync to Supabase if online (fire-and-forget — local write already done)
       if (isOnline) {
-        void syncService.syncToSupabase().catch(err => console.warn('[FoodContext] Sync failed:', err));
+        void syncService.syncToSupabase().catch(err => {
+          console.warn('[FoodContext] Sync failed:', err);
+          showToast('Sync failed. Changes saved locally.', { type: 'error' });
+        });
       }
     } catch (err) {
       console.error('[FoodProvider] Error deleting food:', err);
@@ -181,7 +186,10 @@ export const FoodProvider = ({ children }: { children: ReactNode }) => {
 
       // Sync to Supabase if online (fire-and-forget — local write already done)
       if (isOnline) {
-        void syncService.syncToSupabase().catch(err => console.warn('[FoodContext] Sync failed:', err));
+        void syncService.syncToSupabase().catch(err => {
+          console.warn('[FoodContext] Sync failed:', err);
+          showToast('Sync failed. Changes saved locally.', { type: 'error' });
+        });
       }
     } catch (error) {
       console.error('[FoodProvider] Error adding food:', error);

--- a/contexts/WorkoutsContext.tsx
+++ b/contexts/WorkoutsContext.tsx
@@ -4,6 +4,7 @@ import { localDB } from '../lib/services/database/local-db';
 import { syncService } from '../lib/services/database/sync-service';
 import { useNetwork } from './NetworkContext';
 import { useAuth } from './AuthContext';
+import { useToast } from './ToastContext';
 
 export interface Workout {
   id: string;
@@ -49,6 +50,7 @@ export const WorkoutsProvider = ({ children }: { children: ReactNode }) => {
   const [isWorkoutInProgress, setIsWorkoutInProgress] = useState(false);
   const { isOnline } = useNetwork();
   const { user } = useAuth();
+  const { show: showToast } = useToast();
 
   const loadLocalWorkouts = useCallback(async () => {
     try {
@@ -161,6 +163,7 @@ export const WorkoutsProvider = ({ children }: { children: ReactNode }) => {
       if (isOnline) {
         void syncService.syncToSupabase().catch((syncError) => {
           console.error('[WorkoutsProvider] Background sync failed after add:', syncError);
+          showToast('Sync failed. Changes saved locally.', { type: 'error' });
         });
       }
     } catch (err) {
@@ -193,6 +196,7 @@ export const WorkoutsProvider = ({ children }: { children: ReactNode }) => {
       if (isOnline) {
         void syncService.syncToSupabase().catch((syncError) => {
           console.error('[WorkoutsProvider] Background sync failed after add:', syncError);
+          showToast('Sync failed. Changes saved locally.', { type: 'error' });
         });
       }
     } catch (error) {

--- a/tests/unit/contexts/food-context.test.tsx
+++ b/tests/unit/contexts/food-context.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import type * as FoodContextModule from '@/contexts/FoodContext';
 import type { FoodEntry } from '@/contexts/FoodContext';
+import { ToastProvider } from '@/contexts/ToastContext';
 
 // Mock expo-crypto
 jest.mock('expo-crypto', () => ({
@@ -78,7 +79,9 @@ beforeAll(() => {
 });
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <FoodProvider>{children}</FoodProvider>
+  <ToastProvider>
+    <FoodProvider>{children}</FoodProvider>
+  </ToastProvider>
 );
 
 const makeFoodEntry = (overrides: Partial<FoodEntry> = {}): FoodEntry => ({

--- a/tests/unit/contexts/workouts-context.test.tsx
+++ b/tests/unit/contexts/workouts-context.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import type * as WorkoutsContextModule from '@/contexts/WorkoutsContext';
 import type { Workout } from '@/contexts/WorkoutsContext';
+import { ToastProvider } from '@/contexts/ToastContext';
 
 // Mock expo-crypto
 jest.mock('expo-crypto', () => ({
@@ -77,7 +78,9 @@ beforeAll(() => {
 });
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <WorkoutsProvider>{children}</WorkoutsProvider>
+  <ToastProvider>
+    <WorkoutsProvider>{children}</WorkoutsProvider>
+  </ToastProvider>
 );
 
 const makeWorkout = (overrides: Partial<Workout> = {}): Workout => ({


### PR DESCRIPTION
## Summary
- Add `useToast` import and `showToast` calls in the `.catch` blocks of `WorkoutsContext` and `FoodContext` background sync operations
- Users now see a brief error toast ("Sync failed. Changes saved locally.") when a sync fails instead of silence
- No other logic changed — just surfacing the existing caught errors

## Test plan
- [ ] Trigger a sync failure (e.g., disable network after adding a workout or food entry) — verify toast appears
- [ ] Verify happy-path sync still works with no toast shown
- [ ] Type check and lint pass clean

Closes #380