### PR TITLE
fix(video): prevent Realtime channel accumulation in video comment subscriptions

### DIFF
--- a/app/(modals)/video-comments.tsx
+++ b/app/(modals)/video-comments.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   ActivityIndicator,
@@ -143,11 +143,26 @@ export default function VideoCommentsModal() {
     };
   }, [videoId]);
 
+  const unsubscribeRef = useRef<(() => void) | null>(null);
+
   useEffect(() => {
     if (!videoId || typeof videoId !== 'string') return;
-    return subscribeToVideoComments(videoId, (incoming) => {
+
+    // Always clean up any previously registered subscription before creating a
+    // new one. This guards against rapid videoId changes or React Strict Mode
+    // double-invocations where the cleanup from the previous run may not have
+    // fired yet before the next run starts.
+    unsubscribeRef.current?.();
+
+    const unsubscribe = subscribeToVideoComments(videoId, (incoming) => {
       setComments((prev) => (prev.some((comment) => comment.id === incoming.id) ? prev : [...prev, incoming]));
     });
+    unsubscribeRef.current = unsubscribe;
+
+    return () => {
+      unsubscribe();
+      unsubscribeRef.current = null;
+    };
   }, [videoId]);
 
   const handleSend = useCallback(async () => {

--- a/lib/services/video-service.ts
+++ b/lib/services/video-service.ts
@@ -434,12 +434,25 @@ export async function addVideoComment(videoId: string, comment: string) {
   return data as CommentRecord;
 }
 
+const _activeCommentChannels = new Map<string, ReturnType<typeof supabase.channel>>();
+
 export function subscribeToVideoComments(
   videoId: string,
   onInsert: (comment: CommentRecord) => void
 ) {
+  const channelName = `video-comments-${videoId}`;
+
+  // Remove any pre-existing channel for this videoId before creating a new one.
+  // This prevents duplicate Realtime channels when the hook re-runs (e.g. React
+  // Strict Mode double-invoke, or rapid mount/unmount cycles).
+  const existing = _activeCommentChannels.get(videoId);
+  if (existing) {
+    supabase.removeChannel(existing);
+    _activeCommentChannels.delete(videoId);
+  }
+
   const channel = supabase
-    .channel(`video-comments-${videoId}`)
+    .channel(channelName)
     .on(
       'postgres_changes',
       { event: 'INSERT', schema: 'public', table: 'video_comments', filter: `video_id=eq.${videoId}` },
@@ -449,8 +462,14 @@ export function subscribeToVideoComments(
     )
     .subscribe();
 
+  _activeCommentChannels.set(videoId, channel);
+
   return () => {
     supabase.removeChannel(channel);
+    // Only remove from the map if this is still the active channel for the videoId.
+    if (_activeCommentChannels.get(videoId) === channel) {
+      _activeCommentChannels.delete(videoId);
+    }
   };
 }
 


### PR DESCRIPTION
## Summary
- Added a module-level `_activeCommentChannels` map in `video-service.ts` — before creating a new channel for a `videoId`, any pre-existing channel for that ID is removed via `supabase.removeChannel()` first
- Fixed `app/(modals)/video-comments.tsx` to store the unsubscribe function in a `useRef` and explicitly invoke it both before re-subscribing and in the `useEffect` cleanup return
- Prevents channel accumulation from React Strict Mode double-invokes and mount/unmount cycles

## Test plan
- [ ] Open video comments modal, close, reopen — verify no duplicate channel events fire
- [ ] Check Supabase Realtime dashboard — only 1 channel per videoId open at a time
- [ ] Type check and lint pass

Closes #386