### PR TITLE
fix(video): validate exercise and metrics fields in uploadWorkoutVideo

### DIFF
--- a/lib/services/video-service.ts
+++ b/lib/services/video-service.ts
@@ -5,6 +5,7 @@ import Constants from 'expo-constants';
 import { supabase } from '@/lib/supabase';
 import { ensureUser } from '@/lib/auth-utils';
 import { warnWithTs } from '@/lib/logger';
+import { createError } from '@/lib/services/ErrorHandler';
 
 const VIDEO_BUCKET = 'videos';
 const THUMBNAIL_BUCKET = 'video-thumbnails';
@@ -282,6 +283,19 @@ export async function uploadWorkoutVideo(opts: {
     metrics,
     analysisOnly = false,
   } = opts;
+
+  // Validate exercise and metrics fields before any I/O.
+  if (exercise !== undefined) {
+    if (typeof exercise !== 'string' || exercise.length > 255) {
+      throw createError('validation', 'INVALID_INPUT', 'Exercise name exceeds maximum length');
+    }
+  }
+  if (metrics !== undefined) {
+    const metricsJson = JSON.stringify(metrics);
+    if (new TextEncoder().encode(metricsJson).byteLength > 10240) {
+      throw createError('validation', 'INVALID_INPUT', 'Metrics payload exceeds maximum size');
+    }
+  }
 
   // Validate env before auth/upload calls so failures are explicit and actionable.
   getSupabaseUrl();


### PR DESCRIPTION
## Summary
- Added input validation at the top of `uploadWorkoutVideo()` before any DB or storage operations
- `exercise` strings are rejected if > 255 chars
- `metrics` JSON payloads are rejected if > 10KB (serialized)
- Both throw a structured `createError('validation', 'INVALID_INPUT', ...)` so callers get a typed error

## Test plan
- [ ] Upload video with normal exercise/metrics — succeeds
- [ ] Upload with exercise name > 255 chars — throws validation error
- [ ] Upload with metrics > 10KB — throws validation error
- [ ] Type check and lint pass

Closes #388