### PR TITLE
fix(coach): log errors on conversation persistence failure instead of swallowing

### DIFF
--- a/lib/services/coach-service.ts
+++ b/lib/services/coach-service.ts
@@ -1,6 +1,6 @@
 import { supabase } from '@/lib/supabase';
 import { errorWithTs, warnWithTs } from '@/lib/logger';
-import { createError } from './ErrorHandler';
+import { createError, logError } from './ErrorHandler';
 
 export type CoachRole = 'user' | 'assistant' | 'system';
 
@@ -119,8 +119,21 @@ export async function sendCoachPrompt(
         supabase.from('coach_conversations').insert(insertPayload).then(({ error: retryErr }) => {
           if (retryErr) {
             errorWithTs('[coach] Conversation persist failed after retry', retryErr.message);
+            logError(
+              createError('storage', 'COACH_PERSIST_FAILED', 'Coach conversation persist failed after retry', {
+                details: retryErr,
+                retryable: false,
+                severity: 'error',
+              }),
+              { feature: 'workouts', location: 'coach-service.sendCoachPrompt' }
+            );
           }
         });
+      });
+    } else {
+      console.warn('[coach] Conversation persistence skipped: missing profile.id or sessionId', {
+        hasProfileId: Boolean(context?.profile?.id),
+        hasSessionId: Boolean(context?.sessionId),
       });
     }
 


### PR DESCRIPTION
## Summary
- Coach conversation DB persist failures were silently discarded — now logged via `logError()` with domain `storage` / code `COACH_PERSIST_FAILED` for observability
- Missing context (no profile ID or session ID) now emits a `console.warn` with `hasProfileId`/`hasSessionId` flags instead of silently skipping
- No user-visible changes — error logging only

## Test plan
- [ ] Simulate a DB failure during coach conversation — verify error appears in logs
- [ ] Call coach service without context — verify warning logged
- [ ] Type check and lint pass

Closes #384