### PR TITLE
test(rest-timer): add 12 error path and edge case tests

### DIFF
--- a/tests/unit/services/rest-timer.test.ts
+++ b/tests/unit/services/rest-timer.test.ts
@@ -122,4 +122,154 @@ describe('rest-timer', () => {
 
     expect(mockCancelScheduledNotificationAsync).toHaveBeenCalledWith('notif-1');
   });
+
+  // -------------------------------------------------------------------------
+  // Error paths
+  // -------------------------------------------------------------------------
+
+  it('returns null and does not throw when scheduleNotificationAsync rejects', async () => {
+    mockScheduleNotificationAsync.mockRejectedValueOnce(new Error('permission denied'));
+
+    const result = await restTimer.scheduleRestNotification(60, 'Bench Press', 2);
+
+    expect(result).toBeNull();
+    // The module should have logged a warning rather than crashing
+    const { warnWithTs } = require('@/lib/logger') as typeof import('@/lib/logger');
+    expect(warnWithTs).toHaveBeenCalled();
+  });
+
+  it('does not throw and clears the stored id when cancelScheduledNotificationAsync rejects', async () => {
+    // First schedule so there is an active notification id stored
+    await restTimer.scheduleRestNotification(60);
+    expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+
+    // Make the next cancel call fail
+    mockCancelScheduledNotificationAsync.mockRejectedValueOnce(new Error('system error'));
+
+    // Should resolve without throwing
+    await expect(restTimer.cancelRestNotification()).resolves.toBeUndefined();
+
+    // A subsequent cancel should NOT try to cancel again (id was cleared)
+    await restTimer.cancelRestNotification();
+    // cancelScheduledNotificationAsync was called exactly once (the failing call);
+    // the second cancelRestNotification is a no-op because id is already null
+    expect(mockCancelScheduledNotificationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancelling when no notification is active is a no-op and does not throw', async () => {
+    // No scheduleRestNotification has been called in this test, so id is null
+    await expect(restTimer.cancelRestNotification()).resolves.toBeUndefined();
+    expect(mockCancelScheduledNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('scheduling a second notification cancels the first before scheduling the new one', async () => {
+    // First schedule
+    mockScheduleNotificationAsync.mockResolvedValueOnce('notif-A');
+    await restTimer.scheduleRestNotification(60, 'Squat', 1);
+    expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+
+    // Second schedule — should cancel 'notif-A' then schedule fresh
+    mockScheduleNotificationAsync.mockResolvedValueOnce('notif-B');
+    const result = await restTimer.scheduleRestNotification(90, 'Squat', 2);
+
+    expect(mockCancelScheduledNotificationAsync).toHaveBeenCalledWith('notif-A');
+    expect(result).toBe('notif-B');
+    expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('scheduling while a prior schedule fails still stores null and returns null', async () => {
+    mockScheduleNotificationAsync.mockRejectedValueOnce(new Error('quota exceeded'));
+
+    const result = await restTimer.scheduleRestNotification(120);
+
+    expect(result).toBeNull();
+
+    // A follow-up cancel should be a no-op (nothing stored)
+    await restTimer.cancelRestNotification();
+    expect(mockCancelScheduledNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // computeRestSeconds — boundary / edge case inputs
+  // -------------------------------------------------------------------------
+
+  it('treats overrideSeconds = 0 as absent and falls through to goal profile logic', () => {
+    const result = restTimer.computeRestSeconds({
+      goalProfile: 'strength',
+      isCompound: true,
+      setType: 'normal',
+      overrideSeconds: 0,
+    });
+    // override is 0, which is NOT > 0, so the strength compound base (210) should apply
+    expect(result).toBe(210);
+  });
+
+  it('treats overrideSeconds = null as absent', () => {
+    const result = restTimer.computeRestSeconds({
+      goalProfile: 'endurance',
+      isCompound: false,
+      setType: 'normal',
+      overrideSeconds: null,
+    });
+    expect(result).toBe(45); // endurance isolation base
+  });
+
+  it('applies no RPE modifier when perceivedRpe is null', () => {
+    const result = restTimer.computeRestSeconds({
+      goalProfile: 'hypertrophy',
+      isCompound: true,
+      setType: 'normal',
+      perceivedRpe: null,
+    });
+    expect(result).toBe(120); // unmodified hypertrophy compound base
+  });
+
+  it('applies no RPE modifier when perceivedRpe is below 8', () => {
+    const result = restTimer.computeRestSeconds({
+      goalProfile: 'power',
+      isCompound: false,
+      setType: 'normal',
+      perceivedRpe: 7,
+    });
+    expect(result).toBe(180); // unmodified power isolation base
+  });
+
+  it('handles all goal profiles for compound and isolation correctly', () => {
+    const cases: Array<[import('@/lib/types/workout-session').GoalProfile, boolean, number]> = [
+      ['strength',    true,  210],
+      ['strength',    false, 150],
+      ['power',       true,  240],
+      ['power',       false, 180],
+      ['hypertrophy', true,  120],
+      ['hypertrophy', false, 90],
+      ['endurance',   true,  60],
+      ['endurance',   false, 45],
+      ['mixed',       true,  120],
+      ['mixed',       false, 90],
+    ];
+
+    for (const [goalProfile, isCompound, expected] of cases) {
+      expect(
+        restTimer.computeRestSeconds({ goalProfile, isCompound, setType: 'normal' })
+      ).toBe(expected);
+    }
+  });
+
+  it('applies amrap set-type multiplier (1.3x) on top of goal profile base', () => {
+    const result = restTimer.computeRestSeconds({
+      goalProfile: 'strength',
+      isCompound: true,
+      setType: 'amrap',
+    });
+    expect(result).toBe(Math.round(210 * 1.3)); // 273
+  });
+
+  it('applies failure set-type multiplier (1.3x) on top of goal profile base', () => {
+    const result = restTimer.computeRestSeconds({
+      goalProfile: 'endurance',
+      isCompound: false,
+      setType: 'failure',
+    });
+    expect(result).toBe(Math.round(45 * 1.3)); // 59
+  });
 });


### PR DESCRIPTION
## Summary
Adds 12 new tests to `tests/unit/services/rest-timer.test.ts` covering previously untested error paths and edge cases:

**Error paths:**
- `scheduleNotificationAsync` rejects → returns `null`, warns instead of throwing
- `cancelScheduledNotificationAsync` rejects → resolves without throwing, clears stored ID
- Cancel with no active notification → silent no-op
- Second schedule replaces first → prior ID cancelled before new one scheduled
- Scheduling fails → `activeRestNotificationId` never set; follow-up cancel is no-op

**`computeRestSeconds` boundaries:**
- `overrideSeconds = 0` and `null` both fall through to goal-profile logic
- `perceivedRpe = null` and `< 8` apply no multiplier
- All 5 goal profiles × compound/isolation (10 combos) table-driven
- `amrap` and `failure` set types apply 1.3× multiplier

17/17 tests pass, type check clean.

Closes #391