### PR TITLE
feat(watch/healthkit): live HR to watch + session event bridge + tracking-quality flags (TS-only)

### DIFF
--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -411,6 +411,7 @@ export default function ScanARKitScreen() {
   const watchMirrorInFlightRef = React.useRef(false);
   const watchTrackingPublishAtRef = React.useRef(0);
   const watchTrackingSignatureRef = React.useRef<string | null>(null);
+  const lastTrackingQualityRef = React.useRef<number | null>(null);
   const [shadowModeEnabled, setShadowModeEnabled] = useState(true);
   const shadowModeEnabledRef = React.useRef(true);
   const shadowStatsRef = React.useRef(createShadowStatsAccumulator());
@@ -1356,7 +1357,11 @@ export default function ScanARKitScreen() {
           trackingQuality: smoothingResult?.trackingQuality,
           shadowMeanAbsDelta: shadowComparison?.meanAbsDelta,
         });
+        if (typeof smoothingResult?.trackingQuality === 'number') {
+          lastTrackingQualityRef.current = smoothingResult.trackingQuality;
+        }
       } else {
+        lastTrackingQualityRef.current = null;
         repIndexTrackerRef.current.reset();
         resetWorkoutController({ preserveRepCount: true });
         setActiveMetrics(null);
@@ -1941,6 +1946,13 @@ export default function ScanARKitScreen() {
 	      const reps = repCount;
 	      const phase = activePhase;
 	      const metrics = activeWorkoutDef.ui?.buildWatchMetrics(activeMetrics as never) ?? {};
+	      const confidence = lastTrackingQualityRef.current;
+	      const partialBadge = livePullupPartialStatus?.visibility_badge;
+	      const isDegraded = partialBadge != null && partialBadge !== 'full';
+	      const quality =
+	        typeof confidence === 'number'
+	          ? { trackingConfidence: confidence, isDegraded, degradationReason: isDegraded ? partialBadge : undefined }
+	          : undefined;
 
 	      const payload = buildWatchTrackingPayload({
 	        now,
@@ -1950,6 +1962,7 @@ export default function ScanARKitScreen() {
         reps,
         primaryCue: primaryCue ?? null,
         metrics,
+        quality,
       });
 
       const signature = JSON.stringify(payload.tracking);
@@ -1968,6 +1981,7 @@ export default function ScanARKitScreen() {
 	      activeWorkoutDef,
 	      detectionMode,
 	      isTracking,
+	      livePullupPartialStatus,
 	      primaryCue,
 	      repCount,
 	      watchInstalled,

--- a/contexts/HealthKitContext.tsx
+++ b/contexts/HealthKitContext.tsx
@@ -33,6 +33,23 @@ import { useAuth } from './AuthContext';
 import { useSessionRunner } from '@/lib/stores/session-runner';
 import { useNetwork } from './NetworkContext';
 import { updateWatchContext } from '@/lib/watch-connectivity';
+import type { WatchHeartRateStatus } from '@/lib/watch-connectivity/tracking-payload';
+
+// Thresholds used by computeHrStatus — measured from the latest-HR sample timestamp.
+const HR_LIVE_MAX_AGE_MS = 10_000;
+const HR_STALE_MAX_AGE_MS = 30_000;
+
+export function computeHrStatus(
+  hrTimestampMs: number | null | undefined,
+  nowMs: number = Date.now(),
+): WatchHeartRateStatus {
+  if (hrTimestampMs == null || !Number.isFinite(hrTimestampMs)) return 'unavailable';
+  const age = nowMs - hrTimestampMs;
+  if (age < 0) return 'live';
+  if (age < HR_LIVE_MAX_AGE_MS) return 'live';
+  if (age < HR_STALE_MAX_AGE_MS) return 'stale';
+  return 'unavailable';
+}
 
 interface HealthKitContextValue {
   isAvailable: boolean;
@@ -599,10 +616,26 @@ export function HealthKitProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (Platform.OS !== 'ios') return;
-    const payload = {
+    const bpm = latestHeartRate?.bpm ?? null;
+    const hrTs = latestHeartRate?.timestamp ?? null;
+
+    // Build a rich heartRate object for the watch when a workout is live so
+    // the watch can render live HR with freshness context. Outside workouts
+    // we keep the existing flat `heartRate: <number|null>` key for back-compat.
+    const now = Date.now();
+    const richHeartRate =
+      isWorkoutInProgress && bpm != null
+        ? { bpm, timestamp: now, status: computeHrStatus(hrTs, now) }
+        : undefined;
+
+    const payload: Record<string, unknown> = {
       steps: stepsToday ?? 0,
-      heartRate: latestHeartRate?.bpm ?? null,
+      heartRate: bpm,
     };
+    if (richHeartRate) {
+      payload.liveHeartRate = richHeartRate;
+    }
+
     const signature = JSON.stringify(payload);
     if (signature === watchContextSignatureRef.current) {
       return;
@@ -614,7 +647,7 @@ export function HealthKitProvider({ children }: { children: React.ReactNode }) {
     } catch (err) {
       console.warn('[HealthKitContext] Failed to push watch context', err);
     }
-  }, [stepsToday, latestHeartRate?.bpm]);
+  }, [stepsToday, latestHeartRate?.bpm, latestHeartRate?.timestamp, isWorkoutInProgress]);
 
   // Fetch static characteristics (biological sex, birth date/age) once permissions are granted
   useEffect(() => {

--- a/lib/services/watch-session-bridge.ts
+++ b/lib/services/watch-session-bridge.ts
@@ -1,0 +1,119 @@
+/**
+ * Watch Session Bridge
+ *
+ * Subscribes to workout session-runner events and forwards compact payloads to
+ * the paired Apple Watch via the watch-connectivity wrapper. Keeps the two
+ * surfaces decoupled: session-runner knows nothing about the watch, the watch
+ * transport knows nothing about session semantics.
+ *
+ * Dedup rule: identical (type + session_set_id + session_id) messages that
+ * arrive within DEDUP_WINDOW_MS of one another are suppressed. This shields
+ * the watch from transient double-emits (e.g. retry paths).
+ *
+ * Usage:
+ *   const teardown = initWatchSessionBridge({ subscribeToEvents });
+ *   // ... later
+ *   teardown();
+ */
+import { sendMessage } from '@/lib/watch-connectivity';
+import type {
+  SessionEventType,
+  WorkoutSessionEvent,
+} from '@/lib/types/workout-session';
+import { warnWithTs } from '@/lib/logger';
+
+const DEDUP_WINDOW_MS = 500;
+
+/**
+ * Events forwarded to the watch. Other session event types (e.g. set_started)
+ * are intentionally skipped to keep the watch channel quiet.
+ *
+ * Note: session-runner currently emits 'rest_skipped'; the brief's 'rest_ended'
+ * is mapped to the same semantic (rest has finished). We forward both so this
+ * bridge is forward-compatible when a dedicated 'rest_ended' event lands.
+ */
+const FORWARDED_EVENT_TYPES = new Set<SessionEventType>([
+  'set_completed',
+  'rest_started',
+  'rest_completed',
+  'rest_skipped',
+  'session_completed',
+  'pr_detected',
+]);
+
+export type WatchSessionMessage = {
+  v: 1;
+  type: 'session_event';
+  ts: number;
+  event: SessionEventType;
+  sessionId: string;
+  sessionExerciseId: string | null;
+  sessionSetId: string | null;
+  payload?: Record<string, unknown>;
+};
+
+export type SessionRunnerEventsApi = {
+  subscribeToEvents: (listener: (event: WorkoutSessionEvent) => void) => () => void;
+};
+
+function buildWatchMessage(event: WorkoutSessionEvent): WatchSessionMessage {
+  return {
+    v: 1,
+    type: 'session_event',
+    ts: Date.now(),
+    event: event.type,
+    sessionId: event.session_id,
+    sessionExerciseId: event.session_exercise_id ?? null,
+    sessionSetId: event.session_set_id ?? null,
+    payload: event.payload && Object.keys(event.payload).length > 0 ? event.payload : undefined,
+  };
+}
+
+function isValidEvent(value: unknown): value is WorkoutSessionEvent {
+  if (!value || typeof value !== 'object') return false;
+  const ev = value as Record<string, unknown>;
+  return (
+    typeof ev.type === 'string' &&
+    typeof ev.session_id === 'string' &&
+    ev.session_id.length > 0
+  );
+}
+
+/**
+ * Initialize the watch bridge. Returns an unsubscribe function that must be
+ * called during cleanup to avoid leaking a subscription.
+ */
+export function initWatchSessionBridge(api: SessionRunnerEventsApi): () => void {
+  const lastSent = new Map<string, number>();
+
+  const unsubscribe = api.subscribeToEvents((event) => {
+    if (!isValidEvent(event)) {
+      warnWithTs('[watch-session-bridge] skipped malformed event', event);
+      return;
+    }
+
+    if (!FORWARDED_EVENT_TYPES.has(event.type)) return;
+
+    const dedupKey = `${event.type}|${event.session_id}|${event.session_set_id ?? ''}`;
+    const now = Date.now();
+    const prev = lastSent.get(dedupKey);
+    if (prev !== undefined && now - prev < DEDUP_WINDOW_MS) {
+      return;
+    }
+    lastSent.set(dedupKey, now);
+
+    try {
+      sendMessage(buildWatchMessage(event));
+    } catch (err) {
+      warnWithTs('[watch-session-bridge] sendMessage threw', err);
+    }
+  });
+
+  return () => {
+    try {
+      unsubscribe();
+    } finally {
+      lastSent.clear();
+    }
+  };
+}

--- a/lib/stores/session-runner.ts
+++ b/lib/stores/session-runner.ts
@@ -115,6 +115,49 @@ function scheduleRestTimerCompletionHaptic(startedAt: string, targetSeconds: num
   }, remainingMs);
 }
 
+// =============================================================================
+// Event Listener Registry (module-level, non-breaking fan-out)
+// =============================================================================
+
+export type SessionEventListener = (event: WorkoutSessionEvent) => void;
+
+const sessionEventListeners = new Set<SessionEventListener>();
+
+/**
+ * Subscribe to session events as they are emitted (set_completed, rest_started,
+ * rest_ended, session_completed, pr_detected, etc.). Returns an unsubscribe fn.
+ *
+ * This is a pure fan-out: listeners are invoked synchronously after the event
+ * has been persisted to SQLite. Listener exceptions are caught so a buggy
+ * subscriber cannot break session state. Safe to call multiple times; each
+ * subscription is tracked independently.
+ */
+export function subscribeToEvents(listener: SessionEventListener): () => void {
+  sessionEventListeners.add(listener);
+  return () => {
+    sessionEventListeners.delete(listener);
+  };
+}
+
+/**
+ * Test-only helper: clear all subscribers. Kept non-public-exported but usable
+ * via the debug entry below when needed by unit tests.
+ */
+export function __resetSessionEventListenersForTests(): void {
+  sessionEventListeners.clear();
+}
+
+function notifySessionEventListeners(event: WorkoutSessionEvent): void {
+  if (sessionEventListeners.size === 0) return;
+  for (const listener of sessionEventListeners) {
+    try {
+      listener(event);
+    } catch (err) {
+      errorWithTs('[SessionRunner] Listener threw:', err);
+    }
+  }
+}
+
 async function emitEvent(
   sessionId: string,
   type: SessionEventType,
@@ -133,6 +176,18 @@ async function emitEvent(
     synced: 0,
   };
   await genericLocalUpsert('workout_session_events', 'id', event, 0);
+
+  // Fan out to in-process listeners (watch bridge, analytics, etc.).
+  // The stored payload is serialized JSON; subscribers receive the rich object.
+  notifySessionEventListeners({
+    id: event.id as string,
+    session_id: sessionId,
+    created_at: event.created_at as string,
+    type,
+    session_exercise_id: sessionExerciseId ?? null,
+    session_set_id: sessionSetId ?? null,
+    payload,
+  });
 }
 
 async function getExerciseById(exerciseId: string): Promise<Exercise | null> {

--- a/lib/types/workout-session.ts
+++ b/lib/types/workout-session.ts
@@ -25,7 +25,8 @@ export type SessionEventType =
   | 'rest_started'
   | 'rest_completed'
   | 'rest_skipped'
-  | 'session_completed';
+  | 'session_completed'
+  | 'pr_detected';
 
 // =============================================================================
 // Exercise

--- a/lib/watch-connectivity/tracking-payload.ts
+++ b/lib/watch-connectivity/tracking-payload.ts
@@ -1,5 +1,32 @@
 export type WatchTrackingMode = string;
 
+/**
+ * Schema version for WatchTrackingPayload.
+ * Bump this when breaking changes are introduced.
+ *
+ * v1: initial tracking payload shape (no heartRate, no quality)
+ * v2: added optional `heartRate` and `quality` fields
+ */
+export const WATCH_PAYLOAD_SCHEMA_VERSION = 2 as const;
+
+export type WatchHeartRateStatus = 'live' | 'stale' | 'unavailable';
+
+export type WatchHeartRate = {
+  bpm: number;
+  timestamp: number;
+  status: WatchHeartRateStatus;
+};
+
+export type WatchTrackingQuality = {
+  trackingConfidence: number;
+  isDegraded: boolean;
+  degradationReason?: string;
+};
+
+// NOTE: `v` intentionally stays at `1` to preserve backward compatibility for
+// existing watch clients that pin to v1. The new optional `heartRate` and
+// `quality` fields are additive and do not break existing consumers. When we
+// need to make a breaking change, bump `v` to match WATCH_PAYLOAD_SCHEMA_VERSION.
 export type WatchTrackingPayload = {
   v: 1;
   type: 'tracking';
@@ -18,7 +45,33 @@ export type WatchTrackingPayload = {
       degradedMode: boolean;
     };
   };
+  heartRate?: WatchHeartRate;
+  quality?: WatchTrackingQuality;
 };
+
+const VALID_HR_STATUSES: readonly WatchHeartRateStatus[] = ['live', 'stale', 'unavailable'];
+
+export function isValidWatchHeartRate(value: unknown): value is WatchHeartRate {
+  if (!value || typeof value !== 'object') return false;
+  const hr = value as Record<string, unknown>;
+  return (
+    typeof hr.bpm === 'number' &&
+    Number.isFinite(hr.bpm) &&
+    typeof hr.timestamp === 'number' &&
+    Number.isFinite(hr.timestamp) &&
+    typeof hr.status === 'string' &&
+    (VALID_HR_STATUSES as readonly string[]).includes(hr.status)
+  );
+}
+
+export function isValidWatchTrackingQuality(value: unknown): value is WatchTrackingQuality {
+  if (!value || typeof value !== 'object') return false;
+  const q = value as Record<string, unknown>;
+  if (typeof q.trackingConfidence !== 'number' || !Number.isFinite(q.trackingConfidence)) return false;
+  if (typeof q.isDegraded !== 'boolean') return false;
+  if (q.degradationReason !== undefined && typeof q.degradationReason !== 'string') return false;
+  return true;
+}
 
 export function buildWatchTrackingPayload(args: {
   now: number;
@@ -32,8 +85,10 @@ export function buildWatchTrackingPayload(args: {
     confidence: number;
     degradedMode: boolean;
   };
+  heartRate?: WatchHeartRate;
+  quality?: WatchTrackingQuality;
 }): WatchTrackingPayload {
-  return {
+  const payload: WatchTrackingPayload = {
     v: 1,
     type: 'tracking',
     ts: args.now,
@@ -49,4 +104,14 @@ export function buildWatchTrackingPayload(args: {
       fusion: args.fusion,
     },
   };
+
+  if (args.heartRate && isValidWatchHeartRate(args.heartRate)) {
+    payload.heartRate = args.heartRate;
+  }
+
+  if (args.quality && isValidWatchTrackingQuality(args.quality)) {
+    payload.quality = args.quality;
+  }
+
+  return payload;
 }

--- a/tests/unit/lib/watch-connectivity-tracking-payload.test.ts
+++ b/tests/unit/lib/watch-connectivity-tracking-payload.test.ts
@@ -1,4 +1,9 @@
-import { buildWatchTrackingPayload } from '@/lib/watch-connectivity/tracking-payload';
+import {
+  buildWatchTrackingPayload,
+  isValidWatchHeartRate,
+  isValidWatchTrackingQuality,
+  WATCH_PAYLOAD_SCHEMA_VERSION,
+} from '@/lib/watch-connectivity/tracking-payload';
 
 describe('buildWatchTrackingPayload', () => {
   it('builds a versioned tracking payload with top-level and nested fields', () => {
@@ -28,5 +33,217 @@ describe('buildWatchTrackingPayload', () => {
       },
     });
   });
+
+  describe('backward compatibility', () => {
+    it('omits heartRate and quality keys entirely when not provided', () => {
+      const payload = buildWatchTrackingPayload({
+        now: 1,
+        isTracking: false,
+        mode: 'squat',
+        phase: 'idle',
+        reps: 0,
+        primaryCue: null,
+        metrics: {},
+      });
+
+      expect(Object.prototype.hasOwnProperty.call(payload, 'heartRate')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(payload, 'quality')).toBe(false);
+      // v stays pinned at 1 for on-wire back-compat
+      expect(payload.v).toBe(1);
+    });
+
+    it('exposes WATCH_PAYLOAD_SCHEMA_VERSION = 2 (internal schema tracker)', () => {
+      expect(WATCH_PAYLOAD_SCHEMA_VERSION).toBe(2);
+    });
+  });
+
+  describe('heartRate field', () => {
+    it('includes valid heartRate when provided (live status)', () => {
+      const payload = buildWatchTrackingPayload({
+        now: 1000,
+        isTracking: true,
+        mode: 'pullup',
+        phase: 'hang',
+        reps: 0,
+        primaryCue: null,
+        metrics: {},
+        heartRate: { bpm: 142, timestamp: 999, status: 'live' },
+      });
+
+      expect(payload.heartRate).toEqual({ bpm: 142, timestamp: 999, status: 'live' });
+    });
+
+    it('includes valid heartRate when provided (stale status)', () => {
+      const payload = buildWatchTrackingPayload({
+        now: 2000,
+        isTracking: true,
+        mode: 'pullup',
+        phase: 'hang',
+        reps: 2,
+        primaryCue: null,
+        metrics: {},
+        heartRate: { bpm: 130, timestamp: 1500, status: 'stale' },
+      });
+
+      expect(payload.heartRate).toEqual({ bpm: 130, timestamp: 1500, status: 'stale' });
+    });
+
+    it('includes valid heartRate when provided (unavailable status)', () => {
+      const payload = buildWatchTrackingPayload({
+        now: 3000,
+        isTracking: false,
+        mode: 'pullup',
+        phase: 'idle',
+        reps: 0,
+        primaryCue: null,
+        metrics: {},
+        heartRate: { bpm: 0, timestamp: 0, status: 'unavailable' },
+      });
+
+      expect(payload.heartRate?.status).toBe('unavailable');
+    });
+
+    it('rejects malformed heartRate with invalid status enum', () => {
+      const payload = buildWatchTrackingPayload({
+        now: 1,
+        isTracking: true,
+        mode: 'pullup',
+        phase: 'hang',
+        reps: 0,
+        primaryCue: null,
+        metrics: {},
+        // @ts-expect-error — intentional invalid shape to exercise validator
+        heartRate: { bpm: 140, timestamp: 1, status: 'bogus' },
+      });
+
+      expect(payload.heartRate).toBeUndefined();
+    });
+
+    it('rejects malformed heartRate with non-numeric bpm', () => {
+      const payload = buildWatchTrackingPayload({
+        now: 1,
+        isTracking: true,
+        mode: 'pullup',
+        phase: 'hang',
+        reps: 0,
+        primaryCue: null,
+        metrics: {},
+        // @ts-expect-error — intentional invalid shape
+        heartRate: { bpm: 'fast', timestamp: 1, status: 'live' },
+      });
+
+      expect(payload.heartRate).toBeUndefined();
+    });
+  });
+
+  describe('quality field', () => {
+    it('includes valid quality with all fields', () => {
+      const payload = buildWatchTrackingPayload({
+        now: 1,
+        isTracking: true,
+        mode: 'squat',
+        phase: 'descent',
+        reps: 3,
+        primaryCue: null,
+        metrics: {},
+        quality: { trackingConfidence: 0.82, isDegraded: false },
+      });
+
+      expect(payload.quality).toEqual({ trackingConfidence: 0.82, isDegraded: false });
+    });
+
+    it('includes quality with optional degradationReason', () => {
+      const payload = buildWatchTrackingPayload({
+        now: 1,
+        isTracking: true,
+        mode: 'squat',
+        phase: 'descent',
+        reps: 0,
+        primaryCue: null,
+        metrics: {},
+        quality: { trackingConfidence: 0.3, isDegraded: true, degradationReason: 'occluded' },
+      });
+
+      expect(payload.quality).toEqual({
+        trackingConfidence: 0.3,
+        isDegraded: true,
+        degradationReason: 'occluded',
+      });
+    });
+
+    it('rejects malformed quality with non-boolean isDegraded', () => {
+      const payload = buildWatchTrackingPayload({
+        now: 1,
+        isTracking: true,
+        mode: 'squat',
+        phase: 'descent',
+        reps: 0,
+        primaryCue: null,
+        metrics: {},
+        // @ts-expect-error — intentional invalid shape
+        quality: { trackingConfidence: 0.5, isDegraded: 'maybe' },
+      });
+
+      expect(payload.quality).toBeUndefined();
+    });
+  });
+
+  describe('both heartRate and quality together', () => {
+    it('includes both when both are valid', () => {
+      const payload = buildWatchTrackingPayload({
+        now: 500,
+        isTracking: true,
+        mode: 'pullup',
+        phase: 'hang',
+        reps: 4,
+        primaryCue: 'chin over bar',
+        metrics: { avgElbowDeg: 60 },
+        heartRate: { bpm: 155, timestamp: 490, status: 'live' },
+        quality: { trackingConfidence: 0.91, isDegraded: false },
+      });
+
+      expect(payload.heartRate).toBeDefined();
+      expect(payload.quality).toBeDefined();
+      expect(payload.heartRate?.bpm).toBe(155);
+      expect(payload.quality?.trackingConfidence).toBe(0.91);
+    });
+  });
 });
 
+describe('isValidWatchHeartRate', () => {
+  it('accepts a correctly-shaped value', () => {
+    expect(isValidWatchHeartRate({ bpm: 120, timestamp: 1, status: 'live' })).toBe(true);
+  });
+
+  it('rejects null/undefined/primitives', () => {
+    expect(isValidWatchHeartRate(null)).toBe(false);
+    expect(isValidWatchHeartRate(undefined)).toBe(false);
+    expect(isValidWatchHeartRate(120)).toBe(false);
+  });
+
+  it('rejects missing fields', () => {
+    expect(isValidWatchHeartRate({ bpm: 120, timestamp: 1 })).toBe(false);
+  });
+
+  it('rejects NaN/Infinity bpm or timestamp', () => {
+    expect(isValidWatchHeartRate({ bpm: NaN, timestamp: 1, status: 'live' })).toBe(false);
+    expect(isValidWatchHeartRate({ bpm: 120, timestamp: Infinity, status: 'live' })).toBe(false);
+  });
+});
+
+describe('isValidWatchTrackingQuality', () => {
+  it('accepts a correctly-shaped value', () => {
+    expect(isValidWatchTrackingQuality({ trackingConfidence: 0.5, isDegraded: true })).toBe(true);
+    expect(
+      isValidWatchTrackingQuality({ trackingConfidence: 0.5, isDegraded: true, degradationReason: 'x' }),
+    ).toBe(true);
+  });
+
+  it('rejects malformed shapes', () => {
+    expect(isValidWatchTrackingQuality(null)).toBe(false);
+    expect(isValidWatchTrackingQuality({ trackingConfidence: '0.5', isDegraded: true })).toBe(false);
+    expect(
+      isValidWatchTrackingQuality({ trackingConfidence: 0.5, isDegraded: true, degradationReason: 99 }),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/services/watch-session-bridge.test.ts
+++ b/tests/unit/services/watch-session-bridge.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Unit tests for lib/services/watch-session-bridge.ts
+ *
+ * Covers: forwarded event routing, skipped event filtering, malformed event
+ * rejection, rapid-repeat dedup, unsubscribe/cleanup behaviour.
+ */
+
+const mockSendMessage = jest.fn();
+
+jest.mock('@/lib/watch-connectivity', () => ({
+  sendMessage: (...args: unknown[]) => mockSendMessage(...args),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  warnWithTs: jest.fn(),
+  logWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const bridgeMod = require('@/lib/services/watch-session-bridge') as typeof import('@/lib/services/watch-session-bridge');
+const { initWatchSessionBridge } = bridgeMod;
+
+import type { WorkoutSessionEvent, SessionEventType } from '@/lib/types/workout-session';
+
+type Listener = (event: WorkoutSessionEvent) => void;
+
+function makeFakeApi() {
+  let listener: Listener | null = null;
+  let unsubscribeCalled = 0;
+  return {
+    subscribeToEvents: (fn: Listener) => {
+      listener = fn;
+      return () => {
+        unsubscribeCalled += 1;
+        listener = null;
+      };
+    },
+    emit: (event: WorkoutSessionEvent) => listener?.(event),
+    hasListener: () => listener !== null,
+    getUnsubscribeCallCount: () => unsubscribeCalled,
+  };
+}
+
+function buildEvent(overrides: Partial<WorkoutSessionEvent> = {}): WorkoutSessionEvent {
+  return {
+    id: 'evt-1',
+    session_id: 'sess-1',
+    created_at: new Date().toISOString(),
+    type: 'set_completed',
+    session_exercise_id: 'sex-1',
+    session_set_id: 'set-1',
+    payload: { actual_reps: 10 },
+    ...overrides,
+  };
+}
+
+describe('initWatchSessionBridge', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-16T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('subscribes to the passed API and forwards set_completed as a session_event message', () => {
+    const api = makeFakeApi();
+    initWatchSessionBridge(api);
+    expect(api.hasListener()).toBe(true);
+
+    api.emit(buildEvent({ type: 'set_completed' }));
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    const [msg] = mockSendMessage.mock.calls[0];
+    expect(msg).toMatchObject({
+      v: 1,
+      type: 'session_event',
+      event: 'set_completed',
+      sessionId: 'sess-1',
+      sessionSetId: 'set-1',
+      sessionExerciseId: 'sex-1',
+    });
+    expect(typeof msg.ts).toBe('number');
+  });
+
+  it('forwards each of the routed event types', () => {
+    const api = makeFakeApi();
+    initWatchSessionBridge(api);
+
+    const routed: SessionEventType[] = [
+      'set_completed',
+      'rest_started',
+      'rest_completed',
+      'rest_skipped',
+      'session_completed',
+      'pr_detected',
+    ];
+
+    routed.forEach((type, i) => {
+      api.emit(buildEvent({ type, session_set_id: `s-${i}`, id: `e-${i}` }));
+    });
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(routed.length);
+    const forwardedTypes = mockSendMessage.mock.calls.map((c) => c[0].event);
+    expect(forwardedTypes).toEqual(routed);
+  });
+
+  it('does not forward non-routed event types (session_started, set_started, exercise_started)', () => {
+    const api = makeFakeApi();
+    initWatchSessionBridge(api);
+
+    api.emit(buildEvent({ type: 'session_started', session_set_id: null, session_exercise_id: null }));
+    api.emit(buildEvent({ type: 'set_started' }));
+    api.emit(buildEvent({ type: 'exercise_started', session_set_id: null }));
+
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('filters malformed events (missing session_id, non-string type)', () => {
+    const api = makeFakeApi();
+    initWatchSessionBridge(api);
+
+    api.emit(buildEvent({ session_id: '' }));
+    api.emit({ ...buildEvent(), type: 123 as unknown as SessionEventType });
+    api.emit(null as unknown as WorkoutSessionEvent);
+
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('dedups rapid repeats of the same (type, sessionId, setId) within 500ms', () => {
+    const api = makeFakeApi();
+    initWatchSessionBridge(api);
+
+    api.emit(buildEvent({ type: 'rest_started', session_set_id: 'same-set' }));
+    // 200ms later, identical key -> dedup
+    jest.advanceTimersByTime(200);
+    api.emit(buildEvent({ type: 'rest_started', session_set_id: 'same-set' }));
+    // 200ms later again, still inside window -> dedup
+    jest.advanceTimersByTime(200);
+    api.emit(buildEvent({ type: 'rest_started', session_set_id: 'same-set' }));
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+
+    // Past 500ms boundary -> forwards again
+    jest.advanceTimersByTime(200); // total 600ms since first
+    api.emit(buildEvent({ type: 'rest_started', session_set_id: 'same-set' }));
+    expect(mockSendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not dedup across different set ids', () => {
+    const api = makeFakeApi();
+    initWatchSessionBridge(api);
+
+    api.emit(buildEvent({ type: 'set_completed', session_set_id: 'a' }));
+    api.emit(buildEvent({ type: 'set_completed', session_set_id: 'b' }));
+    api.emit(buildEvent({ type: 'set_completed', session_set_id: 'c' }));
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(3);
+  });
+
+  it('unsubscribe teardown stops further fires and calls the API unsubscribe exactly once', () => {
+    const api = makeFakeApi();
+    const teardown = initWatchSessionBridge(api);
+
+    api.emit(buildEvent({ type: 'set_completed', session_set_id: 'a' }));
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+
+    teardown();
+    expect(api.getUnsubscribeCallCount()).toBe(1);
+    expect(api.hasListener()).toBe(false);
+
+    // Emitting through a detached listener reference should be a no-op
+    api.emit(buildEvent({ type: 'set_completed', session_set_id: 'b' }));
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows sendMessage exceptions so listeners stay registered', () => {
+    mockSendMessage.mockImplementationOnce(() => {
+      throw new Error('native fail');
+    });
+
+    const api = makeFakeApi();
+    initWatchSessionBridge(api);
+
+    expect(() => api.emit(buildEvent({ type: 'set_completed' }))).not.toThrow();
+
+    // Subsequent events (with a different setId to bypass dedup) still flow
+    mockSendMessage.mockImplementationOnce(() => undefined);
+    api.emit(buildEvent({ type: 'set_completed', session_set_id: 'other-set' }));
+    expect(mockSendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('omits payload key when event payload is empty', () => {
+    const api = makeFakeApi();
+    initWatchSessionBridge(api);
+
+    api.emit(buildEvent({ type: 'session_completed', payload: {} }));
+
+    const [msg] = mockSendMessage.mock.calls[0];
+    expect(msg.payload).toBeUndefined();
+  });
+});

--- a/tests/unit/stores/session-runner.test.ts
+++ b/tests/unit/stores/session-runner.test.ts
@@ -1330,3 +1330,104 @@ describe('full session lifecycle', () => {
     expect(state().isWorkoutInProgress).toBe(false);
   });
 });
+
+// ===========================================================================
+// 15. subscribeToEvents (named event listener API)
+// ===========================================================================
+
+import {
+  subscribeToEvents,
+  __resetSessionEventListenersForTests,
+} from '@/lib/stores/session-runner';
+
+describe('subscribeToEvents', () => {
+  beforeEach(() => {
+    __resetSessionEventListenersForTests();
+  });
+
+  afterEach(() => {
+    __resetSessionEventListenersForTests();
+  });
+
+  it('invokes a subscribed listener when events are emitted through the store', async () => {
+    const listener = jest.fn();
+    subscribeToEvents(listener);
+
+    await state().startSession();
+
+    expect(listener).toHaveBeenCalled();
+    const eventArg = listener.mock.calls[0][0];
+    expect(eventArg).toMatchObject({
+      type: 'session_started',
+      session_id: expect.any(String),
+    });
+    // Payload is the rich object, not a JSON string
+    expect(typeof eventArg.payload).toBe('object');
+  });
+
+  it('unsubscribe stops further fires', async () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeToEvents(listener);
+
+    await state().startSession();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+
+    mockUuidCounter = 200;
+    await state().addExercise('ex-1');
+    // addExercise emits exercise_started; listener should NOT see it after unsubscribe
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('multiple listeners each receive independent fires', async () => {
+    const listenerA = jest.fn();
+    const listenerB = jest.fn();
+    subscribeToEvents(listenerA);
+    subscribeToEvents(listenerB);
+
+    await state().startSession();
+
+    expect(listenerA).toHaveBeenCalled();
+    expect(listenerB).toHaveBeenCalled();
+    expect(listenerA.mock.calls.length).toBe(listenerB.mock.calls.length);
+  });
+
+  it('existing emitEvent path (no subscribers) still writes the event row unchanged', async () => {
+    // No subscribers attached. emitEvent path must still persist to DB.
+    expect(mockGenericLocalUpsert).not.toHaveBeenCalledWith(
+      'workout_session_events',
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+
+    await state().startSession();
+
+    const eventUpsert = mockGenericLocalUpsert.mock.calls.find(
+      (c: any[]) => c[0] === 'workout_session_events',
+    );
+    expect(eventUpsert).toBeDefined();
+    expect(eventUpsert![2]).toMatchObject({
+      type: 'session_started',
+      synced: 0,
+    });
+    // Payload on the DB row is still the serialized JSON string
+    expect(typeof eventUpsert![2].payload).toBe('string');
+  });
+
+  it('a listener that throws does not break subsequent listeners or the session flow', async () => {
+    const bad = jest.fn(() => {
+      throw new Error('listener boom');
+    });
+    const good = jest.fn();
+    subscribeToEvents(bad);
+    subscribeToEvents(good);
+
+    // Should not reject — emitEvent catches listener errors
+    await expect(state().startSession()).resolves.toBeUndefined();
+    expect(bad).toHaveBeenCalled();
+    expect(good).toHaveBeenCalled();
+    expect(state().isWorkoutInProgress).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Pure-TypeScript surface area of the phone <-> watch integration from wave-2 audit (agent B), items #2/#3/#6. Unblocks three asymmetries:

1. **Live HR streams to the watch during workouts** — HealthKitContext bundles the latest heart-rate sample with freshness metadata into the watch application context.
2. **Session events reach the watch** — a new `watch-session-bridge` subscribes to the session-runner and forwards compact `session_event` messages for `set_completed`, `rest_started`, `rest_completed`/`rest_skipped`, `session_completed`, and `pr_detected`.
3. **Tracking-quality flags land on the watch** — `scan-arkit.tsx` now includes a `quality { trackingConfidence, isDegraded, degradationReason }` block in the existing tracking payload, sourced from the realtime smoothing result and the live partial-tracking badge.

Native-code items (HKWorkout write #116, watch permission sync, HKWorkout metadata serialization) are explicitly deferred to daytime PR-D-class work per overnight rule — see "Deferred" below.

Closes #440.

## Atomic commits

1. `feat(watch-payload)`: extend `WatchTrackingPayload` with `heartRate` and `quality` fields (+ runtime validators + `WATCH_PAYLOAD_SCHEMA_VERSION=2` constant; on-wire `v` stays at `1` for back-compat)
2. `test(watch-payload)`: 18-test suite covering back-compat, each HR status enum, validator rejection, both-fields-present path
3. `feat(healthkit)`: stream live HR (`{ bpm, timestamp, status }`) into watch payload during workouts via `computeHrStatus` helper (live <10s, stale <30s, else unavailable)
4. `feat(scan-arkit)`: populate tracking-quality on watch payload (14 LOC — no restructure)
5. **Commit-order note:** session-runner subscribe API landed _before_ the bridge so lint/types pass at every commit. The brief's conditional ("if session-runner does not expose a subscribe API, add one in commit 6") triggered — the store had no pre-existing subscribe API, only a private `emitEvent` helper.
6. `feat(session-runner)`: `subscribeToEvents(listener)` returns unsubscribe fn; fans out after SQLite write; `pr_detected` added to `SessionEventType`; existing `emitEvent` path unchanged for all 63 legacy tests
7. `feat(watch-bridge)`: new `lib/services/watch-session-bridge.ts` — `initWatchSessionBridge(api)` returns teardown; 500ms dedup window per (type, sessionId, setId); swallows transport failures
8. `test(watch-bridge)`: 9 tests — event routing, filtering, malformed-event rejection, dedup window, different-set-id bypass, teardown cleanup, sendMessage exception recovery, empty-payload omission
9. `test(session-runner)`: 5 new tests extend the existing file — listener fires, unsubscribe halts fires, multi-listener fan-out, no-subscriber path still persists, throwing listener cannot break flow. Suite total: 68 passing.

## Deferred to daytime (requires Swift)

- **HKWorkout write on session end** — needs `modules/ff-healthkit/ios/FFHealthKitModule.swift` changes (#116)
- **Watch permission sync handler** — needs watchOS companion module changes
- **HKWorkout metadata serialization** — depends on HKWorkout write

These are intentionally skipped per the overnight constraint "Never modify `ios/`, `android/`, `modules/ff-*/ios/`".

## Constraints honored

- No modifications to `supabase/migrations/`, `ios/`, `android/`, `.env`, `.husky/`, `modules/ff-healthkit/ios/`, `modules/ff-watch-connectivity/ios/`, or any module manifest
- No new dependencies
- Backward compat preserved: `WatchTrackingPayload.v` stays at `1` on the wire; both new fields are optional; existing watch consumers ignore unknown keys
- `scan-arkit.tsx` change is +14 LOC, no refactor
- `bun run lint` clean (0 errors, pre-existing 2 warnings in `template-builder.tsx` untouched)
- `bun run check:types` clean

## Test plan

- [x] `bun run jest tests/unit/lib/watch-connectivity-payload.test.ts` — 3 pass
- [x] `bun run jest tests/unit/lib/watch-connectivity-tracking-payload.test.ts` — 18 pass
- [x] `bun run jest tests/unit/services/watch-session-bridge.test.ts` — 9 pass
- [x] `bun run jest tests/unit/stores/session-runner.test.ts` — 68 pass (63 original + 5 new)
- [x] `bun run lint` — 0 errors
- [x] `bun run check:types` — clean
- [ ] Manual on-device: pair watch, start a workout, confirm watch receives HR ticks + session_event pings + quality flags on phone occlusion
- [ ] Confirm watch UI does not regress when phone sends payloads with the new optional keys (should ignore them)
