### PR TITLE
feat(coach): Gemma on-device scaffold — feasibility doc + stub provider + feature flag

### DIFF
--- a/docs/OVERNIGHT_CHANGELOG.md
+++ b/docs/OVERNIGHT_CHANGELOG.md
@@ -1,0 +1,49 @@
+# Overnight Changelog
+
+Tracks work done in headless `claude -p` overnight runs that needs
+follow-up from a human — particularly deferred dependencies, skipped
+native work, or changes that require a dev-client rebuild.
+
+---
+
+## 2026-04-15 — Gemma on-device coach scaffold (issue #415)
+
+**Deferred dep:** `react-native-executorch`
+
+**Why deferred:**
+- Overnight rules prohibit adding new runtime dependencies without human
+  review, and ExecuTorch requires a dev-client rebuild (changes to `ios/`
+  and `android/` native projects) that overnight mode cannot exercise.
+- The native module also needs on-device verification on at least one
+  physical iPhone 14 Pro / A16-class device before it can ship.
+
+**What landed tonight (safe, no native changes):**
+- `docs/gemma-integration.md` — full feasibility writeup (stack, numbers,
+  licensing, risks, rollout plan).
+- `lib/services/coach-local.ts` — provider stub that mirrors the
+  `sendCoachPrompt` interface and throws `COACH_LOCAL_NOT_AVAILABLE`.
+  All `react-native-executorch` integration points are marked with
+  `TODO(#415-followup)`.
+- `lib/services/coach-service.ts` — dispatcher that honours
+  `EXPO_PUBLIC_COACH_LOCAL === '1'`, tries local first, falls back to
+  cloud on the sentinel error. Flag defaults off → cloud behavior is
+  unchanged.
+- `tests/unit/services/coach-local.test.ts` — covers stub error shape
+  and dispatcher fallback path.
+
+**Follow-up work (daytime PRs):**
+1. `bun add react-native-executorch` + `bun run prebuild` + dev-client
+   rebuild. Verify `useLLM` boots on an iPhone 14 Pro dev device.
+2. Wire Expo Background Assets to download the Gemma 3 270M INT4 `.pte`
+   bundle. Opt-in, Wi-Fi-only, resumable.
+3. Replace `COACH_LOCAL_NOT_AVAILABLE` in `coach-local.ts` with a real
+   `generate()` call. Keep the error shape — cloud fallback must still
+   work if the model fails to load.
+4. Benchmark on target devices: throughput, TTFT, battery, thermal.
+5. Ship behind the flag to TestFlight beta, then default-on for A16+.
+
+**Verification done in this PR:**
+- `bun run lint` — clean (2 unrelated pre-existing warnings in
+  `app/(modals)/template-builder.tsx`).
+- `bun run check:types` — clean.
+- Unit tests for `coach-local` and existing `coach-service` tests pass.

