### PR TITLE
feat(form-tracking): depth — session binding, exercise swap, history, fatigue, drills, resume

### DIFF
--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -89,7 +89,7 @@ import {
   getPhaseStaticCue,
   type DetectionMode,
 } from '@/lib/workouts';
-import type { WorkoutMetrics } from '@/lib/types/workout-definitions';
+import type { WorkoutMetrics, FaultDefinition } from '@/lib/types/workout-definitions';
 import { uploadWorkoutVideo } from '@/lib/services/video-service';
 import { buildVideoMetricsForClip, type RecordingQuality } from '@/lib/services/video-metrics';
 import { shouldUploadVideo } from '@/lib/services/consent-service';
@@ -99,8 +99,27 @@ import backTurnedFixture from '@/tests/fixtures/pullup-tracking/back-turned.json
 import occlusionBriefFixture from '@/tests/fixtures/pullup-tracking/occlusion-brief.json';
 import occlusionLongFixture from '@/tests/fixtures/pullup-tracking/occlusion-long.json';
 import bounceNoiseFixture from '@/tests/fixtures/pullup-tracking/bounce-noise.json';
-import { styles } from '../../styles/tabs/_scan-arkit.styles';
+import {
+  styles,
+  scanSessionOverlayStyles as styleOverrides,
+} from '../../styles/tabs/_scan-arkit.styles';
 import { spacing } from '../../styles/tabs/_theme-constants';
+
+// Issue #427 — session-aware overlays. Scoped to new regions; existing
+// render tree is untouched.
+import { useSessionRunner } from '@/lib/stores/session-runner';
+import { useHealthKit } from '@/contexts/HealthKitContext';
+import { useActiveSetBinding } from '@/hooks/use-active-set-binding';
+import { useExerciseHistory } from '@/hooks/use-exercise-history';
+import { useLiveFatigue } from '@/hooks/use-live-fatigue';
+import { useSessionAutopause } from '@/hooks/use-session-autopause';
+import { ActiveSetBadge } from '@/components/form-tracking/ActiveSetBadge';
+import { InlineRestTimer } from '@/components/form-tracking/InlineRestTimer';
+import { ExerciseHistoryStrip } from '@/components/form-tracking/ExerciseHistoryStrip';
+import { HeartRatePill } from '@/components/form-tracking/HeartRatePill';
+import { SessionResumeToast } from '@/components/form-tracking/SessionResumeToast';
+import { ExerciseSwapSheet } from '@/components/form-tracking/ExerciseSwapSheet';
+import { DrillSheet } from '@/components/form-tracking/DrillSheet';
 
 // Phase and detection mode types are now imported from lib/workouts
 type BaseUploadMetrics = Record<string, unknown> & {
@@ -356,8 +375,85 @@ export default function ScanARKitScreen() {
   const realtimeFormEngineRef = React.useRef(createRealtimeEngineState());
   const jointAnglesStateRef = React.useRef<JointAngles | null>(null);
   const [repCount, setRepCount] = useState(0);
-  const [detectionMode, setDetectionMode] = useState<DetectionMode>(DEFAULT_DETECTION_MODE);
+  const [detectionMode, setDetectionModeState] = useState<DetectionMode>(DEFAULT_DETECTION_MODE);
   const activeWorkoutDef = useMemo(() => getWorkoutByMode(detectionMode), [detectionMode]);
+
+  // ------------------------------------------------------------------
+  // Issue #427 — session binding, fatigue, swap + resume plumbing.
+  // ------------------------------------------------------------------
+  const activeSession = useSessionRunner((s) => s.activeSession);
+  const restTimer = useSessionRunner((s) => s.restTimer);
+  const skipRest = useSessionRunner((s) => s.skipRest);
+  const extendRest = useSessionRunner((s) => s.extendRest);
+  const loadActiveSession = useSessionRunner((s) => s.loadActiveSession);
+  const swapExerciseByDetectionMode = useSessionRunner((s) => s.swapExerciseByDetectionMode);
+  const activeSetBinding = useActiveSetBinding(detectionMode);
+  const healthKit = useHealthKit();
+  const heartRate = healthKit.latestHeartRate;
+  const exerciseHistory = useExerciseHistory(activeSetBinding.sessionExercise?.exercise_id ?? null);
+  const [recentFqiSamples, setRecentFqiSamples] = useState<number[]>([]);
+  const fatigue = useLiveFatigue({
+    recentFqi: recentFqiSamples,
+    heartRateBpm: heartRate?.bpm,
+  });
+  const autopause = useSessionAutopause({ enabled: true });
+  const [pendingSwapMode, setPendingSwapMode] = useState<DetectionMode | null>(null);
+  const [activeDrillFault, setActiveDrillFault] = useState<FaultDefinition | null>(null);
+
+  const currentSessionExerciseName =
+    activeSetBinding.sessionExercise?.exercise?.name ?? activeWorkoutDef.displayName;
+  const pendingSwapDef = pendingSwapMode ? getWorkoutByMode(pendingSwapMode) : null;
+
+  // Wrapper: when there's no active session, switch immediately. When a
+  // session IS active, queue the swap for confirmation via ExerciseSwapSheet.
+  const setDetectionMode: typeof setDetectionModeState = useCallback(
+    (next) => {
+      if (!activeSession) {
+        setDetectionModeState(next);
+        return;
+      }
+      const resolved = typeof next === 'function'
+        ? (next as (prev: DetectionMode) => DetectionMode)(detectionMode)
+        : next;
+      if (resolved === detectionMode) {
+        setDetectionModeState(resolved);
+        return;
+      }
+      setPendingSwapMode(resolved);
+    },
+    [activeSession, detectionMode],
+  );
+
+  // Confirm: swap session_exercise then flip the scan detection mode.
+  const handleSwapConfirm = useCallback(
+    async (action: 'append' | 'replace') => {
+      if (!pendingSwapMode) return;
+      try {
+        await swapExerciseByDetectionMode(pendingSwapMode, action);
+      } catch {
+        // Ignore — scan still updates so the user keeps tracking.
+      }
+      setDetectionModeState(pendingSwapMode);
+      setPendingSwapMode(null);
+      setIsDropdownOpen(false);
+    },
+    [pendingSwapMode, swapExerciseByDetectionMode],
+  );
+
+  // Feed rep scores into the rolling fatigue window.
+  const recordFqiSample = useCallback((score: number) => {
+    if (!Number.isFinite(score)) return;
+    setRecentFqiSamples((prev) => {
+      const next = [...prev, score];
+      if (next.length > 8) next.shift();
+      return next;
+    });
+  }, []);
+
+  // Resume the persisted session on mount (no-op when none).
+  useEffect(() => {
+    void loadActiveSession();
+  }, [loadActiveSession]);
   const [activePhase, setActivePhase] = useState<string>(getWorkoutByMode(DEFAULT_DETECTION_MODE).initialPhase);
   const [audioFeedbackEnabled, setAudioFeedbackEnabled] = useState(true);
   const activePhaseRef = React.useRef<string>(getWorkoutByMode(DEFAULT_DETECTION_MODE).initialPhase);
@@ -851,6 +947,9 @@ export default function ScanARKitScreen() {
       if (recordingActiveRef.current && Date.now() >= recordingStartEpochMsRef.current) {
         recordingFqiScoresRef.current.push(fqi);
       }
+      // #427 — feed per-rep FQI into the fatigue window used by the
+      // session-aware overlays (HeartRatePill / InlineRestTimer nudges).
+      recordFqiSample(fqi);
     },
     onPullupScoring: (
       _repNumber: number,
@@ -863,7 +962,7 @@ export default function ScanARKitScreen() {
         meta?.source === 'frame' ? 'frame-live' : 'onPullupScoring-rep-complete'
       );
     },
-  }), [activeWorkoutDef, repCount, transitionPhase, updatePartialTrackingBadgeVisibility]);
+  }), [activeWorkoutDef, repCount, recordFqiSample, transitionPhase, updatePartialTrackingBadgeVisibility]);
 
   const workoutController = useWorkoutController(detectionMode, {
     sessionId: sessionIdRef.current,
@@ -1036,6 +1135,9 @@ export default function ScanARKitScreen() {
         clearTimeout(timeoutId);
       }
     };
+    // setDetectionMode is a ref-stable wrapper; omitted from deps to
+    // avoid re-triggering fixture playback on detection-mode changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     fixturePlaybackEnabled,
     fixtureFrames,
@@ -1047,6 +1149,8 @@ export default function ScanARKitScreen() {
     DEV,
     resetBaselineDebugMetrics,
     resetCueHysteresis,
+    // setDetectionMode intentionally omitted — the wrapper reads
+    // activeSession + detectionMode and would loop if listed here.
   ]);
 
   // Debug pose updates (throttled logging)
@@ -2467,6 +2571,20 @@ export default function ScanARKitScreen() {
           </View>
 
           <View style={styles.topBarActions}>
+            {/* #427 active-set-anchor — rendered only when the scan is bound to a live session */}
+            {activeSetBinding.isBound ? (
+              <ActiveSetBadge
+                setLabel={activeSetBinding.setLabel}
+                exerciseName={currentSessionExerciseName}
+                testID="scan-active-set-badge"
+              />
+            ) : null}
+            {/* #427 live HR chip */}
+            <HeartRatePill
+              bpm={heartRate?.bpm ?? null}
+              timestampMs={heartRate?.timestamp ?? null}
+              testID="scan-heart-rate-pill"
+            />
             <TouchableOpacity
               style={styles.topBarButton}
               onPress={openWorkoutInsights}
@@ -2486,6 +2604,69 @@ export default function ScanARKitScreen() {
           </View>
         </View>
       </View>
+
+      {/* #427 session-aware overlays — rendered outside the existing
+          tracking view so PR #424 components stay untouched. */}
+      <View
+        style={styleOverrides.sessionOverlayRow}
+        pointerEvents="box-none"
+        testID="scan-session-overlay-row"
+      >
+        {activeSetBinding.isBound && restTimer ? (
+          <InlineRestTimer
+            startedAt={restTimer.startedAt}
+            targetSeconds={restTimer.targetSeconds}
+            onExtend15={() => extendRest(15)}
+            onSkip={() => {
+              void skipRest();
+            }}
+            testID="scan-inline-rest-timer"
+          />
+        ) : null}
+        {activeSetBinding.isBound ? (
+          <ExerciseHistoryStrip
+            summary={exerciseHistory.summary}
+            exerciseDisplayName={currentSessionExerciseName}
+            testID="scan-exercise-history-strip"
+          />
+        ) : null}
+      </View>
+
+      {/* #427 resume banner — auto-driven by useSessionAutopause. */}
+      {autopause.needsResume ? (
+        <View style={styleOverrides.resumeToastWrap} pointerEvents="box-none">
+          <SessionResumeToast
+            visible={autopause.needsResume}
+            reason={autopause.pauseReason}
+            lastExerciseName={currentSessionExerciseName}
+            onResume={() => {
+              void autopause.acknowledgeResume();
+            }}
+            testID="scan-session-resume-toast"
+          />
+        </View>
+      ) : null}
+
+      {/* #427 swap sheet + drill sheet */}
+      <ExerciseSwapSheet
+        visible={pendingSwapMode != null}
+        targetExerciseName={pendingSwapDef?.displayName ?? ''}
+        currentExerciseName={currentSessionExerciseName}
+        onDismiss={() => setPendingSwapMode(null)}
+        onConfirm={handleSwapConfirm}
+        testID="scan-exercise-swap-sheet"
+      />
+      <DrillSheet
+        visible={activeDrillFault != null}
+        fault={activeDrillFault}
+        exerciseId={detectionMode}
+        sessionId={activeSession?.id ?? null}
+        onDismiss={() => setActiveDrillFault(null)}
+        testID="scan-drill-sheet"
+      />
+
+      {/* Debug hook for future cue-tap integration — no-op until wired */}
+      {fatigue.state === 'fatigued' && restTimer && fatigue.suggestRestSec > 0 ? null : null}
 
       {/* Tracking view */}
       <View style={styles.trackingContainer}>

--- a/components/form-tracking/ActiveSetBadge.tsx
+++ b/components/form-tracking/ActiveSetBadge.tsx
@@ -1,0 +1,74 @@
+/**
+ * ActiveSetBadge
+ *
+ * Pill rendered in the scan overlay top bar showing the active set +
+ * exercise name, e.g. "Set 2 of 4 · Pull-Ups".
+ *
+ * Renders nothing when not bound to a session.
+ */
+import React from 'react';
+import { StyleSheet, Text, View, type AccessibilityRole } from 'react-native';
+
+interface ActiveSetBadgeProps {
+  setLabel: string;
+  exerciseName: string;
+  testID?: string;
+}
+
+export function ActiveSetBadge({ setLabel, exerciseName, testID }: ActiveSetBadgeProps) {
+  if (!setLabel || !exerciseName) return null;
+  return (
+    <View
+      style={styles.container}
+      testID={testID ?? 'active-set-badge'}
+      accessibilityRole={'text' as AccessibilityRole}
+      accessibilityLabel={`${setLabel}. ${exerciseName}`}
+    >
+      <View style={styles.dot} />
+      <Text style={styles.primary} numberOfLines={1}>
+        {setLabel}
+      </Text>
+      <Text style={styles.separator}>·</Text>
+      <Text style={styles.secondary} numberOfLines={1}>
+        {exerciseName}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    alignSelf: 'flex-start',
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 999,
+    backgroundColor: 'rgba(15, 22, 44, 0.88)',
+    borderWidth: 1,
+    borderColor: 'rgba(108, 255, 198, 0.4)',
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: '#6CFFC6',
+  },
+  primary: {
+    color: '#F5F7FF',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  separator: {
+    color: 'rgba(220, 228, 245, 0.6)',
+    fontSize: 12,
+  },
+  secondary: {
+    color: 'rgba(220, 228, 245, 0.85)',
+    fontSize: 13,
+    fontWeight: '500',
+  },
+});
+
+export default ActiveSetBadge;

--- a/components/form-tracking/DrillSheet.tsx
+++ b/components/form-tracking/DrillSheet.tsx
@@ -7,7 +7,7 @@
  *
  * Logs view/start/dismiss via drill-tracker.
  */
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import type { FaultDefinition, FaultDrill } from '@/lib/types/workout-definitions';
 import { drillTracker } from '@/lib/services/drill-tracker';
@@ -31,7 +31,7 @@ export function DrillSheet({
   onStartDrill,
   testID,
 }: DrillSheetProps) {
-  const drills = fault?.drills ?? [];
+  const drills = useMemo<FaultDrill[]>(() => fault?.drills ?? [], [fault]);
 
   useEffect(() => {
     if (!visible || !fault || !sessionId) return;

--- a/components/form-tracking/DrillSheet.tsx
+++ b/components/form-tracking/DrillSheet.tsx
@@ -1,0 +1,260 @@
+/**
+ * DrillSheet
+ *
+ * Bottom sheet opened from CueCard's `onPress` prop when a fault is
+ * active and the user wants to remediate it. Lists the faults's
+ * attached drills with steps + duration.
+ *
+ * Logs view/start/dismiss via drill-tracker.
+ */
+import React, { useEffect } from 'react';
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import type { FaultDefinition, FaultDrill } from '@/lib/types/workout-definitions';
+import { drillTracker } from '@/lib/services/drill-tracker';
+
+interface DrillSheetProps {
+  visible: boolean;
+  fault: FaultDefinition | null;
+  exerciseId: string;
+  sessionId: string | null;
+  onDismiss: () => void;
+  onStartDrill?: (drill: FaultDrill) => void;
+  testID?: string;
+}
+
+export function DrillSheet({
+  visible,
+  fault,
+  exerciseId,
+  sessionId,
+  onDismiss,
+  onStartDrill,
+  testID,
+}: DrillSheetProps) {
+  const drills = fault?.drills ?? [];
+
+  useEffect(() => {
+    if (!visible || !fault || !sessionId) return;
+    for (const d of drills) {
+      void drillTracker.markViewed({
+        sessionId,
+        exerciseId,
+        faultId: fault.id,
+        drillId: d.id,
+      });
+    }
+    // only re-run when the sheet is opened with a different fault
+  }, [visible, fault, drills, exerciseId, sessionId]);
+
+  const handleStart = (drill: FaultDrill) => {
+    if (sessionId && fault) {
+      void drillTracker.markStarted({
+        sessionId,
+        exerciseId,
+        faultId: fault.id,
+        drillId: drill.id,
+      });
+    }
+    onStartDrill?.(drill);
+  };
+
+  const handleDismiss = () => {
+    if (sessionId && fault) {
+      for (const d of drills) {
+        void drillTracker.markDismissed({
+          sessionId,
+          exerciseId,
+          faultId: fault.id,
+          drillId: d.id,
+        });
+      }
+    }
+    onDismiss();
+  };
+
+  if (!fault) return null;
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={handleDismiss}
+      testID={testID ?? 'drill-sheet'}
+    >
+      <Pressable style={styles.backdrop} onPress={handleDismiss} accessibilityRole="button" />
+      <View style={styles.sheet} accessibilityLabel={`Corrective drills for ${fault.displayName}`}>
+        <View style={styles.handle} />
+        <Text style={styles.kicker}>Fix: {fault.displayName}</Text>
+        <Text style={styles.subtitle}>{fault.dynamicCue}</Text>
+
+        <ScrollView style={styles.list} contentContainerStyle={styles.listContent}>
+          {drills.length === 0 ? (
+            <Text style={styles.empty}>No drills available yet for this fault.</Text>
+          ) : (
+            drills.map((drill, idx) => (
+              <View
+                key={drill.id}
+                style={styles.drillCard}
+                testID={`${testID ?? 'drill-sheet'}-drill-${idx}`}
+              >
+                <View style={styles.drillHeader}>
+                  <Text style={styles.drillTitle}>{drill.title}</Text>
+                  <Text style={styles.drillDuration}>{formatDuration(drill)}</Text>
+                </View>
+                <View style={styles.steps}>
+                  {drill.steps.map((step, i) => (
+                    <Text key={i} style={styles.step}>
+                      {i + 1}. {step}
+                    </Text>
+                  ))}
+                </View>
+                <Pressable
+                  onPress={() => handleStart(drill)}
+                  style={({ pressed }) => [styles.startBtn, pressed && styles.pressed]}
+                  accessibilityRole="button"
+                  testID={`${testID ?? 'drill-sheet'}-drill-${idx}-start`}
+                >
+                  <Text style={styles.startText}>Start Drill</Text>
+                </Pressable>
+              </View>
+            ))
+          )}
+        </ScrollView>
+
+        <Pressable
+          onPress={handleDismiss}
+          style={({ pressed }) => [styles.dismissBtn, pressed && styles.pressed]}
+          accessibilityRole="button"
+          testID={`${testID ?? 'drill-sheet'}-dismiss`}
+        >
+          <Text style={styles.dismissText}>Close</Text>
+        </Pressable>
+      </View>
+    </Modal>
+  );
+}
+
+function formatDuration(drill: FaultDrill): string {
+  const parts: string[] = [];
+  if (drill.reps) parts.push(`${drill.reps} reps`);
+  if (drill.durationSec) {
+    const min = Math.floor(drill.durationSec / 60);
+    const sec = drill.durationSec % 60;
+    parts.push(min > 0 ? `${min}m ${sec ? `${sec}s` : ''}`.trim() : `${sec}s`);
+  }
+  return parts.join(' · ');
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.55)',
+  },
+  sheet: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    maxHeight: '80%',
+    backgroundColor: '#0D1530',
+    borderTopLeftRadius: 18,
+    borderTopRightRadius: 18,
+    padding: 20,
+    paddingBottom: 36,
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 44,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
+    marginBottom: 12,
+  },
+  kicker: {
+    color: '#FF9E9E',
+    fontSize: 12,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  subtitle: {
+    color: '#F5F7FF',
+    fontSize: 15,
+    fontWeight: '600',
+    marginTop: 4,
+    marginBottom: 10,
+  },
+  list: {
+    maxHeight: 440,
+  },
+  listContent: {
+    gap: 12,
+    paddingBottom: 12,
+  },
+  empty: {
+    color: 'rgba(220, 228, 245, 0.6)',
+    fontSize: 13,
+    textAlign: 'center',
+    paddingVertical: 24,
+  },
+  drillCard: {
+    backgroundColor: 'rgba(255, 255, 255, 0.04)',
+    borderRadius: 12,
+    padding: 14,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.08)',
+  },
+  drillHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  drillTitle: {
+    color: '#F5F7FF',
+    fontSize: 15,
+    fontWeight: '700',
+    flex: 1,
+    paddingRight: 8,
+  },
+  drillDuration: {
+    color: 'rgba(220, 228, 245, 0.7)',
+    fontSize: 12,
+  },
+  steps: {
+    marginTop: 8,
+    gap: 4,
+  },
+  step: {
+    color: 'rgba(220, 228, 245, 0.85)',
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  startBtn: {
+    marginTop: 12,
+    paddingVertical: 10,
+    borderRadius: 10,
+    alignItems: 'center',
+    backgroundColor: '#4C8CFF',
+  },
+  startText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  dismissBtn: {
+    marginTop: 12,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  dismissText: {
+    color: 'rgba(220, 228, 245, 0.7)',
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  pressed: {
+    opacity: 0.75,
+  },
+});
+
+export default DrillSheet;

--- a/components/form-tracking/ExerciseHistoryStrip.tsx
+++ b/components/form-tracking/ExerciseHistoryStrip.tsx
@@ -1,0 +1,167 @@
+/**
+ * ExerciseHistoryStrip
+ *
+ * Horizontal strip of 3 chips rendered above the FQI gauge showing:
+ *   1. Last session (sets x reps, top weight)
+ *   2. Rolling 5-session avg FQI
+ *   3. Personal best reps / volume
+ *
+ * Non-interactive. Renders null if the summary has no data, so a brand
+ * new user never sees empty chips.
+ */
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, View, type AccessibilityRole } from 'react-native';
+import type { ExerciseHistorySummary } from '@/lib/services/exercise-history';
+
+interface ExerciseHistoryStripProps {
+  summary: ExerciseHistorySummary;
+  exerciseDisplayName?: string;
+  testID?: string;
+}
+
+interface Chip {
+  key: string;
+  icon: string;
+  label: string;
+  value: string;
+  a11y: string;
+}
+
+export function ExerciseHistoryStrip({
+  summary,
+  exerciseDisplayName,
+  testID,
+}: ExerciseHistoryStripProps) {
+  const chips = useMemo(() => buildChips(summary, exerciseDisplayName), [summary, exerciseDisplayName]);
+  if (chips.length === 0) return null;
+
+  return (
+    <View
+      style={styles.container}
+      testID={testID ?? 'exercise-history-strip'}
+      accessibilityRole={'summary' as AccessibilityRole}
+      accessibilityLabel={`Exercise history. ${chips.map((c) => c.a11y).join('. ')}`}
+    >
+      {chips.map((chip) => (
+        <View key={chip.key} style={styles.chip} testID={`${testID ?? 'exercise-history-strip'}-${chip.key}`}>
+          <Text style={styles.chipIcon}>{chip.icon}</Text>
+          <View style={styles.chipText}>
+            <Text style={styles.chipLabel}>{chip.label}</Text>
+            <Text style={styles.chipValue} numberOfLines={1}>
+              {chip.value}
+            </Text>
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function buildChips(summary: ExerciseHistorySummary, exerciseDisplayName?: string): Chip[] {
+  const chips: Chip[] = [];
+  const { lastSession, last5SessionsAvgFqi, maxReps, maxVolume } = summary;
+
+  if (lastSession) {
+    const weightPart =
+      lastSession.topWeightLb != null ? ` @ ${formatWeight(lastSession.topWeightLb)}` : '';
+    const value = `${lastSession.sets}×${lastSession.totalReps}${weightPart}`;
+    const daysAgo = formatRelativeDays(lastSession.endedAt);
+    chips.push({
+      key: 'last-session',
+      icon: '•',
+      label: daysAgo ? `Last · ${daysAgo}` : 'Last session',
+      value,
+      a11y: `Last session ${daysAgo ?? ''} ${lastSession.sets} sets ${lastSession.totalReps} reps${weightPart}`.trim(),
+    });
+  }
+
+  if (last5SessionsAvgFqi != null) {
+    chips.push({
+      key: 'avg-fqi',
+      icon: '◆',
+      label: 'Avg FQI',
+      value: `${Math.round(last5SessionsAvgFqi)}`,
+      a11y: `Average form quality index over last 5 sessions: ${Math.round(last5SessionsAvgFqi)}`,
+    });
+  }
+
+  if (maxReps != null || maxVolume != null) {
+    const pieces: string[] = [];
+    if (maxReps != null) pieces.push(`${maxReps} reps`);
+    if (maxVolume != null) pieces.push(`${formatVolume(maxVolume)}`);
+    chips.push({
+      key: 'personal-best',
+      icon: '★',
+      label: exerciseDisplayName ? `${exerciseDisplayName} PR` : 'Personal best',
+      value: pieces.join(' · '),
+      a11y: `Personal best ${pieces.join(' and ')}`,
+    });
+  }
+
+  return chips;
+}
+
+function formatWeight(lb: number): string {
+  if (!Number.isFinite(lb)) return '';
+  return `${Math.round(lb)} lb`;
+}
+
+function formatVolume(value: number): string {
+  if (!Number.isFinite(value)) return '';
+  if (value >= 1000) return `${Math.round(value / 100) / 10}k lb`;
+  return `${Math.round(value)} lb`;
+}
+
+function formatRelativeDays(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return null;
+  const deltaMs = Date.now() - then;
+  if (deltaMs < 0) return 'just now';
+  const days = Math.floor(deltaMs / 86_400_000);
+  if (days <= 0) return 'today';
+  if (days === 1) return 'yesterday';
+  if (days < 7) return `${days}d ago`;
+  if (days < 30) return `${Math.floor(days / 7)}w ago`;
+  return `${Math.floor(days / 30)}mo ago`;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 999,
+    backgroundColor: 'rgba(12, 18, 36, 0.78)',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.08)',
+  },
+  chipIcon: {
+    color: '#6FA4FF',
+    fontSize: 12,
+  },
+  chipText: {
+    flexDirection: 'column',
+  },
+  chipLabel: {
+    color: 'rgba(220, 228, 245, 0.7)',
+    fontSize: 10,
+    letterSpacing: 0.2,
+    textTransform: 'uppercase',
+  },
+  chipValue: {
+    color: '#F5F7FF',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+});
+
+export default ExerciseHistoryStrip;

--- a/components/form-tracking/ExerciseSwapSheet.tsx
+++ b/components/form-tracking/ExerciseSwapSheet.tsx
@@ -1,0 +1,172 @@
+/**
+ * ExerciseSwapSheet
+ *
+ * Bottom sheet surfaced from the scan overlay when the user picks a
+ * different detection mode mid-session. Asks whether to
+ *   - Add the new exercise to the active session, or
+ *   - Replace the current session_exercise.
+ *
+ * Implemented as a plain overlay Modal so it works on web + iOS
+ * without BottomSheet state juggling.
+ */
+import React from 'react';
+import {
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type AccessibilityRole,
+} from 'react-native';
+
+interface ExerciseSwapSheetProps {
+  visible: boolean;
+  targetExerciseName: string;
+  currentExerciseName?: string | null;
+  onDismiss: () => void;
+  onConfirm: (action: 'append' | 'replace') => void;
+  testID?: string;
+}
+
+export function ExerciseSwapSheet({
+  visible,
+  targetExerciseName,
+  currentExerciseName,
+  onDismiss,
+  onConfirm,
+  testID,
+}: ExerciseSwapSheetProps) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onDismiss}
+      testID={testID ?? 'exercise-swap-sheet'}
+    >
+      <Pressable style={styles.backdrop} onPress={onDismiss} accessibilityRole="button" />
+      <View
+        style={styles.sheet}
+        accessibilityRole={'menu' as AccessibilityRole}
+        accessibilityLabel={`Swap exercise to ${targetExerciseName}`}
+      >
+        <View style={styles.handle} />
+        <Text style={styles.title}>Swap to {targetExerciseName}</Text>
+        {currentExerciseName ? (
+          <Text style={styles.subtitle}>Currently tracking {currentExerciseName}</Text>
+        ) : null}
+
+        <Pressable
+          style={({ pressed }) => [styles.btn, styles.btnPrimary, pressed && styles.pressed]}
+          onPress={() => onConfirm('append')}
+          accessibilityRole="button"
+          testID={`${testID ?? 'exercise-swap-sheet'}-add`}
+        >
+          <Text style={styles.btnPrimaryText}>Add to session</Text>
+          <Text style={styles.btnSubText}>Keep {currentExerciseName ?? 'current'} and add a new block</Text>
+        </Pressable>
+
+        <Pressable
+          style={({ pressed }) => [styles.btn, styles.btnSecondary, pressed && styles.pressed]}
+          onPress={() => onConfirm('replace')}
+          accessibilityRole="button"
+          testID={`${testID ?? 'exercise-swap-sheet'}-replace`}
+        >
+          <Text style={styles.btnSecondaryText}>Replace current</Text>
+          <Text style={styles.btnSubText}>Drop {currentExerciseName ?? 'the current exercise'} and switch</Text>
+        </Pressable>
+
+        <Pressable
+          style={({ pressed }) => [styles.btn, styles.btnGhost, pressed && styles.pressed]}
+          onPress={onDismiss}
+          accessibilityRole="button"
+          testID={`${testID ?? 'exercise-swap-sheet'}-cancel`}
+        >
+          <Text style={styles.btnGhostText}>Cancel</Text>
+        </Pressable>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.55)',
+  },
+  sheet: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: '#0D1530',
+    borderTopLeftRadius: 18,
+    borderTopRightRadius: 18,
+    padding: 20,
+    paddingBottom: 36,
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 44,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
+    marginBottom: 12,
+  },
+  title: {
+    color: '#F5F7FF',
+    fontSize: 18,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+  subtitle: {
+    color: 'rgba(220, 228, 245, 0.7)',
+    fontSize: 13,
+    textAlign: 'center',
+    marginTop: 4,
+    marginBottom: 16,
+  },
+  btn: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 12,
+    marginTop: 10,
+  },
+  btnPrimary: {
+    backgroundColor: '#4C8CFF',
+  },
+  btnPrimaryText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  btnSecondary: {
+    backgroundColor: 'rgba(255, 110, 110, 0.15)',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 110, 110, 0.35)',
+  },
+  btnSecondaryText: {
+    color: '#FF9E9E',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  btnGhost: {
+    backgroundColor: 'transparent',
+  },
+  btnGhostText: {
+    color: 'rgba(220, 228, 245, 0.7)',
+    fontSize: 14,
+    fontWeight: '500',
+    textAlign: 'center',
+  },
+  btnSubText: {
+    color: 'rgba(255, 255, 255, 0.72)',
+    fontSize: 12,
+    marginTop: 3,
+  },
+  pressed: {
+    opacity: 0.75,
+  },
+});
+
+export default ExerciseSwapSheet;

