### PR TITLE
test(generic-sync): realign realtime-error assertion with ErrorHandler routing

### DIFF
--- a/tests/unit/services/database/generic-sync.test.ts
+++ b/tests/unit/services/database/generic-sync.test.ts
@@ -117,13 +117,14 @@ jest.mock('@/lib/logger', () => ({
 // Mock: ErrorHandler
 // ---------------------------------------------------------------------------
 
+const mockLogError = jest.fn();
 jest.mock('@/lib/services/ErrorHandler', () => ({
   createError: jest.fn((_domain: string, code: string, message: string) => ({
     domain: 'sync',
     code,
     message,
   })),
-  logError: jest.fn(),
+  logError: (...args: unknown[]) => mockLogError(...args),
 }));
 
 // ---------------------------------------------------------------------------
@@ -1228,9 +1229,18 @@ describe('handleGenericRealtimeChange', () => {
       handleGenericRealtimeChange(makeConfig(), payload, notifyCb, conflictCb),
     ).resolves.toBeUndefined();
 
-    expect(errorWithTs).toHaveBeenCalledWith(
-      expect.stringContaining('Error handling realtime'),
-      expect.any(Error),
+    // Error path routes through ErrorHandler.logError with an AppError whose
+    // message describes the failed realtime operation. The ErrorHandler mock
+    // captures the call; verify shape rather than the raw logger.
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: 'sync',
+        code: 'REALTIME_CHANGE_FAILED',
+        message: expect.stringContaining('Failed to apply realtime'),
+      }),
+      expect.objectContaining({
+        location: 'generic-sync.handleGenericRealtimeChange',
+      }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- `handleGenericRealtimeChange` routes catch-path errors through `ErrorHandler.logError(AppError, ctx)` — not the old `errorWithTs('Error handling realtime', error)` signature — but the test at `tests/unit/services/database/generic-sync.test.ts:1231` still asserted the old call.
- `logError` is mocked inside the test, so the mocked `errorWithTs` reference was never invoked. The assertion therefore failed on every run since the error-handler refactor.
- Updated the assertion to verify `logError` was called with the AppError shape `{ domain: 'sync', code: 'REALTIME_CHANGE_FAILED', message: stringContaining('Failed to apply realtime') }` and a context carrying `location: 'generic-sync.handleGenericRealtimeChange'`.
- Hoisted a `mockLogError` `jest.fn()` so the mock factory can keep referring to it (Jest hoists `jest.mock(...)` above variable declarations unless the referenced name starts with `mock`).

## Unblocks

Same test failure was blocking CI on #420, #421, #423, #424, #425. Those PRs should go green on re-run once this lands.

## Verification
- [x] `bunx jest tests/unit/services/database/generic-sync.test.ts` — 73/73 pass locally
- [x] `bun run lint` — clean (2 pre-existing warnings in `app/(modals)/template-builder.tsx`, unrelated)
- [x] `bun run check:types` — clean

Closes #422