--- a/docs/gemma-integration.md
+++ b/docs/gemma-integration.md
@@ -1,0 +1,122 @@
+# Gemma On-Device Coach — Integration Feasibility
+
+**Status:** Research complete. Scaffold in this PR. Full integration tracked in follow-up.
+**Last updated:** 2026-04-15
+**Related issue:** [#415](https://github.com/ThyDrSlen/form-factor/issues/415)
+
+---
+
+## 1. Why on-device?
+
+The current AI coach (`lib/services/coach-service.ts`) invokes a Supabase Edge Function
+(`supabase/functions/coach/`) that relays prompts to a cloud LLM. This path has three
+chronic problems during live workouts:
+
+1. **Latency** — network round-trip + cloud inference adds 1–3s to every reply.
+   Users drop their phone, start a set, and the coach arrives mid-rep.
+2. **Offline failure** — gyms and outdoor training regularly have no signal.
+   The current path simply errors (`COACH_INVOKE_FAILED`).
+3. **Unit economics** — every rep-cue prompt costs tokens. Scaling hot-takes
+   during sets is expensive.
+
+An on-device small model changes the primitives: sub-second time-to-first-token,
+zero network dependency, and effectively free per-token cost after weights are
+downloaded once.
+
+## 2. Recommended stack
+
+| Layer | Choice | Rationale |
+|-------|--------|-----------|
+| Model | **Gemma 3 270M-it, INT4 QAT** | ~240–300 MB on disk, fits <300 MB RAM, instruction-tuned variant already exists. |
+| Runtime | **`react-native-executorch`** (Software Mansion) | Expo-compatible, `useLLM` hook, ships Llama/Qwen/SmolLM examples. Active maintenance. |
+| Fallback runtime | `llama.rn` (mybigday) | If we can't export the model to `.pte` format, `.gguf` is broadly supported. |
+| Distribution | Expo Background Assets, Wi-Fi only, user opt-in | 300 MB is too large to bundle; must be lazy. |
+| Licensing | Gemma 4 Apache 2.0 preferred, Gemma 3 under Google's Gemma Terms | Surface LICENSE in Settings → Legal. |
+| Upgrade path | Gemma 4 E2B | Richer post-session summaries once 270M ships. |
+
+## 3. Expected numbers (iPhone 14 Pro, ANE)
+
+| Metric | Target | Source |
+|--------|--------|--------|
+| Throughput | 30–50 tok/s | ExecuTorch Gemma 3 270M INT4 benchmarks |
+| Time-to-first-token | < 300 ms | ExecuTorch warm-cache, ANE-resident |
+| 150-token reply | ~3–4 s | Derived from throughput |
+| Battery | ~0.75% per 25 conversations | Google Pixel 9 Pro Tensor G4 — ANE should match |
+| Disk | 240–300 MB | INT4 QAT weights + tokenizer |
+| RAM peak | < 300 MB | Held in ANE/GPU pool, not app heap |
+
+These are targets, not measurements. Validation is part of the follow-up PR.
+
+## 4. Licensing
+
+- **Gemma 3 / Gemma 4** ship under the [Gemma Terms of Use](https://ai.google.dev/gemma/terms).
+  Commercial redistribution is allowed with prominent attribution.
+- **Gemma 4 E2B (if we upgrade)** is Apache 2.0 — the easier path.
+- Action items before shipping:
+  - [ ] Add Gemma LICENSE text to Settings → Legal.
+  - [ ] Include the "Built with Gemma" attribution string where required.
+  - [ ] Document the model version + quantization in the release notes on first
+        ship so users can audit.
+
+## 5. Risks and mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Thermal: ARKit body-tracking + LLM decode on the same device | High | Only invoke Gemma **post-set** during rest, never mid-rep. Gate on thermal state via `DeviceThermalState`. |
+| Quality ceiling: 270M loses to Claude/GPT on free-form dialog | Medium | Keep cloud path as fallback for long-form chat; reserve on-device for short, structured cues. |
+| 300 MB first-launch download | Medium | Opt-in after onboarding. Wi-Fi-only gate. Show a progress indicator. Never auto-download on cellular. |
+| Weight export / `.pte` conversion fails | Low-Medium | `llama.rn` with `.gguf` is the documented fallback. |
+| Dev-client rebuild required for ExecuTorch native module | Low | Expected — document in follow-up PR release plan. |
+| Model drift: Google retracts terms or moves to non-commercial | Low | Pin model version; bundle license snapshot in-repo. |
+
+## 6. Scope of **this** PR (the scaffold)
+
+1. This feasibility document.
+2. `lib/services/coach-local.ts` — provider stub with the same signature as
+   `sendCoachPrompt`. Throws `COACH_LOCAL_NOT_AVAILABLE` until the real
+   implementation lands.
+3. `sendCoachPrompt` in `lib/services/coach-service.ts` now checks
+   `EXPO_PUBLIC_COACH_LOCAL === '1'`. When the flag is on it tries the local
+   provider first and falls back to cloud on `COACH_LOCAL_NOT_AVAILABLE`. When
+   the flag is off (default), behavior is **100% unchanged**.
+4. Unit tests: stub error shape + dispatcher fallback to cloud.
+5. Deferred-dependency note in `docs/OVERNIGHT_CHANGELOG.md`.
+
+## 7. Explicitly **out of scope** (follow-up work)
+
+- Adding `react-native-executorch` as a runtime dependency (requires a
+  dev-client rebuild and iOS native changes, both prohibited in overnight mode).
+- Downloading Gemma weights via Expo Background Assets.
+- Implementing the actual `useLLM`/`generate()` call inside `coach-local.ts`.
+- A/B comparison with the cloud coach (quality + latency + battery).
+- Telemetry hooks for thermal state and throttled fallbacks.
+
+## 8. Next steps (daytime PRs)
+
+1. **PR-1 (dev env):** Add `react-native-executorch` dep, rebuild dev client,
+   verify `useLLM` boot on an iPhone 14 Pro dev device.
+2. **PR-2 (asset pipeline):** Wire Expo Background Assets for the Gemma 3
+   270M INT4 `.pte` bundle. Opt-in screen + Wi-Fi gate + resumable download.
+3. **PR-3 (generation):** Replace the `COACH_LOCAL_NOT_AVAILABLE` stub in
+   `coach-local.ts` with a real `generate()` call. Keep the error shape —
+   cloud fallback should still work if the model fails to load.
+4. **PR-4 (validation):** Benchmark throughput, TTFT, battery on target
+   devices. Ship behind `EXPO_PUBLIC_COACH_LOCAL=1` to TestFlight beta.
+5. **PR-5 (GA):** Default flag on for supported devices (A16+). Retain cloud
+   fallback for older hardware and free-form long chat.
+
+## 9. Open questions
+
+- Do we ship the `.pte` bundle signed so we can detect weight corruption?
+- Which conversation surfaces use on-device vs cloud? (Proposal: rep cues +
+  short post-set summary = on-device. Free-form chat tab = cloud.)
+- How do we expose the flag in the UI — hidden dev toggle, Settings entry, or
+  purely env-driven for TestFlight?
+
+## 10. References
+
+- [Gemma models on Hugging Face](https://huggingface.co/google/gemma-3-270m)
+- [react-native-executorch docs](https://docs.swmansion.com/react-native-executorch/)
+- [ExecuTorch on-device LLM tutorial](https://pytorch.org/executorch/stable/llm/getting-started.html)
+- [llama.rn](https://github.com/mybigday/llama.rn) — GGUF fallback runtime
+- [Expo Background Assets](https://docs.expo.dev/versions/latest/sdk/background-assets/)

--- a/lib/services/coach-local.ts
+++ b/lib/services/coach-local.ts
@@ -1,0 +1,79 @@
+/**
+ * On-device coach provider stub.
+ *
+ * Mirrors the public interface of `lib/services/coach-service.ts` so the
+ * dispatcher in `sendCoachPrompt` can try this path first when the
+ * `EXPO_PUBLIC_COACH_LOCAL` flag is on and fall back to cloud cleanly.
+ *
+ * Real implementation will use `react-native-executorch` to load a
+ * quantized Gemma 3 270M (INT4 QAT) `.pte` bundle and call `useLLM().generate()`.
+ * See `docs/gemma-integration.md` for the stack, numbers, and rollout plan.
+ *
+ * For now every call throws a typed `COACH_LOCAL_NOT_AVAILABLE` error that
+ * the dispatcher recognizes as a signal to fall back to the cloud path. The
+ * error shape is stable and covered by unit tests — do not change it without
+ * also updating `coach-service.ts` and `tests/unit/services/coach-local.test.ts`.
+ */
+
+import { createError } from './ErrorHandler';
+import type { CoachContext, CoachMessage } from './coach-service';
+
+/**
+ * Stable error code the dispatcher looks for to trigger the cloud fallback.
+ * Keep in sync with the match in `coach-service.ts` and the test assertions.
+ */
+export const COACH_LOCAL_NOT_AVAILABLE = 'COACH_LOCAL_NOT_AVAILABLE';
+
+/**
+ * On-device variant of `sendCoachPrompt`. Same signature so the dispatcher
+ * can swap providers without changing its call sites.
+ *
+ * @throws AppError with `code === 'COACH_LOCAL_NOT_AVAILABLE'` while the
+ *         ExecuTorch runtime and Gemma weights are not wired up. The
+ *         dispatcher in `coach-service.ts` catches this and retries on cloud.
+ */
+export async function sendCoachPromptLocal(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _messages: CoachMessage[],
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _context?: CoachContext
+): Promise<CoachMessage> {
+  // TODO(#415-followup): load the Gemma 3 270M INT4 `.pte` bundle via
+  // `react-native-executorch` `useLLM`. Guard on Platform.OS === 'ios' and
+  // device capability (A16+). See docs/gemma-integration.md §8 (Next steps).
+
+  // TODO(#415-followup): fetch weights via Expo Background Assets on first
+  // launch, Wi-Fi-only, user opt-in. Surface the download progress to the UI.
+
+  // TODO(#415-followup): map `CoachMessage[]` into the Gemma chat template
+  // (system / user / model turns). Respect `context.focus` as a system-prompt
+  // prefix for per-exercise framing.
+
+  // TODO(#415-followup): call `llm.generate(prompt, { maxTokens: 256 })`
+  // and return `{ role: 'assistant', content: trimmed }`. Propagate thermal
+  // throttling and OOM as retryable errors so the cloud path can pick up.
+
+  throw createError(
+    'ml',
+    COACH_LOCAL_NOT_AVAILABLE,
+    'On-device coach is not available yet. Falling back to cloud.',
+    {
+      retryable: false,
+      severity: 'info',
+    }
+  );
+}
+
+/**
+ * Whether the on-device provider is ready to serve a prompt right now.
+ *
+ * Currently always `false` — the stub exists so the dispatcher and tests can
+ * compile against a stable surface area. Real implementation will check
+ * runtime availability + weights on disk + thermal/battery state.
+ */
+export async function isCoachLocalAvailable(): Promise<boolean> {
+  // TODO(#415-followup): return `true` when the ExecuTorch runtime has loaded
+  // the Gemma `.pte`, the device is not thermally throttled, and the battery
+  // is not in low-power mode.
+  return false;
+}

--- a/lib/services/coach-service.ts
+++ b/lib/services/coach-service.ts
@@ -29,10 +29,53 @@ interface RawCoachResponse {
 
 const functionName = (process.env.EXPO_PUBLIC_COACH_FUNCTION || 'coach').trim();
 
+/**
+ * Flag check is a function (not a module-level constant) so tests and runtime
+ * overrides can toggle `process.env.EXPO_PUBLIC_COACH_LOCAL` between calls.
+ */
+function isLocalCoachEnabled(): boolean {
+  return (process.env.EXPO_PUBLIC_COACH_LOCAL || '').trim() === '1';
+}
+
+/**
+ * Recognise the sentinel error thrown by `coach-local.ts` so we can fall back
+ * to the cloud path without swallowing other errors. Kept duck-typed so we
+ * don't circularly import the local provider (it imports `CoachMessage` from
+ * here).
+ */
+function isLocalUnavailableError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === 'COACH_LOCAL_NOT_AVAILABLE'
+  );
+}
+
 export async function sendCoachPrompt(
   messages: CoachMessage[],
   context?: CoachContext
 ): Promise<CoachMessage> {
+  // Feature-flagged on-device path. When the flag is off, this branch is
+  // skipped entirely and behavior matches the pre-flag implementation.
+  if (isLocalCoachEnabled()) {
+    try {
+      // Lazy require so the bundler does not pull the local provider (and its
+      // future ExecuTorch native dep) into builds where the flag is off.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { sendCoachPromptLocal } = require('./coach-local') as typeof import('./coach-local');
+      return await sendCoachPromptLocal(messages, context);
+    } catch (localErr) {
+      if (!isLocalUnavailableError(localErr)) {
+        // A real local-coach failure (e.g. OOM) should surface to the caller
+        // rather than silently escape to cloud.
+        throw localErr;
+      }
+      warnWithTs('[coach] Local coach unavailable, falling back to cloud');
+      // fall through to cloud path below
+    }
+  }
+
   try {
     const { data, error } = await supabase.functions.invoke<RawCoachResponse>(functionName, {
       body: { messages, context },

--- a/tests/unit/services/coach-local.test.ts
+++ b/tests/unit/services/coach-local.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for the on-device coach stub and the dispatcher fallback in
+ * `coach-service.ts`. See `docs/gemma-integration.md` for the full rollout
+ * plan.
+ */
+
+const mockInvoke = jest.fn();
+const mockInsert = jest.fn();
+const mockFrom = jest.fn(() => ({
+  insert: mockInsert,
+}));
+const mockCreateError = jest.fn(
+  (
+    domain: string,
+    code: string,
+    message: string,
+    opts?: { details?: unknown; retryable?: boolean; severity?: string }
+  ) => ({
+    domain,
+    code,
+    message,
+    retryable: opts?.retryable ?? false,
+    severity: opts?.severity ?? 'error',
+    details: opts?.details,
+  })
+);
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    functions: {
+      invoke: mockInvoke,
+    },
+    from: mockFrom,
+  },
+}));
+
+jest.mock('@/lib/services/ErrorHandler', () => ({
+  createError: mockCreateError,
+  logError: jest.fn(),
+}));
+
+jest.mock('../../../lib/services/ErrorHandler', () => ({
+  createError: mockCreateError,
+  logError: jest.fn(),
+}));
+
+describe('coach-local (stub provider)', () => {
+  // Load the module fresh for each block so the dispatcher flag can flip
+  // between tests without residual state.
+  let sendCoachPromptLocal: typeof import('@/lib/services/coach-local')['sendCoachPromptLocal'];
+  let isCoachLocalAvailable: typeof import('@/lib/services/coach-local')['isCoachLocalAvailable'];
+  let COACH_LOCAL_NOT_AVAILABLE: typeof import('@/lib/services/coach-local')['COACH_LOCAL_NOT_AVAILABLE'];
+
+  beforeAll(() => {
+    ({
+      sendCoachPromptLocal,
+      isCoachLocalAvailable,
+      COACH_LOCAL_NOT_AVAILABLE,
+    } = require('@/lib/services/coach-local'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('exports the stable COACH_LOCAL_NOT_AVAILABLE sentinel the dispatcher matches on', () => {
+    expect(COACH_LOCAL_NOT_AVAILABLE).toBe('COACH_LOCAL_NOT_AVAILABLE');
+  });
+
+  it('throws COACH_LOCAL_NOT_AVAILABLE with the expected shape', async () => {
+    await expect(
+      sendCoachPromptLocal([{ role: 'user', content: 'Help with my squat' }])
+    ).rejects.toMatchObject({
+      domain: 'ml',
+      code: 'COACH_LOCAL_NOT_AVAILABLE',
+      retryable: false,
+      severity: 'info',
+    });
+  });
+
+  it('throws even when a rich context is supplied (stub ignores inputs)', async () => {
+    await expect(
+      sendCoachPromptLocal(
+        [
+          { role: 'system', content: 'You are a coach.' },
+          { role: 'user', content: 'How should I brace?' },
+        ],
+        { profile: { id: 'user-1' }, focus: 'squat', sessionId: 'sess-1' }
+      )
+    ).rejects.toMatchObject({
+      code: 'COACH_LOCAL_NOT_AVAILABLE',
+    });
+  });
+
+  it('reports the provider as not ready from isCoachLocalAvailable()', async () => {
+    await expect(isCoachLocalAvailable()).resolves.toBe(false);
+  });
+});
+
+describe('coach-service dispatcher with EXPO_PUBLIC_COACH_LOCAL', () => {
+  const baseMessages = [{ role: 'user' as const, content: 'How should I squat?' }];
+  const originalFlag = process.env.EXPO_PUBLIC_COACH_LOCAL;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    mockInvoke.mockResolvedValue({ data: { message: 'Cloud reply.' }, error: null });
+    mockInsert.mockResolvedValue({ error: null });
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (originalFlag === undefined) {
+      delete process.env.EXPO_PUBLIC_COACH_LOCAL;
+    } else {
+      process.env.EXPO_PUBLIC_COACH_LOCAL = originalFlag;
+    }
+  });
+
+  it('falls back to cloud when local throws COACH_LOCAL_NOT_AVAILABLE', async () => {
+    process.env.EXPO_PUBLIC_COACH_LOCAL = '1';
+
+    const { sendCoachPrompt } = require('@/lib/services/coach-service') as typeof import('@/lib/services/coach-service');
+
+    const result = await sendCoachPrompt(baseMessages);
+
+    expect(result).toEqual({ role: 'assistant', content: 'Cloud reply.' });
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT try local when the flag is unset — cloud is the only path', async () => {
+    delete process.env.EXPO_PUBLIC_COACH_LOCAL;
+
+    // Spy on the local provider to confirm it is never invoked when flag is off.
+    const localModule = require('@/lib/services/coach-local') as typeof import('@/lib/services/coach-local');
+    const localSpy = jest.spyOn(localModule, 'sendCoachPromptLocal');
+
+    const { sendCoachPrompt } = require('@/lib/services/coach-service') as typeof import('@/lib/services/coach-service');
+
+    const result = await sendCoachPrompt(baseMessages);
+
+    expect(result).toEqual({ role: 'assistant', content: 'Cloud reply.' });
+    expect(localSpy).not.toHaveBeenCalled();
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT try local when the flag is set to something other than "1"', async () => {
+    process.env.EXPO_PUBLIC_COACH_LOCAL = 'true';
+
+    const localModule = require('@/lib/services/coach-local') as typeof import('@/lib/services/coach-local');
+    const localSpy = jest.spyOn(localModule, 'sendCoachPromptLocal');
+
+    const { sendCoachPrompt } = require('@/lib/services/coach-service') as typeof import('@/lib/services/coach-service');
+
+    await sendCoachPrompt(baseMessages);
+
+    expect(localSpy).not.toHaveBeenCalled();
+  });
+
+  it('re-throws non-sentinel local errors without trying cloud', async () => {
+    process.env.EXPO_PUBLIC_COACH_LOCAL = '1';
+
+    // Mock the local provider to throw a different kind of error (e.g. OOM).
+    // A real local failure should surface, not silently escape to cloud.
+    jest.doMock('@/lib/services/coach-local', () => ({
+      COACH_LOCAL_NOT_AVAILABLE: 'COACH_LOCAL_NOT_AVAILABLE',
+      sendCoachPromptLocal: jest.fn().mockRejectedValue({
+        domain: 'ml',
+        code: 'COACH_LOCAL_OOM',
+        message: 'Out of memory',
+        retryable: true,
+      }),
+      isCoachLocalAvailable: jest.fn().mockResolvedValue(false),
+    }));
+
+    const { sendCoachPrompt } = require('@/lib/services/coach-service') as typeof import('@/lib/services/coach-service');
+
+    await expect(sendCoachPrompt(baseMessages)).rejects.toMatchObject({
+      code: 'COACH_LOCAL_OOM',
+    });
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it('returns the local response directly when local succeeds (future path)', async () => {
+    process.env.EXPO_PUBLIC_COACH_LOCAL = '1';
+
+    jest.doMock('@/lib/services/coach-local', () => ({
+      COACH_LOCAL_NOT_AVAILABLE: 'COACH_LOCAL_NOT_AVAILABLE',
+      sendCoachPromptLocal: jest
+        .fn()
+        .mockResolvedValue({ role: 'assistant', content: 'On-device reply.' }),
+      isCoachLocalAvailable: jest.fn().mockResolvedValue(true),
+    }));
+
+    const { sendCoachPrompt } = require('@/lib/services/coach-service') as typeof import('@/lib/services/coach-service');
+
+    const result = await sendCoachPrompt(baseMessages);
+
+    expect(result).toEqual({ role: 'assistant', content: 'On-device reply.' });
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Scaffolds on-device Gemma coaching. Research doc added; local provider stub in place mirroring `coach-service.ts` interface; `EXPO_PUBLIC_COACH_LOCAL` feature flag wired through dispatcher with clean cloud fallback.

Does NOT add `react-native-executorch` — logged in `docs/OVERNIGHT_CHANGELOG.md` for a follow-up (needs dev-client rebuild).

## What's in this PR
- `docs/gemma-integration.md` — stack, numbers, licensing, risks, rollout plan
- `lib/services/coach-local.ts` — stub provider, throws `COACH_LOCAL_NOT_AVAILABLE`, TODOs marking future ExecuTorch integration points
- `lib/services/coach-service.ts` — dispatcher: `EXPO_PUBLIC_COACH_LOCAL === '1'` tries local first, falls back to cloud on sentinel error; re-throws other local errors (e.g. OOM) instead of silently escaping
- `docs/OVERNIGHT_CHANGELOG.md` — deferred-dep note + follow-up plan
- `tests/unit/services/coach-local.test.ts` — 9 tests covering stub error shape + 5 dispatcher paths (flag off, flag set wrong, flag on with local-unavailable → cloud, flag on with local-success, flag on with non-sentinel local error → rethrow)

## Cloud path is unchanged
When `EXPO_PUBLIC_COACH_LOCAL` is unset or `!== '1'`, `sendCoachPrompt` behaves identically — the local branch is skipped entirely. All 25 existing `coach-service` tests continue to pass.

## Verification
- [x] `bun run lint` — clean (2 unrelated pre-existing warnings in `app/(modals)/template-builder.tsx`)
- [x] `bun run check:types` — clean
- [x] `bunx jest tests/unit/services/coach-local.test.ts` — 9/9 pass
- [x] `bunx jest tests/unit/services/coach-service.test.ts` — 25/25 pass (no regressions)

## Hard bans honored
- No new dependencies added
- No changes to `ios/`, `android/`, `supabase/migrations/`, `.env*`, or `supabase/functions/coach/`
- No files modified by other open PRs (verified via `gh pr list`)

Closes #415