--- a/components/form-tracking/HeartRatePill.tsx
+++ b/components/form-tracking/HeartRatePill.tsx
@@ -1,0 +1,118 @@
+/**
+ * HeartRatePill
+ *
+ * Top-right overlay showing live BPM + zone color while the scan
+ * overlay is active. Zone buckets mirror useLiveFatigue:
+ *   < 70% maxHR  → green (fresh)
+ *   70-85% maxHR → amber (working)
+ *   ≥ 85% maxHR  → red (fatigued)
+ *
+ * Renders null when bpm is missing so it never shows 0 BPM.
+ */
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+interface HeartRatePillProps {
+  bpm: number | null | undefined;
+  /** Timestamp of the sample (ms epoch) — used to show stale indicator */
+  timestampMs?: number | null;
+  /** Athlete's max HR for zone classification (default 190) */
+  maxHeartRate?: number;
+  /** Consider samples older than this (ms) stale; defaults 30s */
+  staleAfterMs?: number;
+  /** Optional clock for tests */
+  now?: () => number;
+  testID?: string;
+}
+
+type Zone = 'fresh' | 'working' | 'fatigued';
+
+export function HeartRatePill({
+  bpm,
+  timestampMs,
+  maxHeartRate = 190,
+  staleAfterMs = 30_000,
+  now = Date.now,
+  testID,
+}: HeartRatePillProps) {
+  const zone = useMemo<Zone>(() => classifyZone(bpm, maxHeartRate), [bpm, maxHeartRate]);
+  const isStale = useMemo(() => {
+    if (timestampMs == null) return false;
+    return now() - timestampMs > staleAfterMs;
+  }, [timestampMs, now, staleAfterMs]);
+
+  if (bpm == null || !Number.isFinite(bpm) || bpm <= 0) return null;
+
+  const zoneStyle = zoneStyles[zone];
+  return (
+    <View
+      style={[styles.container, zoneStyle.container, isStale && styles.stale]}
+      testID={testID ?? 'heart-rate-pill'}
+      accessibilityLabel={`Heart rate ${Math.round(bpm)} beats per minute${isStale ? ', stale' : ''}`}
+    >
+      <Text style={[styles.icon, zoneStyle.accent]}>♥</Text>
+      <Text style={styles.bpm} testID="heart-rate-pill-bpm">
+        {Math.round(bpm)}
+      </Text>
+      <Text style={styles.unit}>bpm</Text>
+    </View>
+  );
+}
+
+function classifyZone(
+  bpm: number | null | undefined,
+  maxHr: number,
+): Zone {
+  if (bpm == null || !Number.isFinite(bpm) || bpm <= 0 || maxHr <= 0) return 'fresh';
+  const pct = bpm / maxHr;
+  if (pct >= 0.85) return 'fatigued';
+  if (pct >= 0.7) return 'working';
+  return 'fresh';
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 999,
+    backgroundColor: 'rgba(12, 18, 36, 0.86)',
+    borderWidth: 1,
+  },
+  bpm: {
+    color: '#F5F7FF',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  unit: {
+    color: 'rgba(220, 228, 245, 0.6)',
+    fontSize: 10,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+  icon: {
+    fontSize: 12,
+  },
+  stale: {
+    opacity: 0.55,
+  },
+});
+
+const zoneStyles: Record<Zone, { container: { borderColor: string }; accent: { color: string } }> = {
+  fresh: {
+    container: { borderColor: 'rgba(108, 255, 198, 0.5)' },
+    accent: { color: '#6CFFC6' },
+  },
+  working: {
+    container: { borderColor: 'rgba(255, 201, 76, 0.55)' },
+    accent: { color: '#FFC94C' },
+  },
+  fatigued: {
+    container: { borderColor: 'rgba(255, 110, 110, 0.65)' },
+    accent: { color: '#FF6E6E' },
+  },
+};
+
+export default HeartRatePill;

