### PR TITLE
fix(ux): FAB accessibility labels, better delete errors, and haptic audit

### DIFF
--- a/app/(tabs)/food.tsx
+++ b/app/(tabs)/food.tsx
@@ -85,7 +85,17 @@ export default function FoodScreen() {
         swipeableRefs.current.delete(id);
       } catch (error) {
         errorWithTs('[Food] delete failed', error);
-        showToast('Failed to delete entry', { type: 'error' });
+        const isNetworkError =
+          error instanceof Error &&
+          (error.message.toLowerCase().includes('network') ||
+            error.message.toLowerCase().includes('fetch') ||
+            error.message.toLowerCase().includes('offline'));
+        showToast(
+          isNetworkError
+            ? "Couldn't delete — check your connection"
+            : "Couldn't delete entry — try again",
+          { type: 'error' }
+        );
       }
     },
     [deleteFood, showToast]
@@ -309,9 +319,12 @@ export default function FoodScreen() {
           }
         />
       )}
-      <TouchableOpacity 
-        style={styles.addButton} 
+      <TouchableOpacity
+        style={styles.addButton}
         onPress={handleAddPress}
+        activeOpacity={0.9}
+        accessibilityLabel="Add meal"
+        accessibilityRole="button"
       >
         <Ionicons name="add" size={28} color="#fff" />
       </TouchableOpacity>

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -84,7 +84,17 @@ export default function WorkoutsScreen() {
         swipeableRefs.current.delete(id);
       } catch (error) {
         errorWithTs('[Workouts] delete failed', error);
-        showToast('Failed to delete workout', { type: 'error' });
+        const isNetworkError =
+          error instanceof Error &&
+          (error.message.toLowerCase().includes('network') ||
+            error.message.toLowerCase().includes('fetch') ||
+            error.message.toLowerCase().includes('offline'));
+        showToast(
+          isNetworkError
+            ? "Couldn't delete — check your connection"
+            : "Couldn't delete workout — try again",
+          { type: 'error' }
+        );
       }
     },
     [deleteWorkout, showToast]
@@ -320,10 +330,12 @@ export default function WorkoutsScreen() {
           }
         />
       )}
-      <TouchableOpacity 
-        style={styles.addButton} 
+      <TouchableOpacity
+        style={styles.addButton}
         onPress={handleAddPress}
         activeOpacity={0.9}
+        accessibilityLabel="Add workout"
+        accessibilityRole="button"
       >
         <Ionicons name="add" size={28} color="#fff" />
       </TouchableOpacity>


### PR DESCRIPTION
## Summary
- **#395**: Added `accessibilityLabel` and `accessibilityRole="button"` to the add workout and add meal FABs — screen readers now announce these buttons correctly
- **#397**: Delete error toasts now distinguish network errors ("Couldn't delete — check your connection") from generic failures ("Couldn't delete workout — try again") instead of the previous generic message
- **#398**: Confirmed FAB haptics were already wired through `handleAddPress` — no new changes needed; documented for clarity

## Test plan
- [ ] Enable VoiceOver on iOS — verify FABs are announced as "Add workout" / "Add meal" buttons
- [ ] Simulate network failure then try to delete a workout/food entry — verify specific error toast
- [ ] Tap FABs with haptics enabled — verify tactile feedback fires

Closes #395
Closes #397
Closes #398