### PR TITLE
feat(workouts): model depth — lunge model, dead-hang fault expansion, asymmetry helpers, parametric fault test harness

### DIFF
--- a/lib/workouts/README.md
+++ b/lib/workouts/README.md
@@ -32,3 +32,8 @@ Each workout lives in its own file (for example `pullup.ts`, `pushup.ts`) and ex
 - Prefer keeping **all** workout-specific heuristics inside the workout file (not in `scan-arkit.tsx`).
 - Keep thresholds named and documented (avoid magic numbers sprinkled through the UI).
 - If you need a new metric for UI/telemetry, add it to that workout’s `Metrics` type and compute it in `calculateMetrics`.
+
+## Future work
+
+- **Drill population deferred until PR #434 merges.** The `FaultDefinition` type will gain an optional `drills[]` field on that branch, along with a first pass of per-fault drill suggestions for the existing 8 workouts. Until that lands we only define faults with their `id`, `displayName`, `condition`, `severity`, `dynamicCue`, and `fqiPenalty`.
+- Shared helpers in `lib/workouts/helpers.ts` (`asymmetryCheck`, `sequenceCheck`, `validateAngleInRange`, `clampedDelta`) are available for new workouts; refactoring the existing 8 workouts to use them is a follow-up PR once #434 is in `main`.

--- a/lib/workouts/dead-hang.ts
+++ b/lib/workouts/dead-hang.ts
@@ -58,6 +58,12 @@ export const DEAD_HANG_THRESHOLDS = {
   shoulderElevation: 115,
   /** Minimum hold duration to count as a rep */
   minHoldMs: 1500,
+  /** Shoulder angle below which we flag scapular retraction (arms not packed) */
+  scapularRetractionMin: 80,
+  /** Min oscillation between start / max hip (or shoulder) to flag kipping */
+  kippingOscillationMin: 15,
+  /** Max allowed left/right wrist angle delta before flagging grip-shift */
+  gripShiftMaxDiff: 20,
 } as const;
 
 // =============================================================================
@@ -192,6 +198,64 @@ const faults: FaultDefinition[] = [
     severity: 1,
     dynamicCue: 'Hold a little longer to build grip and control.',
     fqiPenalty: 5,
+  },
+  // ---------------------------------------------------------------------------
+  // Additional faults (issue #438): scapular_retraction, kipping_swing, grip_shift
+  // ---------------------------------------------------------------------------
+  {
+    id: 'scapular_retraction',
+    displayName: 'No Scapular Engagement',
+    condition: (ctx: RepContext) => {
+      // A packed dead hang expects the shoulder-to-torso angle to stay at/below
+      // the scapularRetractionMin threshold (shoulders "pulled down"). A reading
+      // well above this indicates the hanger never engaged the scaps and simply
+      // dangled from the bar.
+      const left = ctx.maxAngles.leftShoulder;
+      const right = ctx.maxAngles.rightShoulder;
+      if (!Number.isFinite(left) || !Number.isFinite(right)) return false;
+      const minShoulder = Math.min(left, right);
+      return minShoulder < DEAD_HANG_THRESHOLDS.scapularRetractionMin;
+    },
+    severity: 2,
+    dynamicCue: 'Pack your shoulders — pull them down and back into the sockets.',
+    fqiPenalty: 10,
+  },
+  {
+    id: 'kipping_swing',
+    displayName: 'Kipping Swing',
+    condition: (ctx: RepContext) => {
+      // Hip-oscillation proxy: if the difference between start-hip and max-hip
+      // (or start-shoulder vs max-shoulder) exceeds kippingOscillationMin on
+      // either side, the athlete swung their body weight through the hold
+      // instead of holding statically.
+      const leftHipDelta = Math.abs(ctx.maxAngles.leftHip - ctx.startAngles.leftHip);
+      const rightHipDelta = Math.abs(ctx.maxAngles.rightHip - ctx.startAngles.rightHip);
+      const leftShoulderDelta = Math.abs(ctx.maxAngles.leftShoulder - ctx.startAngles.leftShoulder);
+      const rightShoulderDelta = Math.abs(ctx.maxAngles.rightShoulder - ctx.startAngles.rightShoulder);
+      const deltas = [leftHipDelta, rightHipDelta, leftShoulderDelta, rightShoulderDelta];
+      if (deltas.some((d) => !Number.isFinite(d))) return false;
+      return deltas.some((d) => d > DEAD_HANG_THRESHOLDS.kippingOscillationMin);
+    },
+    severity: 2,
+    dynamicCue: 'Stay still — resist the urge to swing or kip.',
+    fqiPenalty: 10,
+  },
+  {
+    id: 'grip_shift',
+    displayName: 'Grip Shift',
+    condition: (ctx: RepContext) => {
+      // JointAngles does not expose wrist angles directly; at a dead hang the
+      // left/right ELBOW angle at maximum extension is the closest upstream
+      // proxy for grip stability (a wrist re-grip twists the forearm and
+      // perturbs elbow extension). Threshold tuned to gripShiftMaxDiff.
+      const left = ctx.maxAngles.leftElbow;
+      const right = ctx.maxAngles.rightElbow;
+      if (!Number.isFinite(left) || !Number.isFinite(right)) return false;
+      return Math.abs(left - right) > DEAD_HANG_THRESHOLDS.gripShiftMaxDiff;
+    },
+    severity: 1,
+    dynamicCue: 'Hold your grip steady — avoid re-gripping mid-hang.',
+    fqiPenalty: 6,
   },
 ];
 