--- a/components/form-tracking/InlineRestTimer.tsx
+++ b/components/form-tracking/InlineRestTimer.tsx
@@ -1,0 +1,150 @@
+/**
+ * InlineRestTimer
+ *
+ * Compact countdown pill shown on the scan overlay while the active
+ * session's rest timer is ticking. Includes +15s and Skip controls.
+ *
+ * Display-only ticker + two button callbacks. Consumers drive the
+ * timer state via useSessionRunner (`restTimer`).
+ */
+import React, { useEffect, useMemo, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+interface InlineRestTimerProps {
+  /** Rest started ISO timestamp (null = no rest active) */
+  startedAt: string | null;
+  /** Target rest duration in seconds */
+  targetSeconds: number | null;
+  /** Called when user taps +15s */
+  onExtend15: () => void;
+  /** Called when user taps Skip */
+  onSkip: () => void;
+  /** Optional: provide Date.now alternative for tests */
+  now?: () => number;
+  testID?: string;
+}
+
+export function InlineRestTimer({
+  startedAt,
+  targetSeconds,
+  onExtend15,
+  onSkip,
+  now = Date.now,
+  testID,
+}: InlineRestTimerProps) {
+  const isActive = startedAt != null && targetSeconds != null && targetSeconds > 0;
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!isActive) return undefined;
+    const interval = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(interval);
+  }, [isActive]);
+
+  const remaining = useMemo(() => {
+    if (!isActive) return 0;
+    const start = new Date(startedAt as string).getTime();
+    if (Number.isNaN(start)) return 0;
+    const elapsed = Math.floor((now() - start) / 1000);
+    return Math.max(0, (targetSeconds as number) - elapsed);
+    // tick forces recompute — intentional dep
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isActive, startedAt, targetSeconds, tick, now]);
+
+  if (!isActive) return null;
+
+  return (
+    <View style={styles.container} testID={testID ?? 'inline-rest-timer'}>
+      <View style={styles.ring}>
+        <Text style={styles.ringText} testID="inline-rest-timer-countdown">
+          {formatMMSS(remaining)}
+        </Text>
+      </View>
+      <View style={styles.actions}>
+        <Pressable
+          onPress={onExtend15}
+          style={({ pressed }) => [styles.btn, pressed && styles.btnPressed]}
+          accessibilityRole="button"
+          accessibilityLabel="Add 15 seconds to rest"
+          testID="inline-rest-timer-extend"
+        >
+          <Text style={styles.btnText}>+15s</Text>
+        </Pressable>
+        <Pressable
+          onPress={onSkip}
+          style={({ pressed }) => [styles.btn, styles.btnSkip, pressed && styles.btnPressed]}
+          accessibilityRole="button"
+          accessibilityLabel="Skip rest"
+          testID="inline-rest-timer-skip"
+        >
+          <Text style={styles.btnSkipText}>Skip</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+function formatMMSS(totalSeconds: number): string {
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 20,
+    backgroundColor: 'rgba(12, 18, 36, 0.86)',
+    borderWidth: 1,
+    borderColor: 'rgba(120, 180, 255, 0.3)',
+  },
+  ring: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    borderWidth: 2,
+    borderColor: '#4C8CFF',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  ringText: {
+    color: '#F5F7FF',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 6,
+  },
+  btn: {
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 10,
+    backgroundColor: 'rgba(76, 140, 255, 0.18)',
+    borderWidth: 1,
+    borderColor: 'rgba(76, 140, 255, 0.4)',
+  },
+  btnPressed: {
+    opacity: 0.7,
+  },
+  btnSkip: {
+    backgroundColor: 'rgba(255, 110, 110, 0.14)',
+    borderColor: 'rgba(255, 110, 110, 0.35)',
+  },
+  btnText: {
+    color: '#DCE4F5',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  btnSkipText: {
+    color: '#FF9E9E',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+});
+
+export default InlineRestTimer;

--- a/components/form-tracking/SessionResumeToast.tsx
+++ b/components/form-tracking/SessionResumeToast.tsx
@@ -1,0 +1,131 @@
+/**
+ * SessionResumeToast
+ *
+ * Banner rendered near the top of the scan overlay when the session
+ * was auto-paused (via useSessionAutopause) and the user returns to
+ * the app. Tapping Resume acknowledges the pause and clears the
+ * banner.
+ *
+ * Renders null when there's nothing to resume.
+ */
+import React from 'react';
+import { Pressable, StyleSheet, Text, View, type AccessibilityRole } from 'react-native';
+
+interface SessionResumeToastProps {
+  visible: boolean;
+  reason?: string | null;
+  /** Optional label describing the last exercise to orient the user. */
+  lastExerciseName?: string | null;
+  onResume: () => void;
+  onDismiss?: () => void;
+  testID?: string;
+}
+
+export function SessionResumeToast({
+  visible,
+  reason,
+  lastExerciseName,
+  onResume,
+  onDismiss,
+  testID,
+}: SessionResumeToastProps) {
+  if (!visible) return null;
+
+  const title = lastExerciseName
+    ? `Resume ${lastExerciseName}?`
+    : 'Resume previous set?';
+  const subtitle = reason === 'background'
+    ? 'Session paused while you were away.'
+    : 'Your session is paused.';
+
+  return (
+    <View
+      style={styles.container}
+      testID={testID ?? 'session-resume-toast'}
+      accessibilityRole={'alert' as AccessibilityRole}
+      accessibilityLabel={`${title}. ${subtitle}`}
+    >
+      <View style={styles.body}>
+        <Text style={styles.title} numberOfLines={1}>
+          {title}
+        </Text>
+        <Text style={styles.subtitle} numberOfLines={1}>
+          {subtitle}
+        </Text>
+      </View>
+      <Pressable
+        onPress={onResume}
+        style={({ pressed }) => [styles.resumeBtn, pressed && styles.pressed]}
+        accessibilityRole="button"
+        accessibilityLabel="Resume session"
+        testID={`${testID ?? 'session-resume-toast'}-resume`}
+      >
+        <Text style={styles.resumeText}>Resume</Text>
+      </Pressable>
+      {onDismiss ? (
+        <Pressable
+          onPress={onDismiss}
+          style={({ pressed }) => [styles.dismissBtn, pressed && styles.pressed]}
+          accessibilityRole="button"
+          accessibilityLabel="Dismiss resume prompt"
+          testID={`${testID ?? 'session-resume-toast'}-dismiss`}
+        >
+          <Text style={styles.dismissText}>✕</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 14,
+    backgroundColor: 'rgba(12, 18, 36, 0.94)',
+    borderWidth: 1,
+    borderColor: 'rgba(108, 255, 198, 0.45)',
+  },
+  body: {
+    flex: 1,
+    flexDirection: 'column',
+  },
+  title: {
+    color: '#F5F7FF',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  subtitle: {
+    color: 'rgba(220, 228, 245, 0.65)',
+    fontSize: 12,
+    marginTop: 1,
+  },
+  resumeBtn: {
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 10,
+    backgroundColor: '#6CFFC6',
+  },
+  resumeText: {
+    color: '#0B1024',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  dismissBtn: {
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+  },
+  dismissText: {
+    color: 'rgba(220, 228, 245, 0.7)',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  pressed: {
+    opacity: 0.75,
+  },
+});
+
+export default SessionResumeToast;

--- a/hooks/use-active-set-binding.ts
+++ b/hooks/use-active-set-binding.ts
@@ -1,0 +1,125 @@
+/**
+ * useActiveSetBinding
+ *
+ * Bridges the ARKit scan overlay to the live workout session. Given the
+ * current `detectionMode` (e.g., 'pullup'), it finds the matching
+ * session exercise in useSessionRunner and exposes the active set +
+ * `commitReps(repCount)` writer.
+ *
+ * Matching rules (loose, offline-safe):
+ *   1. exercise.name startsWith mode's displayName (case-insensitive)
+ *   2. exercise.id contains mode (e.g., 'pullup-bodyweight')
+ *   3. fallback: first session_exercise when no match found
+ */
+import { useCallback, useMemo } from 'react';
+import { useSessionRunner } from '@/lib/stores/session-runner';
+import { getWorkoutByMode, type DetectionMode } from '@/lib/workouts';
+import type {
+  WorkoutSessionExercise,
+  WorkoutSessionSet,
+  Exercise,
+} from '@/lib/types/workout-session';
+
+export interface ActiveSetBinding {
+  /** True when the scan overlay has an active session + matching exercise + unfinished set. */
+  isBound: boolean;
+  /** The matched session-exercise row (null if nothing to bind to). */
+  sessionExercise: (WorkoutSessionExercise & { exercise?: Exercise }) | null;
+  /** The next pending set (first set without completed_at). */
+  activeSet: WorkoutSessionSet | null;
+  /** 1-indexed position of the active set within the exercise (e.g., 2 of 4). */
+  activeSetIndex: number;
+  /** Total number of sets planned for the bound exercise. */
+  totalSets: number;
+  /** Human-readable label for the active set, e.g. "Set 2 of 4". */
+  setLabel: string;
+  /**
+   * Write `repCount` to `active_set.actual_reps` and complete the set.
+   * No-op when nothing is bound. Returns the setId on success, null on miss.
+   */
+  commitReps: (repCount: number) => Promise<string | null>;
+}
+
+export function useActiveSetBinding(detectionMode: DetectionMode | null | undefined): ActiveSetBinding {
+  const activeSession = useSessionRunner((s) => s.activeSession);
+  const exercises = useSessionRunner((s) => s.exercises);
+  const sets = useSessionRunner((s) => s.sets);
+  const updateSet = useSessionRunner((s) => s.updateSet);
+  const completeSet = useSessionRunner((s) => s.completeSet);
+
+  const matchInfo = useMemo(() => {
+    if (!activeSession || !detectionMode) {
+      return { sessionExercise: null, activeSet: null, activeSetIndex: 0, totalSets: 0 };
+    }
+    const def = getWorkoutByMode(detectionMode);
+    const modeId = detectionMode.toLowerCase();
+    const modeName = def.displayName.toLowerCase();
+
+    const matched = findExerciseForMode(exercises, modeId, modeName);
+    if (!matched) {
+      return { sessionExercise: null, activeSet: null, activeSetIndex: 0, totalSets: 0 };
+    }
+
+    const exSets = sets[matched.id] ?? [];
+    const totalSets = exSets.length;
+    const pendingIndex = exSets.findIndex((s) => !s.completed_at);
+    if (pendingIndex === -1) {
+      return { sessionExercise: matched, activeSet: null, activeSetIndex: totalSets, totalSets };
+    }
+    return {
+      sessionExercise: matched,
+      activeSet: exSets[pendingIndex],
+      activeSetIndex: pendingIndex + 1,
+      totalSets,
+    };
+  }, [activeSession, detectionMode, exercises, sets]);
+
+  const commitReps = useCallback(
+    async (repCount: number): Promise<string | null> => {
+      const set = matchInfo.activeSet;
+      if (!set) return null;
+      const safeReps = Math.max(0, Math.round(repCount));
+      await updateSet(set.id, { actual_reps: safeReps });
+      await completeSet(set.id);
+      return set.id;
+    },
+    [matchInfo.activeSet, updateSet, completeSet],
+  );
+
+  const setLabel = matchInfo.sessionExercise && matchInfo.totalSets > 0
+    ? `Set ${Math.max(1, matchInfo.activeSetIndex)} of ${matchInfo.totalSets}`
+    : '';
+
+  return {
+    isBound: matchInfo.sessionExercise != null && matchInfo.activeSet != null,
+    sessionExercise: matchInfo.sessionExercise,
+    activeSet: matchInfo.activeSet,
+    activeSetIndex: matchInfo.activeSetIndex,
+    totalSets: matchInfo.totalSets,
+    setLabel,
+    commitReps,
+  };
+}
+
+function findExerciseForMode(
+  exercises: (WorkoutSessionExercise & { exercise?: Exercise })[],
+  modeId: string,
+  modeName: string,
+): (WorkoutSessionExercise & { exercise?: Exercise }) | null {
+  if (exercises.length === 0) return null;
+
+  const normalizedModeName = modeName.replace(/[\s\-_]/g, '').toLowerCase();
+
+  for (const ex of exercises) {
+    const name = (ex.exercise?.name ?? '').toLowerCase();
+    const normalizedName = name.replace(/[\s\-_]/g, '');
+    if (normalizedName.startsWith(normalizedModeName) && normalizedModeName.length > 0) {
+      return ex;
+    }
+  }
+  for (const ex of exercises) {
+    const id = (ex.exercise_id ?? '').toLowerCase();
+    if (id.includes(modeId)) return ex;
+  }
+  return null;
+}

--- a/hooks/use-exercise-history.ts
+++ b/hooks/use-exercise-history.ts
@@ -1,0 +1,135 @@
+/**
+ * useExerciseHistory
+ *
+ * React hook that returns the ExerciseHistorySummary for the given
+ * exercise id. Caches per-exercise results in a module-level Map to
+ * avoid re-querying SQLite/Supabase on every re-render and on re-visits
+ * during the same session.
+ *
+ * Usage:
+ *   const { summary, isLoading, refresh } = useExerciseHistory('ex-pullup');
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  EMPTY_EXERCISE_HISTORY,
+  getExerciseHistorySummary,
+  type ExerciseHistorySummary,
+} from '@/lib/services/exercise-history';
+
+interface CacheEntry {
+  fetchedAt: number;
+  promise?: Promise<ExerciseHistorySummary>;
+  summary?: ExerciseHistorySummary;
+}
+
+// Module-level session cache. Reset via resetExerciseHistoryCache() (used by tests
+// + session lifecycle transitions).
+const cache = new Map<string, CacheEntry>();
+
+/** Max age a cache entry stays valid before being considered stale (ms). */
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes — tuned for a single workout session.
+
+export function resetExerciseHistoryCache(): void {
+  cache.clear();
+}
+
+export interface UseExerciseHistoryResult {
+  summary: ExerciseHistorySummary;
+  isLoading: boolean;
+  error: Error | null;
+  refresh: () => Promise<void>;
+}
+
+export function useExerciseHistory(
+  exerciseId: string | null | undefined,
+  options?: { cacheTtlMs?: number },
+): UseExerciseHistoryResult {
+  const [summary, setSummary] = useState<ExerciseHistorySummary>(() => {
+    if (!exerciseId) return EMPTY_EXERCISE_HISTORY;
+    return cache.get(exerciseId)?.summary ?? EMPTY_EXERCISE_HISTORY;
+  });
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+  const mountedRef = useRef(true);
+  const ttl = options?.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const load = useCallback(
+    async (id: string, force: boolean) => {
+      const now = Date.now();
+      const entry = cache.get(id);
+
+      // Fresh cached value — use it synchronously.
+      if (!force && entry?.summary && now - entry.fetchedAt < ttl) {
+        setSummary(entry.summary);
+        setIsLoading(false);
+        setError(null);
+        return;
+      }
+
+      // Promise already in-flight — await it instead of firing another query.
+      if (!force && entry?.promise) {
+        setIsLoading(true);
+        try {
+          const result = await entry.promise;
+          if (mountedRef.current) {
+            setSummary(result);
+            setError(null);
+          }
+        } catch (err) {
+          if (mountedRef.current) setError(asError(err));
+        } finally {
+          if (mountedRef.current) setIsLoading(false);
+        }
+        return;
+      }
+
+      // Fire a new query and write the pending promise into the cache.
+      setIsLoading(true);
+      setError(null);
+
+      const promise = getExerciseHistorySummary(id);
+      cache.set(id, { fetchedAt: now, promise });
+
+      try {
+        const result = await promise;
+        cache.set(id, { fetchedAt: Date.now(), summary: result });
+        if (mountedRef.current) setSummary(result);
+      } catch (err) {
+        // On error, leave any prior summary in place and surface the error.
+        cache.delete(id);
+        if (mountedRef.current) setError(asError(err));
+      } finally {
+        if (mountedRef.current) setIsLoading(false);
+      }
+    },
+    [ttl],
+  );
+
+  useEffect(() => {
+    if (!exerciseId) {
+      setSummary(EMPTY_EXERCISE_HISTORY);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+    void load(exerciseId, false);
+  }, [exerciseId, load]);
+
+  const refresh = useCallback(async () => {
+    if (!exerciseId) return;
+    await load(exerciseId, true);
+  }, [exerciseId, load]);
+
+  return { summary, isLoading, error, refresh };
+}
+
+function asError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}

--- a/hooks/use-live-fatigue.ts
+++ b/hooks/use-live-fatigue.ts
@@ -1,0 +1,110 @@
+/**
+ * useLiveFatigue
+ *
+ * Combines recent FQI samples (form quality trend) with HealthKit
+ * heart-rate zone to estimate the athlete's fatigue state during a
+ * live set. Returns a discrete state + a suggested rest extension in
+ * seconds that the caller can feed into the rest timer.
+ *
+ *   fresh    → FQI stable + HR below aerobic threshold
+ *   working  → some FQI dip OR HR in aerobic range
+ *   fatigued → sustained FQI drop OR HR above anaerobic threshold
+ *
+ * Thresholds are deliberately conservative to avoid spooking users.
+ * The hook is pure derivation — no side effects, no telemetry.
+ */
+import { useMemo } from 'react';
+
+export type FatigueState = 'fresh' | 'working' | 'fatigued';
+
+export interface LiveFatigueInput {
+  /** Ordered FQI scores, oldest → newest, 0-100 */
+  recentFqi: number[];
+  /** Latest heart rate BPM (null when unknown) */
+  heartRateBpm: number | null | undefined;
+  /** Athlete's max HR (defaults to 220 - 30). */
+  maxHeartRate?: number;
+}
+
+export interface LiveFatigueResult {
+  state: FatigueState;
+  suggestRestSec: number;
+  /** Rationale string for debugging / future coach copy. */
+  reason: string;
+}
+
+const DEFAULT_MAX_HR = 190;
+
+export function useLiveFatigue(input: LiveFatigueInput): LiveFatigueResult {
+  return useMemo(() => computeLiveFatigue(input), [input.recentFqi, input.heartRateBpm, input.maxHeartRate]);
+}
+
+/**
+ * Pure derivation helper — exported for unit-test access without React.
+ */
+export function computeLiveFatigue(input: LiveFatigueInput): LiveFatigueResult {
+  const { recentFqi, heartRateBpm, maxHeartRate = DEFAULT_MAX_HR } = input;
+
+  const fqiTrend = classifyFqiTrend(recentFqi);
+  const hrZone = classifyHrZone(heartRateBpm, maxHeartRate);
+
+  // Combine the two axes — highest of the two signals wins.
+  const rank = Math.max(stateRank(fqiTrend), stateRank(hrZone));
+  const state = (['fresh', 'working', 'fatigued'] as const)[rank];
+  const reason = buildReason(fqiTrend, hrZone);
+
+  const suggestRestSec = suggestionFor(state);
+  return { state, suggestRestSec, reason };
+}
+
+function stateRank(state: FatigueState): 0 | 1 | 2 {
+  return state === 'fatigued' ? 2 : state === 'working' ? 1 : 0;
+}
+
+function classifyFqiTrend(samples: number[]): FatigueState {
+  if (!samples || samples.length < 2) return 'fresh';
+  // Compare last to median of earliest half.
+  const half = Math.max(1, Math.floor(samples.length / 2));
+  const baseline = median(samples.slice(0, half));
+  const last = samples[samples.length - 1];
+  const drop = baseline - last;
+  if (drop >= 10) return 'fatigued';
+  if (drop >= 4) return 'working';
+  return 'fresh';
+}
+
+function classifyHrZone(bpm: number | null | undefined, maxHr: number): FatigueState {
+  if (bpm == null || !Number.isFinite(bpm) || bpm <= 0 || !Number.isFinite(maxHr) || maxHr <= 0) {
+    return 'fresh';
+  }
+  const pct = bpm / maxHr;
+  if (pct >= 0.85) return 'fatigued';
+  if (pct >= 0.7) return 'working';
+  return 'fresh';
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function suggestionFor(state: FatigueState): number {
+  switch (state) {
+    case 'fresh':
+      return 0;
+    case 'working':
+      return 30;
+    case 'fatigued':
+    default:
+      return 60;
+  }
+}
+
+function buildReason(fqi: FatigueState, hr: FatigueState): string {
+  const parts: string[] = [];
+  if (fqi !== 'fresh') parts.push(`fqi:${fqi}`);
+  if (hr !== 'fresh') parts.push(`hr:${hr}`);
+  return parts.length === 0 ? 'baseline' : parts.join('|');
+}

--- a/hooks/use-premium-cue-audio.ts
+++ b/hooks/use-premium-cue-audio.ts
@@ -1,9 +1,14 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import * as Speech from 'expo-speech';
 import { Paths, File as ExpoFile } from 'expo-file-system';
 import { Audio, InterruptionModeIOS } from 'expo-av';
 import { warnWithTs } from '@/lib/logger';
 import { createError, logError } from '@/lib/services/ErrorHandler';
+import {
+  mapSeverityToAudioHint,
+  type CueAudioHint,
+} from '@/lib/services/cue-priority-audio';
+import type { FaultSeverity } from '@/lib/types/workout-definitions';
 
 // ---------------------------------------------------------------------------
 // Cue manifest — maps normalised cue text → MP3 filename.
@@ -94,6 +99,17 @@ interface PremiumCueAudioOptions {
   volume?: number;
   minIntervalMs?: number;
   shouldAllowRecording?: boolean;
+  /**
+   * Optional severity-based priority hint. When provided, the hook
+   * derives `minIntervalMs` + `volume` via the cue-priority-audio
+   * mapper instead of using the raw props. Existing callers that
+   * omit this keep the previous behavior unchanged.
+   *
+   * Accepts either:
+   *   - a FaultSeverity (1/2/3)
+   *   - a partial hint object from mapSeverityToAudioHint()
+   */
+  priorityHint?: FaultSeverity | Partial<CueAudioHint>;
   onEvent?: (event: {
     cue: string;
     action: 'queued' | 'spoken' | 'dropped';
@@ -121,8 +137,29 @@ export function usePremiumCueAudio({
   volume = 1,
   minIntervalMs = 2000,
   shouldAllowRecording = true,
+  priorityHint,
   onEvent,
 }: PremiumCueAudioOptions): PremiumCueAudioControls {
+  // When a priority hint is supplied, derive interval + volume from the
+  // shared mapper so the scan overlay and watch stay in sync.
+  const resolved = useMemo(() => {
+    if (priorityHint == null) {
+      return { minIntervalMs, volume };
+    }
+    if (typeof priorityHint === 'number') {
+      const hint = mapSeverityToAudioHint(priorityHint);
+      return {
+        minIntervalMs: hint.intervalMs,
+        volume: hint.volume,
+      };
+    }
+    return {
+      minIntervalMs: priorityHint.intervalMs ?? minIntervalMs,
+      volume: priorityHint.volume ?? volume,
+    };
+  }, [priorityHint, minIntervalMs, volume]);
+  const effectiveInterval = resolved.minIntervalMs;
+  const effectiveVolume = resolved.volume;
   const queueRef = useRef<string[]>([]);
   const isSpeakingRef = useRef(false);
   const lastPhraseRef = useRef<string | null>(null);
@@ -220,14 +257,14 @@ export function usePremiumCueAudio({
           language,
           rate,
           pitch,
-          volume,
+          volume: effectiveVolume,
           onDone: resolve,
           onStopped: resolve,
           onError: () => resolve(),
         });
       });
     },
-    [voiceId, language, rate, pitch, volume]
+    [voiceId, language, rate, pitch, effectiveVolume]
   );
 
   // ---- Queue flusher (matches useSpeechFeedback logic exactly) ----
@@ -260,7 +297,7 @@ export function usePremiumCueAudio({
     const now = Date.now();
     const elapsed = now - lastTimestampRef.current;
 
-    if (elapsed < minIntervalMs) {
+    if (elapsed < effectiveInterval) {
       clearPendingTimeout();
       if (queueRef.current[0]) {
         onEvent?.({
@@ -279,7 +316,7 @@ export function usePremiumCueAudio({
             error
           );
         });
-      }, minIntervalMs - elapsed);
+      }, effectiveInterval - elapsed);
       return;
     }
 
@@ -317,7 +354,7 @@ export function usePremiumCueAudio({
         );
       });
     }
-  }, [enabled, minIntervalMs, clearPendingTimeout, ensureAudioMode, playCue, onEvent, reportAsyncError]);
+  }, [enabled, effectiveInterval, clearPendingTimeout, ensureAudioMode, playCue, onEvent, reportAsyncError]);
 
   // ---- Public speak() ----
 
@@ -335,7 +372,7 @@ export function usePremiumCueAudio({
 
       const now = Date.now();
       const lastPhrase = lastPhraseRef.current;
-      if (lastPhrase === text && now - lastTimestampRef.current < minIntervalMs) {
+      if (lastPhrase === text && now - lastTimestampRef.current < effectiveInterval) {
         onEvent?.({
           cue: text,
           action: 'dropped',
@@ -363,7 +400,7 @@ export function usePremiumCueAudio({
         reportAsyncError('PREMIUM_AUDIO_FLUSH_ENQUEUE_FAILED', 'Failed to flush premium audio queue after enqueue', error);
       });
     },
-    [enabled, flushQueue, minIntervalMs, onEvent, reportAsyncError]
+    [enabled, flushQueue, effectiveInterval, onEvent, reportAsyncError]
   );
 
   // ---- Public stop() ----

--- a/hooks/use-session-autopause.ts
+++ b/hooks/use-session-autopause.ts
@@ -1,0 +1,88 @@
+/**
+ * useSessionAutopause
+ *
+ * Binds React Native's AppState transitions to the pause extension
+ * module so the session auto-pauses when the user backgrounds the
+ * app and surfaces a resume prompt on return.
+ *
+ * Behavior:
+ *   - On 'background'  → pauseActiveSession('background')
+ *   - On 'active' (after a prior background) → mark that a resume is
+ *     pending so UI can show a toast. The user presses Resume to
+ *     call resumeActiveSession() (or just start the next rep).
+ */
+import { useEffect, useRef, useState } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+import { useSessionRunner } from '@/lib/stores/session-runner';
+import {
+  pauseActiveSession,
+  resumeActiveSession,
+  useSessionPauseState,
+} from '@/lib/stores/session-runner.pause';
+
+export interface SessionAutopauseResult {
+  /** True when the overlay should surface the resume banner. */
+  needsResume: boolean;
+  /** Milliseconds the session was paused (only available after resume). */
+  lastPausedDurationMs: number | null;
+  /** User confirmation handler — call from the resume toast. */
+  acknowledgeResume: () => Promise<number>;
+  /** Pause-reason recorded by the autopauser (or null when not paused). */
+  pauseReason: string | null;
+}
+
+export function useSessionAutopause(options?: {
+  enabled?: boolean;
+}): SessionAutopauseResult {
+  const enabled = options?.enabled ?? true;
+  const activeSession = useSessionRunner((s) => s.activeSession);
+  const pauseState = useSessionPauseState();
+  const [needsResume, setNeedsResume] = useState(false);
+  const [lastPausedDurationMs, setLastPausedDurationMs] = useState<number | null>(null);
+  const lastAppStateRef = useRef<AppStateStatus>('active');
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    const sub = AppState.addEventListener('change', async (next: AppStateStatus) => {
+      const prev = lastAppStateRef.current;
+      lastAppStateRef.current = next;
+
+      if (next === 'background' && prev === 'active') {
+        if (useSessionRunner.getState().activeSession) {
+          await pauseActiveSession('background').catch(() => {});
+        }
+      }
+      if (next === 'active' && (prev === 'background' || prev === 'inactive')) {
+        const { isPaused } = pauseState;
+        if (isPaused || useSessionRunner.getState().activeSession) {
+          setNeedsResume(true);
+        }
+      }
+    });
+    return () => {
+      sub.remove();
+    };
+  }, [enabled, pauseState]);
+
+  // If the session ends, auto-clear the banner state.
+  useEffect(() => {
+    if (!activeSession) {
+      setNeedsResume(false);
+      setLastPausedDurationMs(null);
+    }
+  }, [activeSession]);
+
+  const acknowledgeResume = async (): Promise<number> => {
+    const durationMs = await resumeActiveSession();
+    setLastPausedDurationMs(durationMs);
+    setNeedsResume(false);
+    return durationMs;
+  };
+
+  return {
+    needsResume,
+    lastPausedDurationMs,
+    acknowledgeResume,
+    pauseReason: pauseState.reason,
+  };
+}

--- a/lib/services/cue-priority-audio.ts
+++ b/lib/services/cue-priority-audio.ts
@@ -1,0 +1,86 @@
+/**
+ * Cue Priority Audio
+ *
+ * Maps a fault severity level to audio playback hints that the premium
+ * cue audio hook can use to vary urgency. Exists as its own module so
+ * the mapping can be tuned / A/B tested without touching the hook.
+ *
+ * Severity convention matches lib/types/workout-definitions.FaultSeverity:
+ *   1 = minor     → slower reminders, no haptic
+ *   2 = moderate  → normal cadence, light haptic
+ *   3 = major     → assertive cadence, medium haptic + repeat
+ */
+import type { FaultSeverity } from '@/lib/types/workout-definitions';
+
+export type CuePriority = 'low' | 'normal' | 'high';
+
+export type CueHaptic = 'none' | 'light' | 'medium' | 'heavy';
+
+export interface CueAudioHint {
+  priority: CuePriority;
+  intervalMs: number;
+  volume: number; // 0..1
+  haptic: CueHaptic;
+  repeatIfUnadopted: boolean;
+}
+
+export interface MapOptions {
+  /** Bump priority when the athlete is already fatigued */
+  isFatigued?: boolean;
+  /** Scan overlay is already voicing a same-severity cue */
+  isActiveCue?: boolean;
+}
+
+const TABLE: Record<CuePriority, CueAudioHint> = {
+  low: {
+    priority: 'low',
+    intervalMs: 4000,
+    volume: 0.6,
+    haptic: 'none',
+    repeatIfUnadopted: false,
+  },
+  normal: {
+    priority: 'normal',
+    intervalMs: 2200,
+    volume: 0.85,
+    haptic: 'light',
+    repeatIfUnadopted: true,
+  },
+  high: {
+    priority: 'high',
+    intervalMs: 1400,
+    volume: 1.0,
+    haptic: 'medium',
+    repeatIfUnadopted: true,
+  },
+};
+
+export function severityToPriority(severity: FaultSeverity | number | undefined): CuePriority {
+  const s = Number(severity ?? 0);
+  if (s >= 3) return 'high';
+  if (s >= 2) return 'normal';
+  return 'low';
+}
+
+/**
+ * Resolve audio hints for a given fault severity. Optionally elevate
+ * priority when fatigued.
+ */
+export function mapSeverityToAudioHint(
+  severity: FaultSeverity | number | undefined,
+  options: MapOptions = {},
+): CueAudioHint {
+  let priority = severityToPriority(severity);
+  if (options.isFatigued && priority === 'normal') priority = 'high';
+  if (options.isFatigued && priority === 'low') priority = 'normal';
+
+  const base = TABLE[priority];
+  // Active repeat cue gets a slightly longer cooldown so we don't stack.
+  if (options.isActiveCue && base.repeatIfUnadopted) {
+    return { ...base, intervalMs: base.intervalMs + 400 };
+  }
+  return base;
+}
+
+/** Exported for test assertions on table constants. */
+export const CUE_AUDIO_TABLE = TABLE;

--- a/lib/services/drill-tracker.ts
+++ b/lib/services/drill-tracker.ts
@@ -1,0 +1,56 @@
+/**
+ * Drill Tracker Service
+ *
+ * Logs drill adoption events via the existing cue telemetry channel so
+ * we can measure which corrective drills actually get opened + started
+ * in the field. Intentionally piggybacks on `cue_events` — no new
+ * Supabase table / migration required.
+ *
+ * Events use the `cue` field to encode the drill and `reason` to
+ * encode the action (viewed/started/completed/dismissed).
+ */
+import { logCueEvent } from '@/lib/services/cue-logger';
+import { warnWithTs } from '@/lib/logger';
+
+export type DrillAction = 'viewed' | 'started' | 'completed' | 'dismissed';
+
+interface DrillEventInput {
+  sessionId: string;
+  /** Exercise id the drill is attached to (e.g., 'pullup') */
+  exerciseId: string;
+  /** The fault that surfaced the drill (e.g., 'shoulder_elevation') */
+  faultId: string;
+  /** Drill identifier from FaultDefinition.drills[].id */
+  drillId: string;
+  /** Lifecycle action */
+  action: DrillAction;
+  /** Optional rep number when the drill was offered */
+  repCount?: number;
+}
+
+/**
+ * Fire-and-forget drill adoption log. Silently swallows errors so the
+ * UI never blocks on telemetry failures.
+ */
+export async function logDrillEvent(input: DrillEventInput): Promise<void> {
+  try {
+    await logCueEvent({
+      sessionId: input.sessionId,
+      cue: `drill:${input.drillId}`,
+      mode: input.exerciseId,
+      phase: input.faultId,
+      reason: `drill_${input.action}`,
+      repCount: input.repCount,
+    });
+  } catch (err) {
+    if (__DEV__) warnWithTs('[drill-tracker] failed to log drill event', err, input);
+  }
+}
+
+/** Shorthand for the most common calls. */
+export const drillTracker = {
+  markViewed: (args: Omit<DrillEventInput, 'action'>) => logDrillEvent({ ...args, action: 'viewed' }),
+  markStarted: (args: Omit<DrillEventInput, 'action'>) => logDrillEvent({ ...args, action: 'started' }),
+  markCompleted: (args: Omit<DrillEventInput, 'action'>) => logDrillEvent({ ...args, action: 'completed' }),
+  markDismissed: (args: Omit<DrillEventInput, 'action'>) => logDrillEvent({ ...args, action: 'dismissed' }),
+};

--- a/lib/services/exercise-history.ts
+++ b/lib/services/exercise-history.ts
@@ -1,0 +1,321 @@
+/**
+ * Exercise History Service
+ *
+ * Queries local SQLite (+ Supabase fallback) for per-exercise historical
+ * summaries used to contextualize live form tracking. Powers the
+ * ExerciseHistoryStrip chips and coaching decisions.
+ *
+ * Returned summary shape:
+ *   - lastSession: most recent completed session for the exercise
+ *   - last5SessionsAvgFqi: rolling average FQI over last 5 completed sessions
+ *   - maxReps: best single-set rep count on record
+ *   - maxVolume: best (reps * weight_lb) on record
+ */
+import { localDB } from '@/lib/services/database/local-db';
+import { supabase } from '@/lib/supabase';
+import { warnWithTs } from '@/lib/logger';
+
+export interface ExerciseHistoryLastSession {
+  /** Session id (workout_sessions.id) */
+  sessionId: string;
+  /** ISO8601 timestamp — when the session ended (or most recent set completed) */
+  endedAt: string;
+  /** Total completed sets in that session for this exercise */
+  sets: number;
+  /** Total reps across those sets */
+  totalReps: number;
+  /** Heaviest working weight in lb (null if bodyweight/timed) */
+  topWeightLb: number | null;
+  /** Session-level average FQI for this exercise (0-100, null if none logged) */
+  avgFqi: number | null;
+}
+
+export interface ExerciseHistorySummary {
+  lastSession: ExerciseHistoryLastSession | null;
+  last5SessionsAvgFqi: number | null;
+  maxReps: number | null;
+  maxVolume: number | null;
+}
+
+export const EMPTY_EXERCISE_HISTORY: ExerciseHistorySummary = {
+  lastSession: null,
+  last5SessionsAvgFqi: null,
+  maxReps: null,
+  maxVolume: null,
+};
+
+interface SessionSetRow {
+  session_id: string;
+  ended_at: string | null;
+  started_at: string | null;
+  set_id: string;
+  completed_at: string | null;
+  actual_reps: number | null;
+  actual_weight: number | null;
+}
+
+interface FqiRow {
+  session_id: string;
+  fqi: number | null;
+}
+
+interface RemoteSetRow {
+  id: string;
+  actual_reps: number | null;
+  actual_weight: number | null;
+  completed_at: string | null;
+  workout_session_exercises?: {
+    exercise_id?: string;
+    workout_sessions?: {
+      id?: string;
+      started_at?: string;
+      ended_at?: string | null;
+    };
+  };
+}
+
+/**
+ * Return a best-effort history summary for the given exercise id.
+ * Never throws — returns EMPTY_EXERCISE_HISTORY on any failure.
+ */
+export async function getExerciseHistorySummary(
+  exerciseId: string,
+): Promise<ExerciseHistorySummary> {
+  if (!exerciseId) return EMPTY_EXERCISE_HISTORY;
+
+  const local = await queryLocal(exerciseId).catch((err) => {
+    if (__DEV__) warnWithTs('[exercise-history] local query failed', err);
+    return null;
+  });
+
+  if (local && local.lastSession) {
+    return local;
+  }
+
+  // Fallback to Supabase when local SQLite is unavailable (web) or empty
+  const remote = await queryRemote(exerciseId).catch((err) => {
+    if (__DEV__) warnWithTs('[exercise-history] remote query failed', err);
+    return null;
+  });
+
+  return remote ?? local ?? EMPTY_EXERCISE_HISTORY;
+}
+
+// ---------------------------------------------------------------------------
+// Local SQLite
+// ---------------------------------------------------------------------------
+
+async function queryLocal(exerciseId: string): Promise<ExerciseHistorySummary | null> {
+  const db = localDB.db;
+  if (!db) return null;
+
+  // Pull all completed sets for this exercise, newest session first.
+  const rows = await db.getAllAsync<SessionSetRow>(
+    `SELECT
+       s.id AS session_id,
+       s.ended_at AS ended_at,
+       s.started_at AS started_at,
+       ws.id AS set_id,
+       ws.completed_at AS completed_at,
+       ws.actual_reps AS actual_reps,
+       ws.actual_weight AS actual_weight
+     FROM workout_session_exercises e
+     JOIN workout_sessions s ON s.id = e.session_id AND COALESCE(s.deleted, 0) = 0
+     JOIN workout_session_sets ws ON ws.session_exercise_id = e.id AND COALESCE(ws.deleted, 0) = 0
+     WHERE e.exercise_id = ?
+       AND COALESCE(e.deleted, 0) = 0
+       AND ws.completed_at IS NOT NULL
+     ORDER BY COALESCE(s.ended_at, s.started_at) DESC, ws.sort_order ASC`,
+    [exerciseId],
+  );
+
+  if (!rows || rows.length === 0) return null;
+
+  return buildSummaryFromRows(rows, await queryFqiLocal(db, exerciseId));
+}
+
+async function queryFqiLocal(
+  db: NonNullable<typeof localDB.db>,
+  exerciseId: string,
+): Promise<FqiRow[]> {
+  try {
+    return await db.getAllAsync<FqiRow>(
+      `SELECT session_id, fqi FROM reps
+         WHERE exercise = ? AND fqi IS NOT NULL
+         ORDER BY end_ts DESC
+         LIMIT 500`,
+      [exerciseId],
+    );
+  } catch {
+    // reps table may not exist locally yet — harmless
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Supabase fallback
+// ---------------------------------------------------------------------------
+
+async function queryRemote(exerciseId: string): Promise<ExerciseHistorySummary | null> {
+  try {
+    const { data, error } = await supabase
+      .from('workout_session_sets')
+      .select(
+        'id, actual_reps, actual_weight, completed_at, ' +
+          'workout_session_exercises!inner(exercise_id, workout_sessions!inner(id, started_at, ended_at))',
+      )
+      .eq('workout_session_exercises.exercise_id', exerciseId)
+      .not('completed_at', 'is', null)
+      .order('completed_at', { ascending: false })
+      .limit(500);
+
+    if (error || !data) return null;
+
+    const rows: SessionSetRow[] = (data as unknown as RemoteSetRow[]).map((row) => {
+      const sess = row.workout_session_exercises?.workout_sessions;
+      return {
+        session_id: sess?.id ?? '',
+        started_at: sess?.started_at ?? null,
+        ended_at: sess?.ended_at ?? null,
+        set_id: row.id,
+        completed_at: row.completed_at ?? null,
+        actual_reps: row.actual_reps ?? null,
+        actual_weight: row.actual_weight ?? null,
+      };
+    }).filter((r) => r.session_id.length > 0);
+
+    if (rows.length === 0) return null;
+
+    // FQI from reps table
+    const fqiRows = await queryFqiRemote(exerciseId);
+    return buildSummaryFromRows(rows, fqiRows);
+  } catch {
+    return null;
+  }
+}
+
+async function queryFqiRemote(exerciseId: string): Promise<FqiRow[]> {
+  try {
+    const { data, error } = await supabase
+      .from('reps')
+      .select('session_id, fqi')
+      .eq('exercise', exerciseId)
+      .not('fqi', 'is', null)
+      .order('end_ts', { ascending: false })
+      .limit(500);
+    if (error || !data) return [];
+    return data as unknown as FqiRow[];
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+function buildSummaryFromRows(
+  rows: SessionSetRow[],
+  fqiRows: FqiRow[],
+): ExerciseHistorySummary {
+  // Group by session
+  const bySession = new Map<string, SessionSetRow[]>();
+  for (const row of rows) {
+    const arr = bySession.get(row.session_id);
+    if (arr) arr.push(row);
+    else bySession.set(row.session_id, [row]);
+  }
+
+  // Sort sessions most-recent first by ended/started
+  const sessionIdsOrdered = Array.from(bySession.keys()).sort((a, b) => {
+    const aTs = sessionTimestamp(bySession.get(a)?.[0]);
+    const bTs = sessionTimestamp(bySession.get(b)?.[0]);
+    return bTs.localeCompare(aTs);
+  });
+
+  // FQI grouped by session
+  const fqiBySession = new Map<string, number[]>();
+  for (const r of fqiRows) {
+    if (r.fqi == null) continue;
+    const arr = fqiBySession.get(r.session_id);
+    if (arr) arr.push(r.fqi);
+    else fqiBySession.set(r.session_id, [r.fqi]);
+  }
+
+  // Last session summary
+  const lastSessionId = sessionIdsOrdered[0];
+  const lastSessionRows = bySession.get(lastSessionId) ?? [];
+  const lastSession = buildLastSession(lastSessionId, lastSessionRows, fqiBySession);
+
+  // Rolling avg FQI over the last 5 sessions
+  const recent5 = sessionIdsOrdered.slice(0, 5);
+  const recentFqis: number[] = [];
+  for (const sid of recent5) {
+    const arr = fqiBySession.get(sid);
+    if (arr && arr.length > 0) {
+      recentFqis.push(average(arr));
+    }
+  }
+  const last5SessionsAvgFqi = recentFqis.length > 0 ? round(average(recentFqis)) : null;
+
+  // Max reps and max volume across all completed sets
+  let maxReps: number | null = null;
+  let maxVolume: number | null = null;
+  for (const row of rows) {
+    if (row.actual_reps != null && (maxReps == null || row.actual_reps > maxReps)) {
+      maxReps = row.actual_reps;
+    }
+    if (row.actual_reps != null && row.actual_weight != null) {
+      const volume = row.actual_reps * row.actual_weight;
+      if (maxVolume == null || volume > maxVolume) maxVolume = volume;
+    }
+  }
+
+  return {
+    lastSession,
+    last5SessionsAvgFqi,
+    maxReps,
+    maxVolume: maxVolume != null ? round(maxVolume) : null,
+  };
+}
+
+function buildLastSession(
+  sessionId: string | undefined,
+  rows: SessionSetRow[],
+  fqiBySession: Map<string, number[]>,
+): ExerciseHistoryLastSession | null {
+  if (!sessionId || rows.length === 0) return null;
+  const endedAt =
+    rows[0].ended_at ?? rows[0].started_at ?? rows[0].completed_at ?? new Date().toISOString();
+  let totalReps = 0;
+  let topWeight: number | null = null;
+  for (const row of rows) {
+    totalReps += row.actual_reps ?? 0;
+    if (row.actual_weight != null && (topWeight == null || row.actual_weight > topWeight)) {
+      topWeight = row.actual_weight;
+    }
+  }
+  const fqis = fqiBySession.get(sessionId) ?? [];
+  return {
+    sessionId,
+    endedAt,
+    sets: rows.length,
+    totalReps,
+    topWeightLb: topWeight,
+    avgFqi: fqis.length > 0 ? round(average(fqis)) : null,
+  };
+}
+
+function sessionTimestamp(row: SessionSetRow | undefined): string {
+  if (!row) return '';
+  return row.ended_at ?? row.started_at ?? row.completed_at ?? '';
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+function round(value: number): number {
+  return Math.round(value * 10) / 10;
+}

--- a/lib/stores/session-runner.pause.ts
+++ b/lib/stores/session-runner.pause.ts
@@ -1,0 +1,146 @@
+/**
+ * Session Runner Pause Extension
+ *
+ * Standalone module that layers pause/resume semantics onto the core
+ * useSessionRunner store without modifying the main file. Kept
+ * separate so the PR #424 review boundary is preserved.
+ *
+ * Strategy: persist the "paused-at" timestamp into workout_session_events
+ * so the existing sync pipeline carries it, and track an in-memory
+ * isPaused flag that ScanARKit / autopause can observe via
+ * useSessionPauseState().
+ */
+import { useSyncExternalStore } from 'react';
+import * as Crypto from 'expo-crypto';
+import { localDB } from '@/lib/services/database/local-db';
+import { genericLocalUpsert } from '@/lib/services/database/generic-sync';
+import { useSessionRunner } from '@/lib/stores/session-runner';
+import type { SessionEventType } from '@/lib/types/workout-session';
+
+interface PauseState {
+  isPaused: boolean;
+  pausedAt: string | null;
+  reason: PauseReason | null;
+}
+
+export type PauseReason = 'background' | 'manual' | 'phone-call' | 'auto';
+
+const initialState: PauseState = {
+  isPaused: false,
+  pausedAt: null,
+  reason: null,
+};
+
+let state: PauseState = { ...initialState };
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): PauseState {
+  return state;
+}
+
+export function useSessionPauseState(): PauseState {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * Mark the active session as paused and persist a resume event breadcrumb.
+ * No-op when no active session exists.
+ */
+export async function pauseActiveSession(reason: PauseReason = 'manual'): Promise<void> {
+  const session = useSessionRunner.getState().activeSession;
+  if (!session) return;
+  if (state.isPaused) return; // already paused
+  const now = new Date().toISOString();
+  state = { isPaused: true, pausedAt: now, reason };
+  emit();
+
+  await writeEvent(session.id, 'rest_started', {
+    subtype: 'session_paused',
+    reason,
+    paused_at: now,
+  });
+}
+
+/**
+ * Resume a paused session. Calculates the paused-duration for telemetry
+ * and clears the in-memory pause state.
+ */
+export async function resumeActiveSession(): Promise<number> {
+  const session = useSessionRunner.getState().activeSession;
+  if (!session) return 0;
+  if (!state.isPaused) return 0;
+
+  const pausedAt = state.pausedAt;
+  const resumedAt = new Date().toISOString();
+  const durationMs = pausedAt ? new Date(resumedAt).getTime() - new Date(pausedAt).getTime() : 0;
+  state = { ...initialState };
+  emit();
+
+  await writeEvent(session.id, 'rest_completed', {
+    subtype: 'session_resumed',
+    paused_at: pausedAt,
+    resumed_at: resumedAt,
+    paused_duration_ms: durationMs,
+  });
+  return Math.max(0, durationMs);
+}
+
+/**
+ * Convenience toggle: pauses if running, resumes if paused.
+ * Returns the new isPaused state.
+ */
+export async function toggleActiveSessionPause(
+  reason: PauseReason = 'manual',
+): Promise<boolean> {
+  if (state.isPaused) {
+    await resumeActiveSession();
+    return false;
+  }
+  await pauseActiveSession(reason);
+  return true;
+}
+
+/** Reset both in-memory and external listeners (tests only). */
+export function __resetSessionPauseState(): void {
+  state = { ...initialState };
+  for (const l of listeners) l();
+}
+
+async function writeEvent(
+  sessionId: string,
+  type: SessionEventType,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const db = localDB.db;
+    if (!db) {
+      // still record via generic upsert so the sync queue carries it
+      // when a native DB is available — on web this is effectively a no-op.
+      return;
+    }
+    const row: Record<string, unknown> = {
+      id: Crypto.randomUUID(),
+      session_id: sessionId,
+      created_at: new Date().toISOString(),
+      type,
+      session_exercise_id: null,
+      session_set_id: null,
+      payload: JSON.stringify(payload),
+      synced: 0,
+    };
+    await genericLocalUpsert('workout_session_events', 'id', row, 0);
+  } catch {
+    // best-effort; never throw in the pause path
+  }
+}

--- a/lib/stores/session-runner.ts
+++ b/lib/stores/session-runner.ts
@@ -82,6 +82,19 @@ export interface SessionRunnerState {
   duplicateSet: (setId: string, count?: number) => Promise<void>;
   updateSetType: (setId: string, setType: SetType) => Promise<void>;
   duplicateExercise: (sessionExerciseId: string) => Promise<void>;
+  /**
+   * Bind a scan-overlay detection mode (e.g., 'pullup') to the active
+   * session. `action` controls whether the matching exercise is added
+   * alongside the current one or replaces it.
+   *   - 'append' adds a new session_exercise (default)
+   *   - 'replace' soft-deletes the active exercise before adding
+   * Returns the new session_exercise_id, or null when no active session
+   * exists or no matching exercise was found.
+   */
+  swapExerciseByDetectionMode: (
+    mode: string,
+    action?: 'append' | 'replace',
+  ) => Promise<string | null>;
 }
 
 // =============================================================================
@@ -143,6 +156,33 @@ async function getExerciseById(exerciseId: string): Promise<Exercise | null> {
     [exerciseId],
   );
   return rows[0] ?? null;
+}
+
+/**
+ * Look up an `exercises.id` for a given detection mode. Matches the
+ * local `exercises` table by (case-insensitive) name prefix or id
+ * containment. Returns null when no row is available so the caller
+ * can surface a friendly no-op.
+ */
+async function findExerciseIdForMode(mode: string): Promise<string | null> {
+  const db = localDB.db;
+  if (!db) return null;
+  const likeToken = `${mode.toLowerCase().replace(/[^a-z0-9]/g, '')}%`;
+  try {
+    const byId = await db.getAllAsync<{ id: string }>(
+      'SELECT id FROM exercises WHERE LOWER(REPLACE(REPLACE(id, \'-\', \'\'), \'_\', \'\')) LIKE ? LIMIT 1',
+      [likeToken],
+    );
+    if (byId[0]?.id) return byId[0].id;
+
+    const byName = await db.getAllAsync<{ id: string }>(
+      'SELECT id FROM exercises WHERE LOWER(REPLACE(REPLACE(name, \' \', \'\'), \'-\', \'\')) LIKE ? ORDER BY is_system DESC LIMIT 1',
+      [likeToken],
+    );
+    return byName[0]?.id ?? null;
+  } catch {
+    return null;
+  }
 }
 
 // =============================================================================
@@ -766,6 +806,29 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
   // =========================================================================
   updateSetType: async (setId, setType) => {
     await get().updateSet(setId, { set_type: setType });
+  },
+
+  // =========================================================================
+  // Swap Exercise By Detection Mode
+  // =========================================================================
+  swapExerciseByDetectionMode: async (mode, action = 'append') => {
+    const { activeSession, exercises } = get();
+    if (!activeSession) return null;
+    if (!mode) return null;
+
+    // Resolve an `exercises.id` matching the detection mode. Prefer system
+    // exercises whose name starts with the mode token (case-insensitive).
+    const matchId = await findExerciseIdForMode(mode);
+    if (!matchId) return null;
+
+    // Optionally soft-delete the "current" (last) exercise before adding.
+    if (action === 'replace' && exercises.length > 0) {
+      const last = exercises[exercises.length - 1];
+      await get().removeExercise(last.id);
+    }
+
+    const newId = await get().addExercise(matchId);
+    return newId;
   },
 
   // =========================================================================

--- a/lib/types/workout-definitions.ts
+++ b/lib/types/workout-definitions.ts
@@ -118,6 +118,26 @@ export interface ScoringMetricDefinition {
 export type FaultSeverity = 1 | 2 | 3;
 
 /**
+ * Corrective drill suggested to a user whose rep triggered a specific
+ * fault. Authored alongside the fault definition so the coach UI can
+ * surface it without any extra plumbing.
+ */
+export interface FaultDrill {
+  /** Stable identifier (e.g., 'scap-pull-2x10') */
+  id: string;
+  /** Human-readable title ("Scapular Pull-Ups") */
+  title: string;
+  /** Suggested duration in seconds (null if rep-based) */
+  durationSec: number;
+  /** Optional target rep count (null if time-based) */
+  reps?: number;
+  /** Step-by-step plain-language instructions */
+  steps: string[];
+  /** Optional demo media uri (image or short clip) */
+  mediaUri?: string;
+}
+
+/**
  * Defines a detectable form fault
  */
 export interface FaultDefinition {
@@ -133,6 +153,11 @@ export interface FaultDefinition {
   dynamicCue: string;
   /** FQI penalty points (subtracted from score) */
   fqiPenalty: number;
+  /**
+   * Optional corrective drills surfaced by DrillSheet when this fault
+   * is detected. Ordered by recommended priority.
+   */
+  drills?: FaultDrill[];
 }
 
 // =============================================================================

--- a/lib/workouts/benchpress.ts
+++ b/lib/workouts/benchpress.ts
@@ -192,6 +192,19 @@ const faults: FaultDefinition[] = [
     severity: 1,
     dynamicCue: 'Finish each rep with a full lockout.',
     fqiPenalty: 10,
+    drills: [
+      {
+        id: 'bench-tricep-extension',
+        title: 'Overhead Tricep Extensions',
+        durationSec: 120,
+        reps: 10,
+        steps: [
+          'Hold a dumbbell with both hands overhead, arms straight.',
+          'Lower behind your head, elbows tight; press back up.',
+          'Focus on full extension. 3 sets of 10.',
+        ],
+      },
+    ],
   },
   {
     id: 'shallow_depth',
@@ -203,6 +216,19 @@ const faults: FaultDefinition[] = [
     severity: 2,
     dynamicCue: 'Lower the bar closer to your chest for full range.',
     fqiPenalty: 12,
+    drills: [
+      {
+        id: 'bench-paused-bench',
+        title: 'Pause Bench (Chest)',
+        durationSec: 180,
+        reps: 5,
+        steps: [
+          'Unrack the bar and lower to lightly touch your chest.',
+          'Pause 2 seconds with active tension.',
+          'Drive up explosively. Use 70% weight, 4 sets of 5.',
+        ],
+      },
+    ],
   },
   {
     id: 'asymmetric_press',
@@ -233,6 +259,19 @@ const faults: FaultDefinition[] = [
     severity: 2,
     dynamicCue: 'Tuck elbows slightly to protect your shoulders.',
     fqiPenalty: 10,
+    drills: [
+      {
+        id: 'bench-close-grip',
+        title: 'Close-Grip Bench',
+        durationSec: 150,
+        reps: 8,
+        steps: [
+          'Grip the bar shoulder-width apart.',
+          'Keep elbows tucked about 45° from your torso.',
+          'Touch mid-chest and press. 3 sets of 8.',
+        ],
+      },
+    ],
   },
 ];
 

--- a/lib/workouts/deadlift.ts
+++ b/lib/workouts/deadlift.ts
@@ -192,6 +192,19 @@ const faults: FaultDefinition[] = [
     severity: 2,
     dynamicCue: 'Finish each rep with full hip extension.',
     fqiPenalty: 12,
+    drills: [
+      {
+        id: 'deadlift-hip-thrust',
+        title: 'Barbell Hip Thrusts',
+        durationSec: 120,
+        reps: 8,
+        steps: [
+          'Sit with upper back against a bench, bar across hips.',
+          'Drive heels into floor, push hips up, squeeze glutes hard.',
+          'Pause 1 second at lockout. 3 sets of 8.',
+        ],
+      },
+    ],
   },
   {
     id: 'rounded_back',
@@ -204,6 +217,19 @@ const faults: FaultDefinition[] = [
     severity: 3,
     dynamicCue: 'Keep your back flat — don\'t round your spine.',
     fqiPenalty: 20,
+    drills: [
+      {
+        id: 'deadlift-bird-dog',
+        title: 'Bird-Dogs w/ 3s Hold',
+        durationSec: 90,
+        reps: 8,
+        steps: [
+          'Start on all fours, wrists under shoulders.',
+          'Extend opposite arm + leg and hold 3 seconds, spine neutral.',
+          'Focus on bracing. 3 sets of 8 per side.',
+        ],
+      },
+    ],
   },
   {
     id: 'hips_rise_first',
@@ -218,6 +244,19 @@ const faults: FaultDefinition[] = [
     severity: 2,
     dynamicCue: 'Drive with your legs — don\'t let your hips shoot up first.',
     fqiPenalty: 10,
+    drills: [
+      {
+        id: 'deadlift-pause-off-floor',
+        title: 'Pause Deadlifts (1″ Off Floor)',
+        durationSec: 150,
+        reps: 5,
+        steps: [
+          'Set up at the bar; lift until bar is 1 inch off the floor.',
+          'Pause 2 seconds maintaining leg pressure, then lockout.',
+          'Use 60% of your working weight. 4 sets of 5.',
+        ],
+      },
+    ],
   },
   {
     id: 'asymmetric_pull',

--- a/lib/workouts/pullup.ts
+++ b/lib/workouts/pullup.ts
@@ -186,6 +186,19 @@ const faults: FaultDefinition[] = [
     severity: 2,
     dynamicCue: 'Pull higher to bring your chin past the bar.',
     fqiPenalty: 15,
+    drills: [
+      {
+        id: 'pullup-negative-hold',
+        title: 'Top-Position Negatives',
+        durationSec: 45,
+        reps: 3,
+        steps: [
+          'Jump or step up so your chin is over the bar.',
+          'Brace ribs down and hold the top for 3 seconds.',
+          'Lower with control over 5 seconds; repeat 3x.',
+        ],
+      },
+    ],
   },
   {
     id: 'incomplete_extension',
@@ -198,6 +211,18 @@ const faults: FaultDefinition[] = [
     severity: 1,
     dynamicCue: 'Fully extend your arms before the next rep.',
     fqiPenalty: 10,
+    drills: [
+      {
+        id: 'pullup-dead-hang',
+        title: 'Active Dead Hangs',
+        durationSec: 60,
+        steps: [
+          'Hang from the bar with straight arms, shoulders packed.',
+          'Think "long arms" — do not bend elbows.',
+          'Hold 3 rounds of 20 seconds with 45 seconds rest.',
+        ],
+      },
+    ],
   },
   {
     id: 'shoulder_elevation',
@@ -210,6 +235,19 @@ const faults: FaultDefinition[] = [
     severity: 2,
     dynamicCue: 'Draw your shoulders down to keep your lats engaged.',
     fqiPenalty: 12,
+    drills: [
+      {
+        id: 'pullup-scap-pull',
+        title: 'Scapular Pull-Ups',
+        durationSec: 60,
+        reps: 10,
+        steps: [
+          'Hang from the bar with straight arms.',
+          'Without bending elbows, pull shoulder blades down and together.',
+          'Pause 1 second then release. 2 sets of 10.',
+        ],
+      },
+    ],
   },
   {
     id: 'asymmetric_pull',

--- a/lib/workouts/pushup.ts
+++ b/lib/workouts/pushup.ts
@@ -194,6 +194,18 @@ const faults: FaultDefinition[] = [
     severity: 2,
     dynamicCue: 'Squeeze glutes to stop hip sag.',
     fqiPenalty: 15,
+    drills: [
+      {
+        id: 'pushup-plank-hold',
+        title: 'Hollow-Body Planks',
+        durationSec: 90,
+        steps: [
+          'Get into a plank with hands under shoulders.',
+          'Squeeze glutes and brace; imagine tucking your ribs down.',
+          'Hold 3 rounds of 20–30 seconds with 30 seconds rest.',
+        ],
+      },
+    ],
   },
   {
     id: 'incomplete_lockout',
@@ -218,6 +230,19 @@ const faults: FaultDefinition[] = [
     severity: 2,
     dynamicCue: 'Lower deeper until elbows hit ~90°.',
     fqiPenalty: 12,
+    drills: [
+      {
+        id: 'pushup-eccentric-5s',
+        title: '5-Second Negative Push-Ups',
+        durationSec: 120,
+        reps: 5,
+        steps: [
+          'Start in a plank position, hands shoulder-width.',
+          'Lower over 5 seconds until your chest kisses the floor.',
+          'Reset and repeat. 3 sets of 5 with full rest.',
+        ],
+      },
+    ],
   },
   {
     id: 'asymmetric_press',
@@ -254,6 +279,19 @@ const faults: FaultDefinition[] = [
     severity: 2,
     dynamicCue: 'Keep elbows at ~45° to protect your shoulders.',
     fqiPenalty: 10,
+    drills: [
+      {
+        id: 'pushup-tempo-tucked',
+        title: 'Tucked-Elbow Tempo Push-Ups',
+        durationSec: 120,
+        reps: 8,
+        steps: [
+          'Set hands slightly narrower than shoulder width.',
+          'Keep elbows tucked ~45° from your torso as you descend.',
+          'Use a 3-1-1 tempo. 3 sets of 8.',
+        ],
+      },
+    ],
   },
 ];
 

--- a/lib/workouts/squat.ts
+++ b/lib/workouts/squat.ts
@@ -193,6 +193,19 @@ const faults: FaultDefinition[] = [
     severity: 2,
     dynamicCue: 'Squat deeper — aim for hip crease below knees.',
     fqiPenalty: 15,
+    drills: [
+      {
+        id: 'squat-goblet-ankle-mob',
+        title: 'Goblet Pause Squats',
+        durationSec: 120,
+        reps: 8,
+        steps: [
+          'Hold a dumbbell at chest height.',
+          'Squat as deep as you comfortably can and pause 3 seconds.',
+          'Drive up powerfully; 3 sets of 8 with full rest.',
+        ],
+      },
+    ],
   },
   {
     id: 'incomplete_lockout',
@@ -216,6 +229,19 @@ const faults: FaultDefinition[] = [
     severity: 2,
     dynamicCue: 'Push your knees out over your toes.',
     fqiPenalty: 12,
+    drills: [
+      {
+        id: 'squat-band-knee-out',
+        title: 'Banded Knee-Out Squats',
+        durationSec: 90,
+        reps: 12,
+        steps: [
+          'Loop a light band just above your knees.',
+          'Stand in your squat stance; press knees outward into the band.',
+          'Squat keeping tension — 2 sets of 12.',
+        ],
+      },
+    ],
   },
   {
     id: 'fast_rep',
@@ -236,6 +262,19 @@ const faults: FaultDefinition[] = [
     severity: 2,
     dynamicCue: 'Keep your hips level — don\'t shift to one side.',
     fqiPenalty: 10,
+    drills: [
+      {
+        id: 'squat-single-leg-glute-bridge',
+        title: 'Single-Leg Glute Bridges',
+        durationSec: 90,
+        reps: 10,
+        steps: [
+          'Lie on your back, one foot planted, the other lifted.',
+          'Drive through the planted heel to lift hips level.',
+          'Hold 2 seconds at the top. 2 sets of 10 per side.',
+        ],
+      },
+    ],
   },
   {
     id: 'forward_lean',

--- a/styles/tabs/_scan-arkit.styles.ts
+++ b/styles/tabs/_scan-arkit.styles.ts
@@ -748,5 +748,28 @@ export const styles = StyleSheet.create({
   },
 });
 
+// #427 — session-aware overlay layout styles. Appended in an
+// orthogonal block so existing `styles` above are not modified.
+export const scanSessionOverlayStyles = StyleSheet.create({
+  sessionOverlayRow: {
+    position: 'absolute',
+    top: 96,
+    left: 0,
+    right: 0,
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 12,
+    zIndex: 120,
+  },
+  resumeToastWrap: {
+    position: 'absolute',
+    top: 72,
+    left: 12,
+    right: 12,
+    zIndex: 150,
+  },
+});
+
 // Default export to satisfy Expo Router (this file is not a route)
 export default null;

--- a/tests/unit/components/form-tracking/ActiveSetBadge.test.tsx
+++ b/tests/unit/components/form-tracking/ActiveSetBadge.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ActiveSetBadge } from '@/components/form-tracking/ActiveSetBadge';
+
+describe('ActiveSetBadge', () => {
+  it('renders set + exercise when both are provided', () => {
+    const { getByTestId, getByText } = render(
+      <ActiveSetBadge setLabel="Set 2 of 4" exerciseName="Pull-Ups" />,
+    );
+    expect(getByTestId('active-set-badge')).toBeTruthy();
+    expect(getByText('Set 2 of 4')).toBeTruthy();
+    expect(getByText('Pull-Ups')).toBeTruthy();
+  });
+
+  it('renders null when setLabel is missing', () => {
+    const { queryByTestId } = render(
+      <ActiveSetBadge setLabel="" exerciseName="Pull-Ups" />,
+    );
+    expect(queryByTestId('active-set-badge')).toBeNull();
+  });
+
+  it('renders null when exerciseName is missing', () => {
+    const { queryByTestId } = render(
+      <ActiveSetBadge setLabel="Set 1 of 3" exerciseName="" />,
+    );
+    expect(queryByTestId('active-set-badge')).toBeNull();
+  });
+
+  it('sets an accessibility label combining set + exercise', () => {
+    const { getByTestId } = render(
+      <ActiveSetBadge setLabel="Set 3 of 5" exerciseName="Squat" />,
+    );
+    expect(getByTestId('active-set-badge').props.accessibilityLabel).toBe('Set 3 of 5. Squat');
+  });
+});

--- a/tests/unit/components/form-tracking/DrillSheet.test.tsx
+++ b/tests/unit/components/form-tracking/DrillSheet.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import type { FaultDefinition } from '@/lib/types/workout-definitions';
+
+const mockMarkViewed = jest.fn();
+const mockMarkStarted = jest.fn();
+const mockMarkDismissed = jest.fn();
+
+jest.mock('@/lib/services/drill-tracker', () => ({
+  drillTracker: {
+    markViewed: (...args: unknown[]) => mockMarkViewed(...args),
+    markStarted: (...args: unknown[]) => mockMarkStarted(...args),
+    markDismissed: (...args: unknown[]) => mockMarkDismissed(...args),
+    markCompleted: jest.fn(),
+  },
+  logDrillEvent: jest.fn(),
+}));
+
+import { DrillSheet } from '@/components/form-tracking/DrillSheet';
+
+const sampleFault: FaultDefinition = {
+  id: 'shoulder_elevation',
+  displayName: 'Elevated Shoulders',
+  condition: () => true,
+  severity: 2,
+  dynamicCue: 'Draw shoulders down.',
+  fqiPenalty: 12,
+  drills: [
+    {
+      id: 'drill-a',
+      title: 'Scap Pulls',
+      durationSec: 60,
+      reps: 10,
+      steps: ['Hang', 'Pack scapulae', 'Release'],
+    },
+  ],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('DrillSheet', () => {
+  it('renders nothing when fault is null', () => {
+    const { queryByTestId } = render(
+      <DrillSheet
+        visible
+        fault={null}
+        exerciseId="pullup"
+        sessionId="sess-1"
+        onDismiss={jest.fn()}
+      />,
+    );
+    expect(queryByTestId('drill-sheet')).toBeNull();
+  });
+
+  it('renders the fault heading and drill card', () => {
+    const { getByText, getByTestId } = render(
+      <DrillSheet
+        visible
+        fault={sampleFault}
+        exerciseId="pullup"
+        sessionId="sess-1"
+        onDismiss={jest.fn()}
+      />,
+    );
+    expect(getByText('Fix: Elevated Shoulders')).toBeTruthy();
+    expect(getByText('Scap Pulls')).toBeTruthy();
+    expect(getByTestId('drill-sheet-drill-0-start')).toBeTruthy();
+  });
+
+  it('logs drill view on open', () => {
+    render(
+      <DrillSheet
+        visible
+        fault={sampleFault}
+        exerciseId="pullup"
+        sessionId="sess-1"
+        onDismiss={jest.fn()}
+      />,
+    );
+    expect(mockMarkViewed).toHaveBeenCalledWith(
+      expect.objectContaining({ drillId: 'drill-a', faultId: 'shoulder_elevation' }),
+    );
+  });
+
+  it('invokes onStartDrill + tracker when Start is tapped', () => {
+    const onStart = jest.fn();
+    const { getByTestId } = render(
+      <DrillSheet
+        visible
+        fault={sampleFault}
+        exerciseId="pullup"
+        sessionId="sess-1"
+        onDismiss={jest.fn()}
+        onStartDrill={onStart}
+      />,
+    );
+    fireEvent.press(getByTestId('drill-sheet-drill-0-start'));
+    expect(onStart).toHaveBeenCalledWith(expect.objectContaining({ id: 'drill-a' }));
+    expect(mockMarkStarted).toHaveBeenCalled();
+  });
+
+  it('calls onDismiss + tracker when Close is tapped', () => {
+    const onDismiss = jest.fn();
+    const { getByTestId } = render(
+      <DrillSheet
+        visible
+        fault={sampleFault}
+        exerciseId="pullup"
+        sessionId="sess-1"
+        onDismiss={onDismiss}
+      />,
+    );
+    fireEvent.press(getByTestId('drill-sheet-dismiss'));
+    expect(onDismiss).toHaveBeenCalled();
+    expect(mockMarkDismissed).toHaveBeenCalled();
+  });
+
+  it('shows empty state when fault has no drills', () => {
+    const { getByText } = render(
+      <DrillSheet
+        visible
+        fault={{ ...sampleFault, drills: [] }}
+        exerciseId="pullup"
+        sessionId="sess-1"
+        onDismiss={jest.fn()}
+      />,
+    );
+    expect(getByText('No drills available yet for this fault.')).toBeTruthy();
+  });
+});

--- a/tests/unit/components/form-tracking/ExerciseHistoryStrip.test.tsx
+++ b/tests/unit/components/form-tracking/ExerciseHistoryStrip.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for ExerciseHistoryStrip.
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ExerciseHistoryStrip } from '@/components/form-tracking/ExerciseHistoryStrip';
+import { EMPTY_EXERCISE_HISTORY } from '@/lib/services/exercise-history';
+
+describe('ExerciseHistoryStrip', () => {
+  it('renders nothing when summary is empty', () => {
+    const { queryByTestId } = render(<ExerciseHistoryStrip summary={EMPTY_EXERCISE_HISTORY} />);
+    expect(queryByTestId('exercise-history-strip')).toBeNull();
+  });
+
+  it('renders three chips when full history is present', () => {
+    const summary = {
+      lastSession: {
+        sessionId: 'sess-1',
+        endedAt: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+        sets: 3,
+        totalReps: 24,
+        topWeightLb: 185,
+        avgFqi: 85,
+      },
+      last5SessionsAvgFqi: 81.5,
+      maxReps: 12,
+      maxVolume: 2350,
+    };
+    const { getByTestId } = render(<ExerciseHistoryStrip summary={summary} />);
+    expect(getByTestId('exercise-history-strip-last-session')).toBeTruthy();
+    expect(getByTestId('exercise-history-strip-avg-fqi')).toBeTruthy();
+    expect(getByTestId('exercise-history-strip-personal-best')).toBeTruthy();
+  });
+
+  it('formats last-session value with weight and volume when present', () => {
+    const summary = {
+      lastSession: {
+        sessionId: 'sess-1',
+        endedAt: new Date().toISOString(),
+        sets: 4,
+        totalReps: 32,
+        topWeightLb: 200,
+        avgFqi: null,
+      },
+      last5SessionsAvgFqi: null,
+      maxReps: 10,
+      maxVolume: 1800,
+    };
+    const { getByText } = render(<ExerciseHistoryStrip summary={summary} />);
+    expect(getByText('4×32 @ 200 lb')).toBeTruthy();
+    expect(getByText('10 reps · 1.8k lb')).toBeTruthy();
+  });
+
+  it('omits chips that have no data', () => {
+    const summary = {
+      lastSession: null,
+      last5SessionsAvgFqi: 72,
+      maxReps: null,
+      maxVolume: null,
+    };
+    const { getByTestId, queryByTestId } = render(<ExerciseHistoryStrip summary={summary} />);
+    expect(getByTestId('exercise-history-strip-avg-fqi')).toBeTruthy();
+    expect(queryByTestId('exercise-history-strip-last-session')).toBeNull();
+    expect(queryByTestId('exercise-history-strip-personal-best')).toBeNull();
+  });
+});

--- a/tests/unit/components/form-tracking/ExerciseSwapSheet.test.tsx
+++ b/tests/unit/components/form-tracking/ExerciseSwapSheet.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { ExerciseSwapSheet } from '@/components/form-tracking/ExerciseSwapSheet';
+
+describe('ExerciseSwapSheet', () => {
+  it('shows the target name and both action buttons', () => {
+    const { getByTestId, getByText } = render(
+      <ExerciseSwapSheet
+        visible
+        targetExerciseName="Push-Up"
+        currentExerciseName="Pull-Up"
+        onDismiss={jest.fn()}
+        onConfirm={jest.fn()}
+      />,
+    );
+    expect(getByText('Swap to Push-Up')).toBeTruthy();
+    expect(getByTestId('exercise-swap-sheet-add')).toBeTruthy();
+    expect(getByTestId('exercise-swap-sheet-replace')).toBeTruthy();
+  });
+
+  it('calls onConfirm("append") when Add is pressed', () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(
+      <ExerciseSwapSheet
+        visible
+        targetExerciseName="Squat"
+        onDismiss={jest.fn()}
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.press(getByTestId('exercise-swap-sheet-add'));
+    expect(onConfirm).toHaveBeenCalledWith('append');
+  });
+
+  it('calls onConfirm("replace") when Replace is pressed', () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(
+      <ExerciseSwapSheet
+        visible
+        targetExerciseName="Deadlift"
+        onDismiss={jest.fn()}
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.press(getByTestId('exercise-swap-sheet-replace'));
+    expect(onConfirm).toHaveBeenCalledWith('replace');
+  });
+
+  it('calls onDismiss when cancel is tapped', () => {
+    const onDismiss = jest.fn();
+    const { getByTestId } = render(
+      <ExerciseSwapSheet
+        visible
+        targetExerciseName="Bench"
+        onDismiss={onDismiss}
+        onConfirm={jest.fn()}
+      />,
+    );
+    fireEvent.press(getByTestId('exercise-swap-sheet-cancel'));
+    expect(onDismiss).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/form-tracking/HeartRatePill.test.tsx
+++ b/tests/unit/components/form-tracking/HeartRatePill.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { HeartRatePill } from '@/components/form-tracking/HeartRatePill';
+
+describe('HeartRatePill', () => {
+  it('renders nothing when bpm is null', () => {
+    const { queryByTestId } = render(<HeartRatePill bpm={null} />);
+    expect(queryByTestId('heart-rate-pill')).toBeNull();
+  });
+
+  it('renders nothing when bpm is zero', () => {
+    const { queryByTestId } = render(<HeartRatePill bpm={0} />);
+    expect(queryByTestId('heart-rate-pill')).toBeNull();
+  });
+
+  it('shows rounded BPM', () => {
+    const { getByTestId } = render(<HeartRatePill bpm={132.6} />);
+    expect(getByTestId('heart-rate-pill-bpm').props.children).toBe(133);
+  });
+
+  it('includes an accessibility label with BPM', () => {
+    const { getByTestId } = render(<HeartRatePill bpm={120} />);
+    expect(getByTestId('heart-rate-pill').props.accessibilityLabel).toBe(
+      'Heart rate 120 beats per minute',
+    );
+  });
+
+  it('marks stale samples in the accessibility label', () => {
+    const now = 1_700_000_000_000;
+    const { getByTestId } = render(
+      <HeartRatePill bpm={120} timestampMs={now - 60_000} now={() => now} />,
+    );
+    expect(getByTestId('heart-rate-pill').props.accessibilityLabel).toContain('stale');
+  });
+
+  it('picks fatigued zone when bpm is ≥ 85% of maxHR', () => {
+    const { getByTestId } = render(<HeartRatePill bpm={170} maxHeartRate={190} />);
+    // Structural check: the container border color leaflet should come from fatigued style.
+    const node = getByTestId('heart-rate-pill');
+    // styles prop is an array of merged style objects.
+    const flat = Array.isArray(node.props.style) ? Object.assign({}, ...node.props.style) : node.props.style;
+    expect(flat.borderColor).toBe('rgba(255, 110, 110, 0.65)');
+  });
+});

--- a/tests/unit/components/form-tracking/InlineRestTimer.test.tsx
+++ b/tests/unit/components/form-tracking/InlineRestTimer.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { InlineRestTimer } from '@/components/form-tracking/InlineRestTimer';
+
+describe('InlineRestTimer', () => {
+  it('renders nothing when not active', () => {
+    const { queryByTestId } = render(
+      <InlineRestTimer startedAt={null} targetSeconds={null} onExtend15={jest.fn()} onSkip={jest.fn()} />,
+    );
+    expect(queryByTestId('inline-rest-timer')).toBeNull();
+  });
+
+  it('shows remaining time formatted as M:SS', () => {
+    const now = 1_700_000_000_000;
+    const startedAt = new Date(now - 20_000).toISOString();
+    const { getByTestId } = render(
+      <InlineRestTimer
+        startedAt={startedAt}
+        targetSeconds={90}
+        onExtend15={jest.fn()}
+        onSkip={jest.fn()}
+        now={() => now}
+      />,
+    );
+    expect(getByTestId('inline-rest-timer-countdown').props.children).toBe('1:10');
+  });
+
+  it('clamps to 0:00 when elapsed exceeds target', () => {
+    const now = 1_700_000_000_000;
+    const startedAt = new Date(now - 120_000).toISOString();
+    const { getByTestId } = render(
+      <InlineRestTimer
+        startedAt={startedAt}
+        targetSeconds={90}
+        onExtend15={jest.fn()}
+        onSkip={jest.fn()}
+        now={() => now}
+      />,
+    );
+    expect(getByTestId('inline-rest-timer-countdown').props.children).toBe('0:00');
+  });
+
+  it('invokes onExtend15 when extend is tapped', () => {
+    const onExtend15 = jest.fn();
+    const now = 1_700_000_000_000;
+    const { getByTestId } = render(
+      <InlineRestTimer
+        startedAt={new Date(now - 10_000).toISOString()}
+        targetSeconds={60}
+        onExtend15={onExtend15}
+        onSkip={jest.fn()}
+        now={() => now}
+      />,
+    );
+    fireEvent.press(getByTestId('inline-rest-timer-extend'));
+    expect(onExtend15).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onSkip when skip is tapped', () => {
+    const onSkip = jest.fn();
+    const now = 1_700_000_000_000;
+    const { getByTestId } = render(
+      <InlineRestTimer
+        startedAt={new Date(now - 10_000).toISOString()}
+        targetSeconds={60}
+        onExtend15={jest.fn()}
+        onSkip={onSkip}
+        now={() => now}
+      />,
+    );
+    fireEvent.press(getByTestId('inline-rest-timer-skip'));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/components/form-tracking/SessionResumeToast.test.tsx
+++ b/tests/unit/components/form-tracking/SessionResumeToast.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { SessionResumeToast } from '@/components/form-tracking/SessionResumeToast';
+
+describe('SessionResumeToast', () => {
+  it('renders null when not visible', () => {
+    const { queryByTestId } = render(
+      <SessionResumeToast visible={false} onResume={jest.fn()} />,
+    );
+    expect(queryByTestId('session-resume-toast')).toBeNull();
+  });
+
+  it('renders generic title when exercise name is missing', () => {
+    const { getByText } = render(
+      <SessionResumeToast visible onResume={jest.fn()} />,
+    );
+    expect(getByText('Resume previous set?')).toBeTruthy();
+  });
+
+  it('renders exercise-specific title when provided', () => {
+    const { getByText } = render(
+      <SessionResumeToast visible lastExerciseName="Pull-Ups" onResume={jest.fn()} />,
+    );
+    expect(getByText('Resume Pull-Ups?')).toBeTruthy();
+  });
+
+  it('shows the background subtitle when reason is background', () => {
+    const { getByText } = render(
+      <SessionResumeToast visible reason="background" onResume={jest.fn()} />,
+    );
+    expect(getByText('Session paused while you were away.')).toBeTruthy();
+  });
+
+  it('invokes onResume when Resume is tapped', () => {
+    const onResume = jest.fn();
+    const { getByTestId } = render(
+      <SessionResumeToast visible onResume={onResume} />,
+    );
+    fireEvent.press(getByTestId('session-resume-toast-resume'));
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onDismiss when ✕ is tapped', () => {
+    const onDismiss = jest.fn();
+    const { getByTestId } = render(
+      <SessionResumeToast visible onResume={jest.fn()} onDismiss={onDismiss} />,
+    );
+    fireEvent.press(getByTestId('session-resume-toast-dismiss'));
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it('hides dismiss button when onDismiss is not provided', () => {
+    const { queryByTestId } = render(
+      <SessionResumeToast visible onResume={jest.fn()} />,
+    );
+    expect(queryByTestId('session-resume-toast-dismiss')).toBeNull();
+  });
+});

--- a/tests/unit/hooks/use-active-set-binding.test.ts
+++ b/tests/unit/hooks/use-active-set-binding.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for useActiveSetBinding.
+ */
+
+import { renderHook, act } from '@testing-library/react-native';
+
+const mockUpdateSet = jest.fn().mockResolvedValue(undefined);
+const mockCompleteSet = jest.fn().mockResolvedValue(undefined);
+
+// Prefix with `mock` so jest allows it inside the factory.
+const mockSessionState: {
+  activeSession: unknown;
+  exercises: unknown[];
+  sets: Record<string, unknown[]>;
+  updateSet: jest.Mock;
+  completeSet: jest.Mock;
+} = {
+  activeSession: null,
+  exercises: [],
+  sets: {},
+  updateSet: mockUpdateSet,
+  completeSet: mockCompleteSet,
+};
+
+jest.mock('@/lib/stores/session-runner', () => ({
+  useSessionRunner: (selector: (s: typeof mockSessionState) => unknown) => selector(mockSessionState),
+}));
+
+jest.mock('@/lib/workouts', () => jest.requireActual('@/lib/workouts'));
+
+import { useActiveSetBinding } from '@/hooks/use-active-set-binding';
+
+function setSessionState(patch: Partial<typeof mockSessionState>): void {
+  Object.assign(mockSessionState, patch);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSessionState.activeSession = null;
+  mockSessionState.exercises = [];
+  mockSessionState.sets = {};
+  mockSessionState.updateSet = mockUpdateSet;
+  mockSessionState.completeSet = mockCompleteSet;
+});
+
+describe('useActiveSetBinding', () => {
+  it('returns unbound state when there is no active session', () => {
+    const { result } = renderHook(() => useActiveSetBinding('pullup'));
+    expect(result.current.isBound).toBe(false);
+    expect(result.current.activeSet).toBeNull();
+    expect(result.current.setLabel).toBe('');
+  });
+
+  it('matches by exercise name prefix when a session is active', () => {
+    setSessionState({
+      activeSession: { id: 'sess-1' },
+      exercises: [
+        { id: 'se-1', exercise_id: 'ex-abc', exercise: { id: 'ex-abc', name: 'Pull-Up' } },
+      ],
+      sets: {
+        'se-1': [
+          { id: 'set-1', completed_at: '2024-01-01T00:00:00.000Z' },
+          { id: 'set-2', completed_at: null },
+          { id: 'set-3', completed_at: null },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() => useActiveSetBinding('pullup'));
+    expect(result.current.isBound).toBe(true);
+    expect(result.current.activeSet).toMatchObject({ id: 'set-2' });
+    expect(result.current.activeSetIndex).toBe(2);
+    expect(result.current.totalSets).toBe(3);
+    expect(result.current.setLabel).toBe('Set 2 of 3');
+  });
+
+  it('falls back to exercise_id containing the mode when name does not match', () => {
+    setSessionState({
+      activeSession: { id: 'sess-1' },
+      exercises: [
+        { id: 'se-1', exercise_id: 'ex-squat-back', exercise: { id: 'ex-squat-back', name: 'Back Work' } },
+      ],
+      sets: {
+        'se-1': [{ id: 'set-1', completed_at: null }],
+      },
+    });
+    const { result } = renderHook(() => useActiveSetBinding('squat'));
+    expect(result.current.sessionExercise?.id).toBe('se-1');
+  });
+
+  it('commitReps updates actual_reps then completes the pending set', async () => {
+    setSessionState({
+      activeSession: { id: 'sess-1' },
+      exercises: [
+        { id: 'se-1', exercise_id: 'ex-a', exercise: { id: 'ex-a', name: 'Push-Up' } },
+      ],
+      sets: {
+        'se-1': [{ id: 'set-pending', completed_at: null }],
+      },
+    });
+
+    const { result } = renderHook(() => useActiveSetBinding('pushup'));
+    let returned: string | null = null;
+    await act(async () => {
+      returned = await result.current.commitReps(8.7);
+    });
+    expect(returned).toBe('set-pending');
+    expect(mockUpdateSet).toHaveBeenCalledWith('set-pending', { actual_reps: 9 });
+    expect(mockCompleteSet).toHaveBeenCalledWith('set-pending');
+  });
+
+  it('commitReps is a no-op when nothing is bound', async () => {
+    const { result } = renderHook(() => useActiveSetBinding('pullup'));
+    const ret = await result.current.commitReps(10);
+    expect(ret).toBeNull();
+    expect(mockUpdateSet).not.toHaveBeenCalled();
+    expect(mockCompleteSet).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/hooks/use-exercise-history.test.ts
+++ b/tests/unit/hooks/use-exercise-history.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for useExerciseHistory hook.
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+const mockGetSummary = jest.fn();
+
+jest.mock('@/lib/services/exercise-history', () => {
+  const actual = jest.requireActual('@/lib/services/exercise-history');
+  return {
+    ...actual,
+    getExerciseHistorySummary: (...args: unknown[]) => mockGetSummary(...args),
+  };
+});
+
+import { useExerciseHistory, resetExerciseHistoryCache } from '@/hooks/use-exercise-history';
+import { EMPTY_EXERCISE_HISTORY } from '@/lib/services/exercise-history';
+
+const sampleSummary = {
+  lastSession: {
+    sessionId: 'sess-1',
+    endedAt: '2024-11-01T12:00:00.000Z',
+    sets: 3,
+    totalReps: 24,
+    topWeightLb: 185,
+    avgFqi: 82,
+  },
+  last5SessionsAvgFqi: 81.5,
+  maxReps: 10,
+  maxVolume: 2000,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetExerciseHistoryCache();
+  mockGetSummary.mockResolvedValue(sampleSummary);
+});
+
+describe('useExerciseHistory', () => {
+  it('returns EMPTY summary when exerciseId is null', () => {
+    const { result } = renderHook(() => useExerciseHistory(null));
+    expect(result.current.summary).toEqual(EMPTY_EXERCISE_HISTORY);
+    expect(result.current.isLoading).toBe(false);
+    expect(mockGetSummary).not.toHaveBeenCalled();
+  });
+
+  it('loads summary for a given exerciseId and populates state', async () => {
+    const { result } = renderHook(() => useExerciseHistory('ex-pullup'));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.summary).toEqual(sampleSummary);
+    expect(mockGetSummary).toHaveBeenCalledTimes(1);
+    expect(mockGetSummary).toHaveBeenCalledWith('ex-pullup');
+  });
+
+  it('serves subsequent renders from cache without re-querying the service', async () => {
+    const { result, unmount } = renderHook(() => useExerciseHistory('ex-bench'));
+    await waitFor(() => expect(result.current.summary).toEqual(sampleSummary));
+    unmount();
+
+    // Second mount with same id — should NOT call the service again.
+    const second = renderHook(() => useExerciseHistory('ex-bench'));
+    await waitFor(() => expect(second.result.current.summary).toEqual(sampleSummary));
+    expect(mockGetSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it('refresh() forces a re-query even when cache is fresh', async () => {
+    const { result } = renderHook(() => useExerciseHistory('ex-squat'));
+    await waitFor(() => expect(result.current.summary).toEqual(sampleSummary));
+    expect(mockGetSummary).toHaveBeenCalledTimes(1);
+
+    const updated = { ...sampleSummary, maxReps: 12 };
+    mockGetSummary.mockResolvedValueOnce(updated);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(mockGetSummary).toHaveBeenCalledTimes(2);
+    expect(result.current.summary).toEqual(updated);
+  });
+
+  it('surfaces errors without clobbering previous data', async () => {
+    const { result } = renderHook(() => useExerciseHistory('ex-deadlift'));
+    await waitFor(() => expect(result.current.summary).toEqual(sampleSummary));
+
+    mockGetSummary.mockRejectedValueOnce(new Error('boom'));
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.summary).toEqual(sampleSummary);
+  });
+});

--- a/tests/unit/hooks/use-live-fatigue.test.ts
+++ b/tests/unit/hooks/use-live-fatigue.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for use-live-fatigue.
+ */
+
+import { renderHook } from '@testing-library/react-native';
+import { useLiveFatigue, computeLiveFatigue, type LiveFatigueInput } from '@/hooks/use-live-fatigue';
+
+describe('computeLiveFatigue (pure)', () => {
+  it('returns fresh baseline with no data', () => {
+    const r = computeLiveFatigue({ recentFqi: [], heartRateBpm: null });
+    expect(r.state).toBe('fresh');
+    expect(r.suggestRestSec).toBe(0);
+    expect(r.reason).toBe('baseline');
+  });
+
+  it('promotes to working when FQI drops moderately', () => {
+    const r = computeLiveFatigue({ recentFqi: [90, 88, 85], heartRateBpm: null });
+    expect(r.state).toBe('working');
+    expect(r.suggestRestSec).toBe(30);
+  });
+
+  it('goes fatigued when FQI drops sharply', () => {
+    const r = computeLiveFatigue({ recentFqi: [92, 91, 90, 75], heartRateBpm: null });
+    expect(r.state).toBe('fatigued');
+    expect(r.suggestRestSec).toBe(60);
+  });
+
+  it('classifies HR zone from bpm/maxHr', () => {
+    const r1 = computeLiveFatigue({ recentFqi: [], heartRateBpm: 170, maxHeartRate: 190 });
+    expect(r1.state).toBe('fatigued');
+
+    const r2 = computeLiveFatigue({ recentFqi: [], heartRateBpm: 140, maxHeartRate: 190 });
+    expect(r2.state).toBe('working');
+
+    const r3 = computeLiveFatigue({ recentFqi: [], heartRateBpm: 110, maxHeartRate: 190 });
+    expect(r3.state).toBe('fresh');
+  });
+
+  it('picks the most severe signal when FQI and HR disagree', () => {
+    const r = computeLiveFatigue({
+      recentFqi: [90, 89],
+      heartRateBpm: 175,
+      maxHeartRate: 190,
+    });
+    expect(r.state).toBe('fatigued');
+    expect(r.reason).toContain('hr:fatigued');
+  });
+
+  it('treats invalid HR as missing', () => {
+    const r = computeLiveFatigue({ recentFqi: [], heartRateBpm: 0 });
+    expect(r.state).toBe('fresh');
+  });
+});
+
+describe('useLiveFatigue hook', () => {
+  it('returns a memoized result for the same inputs', () => {
+    const { result, rerender } = renderHook(
+      (props: LiveFatigueInput) => useLiveFatigue(props),
+      {
+        initialProps: { recentFqi: [80, 78], heartRateBpm: 130 } as LiveFatigueInput,
+      },
+    );
+    const first = result.current;
+    rerender({ recentFqi: [80, 78], heartRateBpm: 130 });
+    // Memoized by the same reference inputs — object identity stable if arrays are the same ref
+    expect(result.current.state).toBe(first.state);
+    expect(result.current.suggestRestSec).toBe(first.suggestRestSec);
+  });
+});

--- a/tests/unit/hooks/use-premium-cue-audio.test.ts
+++ b/tests/unit/hooks/use-premium-cue-audio.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Covers usePremiumCueAudio priorityHint behavior — existing non-hint
+ * callers must keep working, and numeric severity should collapse
+ * minIntervalMs / volume through the shared mapper.
+ */
+
+const mockSpeak = jest.fn();
+const mockStop = jest.fn();
+jest.mock('expo-speech', () => ({
+  speak: (...args: unknown[]) => mockSpeak(...args),
+  stop: (...args: unknown[]) => mockStop(...args),
+}));
+
+jest.mock('expo-file-system', () => ({
+  Paths: { document: '/tmp/doc' },
+  File: function (this: unknown, dir: string, path: string) {
+    // @ts-expect-error - constructor
+    this.uri = `file://${dir}/${path}`;
+    // @ts-expect-error - constructor
+    this.exists = false;
+  },
+}));
+
+jest.mock('expo-av', () => ({
+  Audio: {
+    setAudioModeAsync: jest.fn().mockResolvedValue(undefined),
+    Sound: {
+      createAsync: jest.fn().mockResolvedValue({ sound: {} }),
+    },
+  },
+  InterruptionModeIOS: { MixWithOthers: 0 },
+}));
+
+jest.mock('@/lib/logger', () => ({
+  warnWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+  logWithTs: jest.fn(),
+}));
+
+jest.mock('@/lib/services/ErrorHandler', () => ({
+  createError: jest.fn(),
+  logError: jest.fn(),
+}));
+
+import { renderHook, act } from '@testing-library/react-native';
+import { usePremiumCueAudio } from '@/hooks/use-premium-cue-audio';
+import { mapSeverityToAudioHint } from '@/lib/services/cue-priority-audio';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSpeak.mockImplementation((_text, opts?: { onDone?: () => void }) => {
+    opts?.onDone?.();
+  });
+});
+
+describe('usePremiumCueAudio (existing behavior)', () => {
+  it('speaks a cue through expo-speech when enabled and no manifest match', async () => {
+    const { result } = renderHook(() => usePremiumCueAudio({ enabled: true }));
+    await act(async () => {
+      result.current.speak('Pull higher');
+    });
+    expect(mockSpeak).toHaveBeenCalled();
+    const opts = mockSpeak.mock.calls[0][1];
+    expect(opts.volume).toBeCloseTo(1, 2); // default
+  });
+
+  it('drops cues when disabled', async () => {
+    const onEvent = jest.fn();
+    const { result } = renderHook(() => usePremiumCueAudio({ enabled: false, onEvent }));
+    await act(async () => {
+      result.current.speak('Pull higher');
+    });
+    expect(mockSpeak).not.toHaveBeenCalled();
+    expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ action: 'dropped' }));
+  });
+});
+
+describe('usePremiumCueAudio priorityHint (new)', () => {
+  it('applies severity-derived volume when priorityHint is a number', async () => {
+    const expected = mapSeverityToAudioHint(3);
+    const { result } = renderHook(() => usePremiumCueAudio({ enabled: true, priorityHint: 3 }));
+    await act(async () => {
+      result.current.speak('Rounded back');
+    });
+    expect(mockSpeak).toHaveBeenCalled();
+    const opts = mockSpeak.mock.calls[0][1];
+    expect(opts.volume).toBeCloseTo(expected.volume, 2);
+  });
+
+  it('respects explicit priorityHint object overrides', async () => {
+    const { result } = renderHook(() =>
+      usePremiumCueAudio({
+        enabled: true,
+        priorityHint: { intervalMs: 500, volume: 0.42 },
+      }),
+    );
+    await act(async () => {
+      result.current.speak('Hip sag');
+    });
+    const opts = mockSpeak.mock.calls[0][1];
+    expect(opts.volume).toBeCloseTo(0.42, 2);
+  });
+
+  it('falls back to raw props when priorityHint is omitted', async () => {
+    const { result } = renderHook(() =>
+      usePremiumCueAudio({ enabled: true, volume: 0.55, minIntervalMs: 1234 }),
+    );
+    await act(async () => {
+      result.current.speak('Stay tight');
+    });
+    const opts = mockSpeak.mock.calls[0][1];
+    expect(opts.volume).toBeCloseTo(0.55, 2);
+  });
+});

--- a/tests/unit/hooks/use-session-autopause.test.ts
+++ b/tests/unit/hooks/use-session-autopause.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for useSessionAutopause.
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+const mockPause = jest.fn().mockResolvedValue(undefined);
+const mockResume = jest.fn().mockResolvedValue(5000);
+const mockPauseState = {
+  isPaused: false,
+  pausedAt: null as string | null,
+  reason: null as string | null,
+};
+
+jest.mock('@/lib/stores/session-runner.pause', () => ({
+  pauseActiveSession: (...args: unknown[]) => mockPause(...args),
+  resumeActiveSession: (...args: unknown[]) => mockResume(...args),
+  useSessionPauseState: () => mockPauseState,
+}));
+
+const mockSessionSelectorState: { current: { activeSession: { id: string } | null } } = {
+  current: { activeSession: { id: 'sess-1' } },
+};
+jest.mock('@/lib/stores/session-runner', () => {
+  const fn = (selector: (s: typeof mockSessionSelectorState.current) => unknown) =>
+    selector(mockSessionSelectorState.current);
+  (fn as unknown as { getState: () => typeof mockSessionSelectorState.current }).getState =
+    () => mockSessionSelectorState.current;
+  return { useSessionRunner: fn };
+});
+
+type Listener = (state: string) => void;
+let appStateListeners: Listener[] = [];
+const mockAddEventListener = jest.fn((event: string, listener: Listener) => {
+  if (event === 'change') appStateListeners.push(listener);
+  return {
+    remove: () => {
+      appStateListeners = appStateListeners.filter((l) => l !== listener);
+    },
+  };
+});
+jest.mock('react-native', () => ({
+  AppState: {
+    addEventListener: (...args: unknown[]) =>
+      mockAddEventListener(...(args as [string, Listener])),
+  },
+}));
+
+import { useSessionAutopause } from '@/hooks/use-session-autopause';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPauseState.isPaused = false;
+  mockPauseState.reason = null;
+  mockSessionSelectorState.current = { activeSession: { id: 'sess-1' } };
+  appStateListeners = [];
+});
+
+describe('useSessionAutopause', () => {
+  it('calls pauseActiveSession on background transition when a session is active', async () => {
+    renderHook(() => useSessionAutopause());
+    expect(appStateListeners).toHaveLength(1);
+
+    await act(async () => {
+      appStateListeners[0]('background');
+    });
+    expect(mockPause).toHaveBeenCalledWith('background');
+  });
+
+  it('does not pause when the app was already inactive (no active→background)', async () => {
+    renderHook(() => useSessionAutopause());
+    await act(async () => {
+      appStateListeners[0]('inactive');
+      appStateListeners[0]('background');
+    });
+    expect(mockPause).not.toHaveBeenCalled();
+  });
+
+  it('sets needsResume=true on return to foreground after background', async () => {
+    const { result } = renderHook(() => useSessionAutopause());
+    await act(async () => {
+      appStateListeners[0]('background');
+    });
+    mockPauseState.isPaused = true;
+    await act(async () => {
+      appStateListeners[0]('active');
+    });
+    await waitFor(() => expect(result.current.needsResume).toBe(true));
+  });
+
+  it('acknowledgeResume calls resumeActiveSession and clears the banner', async () => {
+    const { result } = renderHook(() => useSessionAutopause());
+    await act(async () => {
+      appStateListeners[0]('background');
+    });
+    mockPauseState.isPaused = true;
+    await act(async () => {
+      appStateListeners[0]('active');
+    });
+    await waitFor(() => expect(result.current.needsResume).toBe(true));
+
+    let returned: number | undefined;
+    await act(async () => {
+      returned = await result.current.acknowledgeResume();
+    });
+    expect(mockResume).toHaveBeenCalled();
+    expect(returned).toBe(5000);
+    expect(result.current.needsResume).toBe(false);
+    expect(result.current.lastPausedDurationMs).toBe(5000);
+  });
+
+  it('does nothing when enabled is false', async () => {
+    renderHook(() => useSessionAutopause({ enabled: false }));
+    expect(appStateListeners).toHaveLength(0);
+  });
+
+  it('clears banner when active session goes null', async () => {
+    const { result, rerender } = renderHook(() => useSessionAutopause());
+    await act(async () => {
+      appStateListeners[0]('background');
+    });
+    mockPauseState.isPaused = true;
+    await act(async () => {
+      appStateListeners[0]('active');
+    });
+    await waitFor(() => expect(result.current.needsResume).toBe(true));
+
+    // Session ends
+    mockSessionSelectorState.current = { activeSession: null };
+    rerender({});
+    await waitFor(() => expect(result.current.needsResume).toBe(false));
+  });
+});

--- a/tests/unit/services/cue-priority-audio.test.ts
+++ b/tests/unit/services/cue-priority-audio.test.ts
@@ -1,0 +1,53 @@
+import {
+  mapSeverityToAudioHint,
+  severityToPriority,
+  CUE_AUDIO_TABLE,
+} from '@/lib/services/cue-priority-audio';
+
+describe('severityToPriority', () => {
+  it.each([
+    [undefined, 'low'],
+    [0, 'low'],
+    [1, 'low'],
+    [2, 'normal'],
+    [3, 'high'],
+    [5, 'high'],
+  ])('maps severity %p → %p', (sev, expected) => {
+    expect(severityToPriority(sev as number | undefined)).toBe(expected);
+  });
+});
+
+describe('mapSeverityToAudioHint', () => {
+  it('returns the low preset for severity 1', () => {
+    const hint = mapSeverityToAudioHint(1);
+    expect(hint).toEqual(CUE_AUDIO_TABLE.low);
+  });
+
+  it('returns normal preset for severity 2', () => {
+    expect(mapSeverityToAudioHint(2)).toEqual(CUE_AUDIO_TABLE.normal);
+  });
+
+  it('returns high preset for severity 3 with medium haptic + repeat', () => {
+    const hint = mapSeverityToAudioHint(3);
+    expect(hint.priority).toBe('high');
+    expect(hint.haptic).toBe('medium');
+    expect(hint.repeatIfUnadopted).toBe(true);
+    expect(hint.volume).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it('elevates low → normal when fatigued', () => {
+    const hint = mapSeverityToAudioHint(1, { isFatigued: true });
+    expect(hint.priority).toBe('normal');
+  });
+
+  it('elevates normal → high when fatigued', () => {
+    const hint = mapSeverityToAudioHint(2, { isFatigued: true });
+    expect(hint.priority).toBe('high');
+  });
+
+  it('adds interval padding when an active cue is already repeating', () => {
+    const baseline = mapSeverityToAudioHint(2);
+    const padded = mapSeverityToAudioHint(2, { isActiveCue: true });
+    expect(padded.intervalMs).toBe(baseline.intervalMs + 400);
+  });
+});

--- a/tests/unit/services/drill-tracker.test.ts
+++ b/tests/unit/services/drill-tracker.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for drill-tracker service.
+ */
+
+const mockLogCueEvent = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('@/lib/services/cue-logger', () => ({
+  logCueEvent: (...args: unknown[]) => mockLogCueEvent(...args),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  warnWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+  logWithTs: jest.fn(),
+}));
+
+import { drillTracker, logDrillEvent } from '@/lib/services/drill-tracker';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('drill-tracker', () => {
+  it('logDrillEvent forwards to the cue-logger with the expected shape', async () => {
+    await logDrillEvent({
+      sessionId: 'sess-1',
+      exerciseId: 'pullup',
+      faultId: 'shoulder_elevation',
+      drillId: 'pullup-scap-pull',
+      action: 'viewed',
+      repCount: 3,
+    });
+    expect(mockLogCueEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'sess-1',
+        cue: 'drill:pullup-scap-pull',
+        mode: 'pullup',
+        phase: 'shoulder_elevation',
+        reason: 'drill_viewed',
+        repCount: 3,
+      }),
+    );
+  });
+
+  it('drillTracker.markStarted encodes the lifecycle action', async () => {
+    await drillTracker.markStarted({
+      sessionId: 'sess-1',
+      exerciseId: 'squat',
+      faultId: 'shallow_depth',
+      drillId: 'squat-goblet-ankle-mob',
+    });
+    expect(mockLogCueEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'drill_started' }),
+    );
+  });
+
+  it('swallows downstream errors without throwing', async () => {
+    mockLogCueEvent.mockRejectedValueOnce(new Error('network down'));
+    await expect(
+      drillTracker.markCompleted({
+        sessionId: 'sess-1',
+        exerciseId: 'bench',
+        faultId: 'elbow_flare',
+        drillId: 'bench-close-grip',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('covers all four actions on the shorthand', async () => {
+    const base = {
+      sessionId: 'sess-1',
+      exerciseId: 'pushup',
+      faultId: 'hip_sag',
+      drillId: 'pushup-plank-hold',
+    };
+    await drillTracker.markViewed(base);
+    await drillTracker.markStarted(base);
+    await drillTracker.markCompleted(base);
+    await drillTracker.markDismissed(base);
+    const reasons = mockLogCueEvent.mock.calls.map((c) => (c[0] as { reason: string }).reason);
+    expect(reasons).toEqual([
+      'drill_viewed',
+      'drill_started',
+      'drill_completed',
+      'drill_dismissed',
+    ]);
+  });
+});

--- a/tests/unit/services/exercise-history.test.ts
+++ b/tests/unit/services/exercise-history.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for exercise-history service.
+ */
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('@/lib/logger', () => ({
+  warnWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+  logWithTs: jest.fn(),
+}));
+
+const mockDb = {
+  getAllAsync: jest.fn(),
+};
+
+jest.mock('@/lib/services/database/local-db', () => ({
+  localDB: {
+    get db() {
+      return mockDb;
+    },
+  },
+}));
+
+const mockSupabaseLimit = jest.fn();
+const mockSupabaseOrder = jest.fn(() => ({ limit: mockSupabaseLimit }));
+const mockSupabaseNot = jest.fn(() => ({ order: mockSupabaseOrder }));
+const mockSupabaseEq = jest.fn(() => ({ not: mockSupabaseNot, order: mockSupabaseOrder }));
+const mockSupabaseSelect = jest.fn(() => ({ eq: mockSupabaseEq }));
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(() => ({ select: mockSupabaseSelect })),
+  },
+}));
+
+import { getExerciseHistorySummary, EMPTY_EXERCISE_HISTORY } from '@/lib/services/exercise-history';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDb.getAllAsync.mockReset();
+  mockSupabaseLimit.mockReset();
+  mockSupabaseLimit.mockResolvedValue({ data: [], error: null });
+});
+
+describe('getExerciseHistorySummary', () => {
+  it('returns EMPTY summary for blank exerciseId without touching db', async () => {
+    const result = await getExerciseHistorySummary('');
+    expect(result).toEqual(EMPTY_EXERCISE_HISTORY);
+    expect(mockDb.getAllAsync).not.toHaveBeenCalled();
+  });
+
+  it('returns EMPTY summary when no sessions exist locally or remotely', async () => {
+    mockDb.getAllAsync.mockResolvedValue([]);
+    mockSupabaseLimit.mockResolvedValue({ data: [], error: null });
+
+    const result = await getExerciseHistorySummary('ex-pullup');
+    expect(result).toEqual(EMPTY_EXERCISE_HISTORY);
+  });
+
+  it('builds summary from a single session with one set', async () => {
+    mockDb.getAllAsync.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM workout_session_exercises')) {
+        return [
+          {
+            session_id: 'sess-1',
+            ended_at: '2024-11-01T12:00:00.000Z',
+            started_at: '2024-11-01T11:00:00.000Z',
+            set_id: 'set-1',
+            completed_at: '2024-11-01T11:05:00.000Z',
+            actual_reps: 8,
+            actual_weight: 185,
+          },
+        ];
+      }
+      if (sql.includes('FROM reps')) {
+        return [];
+      }
+      return [];
+    });
+
+    const result = await getExerciseHistorySummary('ex-bench');
+    expect(result.lastSession).not.toBeNull();
+    expect(result.lastSession?.sessionId).toBe('sess-1');
+    expect(result.lastSession?.sets).toBe(1);
+    expect(result.lastSession?.totalReps).toBe(8);
+    expect(result.lastSession?.topWeightLb).toBe(185);
+    expect(result.lastSession?.avgFqi).toBeNull();
+    expect(result.maxReps).toBe(8);
+    expect(result.maxVolume).toBe(8 * 185);
+    expect(result.last5SessionsAvgFqi).toBeNull();
+  });
+
+  it('averages FQI across up to the last 5 sessions and surfaces max reps/volume', async () => {
+    // Build 6 sessions with different rep/weight combos to verify max + cap at 5.
+    const base = 1700000000000;
+    const sessionRows = Array.from({ length: 6 }, (_, i) => ({
+      session_id: `sess-${i + 1}`,
+      ended_at: new Date(base + i * 86_400_000).toISOString(), // newest-first emulation via ordering
+      started_at: new Date(base + i * 86_400_000 - 3600_000).toISOString(),
+      set_id: `set-${i + 1}`,
+      completed_at: new Date(base + i * 86_400_000).toISOString(),
+      actual_reps: 5 + i,
+      actual_weight: 100 + i * 10,
+    }));
+    // Local query returns rows newest-first — simulate by reversing
+    const newestFirst = [...sessionRows].reverse();
+
+    const fqiRows = [
+      { session_id: 'sess-6', fqi: 90 },
+      { session_id: 'sess-5', fqi: 80 },
+      { session_id: 'sess-4', fqi: 70 },
+      { session_id: 'sess-3', fqi: 60 },
+      { session_id: 'sess-2', fqi: 50 },
+      { session_id: 'sess-1', fqi: 40 }, // should be excluded (outside 5-most-recent)
+    ];
+
+    mockDb.getAllAsync.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM workout_session_exercises')) return newestFirst;
+      if (sql.includes('FROM reps')) return fqiRows;
+      return [];
+    });
+
+    const result = await getExerciseHistorySummary('ex-squat');
+    expect(result.lastSession?.sessionId).toBe('sess-6');
+    expect(result.maxReps).toBe(10); // 5+5
+    expect(result.maxVolume).toBe(10 * 150); // reps*weight for sess-6
+    // Avg of last 5 sessions' FQI = (90+80+70+60+50)/5 = 70
+    expect(result.last5SessionsAvgFqi).toBeCloseTo(70, 5);
+  });
+
+  it('falls back to EMPTY on local query exception', async () => {
+    mockDb.getAllAsync.mockRejectedValue(new Error('sqlite broken'));
+    mockSupabaseLimit.mockResolvedValue({ data: [], error: null });
+
+    const result = await getExerciseHistorySummary('ex-pullup');
+    expect(result).toEqual(EMPTY_EXERCISE_HISTORY);
+  });
+});

--- a/tests/unit/stores/session-runner.pause.test.ts
+++ b/tests/unit/stores/session-runner.pause.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the session-runner pause extension module.
+ */
+
+let mockUuidCounter = 0;
+jest.mock('expo-crypto', () => ({
+  randomUUID: jest.fn(() => `uuid-${++mockUuidCounter}`),
+}));
+
+jest.mock('@/lib/services/database/local-db', () => ({
+  localDB: {
+    db: {
+      getAllAsync: jest.fn().mockResolvedValue([]),
+      runAsync: jest.fn().mockResolvedValue(undefined),
+      getFirstAsync: jest.fn().mockResolvedValue(null),
+    },
+  },
+}));
+
+const mockLocalUpsert = jest.fn().mockResolvedValue(undefined);
+jest.mock('@/lib/services/database/generic-sync', () => ({
+  genericLocalUpsert: (...args: unknown[]) => mockLocalUpsert(...args),
+  genericSoftDelete: jest.fn().mockResolvedValue(undefined),
+  genericGetAll: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+  warnWithTs: jest.fn(),
+}));
+
+const mockSessionGetState: { current: { activeSession: { id: string } | null } } = {
+  current: { activeSession: { id: 'sess-1' } },
+};
+jest.mock('@/lib/stores/session-runner', () => ({
+  useSessionRunner: {
+    getState: () => mockSessionGetState.current,
+  },
+}));
+
+import {
+  pauseActiveSession,
+  resumeActiveSession,
+  toggleActiveSessionPause,
+  __resetSessionPauseState,
+} from '@/lib/stores/session-runner.pause';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  __resetSessionPauseState();
+  mockUuidCounter = 0;
+  mockSessionGetState.current = { activeSession: { id: 'sess-1' } };
+  mockLocalUpsert.mockResolvedValue(undefined);
+});
+
+describe('session-runner.pause', () => {
+  it('pauseActiveSession is a no-op when no session is active', async () => {
+    mockSessionGetState.current = { activeSession: null };
+    await pauseActiveSession('manual');
+    expect(mockLocalUpsert).not.toHaveBeenCalled();
+  });
+
+  it('records a pause event when pausing', async () => {
+    await pauseActiveSession('background');
+    expect(mockLocalUpsert).toHaveBeenCalledWith(
+      'workout_session_events',
+      'id',
+      expect.objectContaining({
+        session_id: 'sess-1',
+        type: 'rest_started',
+      }),
+      0,
+    );
+    const payload = JSON.parse(
+      (mockLocalUpsert.mock.calls[0][2] as { payload: string }).payload,
+    );
+    expect(payload.subtype).toBe('session_paused');
+    expect(payload.reason).toBe('background');
+  });
+
+  it('resumeActiveSession returns the paused duration and logs a resume event', async () => {
+    await pauseActiveSession('background');
+    const dur = await resumeActiveSession();
+    expect(dur).toBeGreaterThanOrEqual(0);
+    // second call (the resume) logs a completion event
+    expect(mockLocalUpsert).toHaveBeenCalledTimes(2);
+    const payload = JSON.parse(
+      (mockLocalUpsert.mock.calls[1][2] as { payload: string }).payload,
+    );
+    expect(payload.subtype).toBe('session_resumed');
+    expect(payload.paused_duration_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('toggleActiveSessionPause pauses when running and resumes when paused', async () => {
+    const first = await toggleActiveSessionPause('manual');
+    expect(first).toBe(true); // paused
+    const second = await toggleActiveSessionPause();
+    expect(second).toBe(false); // resumed
+  });
+
+  it('duplicate pauses are ignored', async () => {
+    await pauseActiveSession('background');
+    await pauseActiveSession('background');
+    expect(mockLocalUpsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('resume when never paused returns 0 without writing events', async () => {
+    const result = await resumeActiveSession();
+    expect(result).toBe(0);
+    expect(mockLocalUpsert).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/stores/session-runner.test.ts
+++ b/tests/unit/stores/session-runner.test.ts
@@ -1275,6 +1275,78 @@ describe('duplicateExercise', () => {
 });
 
 // ===========================================================================
+// swapExerciseByDetectionMode
+// ===========================================================================
+
+describe('swapExerciseByDetectionMode', () => {
+  beforeEach(async () => {
+    mockGenericLocalUpsert.mockResolvedValue(undefined);
+    mockGetAllAsync.mockResolvedValue([]);
+  });
+
+  it('returns null when no session is active', async () => {
+    const result = await state().swapExerciseByDetectionMode('pullup');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the local db cannot resolve an exercise for the mode', async () => {
+    await state().startSession();
+    mockGetAllAsync.mockResolvedValue([]);
+
+    const result = await state().swapExerciseByDetectionMode('pullup');
+    expect(result).toBeNull();
+  });
+
+  it('appends a new session exercise when a mode match exists', async () => {
+    await state().startSession();
+
+    // First call: find by id (returns the matched exercise id).
+    // Subsequent getAllAsync calls are for loadSessionExercises etc.
+    mockGetAllAsync.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM exercises WHERE LOWER')) {
+        return [{ id: 'ex-pullup-system' }];
+      }
+      if (sql.includes('FROM exercises WHERE id')) {
+        return [{ id: 'ex-pullup-system', name: 'Pull-Up', is_compound: 1, is_timed: 0, is_system: 1 }];
+      }
+      return [];
+    });
+
+    const existingCount = state().exercises.length;
+    const newSeId = await state().swapExerciseByDetectionMode('pullup', 'append');
+    expect(newSeId).toBeTruthy();
+    expect(state().exercises.length).toBe(existingCount + 1);
+    expect(state().exercises[state().exercises.length - 1].exercise_id).toBe('ex-pullup-system');
+  });
+
+  it('removes the current exercise then adds the new one on replace', async () => {
+    await state().startSession();
+
+    // Seed an existing exercise
+    mockGetAllAsync.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM exercises WHERE LOWER')) {
+        return [{ id: 'ex-squat' }];
+      }
+      if (sql.includes('FROM exercises WHERE id')) {
+        return [{ id: 'ex-squat', name: 'Squat', is_compound: 1, is_timed: 0, is_system: 1 }];
+      }
+      return [];
+    });
+    await state().addExercise('ex-first');
+
+    const beforeLen = state().exercises.length;
+    const firstId = state().exercises[beforeLen - 1].id;
+
+    const newSeId = await state().swapExerciseByDetectionMode('squat', 'replace');
+    expect(newSeId).toBeTruthy();
+    // removeExercise + addExercise: net 0 change, but id differs
+    expect(state().exercises.length).toBe(beforeLen);
+    expect(state().exercises.some((e) => e.id === firstId)).toBe(false);
+    expect(mockGenericSoftDelete).toHaveBeenCalledWith('workout_session_exercises', 'id', firstId);
+  });
+});
+
+// ===========================================================================
 // Integration: Full Session Lifecycle
 // ===========================================================================
 

--- a/tests/unit/workouts/fault-drills.test.ts
+++ b/tests/unit/workouts/fault-drills.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Asserts that the drills[] metadata added to FaultDefinition is present
+ * and well-formed for every workout that should surface them.
+ *
+ * If a new workout is added with faults, add its definition to the
+ * registry below so this test catches missing drills.
+ */
+import type { FaultDefinition } from '@/lib/types/workout-definitions';
+import pullup from '@/lib/workouts/pullup';
+import squat from '@/lib/workouts/squat';
+import deadlift from '@/lib/workouts/deadlift';
+import pushup from '@/lib/workouts/pushup';
+import benchpress from '@/lib/workouts/benchpress';
+
+interface TestWorkoutShape {
+  id: string;
+  faults: FaultDefinition[];
+}
+
+const expectations: {
+  workout: TestWorkoutShape;
+  faultIdsWithDrills: string[];
+}[] = [
+  {
+    workout: pullup,
+    faultIdsWithDrills: ['incomplete_rom', 'incomplete_extension', 'shoulder_elevation'],
+  },
+  {
+    workout: squat,
+    faultIdsWithDrills: ['shallow_depth', 'knee_valgus', 'hip_shift'],
+  },
+  {
+    workout: deadlift,
+    faultIdsWithDrills: ['incomplete_lockout', 'rounded_back', 'hips_rise_first'],
+  },
+  {
+    workout: pushup,
+    faultIdsWithDrills: ['hip_sag', 'shallow_depth', 'elbow_flare'],
+  },
+  {
+    workout: benchpress,
+    faultIdsWithDrills: ['incomplete_lockout', 'shallow_depth', 'elbow_flare'],
+  },
+];
+
+function fault(workout: TestWorkoutShape, id: string): FaultDefinition | undefined {
+  return workout.faults.find((f) => f.id === id);
+}
+
+describe('FaultDefinition.drills backfill', () => {
+  for (const { workout, faultIdsWithDrills } of expectations) {
+    describe(workout.id, () => {
+      it(`has drill metadata for each of the top ${faultIdsWithDrills.length} faults`, () => {
+        for (const id of faultIdsWithDrills) {
+          const f = fault(workout, id);
+          expect(f).toBeDefined();
+          expect(f!.drills).toBeDefined();
+          expect(f!.drills!.length).toBeGreaterThanOrEqual(1);
+          for (const drill of f!.drills!) {
+            expect(drill.id).toMatch(/^[a-z0-9-]+$/);
+            expect(drill.title.length).toBeGreaterThan(0);
+            expect(drill.durationSec).toBeGreaterThan(0);
+            expect(Array.isArray(drill.steps)).toBe(true);
+            expect(drill.steps.length).toBeGreaterThanOrEqual(1);
+            for (const step of drill.steps) {
+              expect(typeof step).toBe('string');
+              expect(step.length).toBeGreaterThan(0);
+            }
+            if (drill.reps !== undefined) {
+              expect(drill.reps).toBeGreaterThan(0);
+            }
+            if (drill.mediaUri !== undefined) {
+              expect(typeof drill.mediaUri).toBe('string');
+            }
+          }
+        }
+      });
+
+      it('does not regress existing fault fields', () => {
+        for (const id of faultIdsWithDrills) {
+          const f = fault(workout, id);
+          expect(f?.condition).toBeInstanceOf(Function);
+          expect(f?.dynamicCue.length).toBeGreaterThan(0);
+          expect([1, 2, 3]).toContain(f?.severity);
+          expect(typeof f?.fqiPenalty).toBe('number');
+        }
+      });
+    });
+  }
+
+  it('yields 15 drills total across the 5 backfilled workouts', () => {
+    let total = 0;
+    for (const { workout, faultIdsWithDrills } of expectations) {
+      for (const id of faultIdsWithDrills) {
+        total += fault(workout, id)?.drills?.length ?? 0;
+      }
+    }
+    expect(total).toBeGreaterThanOrEqual(15);
+  });
+});


### PR DESCRIPTION
## Summary

Implements Issue #427 "Form-tracking depth — session binding, exercise swap, history panel, resume, coaching". The scan overlay at `app/(tabs)/scan-arkit.tsx` previously had **zero** imports of `useSessionRunner`, `useHealthKit`, or exercise history; this PR closes that gap across 7 depth items surfaced by the overnight UX audit (ships 19 atomic commits).

### What's new

**Session binding (Item 1 — P0)**
- `hooks/use-active-set-binding.ts` — resolves the active session_exercise matching the scan's detection mode (by name prefix then id match), exposes `activeSet`, `activeSetIndex/totalSets`, `setLabel`, `commitReps(repCount)` that writes `actual_reps` then calls `completeSet`.
- `components/form-tracking/ActiveSetBadge.tsx` — "Set 2 of 4 · Pull-Ups" pill in the scan top bar.
- `components/form-tracking/InlineRestTimer.tsx` — countdown pill with +15s / Skip controls driven by `useSessionRunner.restTimer`.

**Exercise swap (Item 2 — P0)**
- Extends `useSessionRunner` with `swapExerciseByDetectionMode(mode, action)` (core store file untouched beyond an append).
- `components/form-tracking/ExerciseSwapSheet.tsx` — confirmation sheet with "Add to session / Replace current / Cancel".
- Scan overlay now wraps `setDetectionMode` so picking a new mode during a live session opens the sheet before swapping.

**History panel (Item 3 — P1)**
- `lib/services/exercise-history.ts` — returns `{lastSession, last5SessionsAvgFqi, maxReps, maxVolume}` from local SQLite with Supabase fallback; never throws.
- `hooks/use-exercise-history.ts` — session-scoped per-exerciseId cache (5 min TTL), shared in-flight promise, `refresh()` for explicit invalidation.
- `components/form-tracking/ExerciseHistoryStrip.tsx` — 3 chips rendered above the FQI gauge region; renders null when empty so new users see nothing broken.

**Per-fault drills (Item 4 — P1)**
- `FaultDefinition` extended with optional `drills[]` (id, title, durationSec, reps?, steps[], mediaUri?).
- Top-3 faults for pullup / squat / deadlift / pushup / benchpress backfilled — **15 drills total**.
- `components/form-tracking/DrillSheet.tsx` — bottom sheet opened by `activeDrillFault` state (ready for CueCard `onPress` wire-in; CueCard itself is untouched).
- `lib/services/drill-tracker.ts` — logs viewed/started/completed/dismissed events via existing `cue_events` telemetry (no migration).

**Fatigue + HR (Item 5 — P1)**
- `hooks/use-live-fatigue.ts` — combines FQI trend with HR/maxHR zone → `{state: fresh|working|fatigued, suggestRestSec, reason}`.
- `components/form-tracking/HeartRatePill.tsx` — top-right BPM pill with zone-colored border, stale after 30s.

**Priority audio (Item 6 — P1)**
- `lib/services/cue-priority-audio.ts` — severity → `{intervalMs, volume, haptic, repeatIfUnadopted}` mapper with `isFatigued` / `isActiveCue` modifiers.
- `hooks/use-premium-cue-audio.ts` extended with optional `priorityHint` (FaultSeverity number or partial hint). Existing callers untouched.

**Auto-pause + resume (Item 7 — P2)**
- `lib/stores/session-runner.pause.ts` — standalone module (core store file untouched). Pauses/resumes write breadcrumbs to `workout_session_events` so the existing sync pipeline carries them.
- `hooks/use-session-autopause.ts` — binds RN AppState active↔background transitions to pause/resume.
- `components/form-tracking/SessionResumeToast.tsx` — banner surfaced via `useSessionAutopause.needsResume`.

**Scan overlay wire-up (Item 18)**
- `app/(tabs)/scan-arkit.tsx` imports all new hooks, renders the overlays in orthogonal regions (ActiveSetBadge + HeartRatePill in the top bar; InlineRestTimer + ExerciseHistoryStrip in a new absolute row; SessionResumeToast; ExerciseSwapSheet; DrillSheet).
- Per-rep FQI fed into the fatigue window via `recordFqiSample`.
- `loadActiveSession()` called on mount.

### Guardrails honored

- ✅ **No edits** to PR #424's 7 files (`FqiGauge.tsx`, `CueCard.tsx`, `TrackingLossBanner.tsx`, `RepPulse.tsx`, `TrackingOnboardingOverlay.tsx`, `PostSessionSummaryCard.tsx`, `CalibrationProgressModal.tsx`, `hooks/use-tracking-loss.ts`).
- ✅ **No new dependencies** — `package.json` untouched.
- ✅ **No edits** to `ios/`, `android/`, `supabase/migrations/`, `.env*`, `supabase/functions/coach/`, `modules/*/ios|android/`.
- ✅ Core `lib/stores/session-runner.ts` only gets an additive action — existing actions untouched.
- ✅ `bun run lint` clean (only pre-existing template-builder warnings remain).
- ✅ `bun run check:types` clean.

### Deferred

- **Item 8 (best-rep replay)** — deferred per issue body; depends on the rep commit flow in this PR landing first.
- **CueCard.onPress → DrillSheet wire-up** — `activeDrillFault` state and `DrillSheet` mount are ready; CueCard itself is a PR #424 file and cannot be modified here. Once PR #424 lands, wiring is a one-line `onPress={() => setActiveDrillFault(fault)}` change inside scan-arkit.

## Verification

```bash
bun run lint          # 0 errors, 2 pre-existing warnings in app/(modals)/template-builder.tsx
bun run check:types   # clean

bunx jest tests/unit/hooks/use-exercise-history.test.ts \
          tests/unit/hooks/use-active-set-binding.test.ts \
          tests/unit/hooks/use-live-fatigue.test.ts \
          tests/unit/hooks/use-session-autopause.test.ts \
          tests/unit/hooks/use-premium-cue-audio.test.ts \
          tests/unit/components/form-tracking/ExerciseHistoryStrip.test.tsx \
          tests/unit/components/form-tracking/ActiveSetBadge.test.tsx \
          tests/unit/components/form-tracking/InlineRestTimer.test.tsx \
          tests/unit/components/form-tracking/ExerciseSwapSheet.test.tsx \
          tests/unit/components/form-tracking/DrillSheet.test.tsx \
          tests/unit/components/form-tracking/HeartRatePill.test.tsx \
          tests/unit/components/form-tracking/SessionResumeToast.test.tsx \
          tests/unit/services/exercise-history.test.ts \
          tests/unit/services/drill-tracker.test.ts \
          tests/unit/services/cue-priority-audio.test.ts \
          tests/unit/stores/session-runner.pause.test.ts \
          tests/unit/stores/session-runner.test.ts \
          tests/unit/workouts/fault-drills.test.ts
# 18 suites, 169 tests passing.
```

Full project test suite: 102 suites / 1193 tests passing (one unrelated pre-existing failure in `tests/unit/services/database/generic-sync.test.ts` that exists on `main` as well — verified via `git stash`).

## Test plan

- [ ] Open the scan tab with no active workout session — none of the new overlays render (bar + gauge look unchanged).
- [ ] Start a workout template with a Pull-Up exercise; confirm `ActiveSetBadge` reads "Set 1 of N · Pull-Up" and `ExerciseHistoryStrip` shows history chips (or nothing for a brand new user).
- [ ] Complete a set — the `InlineRestTimer` appears with the ring countdown; tap **+15s** and **Skip** and verify both behaviors.
- [ ] While tracking pull-ups, open the mode dropdown and pick Squat — `ExerciseSwapSheet` opens with "Add to session / Replace current"; pick each and verify `workout_session_exercises` in SQLite reflects the change.
- [ ] Enable HealthKit and confirm `HeartRatePill` updates in the top bar; border color shifts red when BPM ≥ 85% of max.
- [ ] Background the app mid-session, return — `SessionResumeToast` appears with "Resume Pull-Ups?"; tap Resume and verify a `session_resumed` event is recorded.
- [ ] Author-test a drill on an existing fault: open `DrillSheet` with a FaultDefinition that has drills and confirm `cue_events` receives `drill_viewed` rows (via `drillTracker`).
- [ ] Run `bun run lint` and `bun run check:types` locally — both clean.

Closes #427