--- a/lib/workouts/dead-hang.ts
+++ b/lib/workouts/dead-hang.ts
@@ -224,17 +224,17 @@ const faults: FaultDefinition[] = [
     id: 'kipping_swing',
     displayName: 'Kipping Swing',
     condition: (ctx: RepContext) => {
-      // Hip-oscillation proxy: if the difference between start-hip and max-hip
-      // (or start-shoulder vs max-shoulder) exceeds kippingOscillationMin on
-      // either side, the athlete swung their body weight through the hold
-      // instead of holding statically.
+      // Hip-oscillation only. Shoulder angle naturally varies during a static
+      // hang as the scapulae engage/disengage, so using shoulder delta as a
+      // kipping proxy false-positives on clean holds. If hip joints aren't
+      // tracked, skip the fault rather than fall back to a misleading signal.
       const leftHipDelta = Math.abs(ctx.maxAngles.leftHip - ctx.startAngles.leftHip);
       const rightHipDelta = Math.abs(ctx.maxAngles.rightHip - ctx.startAngles.rightHip);
-      const leftShoulderDelta = Math.abs(ctx.maxAngles.leftShoulder - ctx.startAngles.leftShoulder);
-      const rightShoulderDelta = Math.abs(ctx.maxAngles.rightShoulder - ctx.startAngles.rightShoulder);
-      const deltas = [leftHipDelta, rightHipDelta, leftShoulderDelta, rightShoulderDelta];
-      if (deltas.some((d) => !Number.isFinite(d))) return false;
-      return deltas.some((d) => d > DEAD_HANG_THRESHOLDS.kippingOscillationMin);
+      if (!Number.isFinite(leftHipDelta) || !Number.isFinite(rightHipDelta)) return false;
+      return (
+        leftHipDelta > DEAD_HANG_THRESHOLDS.kippingOscillationMin ||
+        rightHipDelta > DEAD_HANG_THRESHOLDS.kippingOscillationMin
+      );
     },
     severity: 2,
     dynamicCue: 'Stay still — resist the urge to swing or kip.',

--- a/lib/workouts/helpers.ts
+++ b/lib/workouts/helpers.ts
@@ -1,4 +1,4 @@
-import type { WorkoutDefinition, WorkoutMetrics } from '@/lib/types/workout-definitions';
+import type { AngleRange, WorkoutDefinition, WorkoutMetrics } from '@/lib/types/workout-definitions';
 
 export function getPhaseStaticCue<P extends string, M extends WorkoutMetrics>(
   definition: WorkoutDefinition<P, M>,
@@ -13,4 +13,119 @@ export function getPhaseStaticCue(
   phaseId: string
 ): string | null {
   return definition.phases.find((phase) => phase.id === phaseId)?.staticCue ?? null;
+}
+
+// =============================================================================
+// Validation helpers (shared between workouts)
+// =============================================================================
+
+/**
+ * Type guard: returns true iff value is a finite number (not NaN, not Infinity).
+ * Safer than `Number.isFinite` in strict-typed code because it narrows the type.
+ */
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+/**
+ * Returns true iff the asymmetry between `left` and `right` exceeds `maxDiffPct`
+ * (expressed as a percentage, 0-100) of the larger of the two magnitudes.
+ *
+ * NaN-safe: returns `false` on any non-finite input or when both sides are zero.
+ *
+ * @example
+ *   asymmetryCheck(90, 110, 15) // true — 20° diff > 15% of 110
+ *   asymmetryCheck(100, 98, 5) // false — 2° diff well under 5% of 100
+ *   asymmetryCheck(NaN, 90, 10) // false — bad input
+ */
+export function asymmetryCheck(left: number, right: number, maxDiffPct: number): boolean {
+  if (!isFiniteNumber(left) || !isFiniteNumber(right) || !isFiniteNumber(maxDiffPct)) {
+    return false;
+  }
+  if (maxDiffPct < 0) {
+    return false;
+  }
+  const larger = Math.max(Math.abs(left), Math.abs(right));
+  if (larger === 0) {
+    return false;
+  }
+  const diff = Math.abs(left - right);
+  const pct = (diff / larger) * 100;
+  return pct > maxDiffPct;
+}
+
+/**
+ * Returns `true` iff the sequencing between two joints is faulty.
+ *
+ * A sequencing fault occurs when the joint expected to lead the movement does
+ * NOT move more than the lagging joint. For example, in a deadlift the hips
+ * should rise before the shoulders — if the shoulder delta outpaces the hip
+ * delta (i.e. the back rounds), this returns `true`.
+ *
+ * @param primaryStart starting angle of the primary (should-lead) joint
+ * @param primaryMax peak angle of the primary joint during the movement
+ * @param secondaryStart starting angle of the secondary (should-follow) joint
+ * @param secondaryMax peak angle of the secondary joint during the movement
+ * @param shouldPrimaryRiseFirst when `true`, the primary is expected to move
+ *   *more* than the secondary; when `false`, the check is inverted.
+ *
+ * NaN-safe: returns `false` on any non-finite input.
+ */
+export function sequenceCheck(
+  primaryStart: number,
+  primaryMax: number,
+  secondaryStart: number,
+  secondaryMax: number,
+  shouldPrimaryRiseFirst: boolean
+): boolean {
+  if (
+    !isFiniteNumber(primaryStart) ||
+    !isFiniteNumber(primaryMax) ||
+    !isFiniteNumber(secondaryStart) ||
+    !isFiniteNumber(secondaryMax)
+  ) {
+    return false;
+  }
+  const primaryDelta = Math.abs(primaryMax - primaryStart);
+  const secondaryDelta = Math.abs(secondaryMax - secondaryStart);
+  if (shouldPrimaryRiseFirst) {
+    return primaryDelta < secondaryDelta;
+  }
+  return primaryDelta > secondaryDelta;
+}
+
+/**
+ * Returns `true` iff `angle` sits inside `[range.min, range.max]`.
+ *
+ * Note: this is an inclusive range check and does NOT incorporate `optimal`
+ * or `tolerance`; use those fields separately when building fault conditions
+ * that need to penalize deviation from an optimal target.
+ *
+ * NaN-safe: returns `false` on any non-finite `angle` or malformed range.
+ */
+export function validateAngleInRange(angle: number, range: AngleRange): boolean {
+  if (!isFiniteNumber(angle) || !range) {
+    return false;
+  }
+  if (!isFiniteNumber(range.min) || !isFiniteNumber(range.max)) {
+    return false;
+  }
+  if (range.max < range.min) {
+    return false;
+  }
+  return angle >= range.min && angle <= range.max;
+}
+
+/**
+ * NaN-safe delta between two scalars.
+ *
+ * Returns `0` if either value is non-finite. Useful for building fault
+ * conditions that reference `maxAngles.x - startAngles.x` without littering
+ * guards throughout the workout files.
+ */
+export function clampedDelta(from: number, to: number): number {
+  if (!isFiniteNumber(from) || !isFiniteNumber(to)) {
+    return 0;
+  }
+  return to - from;
 }

--- a/lib/workouts/index.ts
+++ b/lib/workouts/index.ts
@@ -12,6 +12,7 @@ import { benchpressDefinition, type BenchPressPhase, type BenchPressMetrics } fr
 import { deadHangDefinition, type DeadHangPhase, type DeadHangMetrics } from './dead-hang';
 import { deadliftDefinition, type DeadliftPhase, type DeadliftMetrics } from './deadlift';
 import { farmersWalkDefinition, type FarmersWalkPhase, type FarmersWalkMetrics } from './farmers-walk';
+import { lungeDefinition, type LungePhase, type LungeMetrics } from './lunge';
 import { pullupDefinition, type PullUpPhase, type PullUpMetrics } from './pullup';
 import { pushupDefinition, type PushUpPhase, type PushUpMetrics } from './pushup';
 import { rdlDefinition, type RDLPhase, type RDLMetrics } from './rdl';
@@ -22,6 +23,7 @@ export const workoutsByMode = {
   dead_hang: deadHangDefinition,
   deadlift: deadliftDefinition,
   farmers_walk: farmersWalkDefinition,
+  lunge: lungeDefinition,
   pullup: pullupDefinition,
   pushup: pushupDefinition,
   rdl: rdlDefinition,
@@ -37,6 +39,7 @@ export { benchpressDefinition, BENCHPRESS_THRESHOLDS, type BenchPressPhase, type
 export { deadHangDefinition, DEAD_HANG_THRESHOLDS, type DeadHangPhase, type DeadHangMetrics } from './dead-hang';
 export { deadliftDefinition, DEADLIFT_THRESHOLDS, type DeadliftPhase, type DeadliftMetrics } from './deadlift';
 export { farmersWalkDefinition, FARMERS_WALK_THRESHOLDS, type FarmersWalkPhase, type FarmersWalkMetrics } from './farmers-walk';
+export { lungeDefinition, LUNGE_THRESHOLDS, type LungePhase, type LungeMetrics } from './lunge';
 export { pullupDefinition, PULLUP_THRESHOLDS, type PullUpPhase, type PullUpMetrics } from './pullup';
 export { pushupDefinition, PUSHUP_THRESHOLDS, type PushUpPhase, type PushUpMetrics } from './pushup';
 export { rdlDefinition, RDL_THRESHOLDS, type RDLPhase, type RDLMetrics } from './rdl';
@@ -62,6 +65,7 @@ export const workoutRegistry: WorkoutRegistry = {
   dead_hang: deadHangDefinition as unknown as WorkoutDefinition,
   deadlift: deadliftDefinition as unknown as WorkoutDefinition,
   farmers_walk: farmersWalkDefinition as unknown as WorkoutDefinition,
+  lunge: lungeDefinition as unknown as WorkoutDefinition,
   pullup: pullupDefinition as unknown as WorkoutDefinition,
   pushup: pushupDefinition as unknown as WorkoutDefinition,
   rdl: rdlDefinition as unknown as WorkoutDefinition,

--- a/lib/workouts/lunge.ts
+++ b/lib/workouts/lunge.ts
@@ -1,0 +1,476 @@
+/**
+ * Lunge Workout Definition
+ *
+ * Defines all the logic for tracking lunge form:
+ * - Phases: setup → descent → bottom → ascent → standing
+ * - Rep boundaries: starts at 'descent', ends at 'standing'
+ * - Thresholds for front-knee / rear-knee / front-hip angles
+ * - Fault detection conditions (6 faults)
+ * - FQI calculation weights
+ *
+ * The lunge tracker models a single working rep as:
+ *   standing → descent → bottom → ascent → standing
+ * where the "front" leg is approximated by the deeper-bending knee during
+ * the rep (the tracker does not assume handedness/laterality up-front).
+ *
+ * Angle-range targets derive from `movementProfile.lunge` in
+ * `lib/fusion/movements.ts` (frontKneeFlexionDeg: 80–110,
+ * rearKneeFlexionDeg: 75–115). Additional thresholds used below that
+ * are NOT present in `movements.ts` (knee-over-toe cue, hyperextension
+ * lockout, asymmetric-depth max diff) are kept local here per the
+ * project constraint that we do not modify `movements.ts` from this PR.
+ */
+
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import { getMovementProfile } from '@/lib/fusion/movements';
+import type {
+  WorkoutDefinition,
+  PhaseDefinition,
+  RepBoundary,
+  FaultDefinition,
+  FQIWeights,
+  AngleRange,
+  WorkoutMetrics,
+  RepContext,
+  ScoringMetricDefinition,
+} from '@/lib/types/workout-definitions';
+import { asymmetryCheck } from './helpers';
+
+// =============================================================================
+// Phase Type
+// =============================================================================
+
+export type LungePhase = 'setup' | 'descent' | 'bottom' | 'ascent' | 'standing';
+
+// =============================================================================
+// Metrics Type
+// =============================================================================
+
+export interface LungeMetrics extends WorkoutMetrics {
+  /** Deeper of the two knee angles this frame (the "front" knee proxy) */
+  frontKnee: number;
+  /** Shallower of the two knee angles this frame (the "rear" knee proxy) */
+  rearKnee: number;
+  /** Average hip angle (for trunk/forward-lean sanity checks) */
+  avgHip: number;
+  legsTracked: boolean;
+}
+
+// =============================================================================
+// Thresholds
+// =============================================================================
+
+const lungeProfile = getMovementProfile('lunge');
+const FRONT_KNEE_PROFILE = lungeProfile.thresholds.find((t) => t.metric === 'frontKneeFlexionDeg');
+const REAR_KNEE_PROFILE = lungeProfile.thresholds.find((t) => t.metric === 'rearKneeFlexionDeg');
+
+export const LUNGE_THRESHOLDS = {
+  /** Upright standing (both legs near-extended) */
+  standing: 160,
+  /** Begin a descent — front knee starts to flex */
+  descentStart: 145,
+  /** Front-knee target bottom (derived from movement profile: 80–110°, midpoint-ish) */
+  parallel: FRONT_KNEE_PROFILE?.min ?? 80,
+  /** Deepest acceptable front-knee flexion (below this = excessive / "forward knee") */
+  frontKneeForwardLimit: 70,
+  /** Rear-knee target bottom (derived from movement profile: 75–115°) */
+  rearParallel: REAR_KNEE_PROFILE?.min ?? 75,
+  /** Front-knee threshold to leave the bottom (transitioning to ascent) */
+  ascent: 115,
+  /** Completed rep (near standing) */
+  finish: 155,
+  /** Max %-asymmetry between front/rear knee flexion (front deeper is fine;
+   *  large symmetric-depth imbalance at bottom indicates poor split squat) */
+  asymmetricDepthMaxPct: 40,
+  /**
+   * Max knee-cave angle diff between left/right at the bottom — fallback not
+   * present in `movements.ts`; calibrated to match squat's valgus threshold.
+   */
+  kneeCaveMax: 25,
+  /**
+   * Hip-angle diff at bottom used as proxy for "heel off the ground" on the
+   * rear side: a rear heel that lifts substantially drops the rear-hip angle
+   * away from the front-hip angle. Fallback heuristic — no direct foot sensor.
+   */
+  heelOffHipDiffMax: 30,
+  /** Max elbow/knee extension delta indicating hyperextension lockout */
+  hyperExtensionMax: 182,
+} as const;
+
+// =============================================================================
+// Angle Ranges
+// =============================================================================
+
+const angleRanges: Record<string, AngleRange> = {
+  frontKnee: {
+    min: FRONT_KNEE_PROFILE?.min ?? 80,
+    max: FRONT_KNEE_PROFILE?.max ?? 110,
+    optimal: 90,
+    tolerance: 15,
+  },
+  rearKnee: {
+    min: REAR_KNEE_PROFILE?.min ?? 75,
+    max: REAR_KNEE_PROFILE?.max ?? 115,
+    optimal: 95,
+    tolerance: 20,
+  },
+  hip: {
+    min: 70,
+    max: 180,
+    optimal: 110,
+    tolerance: 20,
+  },
+};
+
+const scoringMetrics: ScoringMetricDefinition[] = [
+  {
+    id: 'knee',
+    extract: (rep, side) => {
+      if (side === 'left') {
+        return {
+          start: rep.start.leftKnee,
+          end: rep.end.leftKnee,
+          min: rep.min.leftKnee,
+          max: rep.max.leftKnee,
+        };
+      }
+      return {
+        start: rep.start.rightKnee,
+        end: rep.end.rightKnee,
+        min: rep.min.rightKnee,
+        max: rep.max.rightKnee,
+      };
+    },
+  },
+  {
+    id: 'hip',
+    extract: (rep, side) => {
+      if (side === 'left') {
+        return {
+          start: rep.start.leftHip,
+          end: rep.end.leftHip,
+          min: rep.min.leftHip,
+          max: rep.max.leftHip,
+        };
+      }
+      return {
+        start: rep.start.rightHip,
+        end: rep.end.rightHip,
+        min: rep.min.rightHip,
+        max: rep.max.rightHip,
+      };
+    },
+  },
+];
+
+// =============================================================================
+// Phase Definitions
+// =============================================================================
+
+const phases: PhaseDefinition<LungePhase>[] = [
+  {
+    id: 'setup',
+    displayName: 'Setup',
+    enterCondition: () => true,
+    staticCue: 'Split stance — front foot flat, rear heel lifted, chest tall.',
+  },
+  {
+    id: 'standing',
+    displayName: 'Standing',
+    enterCondition: (angles: JointAngles) => {
+      const minKnee = Math.min(angles.leftKnee, angles.rightKnee);
+      return minKnee >= LUNGE_THRESHOLDS.standing;
+    },
+    staticCue: 'Breath in, brace, then step down with control.',
+  },
+  {
+    id: 'descent',
+    displayName: 'Descending',
+    enterCondition: (angles: JointAngles, prevPhase: LungePhase) => {
+      const minKnee = Math.min(angles.leftKnee, angles.rightKnee);
+      return prevPhase === 'standing' && minKnee <= LUNGE_THRESHOLDS.descentStart;
+    },
+    staticCue: 'Drop straight down — rear knee tracks toward the floor.',
+  },
+  {
+    id: 'bottom',
+    displayName: 'Bottom Position',
+    enterCondition: (angles: JointAngles, prevPhase: LungePhase) => {
+      const minKnee = Math.min(angles.leftKnee, angles.rightKnee);
+      return prevPhase === 'descent' && minKnee <= LUNGE_THRESHOLDS.parallel;
+    },
+    staticCue: 'Both knees around 90° — chest proud, drive back up.',
+  },
+  {
+    id: 'ascent',
+    displayName: 'Ascending',
+    enterCondition: (angles: JointAngles, prevPhase: LungePhase) => {
+      const minKnee = Math.min(angles.leftKnee, angles.rightKnee);
+      return prevPhase === 'bottom' && minKnee >= LUNGE_THRESHOLDS.ascent;
+    },
+    staticCue: 'Push through the front heel — stand tall.',
+  },
+];
+
+// =============================================================================
+// Rep Boundary
+// =============================================================================
+
+const repBoundary: RepBoundary<LungePhase> = {
+  startPhase: 'descent',
+  endPhase: 'standing',
+  minDurationMs: 700,
+};
+
+// =============================================================================
+// Fault Definitions (6 faults per spec)
+// =============================================================================
+
+const faults: FaultDefinition[] = [
+  {
+    id: 'shallow_depth',
+    displayName: 'Shallow Depth',
+    condition: (ctx: RepContext) => {
+      const minFront = Math.min(ctx.minAngles.leftKnee, ctx.minAngles.rightKnee);
+      if (!Number.isFinite(minFront)) return false;
+      return minFront > LUNGE_THRESHOLDS.parallel + 15;
+    },
+    severity: 2,
+    dynamicCue: 'Drop deeper — aim for front thigh parallel to the floor.',
+    fqiPenalty: 15,
+  },
+  {
+    id: 'knee_cave',
+    displayName: 'Knee Cave (Valgus)',
+    condition: (ctx: RepContext) => {
+      const left = ctx.minAngles.leftKnee;
+      const right = ctx.minAngles.rightKnee;
+      if (!Number.isFinite(left) || !Number.isFinite(right)) return false;
+      return Math.abs(left - right) > LUNGE_THRESHOLDS.kneeCaveMax;
+    },
+    severity: 2,
+    dynamicCue: 'Push the front knee out — track it over the middle toes.',
+    fqiPenalty: 12,
+  },
+  {
+    id: 'heels_off_ground',
+    displayName: 'Heels Off Ground',
+    condition: (ctx: RepContext) => {
+      // Rear-hip dropping far below front-hip at the bottom suggests the rear
+      // heel lifted and the rear leg collapsed. We detect this as a large
+      // asymmetric hip-angle spread at min depth.
+      const leftHip = ctx.minAngles.leftHip;
+      const rightHip = ctx.minAngles.rightHip;
+      if (!Number.isFinite(leftHip) || !Number.isFinite(rightHip)) return false;
+      return Math.abs(leftHip - rightHip) > LUNGE_THRESHOLDS.heelOffHipDiffMax;
+    },
+    severity: 1,
+    dynamicCue: 'Keep the front heel planted — weight through the middle of the foot.',
+    fqiPenalty: 8,
+  },
+  {
+    id: 'asymmetric_depth',
+    displayName: 'Asymmetric Depth',
+    condition: (ctx: RepContext) => {
+      // Compare the deepest-knee angle each rep vs the shallower knee to catch
+      // sessions where one leg barely works. Uses the shared `asymmetryCheck`
+      // helper so this fault's behavior stays in lockstep with other workouts
+      // adopting asymmetry detection.
+      return asymmetryCheck(
+        ctx.minAngles.leftKnee,
+        ctx.minAngles.rightKnee,
+        LUNGE_THRESHOLDS.asymmetricDepthMaxPct
+      );
+    },
+    severity: 2,
+    dynamicCue: 'Even out both knees — don\'t lean on just one leg.',
+    fqiPenalty: 10,
+  },
+  {
+    id: 'forward_knee',
+    displayName: 'Knee Over Toes',
+    condition: (ctx: RepContext) => {
+      // Front knee flexing past a very acute angle (below frontKneeForwardLimit)
+      // indicates the knee has shot out over the toes instead of staying over
+      // the midfoot / ankle.
+      const minFront = Math.min(ctx.minAngles.leftKnee, ctx.minAngles.rightKnee);
+      if (!Number.isFinite(minFront)) return false;
+      return minFront < LUNGE_THRESHOLDS.frontKneeForwardLimit;
+    },
+    severity: 1,
+    dynamicCue: 'Keep the front knee stacked over the ankle, not past the toes.',
+    fqiPenalty: 8,
+  },
+  {
+    id: 'hyper_extension',
+    displayName: 'Hyperextension at Lockout',
+    condition: (ctx: RepContext) => {
+      // At the top of the rep, a fully-locked knee snapping past 180° signals
+      // hyperextension. We compare the larger of the two end-rep knee angles.
+      const maxEnd = Math.max(ctx.endAngles.leftKnee, ctx.endAngles.rightKnee);
+      if (!Number.isFinite(maxEnd)) return false;
+      return maxEnd > LUNGE_THRESHOLDS.hyperExtensionMax;
+    },
+    severity: 1,
+    dynamicCue: 'Stand tall but don\'t snap into your knee — stop just shy of lockout.',
+    fqiPenalty: 6,
+  },
+];
+
+// =============================================================================
+// FQI Weights
+// =============================================================================
+
+const fqiWeights: FQIWeights = {
+  rom: 0.25,
+  depth: 0.45,
+  faults: 0.30,
+};
+
+// =============================================================================
+// Metrics Calculator
+// =============================================================================
+
+function calculateMetrics(
+  angles: JointAngles,
+  _joints?: Map<string, { x: number; y: number; isTracked: boolean }>
+): LungeMetrics {
+  const frontKnee = Math.min(angles.leftKnee, angles.rightKnee);
+  const rearKnee = Math.max(angles.leftKnee, angles.rightKnee);
+  const avgHip = (angles.leftHip + angles.rightHip) / 2;
+
+  const legsTracked =
+    angles.leftKnee > 0 && angles.leftKnee < 180 &&
+    angles.rightKnee > 0 && angles.rightKnee < 180 &&
+    angles.leftHip > 0 && angles.leftHip < 180 &&
+    angles.rightHip > 0 && angles.rightHip < 180;
+
+  return {
+    frontKnee,
+    rearKnee,
+    avgHip,
+    armsTracked: false, // lunge does not require upper-body tracking
+    legsTracked,
+  };
+}
+
+// =============================================================================
+// Phase State Machine
+// =============================================================================
+
+function getNextPhase(
+  currentPhase: LungePhase,
+  _angles: JointAngles,
+  metrics: LungeMetrics
+): LungePhase {
+  if (!metrics.legsTracked) {
+    return 'setup';
+  }
+
+  const knee = metrics.frontKnee;
+
+  switch (currentPhase) {
+    case 'setup':
+      if (knee >= LUNGE_THRESHOLDS.standing) {
+        return 'standing';
+      }
+      return 'setup';
+
+    case 'standing':
+      if (knee <= LUNGE_THRESHOLDS.descentStart) {
+        return 'descent';
+      }
+      return 'standing';
+
+    case 'descent':
+      if (knee <= LUNGE_THRESHOLDS.parallel) {
+        return 'bottom';
+      }
+      return 'descent';
+
+    case 'bottom':
+      if (knee >= LUNGE_THRESHOLDS.ascent) {
+        return 'ascent';
+      }
+      return 'bottom';
+
+    case 'ascent':
+      if (knee >= LUNGE_THRESHOLDS.finish) {
+        return 'standing';
+      }
+      return 'ascent';
+
+    default:
+      return 'setup';
+  }
+}
+
+// =============================================================================
+// Export Workout Definition
+// =============================================================================
+
+export const lungeDefinition: WorkoutDefinition<LungePhase, LungeMetrics> = {
+  id: 'lunge',
+  displayName: 'Lunge',
+  description: 'Unilateral lower body movement targeting quads, glutes, and stability.',
+  category: 'lower_body',
+  difficulty: 'beginner',
+
+  phases,
+  initialPhase: 'setup',
+  repBoundary,
+  thresholds: LUNGE_THRESHOLDS,
+  angleRanges,
+  scoringMetrics,
+  faults,
+  fqiWeights,
+
+  ui: {
+    iconName: 'walk-outline',
+    primaryMetric: { key: 'frontKneeDeg', label: 'Front Knee', format: 'deg' },
+    secondaryMetric: { key: 'rearKneeDeg', label: 'Rear Knee', format: 'deg' },
+    buildUploadMetrics: (metrics) => ({
+      frontKneeDeg: metrics?.frontKnee ?? null,
+      rearKneeDeg: metrics?.rearKnee ?? null,
+      avgHipDeg: metrics?.avgHip ?? null,
+    }),
+    buildWatchMetrics: (metrics) => ({
+      frontKneeDeg: metrics?.frontKnee ?? null,
+      rearKneeDeg: metrics?.rearKnee ?? null,
+    }),
+    getRealtimeCues: ({ phaseId, metrics }) => {
+      const messages: string[] = [];
+
+      if (
+        phaseId === 'bottom' &&
+        typeof metrics.frontKnee === 'number' &&
+        metrics.frontKnee > LUNGE_THRESHOLDS.parallel + 15
+      ) {
+        messages.push('Drop deeper — front thigh parallel to the floor.');
+      }
+
+      if (
+        phaseId === 'bottom' &&
+        typeof metrics.frontKnee === 'number' &&
+        metrics.frontKnee < LUNGE_THRESHOLDS.frontKneeForwardLimit
+      ) {
+        messages.push('Ease off — keep the front knee stacked over the ankle.');
+      }
+
+      if (phaseId === 'standing') {
+        messages.push('Reset your stance, breathe, then repeat.');
+      }
+
+      if (messages.length === 0) {
+        messages.push('Controlled tempo — own every inch of the movement.');
+      }
+
+      return messages;
+    },
+  },
+
+  calculateMetrics,
+  getNextPhase,
+};
+
+export default lungeDefinition;

--- a/tests/unit/workouts-dead-hang.test.ts
+++ b/tests/unit/workouts-dead-hang.test.ts
@@ -1,4 +1,7 @@
 import { getWorkoutByMode, getWorkoutIds } from '@/lib/workouts';
+import { deadHangDefinition, DEAD_HANG_THRESHOLDS } from '@/lib/workouts/dead-hang';
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { RepContext } from '@/lib/types/workout-definitions';
 
 test('dead_hang is registered as a detection mode', () => {
   expect(getWorkoutIds()).toContain('dead_hang');
@@ -9,5 +12,140 @@ test('dead_hang exposes a UI adapter', () => {
   expect(def.id).toBe('dead_hang');
   expect(def.ui).toBeTruthy();
   expect(def.ui?.primaryMetric.key).toBeTruthy();
+});
+
+// ---------------------------------------------------------------------------
+// Added-in-#438 faults: scapular_retraction, kipping_swing, grip_shift
+// ---------------------------------------------------------------------------
+
+function angles(overrides: Partial<JointAngles> = {}): JointAngles {
+  return {
+    leftElbow: 170,
+    rightElbow: 170,
+    leftShoulder: 100,
+    rightShoulder: 100,
+    leftKnee: 170,
+    rightKnee: 170,
+    leftHip: 170,
+    rightHip: 170,
+    ...overrides,
+  };
+}
+
+function ctx(opts: {
+  start?: Partial<JointAngles>;
+  end?: Partial<JointAngles>;
+  min?: Partial<JointAngles>;
+  max?: Partial<JointAngles>;
+  durationMs?: number;
+}): RepContext {
+  return {
+    startAngles: angles(opts.start),
+    endAngles: angles(opts.end),
+    minAngles: angles(opts.min),
+    maxAngles: angles(opts.max),
+    durationMs: opts.durationMs ?? 5000,
+    repNumber: 1,
+    workoutId: 'dead_hang',
+  };
+}
+
+const NaNAngles: JointAngles = {
+  leftElbow: NaN, rightElbow: NaN, leftShoulder: NaN, rightShoulder: NaN,
+  leftKnee: NaN, rightKnee: NaN, leftHip: NaN, rightHip: NaN,
+};
+
+function nanCtx(): RepContext {
+  return {
+    startAngles: NaNAngles,
+    endAngles: NaNAngles,
+    minAngles: NaNAngles,
+    maxAngles: NaNAngles,
+    durationMs: 5000,
+    repNumber: 1,
+    workoutId: 'dead_hang',
+  };
+}
+
+function fault(id: string) {
+  const f = deadHangDefinition.faults.find((f) => f.id === id);
+  if (!f) throw new Error(`Dead-hang fault '${id}' not found`);
+  return f;
+}
+
+test('dead_hang registers 6 faults after extension', () => {
+  expect(deadHangDefinition.faults.length).toBe(6);
+});
+
+// scapular_retraction
+describe('dead_hang fault: scapular_retraction', () => {
+  const f = fault('scapular_retraction');
+
+  test('positive: both shoulders below scapularRetractionMin fires fault', () => {
+    // scapularRetractionMin = 80
+    const c = ctx({ max: { leftShoulder: 70, rightShoulder: 70 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: shoulders packed (>= 80) does not fire', () => {
+    const c = ctx({ max: { leftShoulder: 95, rightShoulder: 95 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// kipping_swing
+describe('dead_hang fault: kipping_swing', () => {
+  const f = fault('kipping_swing');
+
+  test('positive: hip oscillation > kippingOscillationMin fires fault', () => {
+    // kippingOscillationMin = 15, leftHip delta = |200? no. start=170, max=190 -> 20 > 15
+    const c = ctx({
+      start: { leftHip: 170, rightHip: 170, leftShoulder: 100, rightShoulder: 100 },
+      max: { leftHip: 190, rightHip: 170, leftShoulder: 100, rightShoulder: 100 },
+    });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: steady body (deltas under threshold) does not fire', () => {
+    const c = ctx({
+      start: { leftHip: 170, rightHip: 170, leftShoulder: 100, rightShoulder: 100 },
+      max: { leftHip: 172, rightHip: 172, leftShoulder: 102, rightShoulder: 102 },
+    });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// grip_shift
+describe('dead_hang fault: grip_shift', () => {
+  const f = fault('grip_shift');
+
+  test('positive: left/right elbow delta > gripShiftMaxDiff fires fault', () => {
+    // gripShiftMaxDiff = 20; delta = |150 - 180| = 30 > 20
+    const c = ctx({ max: { leftElbow: 150, rightElbow: 180 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: elbow delta within threshold does not fire', () => {
+    const c = ctx({ max: { leftElbow: 170, rightElbow: 180 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+test('DEAD_HANG_THRESHOLDS exposes added fields', () => {
+  expect(DEAD_HANG_THRESHOLDS.scapularRetractionMin).toBeGreaterThan(0);
+  expect(DEAD_HANG_THRESHOLDS.kippingOscillationMin).toBeGreaterThan(0);
+  expect(DEAD_HANG_THRESHOLDS.gripShiftMaxDiff).toBeGreaterThan(0);
 });
 

--- a/tests/unit/workouts-faults.parametric.test.ts
+++ b/tests/unit/workouts-faults.parametric.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Parametric fault harness — issue #438
+ *
+ * Exercises every registered fault in every workout definition under two
+ * synthetic conditions:
+ *
+ *   1. A per-workout "ideal rep" `RepContext` is handed to every fault; each
+ *      fault must return `false`. This is a sanity baseline — if any fault
+ *      mis-fires on a good rep, it needs thresholds re-tuned.
+ *   2. For a named subset of faults with well-defined biomechanical triggers,
+ *      a minimal "triggering" RepContext asserts that the fault returns
+ *      `true`. This includes all 6 lunge faults + 6 dead-hang faults, plus
+ *      a curated set of high-signal faults from other workouts.
+ */
+
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { FaultDefinition, RepContext, WorkoutDefinition } from '@/lib/types/workout-definitions';
+import { workoutsByMode, type DetectionMode } from '@/lib/workouts';
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-workout "ideal rep" angle snapshots. Each position is hand-picked to
+ * sit well inside every known fault's non-triggering envelope.
+ */
+interface IdealProfile {
+  start: JointAngles;
+  end: JointAngles;
+  min: JointAngles;
+  max: JointAngles;
+  durationMs: number;
+}
+
+function joints(a: Partial<JointAngles>): JointAngles {
+  return {
+    leftElbow: 170,
+    rightElbow: 170,
+    leftShoulder: 95,
+    rightShoulder: 95,
+    leftKnee: 170,
+    rightKnee: 170,
+    leftHip: 170,
+    rightHip: 170,
+    ...a,
+  };
+}
+
+const IDEAL_PROFILES: Record<DetectionMode, IdealProfile> = {
+  pullup: {
+    start: joints({ leftElbow: 165, rightElbow: 165, leftShoulder: 100, rightShoulder: 100 }),
+    end: joints({ leftElbow: 165, rightElbow: 165 }),
+    // top of pullup = elbow flexed to ~80°
+    min: joints({ leftElbow: 82, rightElbow: 85 }),
+    max: joints({ leftElbow: 170, rightElbow: 170, leftShoulder: 115, rightShoulder: 115 }),
+    durationMs: 2500,
+  },
+  pushup: {
+    start: joints({ leftElbow: 165, rightElbow: 165, leftHip: 175, rightHip: 175 }),
+    end: joints({ leftElbow: 165, rightElbow: 165, leftHip: 175, rightHip: 175 }),
+    min: joints({ leftElbow: 90, rightElbow: 92, leftHip: 172, rightHip: 172 }),
+    max: joints({ leftElbow: 170, rightElbow: 170, leftShoulder: 110, rightShoulder: 110, leftHip: 175, rightHip: 175 }),
+    durationMs: 1800,
+  },
+  squat: {
+    start: joints({ leftKnee: 170, rightKnee: 170, leftHip: 175, rightHip: 175 }),
+    end: joints({ leftKnee: 170, rightKnee: 170 }),
+    min: joints({ leftKnee: 88, rightKnee: 90, leftHip: 90, rightHip: 90 }),
+    max: joints({ leftKnee: 175, rightKnee: 175, leftHip: 180, rightHip: 180 }),
+    durationMs: 2800,
+  },
+  deadlift: {
+    start: joints({ leftHip: 105, rightHip: 105, leftKnee: 125, rightKnee: 125 }),
+    end: joints({ leftHip: 170, rightHip: 170, leftKnee: 170, rightKnee: 170 }),
+    min: joints({ leftHip: 105, rightHip: 105, leftKnee: 125, rightKnee: 125, leftShoulder: 85, rightShoulder: 85 }),
+    max: joints({ leftHip: 170, rightHip: 170, leftKnee: 170, rightKnee: 170, leftShoulder: 95, rightShoulder: 95 }),
+    durationMs: 2500,
+  },
+  rdl: {
+    start: joints({ leftHip: 175, rightHip: 175, leftKnee: 160, rightKnee: 160 }),
+    end: joints({ leftHip: 170, rightHip: 170, leftKnee: 160, rightKnee: 160 }),
+    min: joints({ leftHip: 95, rightHip: 95, leftKnee: 150, rightKnee: 150, leftShoulder: 100, rightShoulder: 100 }),
+    max: joints({ leftHip: 175, rightHip: 175, leftKnee: 170, rightKnee: 170, leftShoulder: 115, rightShoulder: 115 }),
+    durationMs: 3500,
+  },
+  benchpress: {
+    start: joints({ leftElbow: 165, rightElbow: 165, leftShoulder: 95, rightShoulder: 95 }),
+    end: joints({ leftElbow: 165, rightElbow: 165 }),
+    min: joints({ leftElbow: 88, rightElbow: 92 }),
+    max: joints({ leftElbow: 170, rightElbow: 170, leftShoulder: 110, rightShoulder: 110 }),
+    durationMs: 1800,
+  },
+  dead_hang: {
+    // static hold: start=max=min=end
+    start: joints({ leftElbow: 170, rightElbow: 170, leftShoulder: 95, rightShoulder: 95 }),
+    end: joints({ leftElbow: 170, rightElbow: 170, leftShoulder: 95, rightShoulder: 95 }),
+    min: joints({ leftElbow: 168, rightElbow: 168, leftShoulder: 95, rightShoulder: 95 }),
+    max: joints({ leftElbow: 172, rightElbow: 172, leftShoulder: 100, rightShoulder: 100 }),
+    durationMs: 5000,
+  },
+  farmers_walk: {
+    start: joints({ leftHip: 170, rightHip: 170, leftShoulder: 90, rightShoulder: 90 }),
+    end: joints({ leftHip: 170, rightHip: 170 }),
+    min: joints({ leftHip: 168, rightHip: 170, leftShoulder: 88, rightShoulder: 90 }),
+    max: joints({ leftHip: 172, rightHip: 172, leftShoulder: 95, rightShoulder: 95 }),
+    durationMs: 12000,
+  },
+  lunge: {
+    start: joints({ leftKnee: 170, rightKnee: 170, leftHip: 170, rightHip: 170 }),
+    end: joints({ leftKnee: 170, rightKnee: 170 }),
+    min: joints({ leftKnee: 88, rightKnee: 100, leftHip: 110, rightHip: 125 }),
+    max: joints({ leftKnee: 175, rightKnee: 175, leftHip: 175, rightHip: 175 }),
+    durationMs: 2500,
+  },
+};
+
+function ctxFromProfile(id: DetectionMode): RepContext {
+  const p = IDEAL_PROFILES[id];
+  return {
+    startAngles: p.start,
+    endAngles: p.end,
+    minAngles: p.min,
+    maxAngles: p.max,
+    durationMs: p.durationMs,
+    repNumber: 1,
+    workoutId: id,
+  };
+}
+
+function getDef(id: DetectionMode): WorkoutDefinition {
+  return workoutsByMode[id] as unknown as WorkoutDefinition;
+}
+
+// ---------------------------------------------------------------------------
+// Sanity baseline — every fault in every workout must return `false` on the
+// per-workout ideal rep.
+// ---------------------------------------------------------------------------
+
+describe('parametric fault baseline — ideal rep fires no faults', () => {
+  const workoutIds = Object.keys(workoutsByMode) as DetectionMode[];
+
+  for (const id of workoutIds) {
+    describe(`workout: ${id}`, () => {
+      const def = getDef(id);
+      const ctx = ctxFromProfile(id);
+
+      for (const fault of def.faults) {
+        test(`fault '${fault.id}' does not fire on ideal rep`, () => {
+          const fired = fault.condition(ctx);
+          if (fired) {
+            // Helpful debugging output
+            throw new Error(
+              `[${id}.${fault.id}] mis-fired on ideal rep — update IDEAL_PROFILES or fault thresholds`
+            );
+          }
+          expect(fired).toBe(false);
+        });
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Targeted positives — hand-crafted RepContexts that SHOULD trigger each
+// listed fault. Covers all 6 lunge + 6 dead-hang faults + a curated subset
+// of other-workout faults.
+// ---------------------------------------------------------------------------
+
+interface PositiveCase {
+  workout: DetectionMode;
+  fault: string;
+  build: () => RepContext;
+}
+
+function positiveCtx(id: DetectionMode, overrides: Partial<RepContext>): RepContext {
+  const base = ctxFromProfile(id);
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+const POSITIVE_CASES: PositiveCase[] = [
+  // ---- lunge (6) ----
+  {
+    workout: 'lunge', fault: 'shallow_depth',
+    build: () => positiveCtx('lunge', { minAngles: joints({ leftKnee: 130, rightKnee: 130, leftHip: 140, rightHip: 140 }) }),
+  },
+  {
+    workout: 'lunge', fault: 'knee_cave',
+    build: () => positiveCtx('lunge', { minAngles: joints({ leftKnee: 60, rightKnee: 110, leftHip: 110, rightHip: 110 }) }),
+  },
+  {
+    workout: 'lunge', fault: 'heels_off_ground',
+    build: () => positiveCtx('lunge', { minAngles: joints({ leftHip: 70, rightHip: 130, leftKnee: 95, rightKnee: 95 }) }),
+  },
+  {
+    workout: 'lunge', fault: 'asymmetric_depth',
+    build: () => positiveCtx('lunge', { minAngles: joints({ leftKnee: 55, rightKnee: 170, leftHip: 110, rightHip: 110 }) }),
+  },
+  {
+    workout: 'lunge', fault: 'forward_knee',
+    build: () => positiveCtx('lunge', { minAngles: joints({ leftKnee: 55, rightKnee: 90, leftHip: 110, rightHip: 110 }) }),
+  },
+  {
+    workout: 'lunge', fault: 'hyper_extension',
+    build: () => positiveCtx('lunge', { endAngles: joints({ leftKnee: 185, rightKnee: 170 }) }),
+  },
+
+  // ---- dead-hang (6 total: 3 pre-existing + 3 new) ----
+  {
+    workout: 'dead_hang', fault: 'bent_arms',
+    build: () => positiveCtx('dead_hang', { minAngles: joints({ leftElbow: 130, rightElbow: 130, leftShoulder: 95, rightShoulder: 95 }) }),
+  },
+  {
+    workout: 'dead_hang', fault: 'shrugged_shoulders',
+    build: () => positiveCtx('dead_hang', { maxAngles: joints({ leftElbow: 170, rightElbow: 170, leftShoulder: 130, rightShoulder: 100 }) }),
+  },
+  {
+    workout: 'dead_hang', fault: 'short_hold',
+    build: () => positiveCtx('dead_hang', { durationMs: 1000 }),
+  },
+  {
+    workout: 'dead_hang', fault: 'scapular_retraction',
+    build: () => positiveCtx('dead_hang', { maxAngles: joints({ leftElbow: 170, rightElbow: 170, leftShoulder: 70, rightShoulder: 70 }) }),
+  },
+  {
+    workout: 'dead_hang', fault: 'kipping_swing',
+    build: () => positiveCtx('dead_hang', {
+      startAngles: joints({ leftElbow: 170, rightElbow: 170, leftHip: 170, rightHip: 170, leftShoulder: 95, rightShoulder: 95 }),
+      maxAngles: joints({ leftElbow: 170, rightElbow: 170, leftHip: 195, rightHip: 170, leftShoulder: 100, rightShoulder: 100 }),
+    }),
+  },
+  {
+    workout: 'dead_hang', fault: 'grip_shift',
+    build: () => positiveCtx('dead_hang', { maxAngles: joints({ leftElbow: 150, rightElbow: 180, leftShoulder: 100, rightShoulder: 100 }) }),
+  },
+
+  // ---- squat (4) ----
+  {
+    workout: 'squat', fault: 'shallow_depth',
+    build: () => positiveCtx('squat', { minAngles: joints({ leftKnee: 118, rightKnee: 118, leftHip: 130, rightHip: 130 }) }),
+  },
+  {
+    workout: 'squat', fault: 'knee_valgus',
+    build: () => positiveCtx('squat', { minAngles: joints({ leftKnee: 80, rightKnee: 115, leftHip: 95, rightHip: 95 }) }),
+  },
+  {
+    workout: 'squat', fault: 'hip_shift',
+    build: () => positiveCtx('squat', { minAngles: joints({ leftKnee: 95, rightKnee: 95, leftHip: 70, rightHip: 100 }) }),
+  },
+  {
+    workout: 'squat', fault: 'fast_rep',
+    build: () => positiveCtx('squat', { durationMs: 500 }),
+  },
+
+  // ---- pushup (2) ----
+  {
+    workout: 'pushup', fault: 'shallow_depth',
+    build: () => positiveCtx('pushup', { minAngles: joints({ leftElbow: 112, rightElbow: 112, leftHip: 175, rightHip: 175 }) }),
+  },
+  {
+    workout: 'pushup', fault: 'hip_sag',
+    build: () => positiveCtx('pushup', { minAngles: joints({ leftElbow: 95, rightElbow: 95, leftHip: 150, rightHip: 150 }) }),
+  },
+
+  // ---- pullup (2) ----
+  {
+    workout: 'pullup', fault: 'incomplete_rom',
+    build: () => positiveCtx('pullup', { minAngles: joints({ leftElbow: 105, rightElbow: 105, leftShoulder: 100, rightShoulder: 100 }) }),
+  },
+  {
+    workout: 'pullup', fault: 'shoulder_elevation',
+    build: () => positiveCtx('pullup', { maxAngles: joints({ leftElbow: 170, rightElbow: 170, leftShoulder: 125, rightShoulder: 115 }) }),
+  },
+
+  // ---- deadlift (2) ----
+  {
+    workout: 'deadlift', fault: 'rounded_back',
+    build: () => positiveCtx('deadlift', { maxAngles: joints({ leftShoulder: 125, rightShoulder: 110, leftHip: 170, rightHip: 170, leftKnee: 170, rightKnee: 170 }) }),
+  },
+  {
+    workout: 'deadlift', fault: 'fast_descent',
+    build: () => positiveCtx('deadlift', { durationMs: 1000 }),
+  },
+
+  // ---- rdl (1) ----
+  {
+    workout: 'rdl', fault: 'asymmetric_hinge',
+    build: () => positiveCtx('rdl', { minAngles: joints({ leftHip: 80, rightHip: 115, leftKnee: 150, rightKnee: 150, leftShoulder: 100, rightShoulder: 100 }) }),
+  },
+
+  // ---- benchpress (1) ----
+  {
+    workout: 'benchpress', fault: 'asymmetric_press',
+    build: () => positiveCtx('benchpress', { minAngles: joints({ leftElbow: 80, rightElbow: 110 }) }),
+  },
+
+  // ---- farmers_walk (1) ----
+  {
+    workout: 'farmers_walk', fault: 'lateral_lean',
+    build: () => positiveCtx('farmers_walk', { minAngles: joints({ leftHip: 150, rightHip: 175, leftShoulder: 90, rightShoulder: 90 }) }),
+  },
+];
+
+describe('parametric fault harness — targeted positive triggers', () => {
+  for (const pc of POSITIVE_CASES) {
+    test(`${pc.workout}.${pc.fault} fires on a minimally-triggering RepContext`, () => {
+      const def = getDef(pc.workout);
+      const fault: FaultDefinition | undefined = def.faults.find((f) => f.id === pc.fault);
+      if (!fault) {
+        throw new Error(`Fault '${pc.workout}.${pc.fault}' not registered`);
+      }
+      expect(fault.condition(pc.build())).toBe(true);
+    });
+  }
+
+  test('at least 20 targeted positive cases registered', () => {
+    expect(POSITIVE_CASES.length).toBeGreaterThanOrEqual(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NaN-angles guard — every fault must return `false` on fully-NaN input.
+// ---------------------------------------------------------------------------
+
+describe('parametric fault harness — NaN angles do not fire faults', () => {
+  const NaNAngles: JointAngles = {
+    leftElbow: NaN, rightElbow: NaN, leftShoulder: NaN, rightShoulder: NaN,
+    leftKnee: NaN, rightKnee: NaN, leftHip: NaN, rightHip: NaN,
+  };
+  const nanCtx: RepContext = {
+    startAngles: NaNAngles,
+    endAngles: NaNAngles,
+    minAngles: NaNAngles,
+    maxAngles: NaNAngles,
+    durationMs: 4000,
+    repNumber: 1,
+    workoutId: 'parametric-nan',
+  };
+
+  const workoutIds = Object.keys(workoutsByMode) as DetectionMode[];
+  for (const id of workoutIds) {
+    const def = getDef(id);
+    for (const fault of def.faults) {
+      // Duration-only faults (fast_rep, short_hold, rushed_pickup, short_carry,
+      // fast_descent) are expected to still evaluate deterministically under
+      // NaN because they only look at `durationMs`. Filter them out of the
+      // NaN-guard assertion.
+      const isDurationFault = /fast|short|rushed/.test(fault.id);
+      if (isDurationFault) continue;
+      test(`${id}.${fault.id} does not fire on all-NaN angles`, () => {
+        expect(fault.condition(nanCtx)).toBe(false);
+      });
+    }
+  }
+});

--- a/tests/unit/workouts-helpers.test.ts
+++ b/tests/unit/workouts-helpers.test.ts
@@ -1,0 +1,158 @@
+import {
+  asymmetryCheck,
+  sequenceCheck,
+  validateAngleInRange,
+  clampedDelta,
+} from '@/lib/workouts/helpers';
+import type { AngleRange } from '@/lib/types/workout-definitions';
+
+const range: AngleRange = { min: 80, max: 120, optimal: 100, tolerance: 10 };
+
+// ---------------------------------------------------------------------------
+// asymmetryCheck
+// ---------------------------------------------------------------------------
+
+describe('asymmetryCheck', () => {
+  test('returns true when left/right diverge beyond threshold', () => {
+    expect(asymmetryCheck(90, 110, 15)).toBe(true);
+  });
+
+  test('returns false when left/right are within threshold', () => {
+    expect(asymmetryCheck(100, 98, 5)).toBe(false);
+  });
+
+  test('returns false for identical values', () => {
+    expect(asymmetryCheck(100, 100, 5)).toBe(false);
+  });
+
+  test('NaN guard: returns false when left is NaN', () => {
+    expect(asymmetryCheck(NaN, 90, 10)).toBe(false);
+  });
+
+  test('NaN guard: returns false when right is NaN', () => {
+    expect(asymmetryCheck(90, NaN, 10)).toBe(false);
+  });
+
+  test('NaN guard: returns false when threshold is NaN', () => {
+    expect(asymmetryCheck(90, 110, NaN)).toBe(false);
+  });
+
+  test('returns false when both sides are zero', () => {
+    expect(asymmetryCheck(0, 0, 10)).toBe(false);
+  });
+
+  test('returns false for negative threshold', () => {
+    expect(asymmetryCheck(90, 110, -5)).toBe(false);
+  });
+
+  test('boundary: diff exactly equal to threshold is not a fault', () => {
+    // 10% diff on larger=100, threshold 10% -> not strictly greater
+    expect(asymmetryCheck(90, 100, 10)).toBe(false);
+  });
+
+  test('boundary: diff just over threshold is a fault', () => {
+    // 10.1% diff on larger=100
+    expect(asymmetryCheck(89.8, 100, 10)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sequenceCheck
+// ---------------------------------------------------------------------------
+
+describe('sequenceCheck', () => {
+  test('primary-leads: fault when primary delta is smaller than secondary', () => {
+    // deadlift-style: hips (primary) should rise more than shoulders (secondary)
+    expect(sequenceCheck(170, 172, 170, 180, true)).toBe(true);
+  });
+
+  test('primary-leads: no fault when primary delta outpaces secondary', () => {
+    expect(sequenceCheck(90, 170, 90, 120, true)).toBe(false);
+  });
+
+  test('primary-follows: fault when primary outpaces secondary', () => {
+    expect(sequenceCheck(90, 170, 90, 120, false)).toBe(true);
+  });
+
+  test('NaN guard: returns false when primaryStart is NaN', () => {
+    expect(sequenceCheck(NaN, 170, 90, 120, true)).toBe(false);
+  });
+
+  test('NaN guard: returns false when any input is non-finite', () => {
+    expect(sequenceCheck(1, Infinity, 1, 1, true)).toBe(false);
+  });
+
+  test('equal deltas: no fault under primary-leads (not strictly less)', () => {
+    expect(sequenceCheck(100, 120, 100, 120, true)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateAngleInRange
+// ---------------------------------------------------------------------------
+
+describe('validateAngleInRange', () => {
+  test('returns true for angle within bounds', () => {
+    expect(validateAngleInRange(100, range)).toBe(true);
+  });
+
+  test('returns true at lower boundary (inclusive)', () => {
+    expect(validateAngleInRange(80, range)).toBe(true);
+  });
+
+  test('returns true at upper boundary (inclusive)', () => {
+    expect(validateAngleInRange(120, range)).toBe(true);
+  });
+
+  test('returns false below min', () => {
+    expect(validateAngleInRange(79.9, range)).toBe(false);
+  });
+
+  test('returns false above max', () => {
+    expect(validateAngleInRange(120.1, range)).toBe(false);
+  });
+
+  test('NaN guard: returns false on NaN angle', () => {
+    expect(validateAngleInRange(NaN, range)).toBe(false);
+  });
+
+  test('NaN guard: returns false on malformed range', () => {
+    const bad: AngleRange = { min: NaN, max: 100, optimal: 90, tolerance: 5 };
+    expect(validateAngleInRange(90, bad)).toBe(false);
+  });
+
+  test('returns false when max < min (degenerate range)', () => {
+    const inverted: AngleRange = { min: 120, max: 80, optimal: 100, tolerance: 5 };
+    expect(validateAngleInRange(100, inverted)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clampedDelta
+// ---------------------------------------------------------------------------
+
+describe('clampedDelta', () => {
+  test('returns the signed delta from-to', () => {
+    expect(clampedDelta(100, 120)).toBe(20);
+  });
+
+  test('returns negative delta when to < from', () => {
+    expect(clampedDelta(120, 100)).toBe(-20);
+  });
+
+  test('NaN guard: returns 0 on NaN from', () => {
+    expect(clampedDelta(NaN, 100)).toBe(0);
+  });
+
+  test('NaN guard: returns 0 on NaN to', () => {
+    expect(clampedDelta(100, NaN)).toBe(0);
+  });
+
+  test('NaN guard: returns 0 on Infinity', () => {
+    expect(clampedDelta(100, Infinity)).toBe(0);
+  });
+
+  test('zero delta when from === to', () => {
+    expect(clampedDelta(90, 90)).toBe(0);
+  });
+});

--- a/tests/unit/workouts-lunge.test.ts
+++ b/tests/unit/workouts-lunge.test.ts
@@ -1,0 +1,263 @@
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { RepContext } from '@/lib/types/workout-definitions';
+
+import { lungeDefinition, LUNGE_THRESHOLDS } from '@/lib/workouts/lunge';
+import { getWorkoutByMode, getWorkoutIds } from '@/lib/workouts';
+
+// ---------------------------------------------------------------------------
+// Helpers mirroring tests/unit/services/fqi-faults.test.ts
+// ---------------------------------------------------------------------------
+
+function angles(overrides: Partial<JointAngles> = {}): JointAngles {
+  return {
+    leftElbow: 170,
+    rightElbow: 170,
+    leftShoulder: 90,
+    rightShoulder: 90,
+    // "Neutral" knee / hip values chosen close to the lunge `optimal`
+    // and above all fault thresholds so the baseline never fires faults.
+    leftKnee: 95,
+    rightKnee: 95,
+    leftHip: 110,
+    rightHip: 110,
+    ...overrides,
+  };
+}
+
+function ctx(opts: {
+  start?: Partial<JointAngles>;
+  end?: Partial<JointAngles>;
+  min?: Partial<JointAngles>;
+  max?: Partial<JointAngles>;
+  durationMs?: number;
+  repNumber?: number;
+  workoutId?: string;
+}): RepContext {
+  return {
+    startAngles: angles(opts.start),
+    endAngles: opts.end ? angles(opts.end) : angles({ leftKnee: 170, rightKnee: 170, leftHip: 170, rightHip: 170 }),
+    minAngles: angles(opts.min),
+    maxAngles: angles(opts.max),
+    durationMs: opts.durationMs ?? 2500,
+    repNumber: opts.repNumber ?? 1,
+    workoutId: opts.workoutId ?? 'lunge',
+  };
+}
+
+function fault(id: string) {
+  const f = lungeDefinition.faults.find((f) => f.id === id);
+  if (!f) throw new Error(`Lunge fault '${id}' not found`);
+  return f;
+}
+
+const NaNAngles: JointAngles = {
+  leftElbow: NaN, rightElbow: NaN, leftShoulder: NaN, rightShoulder: NaN,
+  leftKnee: NaN, rightKnee: NaN, leftHip: NaN, rightHip: NaN,
+};
+
+function nanCtx(): RepContext {
+  return {
+    startAngles: NaNAngles,
+    endAngles: NaNAngles,
+    minAngles: NaNAngles,
+    maxAngles: NaNAngles,
+    durationMs: 2500,
+    repNumber: 1,
+    workoutId: 'lunge',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registration sanity
+// ---------------------------------------------------------------------------
+
+describe('lunge registration', () => {
+  test('lunge is registered as a detection mode', () => {
+    expect(getWorkoutIds()).toContain('lunge');
+  });
+
+  test('getWorkoutByMode returns the lunge definition', () => {
+    const def = getWorkoutByMode('lunge');
+    expect(def.id).toBe('lunge');
+    expect(def.displayName).toBe('Lunge');
+  });
+
+  test('lunge registers 6 faults', () => {
+    expect(lungeDefinition.faults.length).toBe(6);
+  });
+
+  test('lunge thresholds are finite', () => {
+    for (const [key, val] of Object.entries(LUNGE_THRESHOLDS)) {
+      expect(Number.isFinite(val)).toBe(true);
+      // Typescript narrow: all LUNGE_THRESHOLDS values are numeric
+      if (typeof val !== 'number') {
+        throw new Error(`LUNGE_THRESHOLDS.${key} is not a number`);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shallow_depth
+// ---------------------------------------------------------------------------
+
+describe('lunge fault: shallow_depth', () => {
+  const f = fault('shallow_depth');
+
+  test('positive: min knee well above parallel+15 fires fault', () => {
+    // parallel = 80 by default; 80+15=95, so 120 > 95 ⇒ fault
+    const c = ctx({ min: { leftKnee: 120, rightKnee: 120 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: min knee at optimal depth does not fire', () => {
+    const c = ctx({ min: { leftKnee: 85, rightKnee: 85 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// knee_cave
+// ---------------------------------------------------------------------------
+
+describe('lunge fault: knee_cave', () => {
+  const f = fault('knee_cave');
+
+  test('positive: left/right knee diff beyond kneeCaveMax fires fault', () => {
+    // kneeCaveMax = 25, diff = |60 - 100| = 40 > 25
+    const c = ctx({ min: { leftKnee: 60, rightKnee: 100 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: symmetric knees do not fire', () => {
+    const c = ctx({ min: { leftKnee: 90, rightKnee: 95 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// heels_off_ground
+// ---------------------------------------------------------------------------
+
+describe('lunge fault: heels_off_ground', () => {
+  const f = fault('heels_off_ground');
+
+  test('positive: rear-vs-front hip diff exceeding heelOffHipDiffMax fires', () => {
+    // heelOffHipDiffMax = 30, diff = |80 - 130| = 50 > 30
+    const c = ctx({ min: { leftHip: 80, rightHip: 130 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: hips balanced does not fire', () => {
+    const c = ctx({ min: { leftHip: 105, rightHip: 115 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// asymmetric_depth
+// ---------------------------------------------------------------------------
+
+describe('lunge fault: asymmetric_depth', () => {
+  const f = fault('asymmetric_depth');
+
+  test('positive: one knee well shallower than the other fires (>40% diff)', () => {
+    // larger=170, diff=|60-170|=110, pct ≈ 64.7% > 40
+    const c = ctx({ min: { leftKnee: 60, rightKnee: 170 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: both knees nearly matched does not fire', () => {
+    // larger=100, diff=5, pct=5% < 40
+    const c = ctx({ min: { leftKnee: 95, rightKnee: 100 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forward_knee
+// ---------------------------------------------------------------------------
+
+describe('lunge fault: forward_knee', () => {
+  const f = fault('forward_knee');
+
+  test('positive: front knee past frontKneeForwardLimit (acute) fires fault', () => {
+    // frontKneeForwardLimit = 70, min front = 55 < 70
+    const c = ctx({ min: { leftKnee: 55, rightKnee: 90 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: knee at or beyond the limit does not fire', () => {
+    // both at/above 70
+    const c = ctx({ min: { leftKnee: 80, rightKnee: 95 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hyper_extension
+// ---------------------------------------------------------------------------
+
+describe('lunge fault: hyper_extension', () => {
+  const f = fault('hyper_extension');
+
+  test('positive: end-rep knee beyond hyperExtensionMax fires fault', () => {
+    // hyperExtensionMax = 182, max end = 185 > 182
+    const c = ctx({ end: { leftKnee: 185, rightKnee: 170 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: end-rep near lockout but below hyperextension does not fire', () => {
+    const c = ctx({ end: { leftKnee: 175, rightKnee: 178 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateMetrics / getNextPhase sanity
+// ---------------------------------------------------------------------------
+
+describe('lunge definition sanity', () => {
+  test('calculateMetrics picks the deeper knee as frontKnee', () => {
+    const m = lungeDefinition.calculateMetrics(angles({ leftKnee: 85, rightKnee: 165 }));
+    expect(m.frontKnee).toBe(85);
+    expect(m.rearKnee).toBe(165);
+    expect(m.legsTracked).toBe(true);
+  });
+
+  test('getNextPhase transitions setup -> standing at threshold', () => {
+    const a = angles({ leftKnee: 170, rightKnee: 170 });
+    const m = lungeDefinition.calculateMetrics(a);
+    expect(lungeDefinition.getNextPhase('setup', a, m)).toBe('standing');
+  });
+
+  test('getNextPhase transitions standing -> descent when knee flexes', () => {
+    const a = angles({ leftKnee: 140, rightKnee: 160 });
+    const m = lungeDefinition.calculateMetrics(a);
+    expect(lungeDefinition.getNextPhase('standing', a, m)).toBe('descent');
+  });
+});


### PR DESCRIPTION
## Summary

Addresses form-model coverage gaps identified in the wave-2 audit (issue #438):

- Adds a full lunge form model with 6 faults and a registered `lunge` detection mode.
- Expands dead-hang from 3 → 6 faults (appended only; existing behavior untouched).
- Introduces shared helpers (`asymmetryCheck`, `sequenceCheck`, `validateAngleInRange`, `clampedDelta`) for NaN-safe biomechanical checks that future workouts can adopt.
- Adds a parametric test harness that exercises every registered fault across all 9 workouts with a sanity-baseline ideal rep, 25 targeted positive triggers, and a NaN-angles guard for every non-duration fault.

Motivated by the upstream quality concerns tracked in #166 (squat endAngles coverage) and #436 (deadlift asymmetry blind spots).

## Atomic commits

1. `feat(workouts): add helpers for asymmetry/sequence/angle-range validation` — four NaN-safe helpers in `lib/workouts/helpers.ts`, all returning `false`/`0` on bad input.
2. `test(workouts): unit coverage for new helpers` — 30 assertions covering happy paths, NaN guards, boundaries, and degenerate inputs.
3. `feat(workouts): add lunge form model with 6 faults` — `lib/workouts/lunge.ts` modelled after `squat.ts`, phases `setup→descent→bottom→ascent→standing`, faults `shallow_depth`, `knee_cave`, `heels_off_ground`, `asymmetric_depth`, `forward_knee`, `hyper_extension`. Consumes `movementProfile.lunge` from `lib/fusion/movements.ts`; local fallback thresholds documented inline for fields not yet present in that profile.
4. `feat(workouts): register lunge in workoutsByMode and workoutRegistry` — pure additive edit to `lib/workouts/index.ts`.
5. `test(workouts): lunge parametric fault coverage` — 38 assertions (6 faults × positive/negative/NaN + registration/metrics/phase sanity).
6. `feat(workouts): extend dead-hang with 3 faults — scapular_retraction, kipping_swing, grip_shift` — appended only; existing 3 faults untouched.
7. `test(workouts): extend dead-hang coverage for new faults` — 17 assertions (3 new faults × positive/negative/NaN + threshold/count sanity).
8. `test(workouts): parametric harness exercising every registered fault` — 119 assertions iterating all 9 workouts × all 45 registered faults for the baseline, plus 25 targeted positives and per-fault NaN guards.
9. `docs(workouts): note drill population deferred to post-#434 in lib/workouts/README.md` — short "Future work" section calling out the dependency.

## Test counts

- `tests/unit/workouts-helpers.test.ts` — 30 assertions
- `tests/unit/workouts-lunge.test.ts` — 38 assertions
- `tests/unit/workouts-dead-hang.test.ts` — 17 assertions (includes 2 pre-existing)
- `tests/unit/workouts-faults.parametric.test.ts` — 119 assertions

**Total (new suites): 187 tests / 204 expect() calls — all green.**

`bun run lint` — 0 errors, 2 pre-existing warnings (unrelated to this PR, in `app/(modals)/template-builder.tsx`).
`bun run check:types` — passes (`tsc --noEmit`).

## Out of scope (deferred)

- **Drill population (`FaultDefinition.drills[]`)** — blocked on #434, which owns the type extension and the backfill for all 8 existing workouts.
- **Refactor of existing 8 workouts to adopt the new helpers** — deliberate follow-up once #434 lands to avoid conflicts.
- **Dumbbell variants** — out of scope; own PR (large).
- **Scaffold CLI** — out of scope.

## File-overlap matrix

| Path | Action | Risk of conflict with other PRs |
|------|--------|---------------------------------|
| `lib/workouts/helpers.ts` | Extend (add 4 helpers; existing `getPhaseStaticCue` untouched) | Low — isolated additive edit |
| `lib/workouts/lunge.ts` | **New file** | None |
| `lib/workouts/index.ts` | Additive (add lunge import/export/registry entry) | Low — lexicographic slot only |
| `lib/workouts/dead-hang.ts` | Append 3 faults + 3 threshold constants; existing faults untouched | Low — append-only |
| `lib/workouts/{squat,deadlift,rdl,benchpress,pullup,pushup,farmers-walk}.ts` | **Not modified** | None — explicitly preserved for #434 et al. |
| `tests/unit/workouts-helpers.test.ts` | **New file** | None |
| `tests/unit/workouts-lunge.test.ts` | **New file** | None |
| `tests/unit/workouts-dead-hang.test.ts` | Extend (append block; pre-existing 2 tests untouched) | Low |
| `tests/unit/workouts-faults.parametric.test.ts` | **New file** | None |
| `lib/workouts/README.md` | Append "Future work" section | Low — append-only |

Closes #438
Related: #166, #436
