### PR TITLE
feat(coach): live session context + on-device routing UX + cue adoption telemetry

### DIFF
--- a/app/(modals)/_layout.tsx
+++ b/app/(modals)/_layout.tsx
@@ -65,6 +65,14 @@ export default function ModalsLayout() {
           contentStyle: { backgroundColor: '#050E1F' },
         }}
       />
+      <Stack.Screen
+        name="settings-coaching"
+        options={{
+          presentation: 'modal',
+          gestureEnabled: true,
+          contentStyle: { backgroundColor: '#050E1F' },
+        }}
+      />
     </Stack>
   );
 }

--- a/app/(modals)/settings-coaching.tsx
+++ b/app/(modals)/settings-coaching.tsx
@@ -1,0 +1,144 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Text } from 'react-native-paper';
+import { Ionicons } from '@expo/vector-icons';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { CoachModelCard } from '@/components/settings/CoachModelCard';
+import { CoachRoutingPreference } from '@/components/settings/CoachRoutingPreference';
+import {
+  getStatus as getCoachModelStatus,
+  subscribe as subscribeCoachModel,
+  type CoachModelState,
+} from '@/lib/services/coach-model-manager';
+import type { CoachRoutingPreference as RoutingPref } from '@/lib/services/coach-dispatch';
+import { useSafeBack } from '@/hooks/use-safe-back';
+
+export const COACH_ROUTING_PREFERENCE_KEY = 'coach_routing_preference';
+
+const ROUTING_VALUES: RoutingPref[] = ['cloud_only', 'prefer_local', 'local_only'];
+
+function isRoutingPref(v: string | null | undefined): v is RoutingPref {
+  return !!v && (ROUTING_VALUES as string[]).includes(v);
+}
+
+export default function SettingsCoachingModal() {
+  const safeBack = useSafeBack(['/(tabs)/profile', '/profile'], { alwaysReplace: true });
+  const [modelState, setModelState] = useState<CoachModelState>(getCoachModelStatus());
+  const [preference, setPreference] = useState<RoutingPref>('cloud_only');
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = subscribeCoachModel(setModelState);
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    AsyncStorage.getItem(COACH_ROUTING_PREFERENCE_KEY).then((stored) => {
+      if (!alive) return;
+      if (isRoutingPref(stored)) {
+        setPreference(stored);
+      }
+      setLoaded(true);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const handlePreferenceChange = useCallback((next: RoutingPref) => {
+    setPreference(next);
+    AsyncStorage.setItem(COACH_ROUTING_PREFERENCE_KEY, next).catch(() => {
+      // Non-fatal — UI already reflects the choice. A future sync will
+      // re-attempt on navigation.
+    });
+  }, []);
+
+  const localDisabled = modelState.status !== 'ready';
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={safeBack} style={styles.backButton} accessibilityLabel="Close">
+          <Ionicons name="arrow-back" size={24} color="#E8EDF5" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Coaching</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+      <ScrollView style={styles.content} contentContainerStyle={styles.contentInner}>
+        <Text variant="titleMedium" style={styles.sectionTitle}>
+          On-device model
+        </Text>
+        <CoachModelCard
+          status={modelState.status}
+          progress={modelState.progress}
+          errorMessage={modelState.errorMessage}
+          modelId={modelState.modelId}
+        />
+
+        <View style={styles.divider} />
+
+        <Text variant="titleMedium" style={styles.sectionTitle}>
+          Routing preference
+        </Text>
+        {loaded && (
+          <CoachRoutingPreference
+            value={preference}
+            onChange={handlePreferenceChange}
+            localDisabled={localDisabled}
+          />
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#050E1F',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingTop: 60,
+    paddingBottom: 16,
+    backgroundColor: '#050E1F',
+    borderBottomWidth: 1,
+    borderBottomColor: '#1B2E4A',
+  },
+  backButton: {
+    padding: 4,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 20,
+    fontWeight: '600',
+    color: '#E8EDF5',
+    textAlign: 'center',
+    marginRight: 40,
+  },
+  headerSpacer: {
+    width: 32,
+  },
+  content: {
+    flex: 1,
+  },
+  contentInner: {
+    padding: 16,
+  },
+  sectionTitle: {
+    color: '#E8EDF5',
+    marginTop: 16,
+    marginBottom: 8,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: '#1B2E4A',
+    marginVertical: 16,
+  },
+});

--- a/components/settings/CoachModelCard.tsx
+++ b/components/settings/CoachModelCard.tsx
@@ -1,0 +1,109 @@
+import { StyleSheet, View } from 'react-native';
+import { Button, Card, ProgressBar, Text } from 'react-native-paper';
+import type { CoachModelStatus } from '@/lib/services/coach-model-manager';
+
+export interface CoachModelCardProps {
+  status: CoachModelStatus;
+  /** 0..1 when downloading */
+  progress?: number;
+  errorMessage?: string;
+  modelId?: string;
+  onStartDownload?: () => void;
+  onRetry?: () => void;
+  onCancel?: () => void;
+}
+
+interface StatusCopy {
+  title: string;
+  body: string;
+  accessibilityLabel: string;
+}
+
+function statusCopy(status: CoachModelStatus, modelId?: string, errorMessage?: string): StatusCopy {
+  switch (status) {
+    case 'none':
+      return {
+        title: 'On-device coach',
+        body: 'Download the Gemma model to run the coach privately on your device.',
+        accessibilityLabel: 'On-device coach model not downloaded',
+      };
+    case 'downloading':
+      return {
+        title: 'Downloading model…',
+        body: 'Keep the app open. You can cancel at any time.',
+        accessibilityLabel: 'On-device coach model is downloading',
+      };
+    case 'ready':
+      return {
+        title: 'On-device coach ready',
+        body: modelId ? `Model: ${modelId}. Coach can run offline.` : 'Coach can run offline.',
+        accessibilityLabel: 'On-device coach model is ready',
+      };
+    case 'error':
+      return {
+        title: 'Model download failed',
+        body: errorMessage || 'Something went wrong. You can try again or stay on the cloud coach.',
+        accessibilityLabel: 'On-device coach model error',
+      };
+  }
+}
+
+export function CoachModelCard(props: CoachModelCardProps) {
+  const { status, progress, errorMessage, modelId, onStartDownload, onRetry, onCancel } = props;
+  const copy = statusCopy(status, modelId, errorMessage);
+
+  return (
+    <Card
+      mode="outlined"
+      style={styles.card}
+      accessible
+      accessibilityLabel={copy.accessibilityLabel}
+      testID="coach-model-card"
+    >
+      <Card.Title
+        title={copy.title}
+        subtitle={copy.body}
+        subtitleNumberOfLines={3}
+      />
+      {status === 'downloading' && typeof progress === 'number' && (
+        <View style={styles.progressWrap} testID="coach-model-card-progress">
+          <ProgressBar progress={Math.max(0, Math.min(1, progress))} />
+          <Text variant="labelSmall" style={styles.progressLabel}>
+            {Math.round(Math.max(0, Math.min(1, progress)) * 100)}%
+          </Text>
+        </View>
+      )}
+      <Card.Actions>
+        {status === 'none' && onStartDownload && (
+          <Button onPress={onStartDownload} accessibilityLabel="Download coach model" testID="coach-model-card-download">
+            Download
+          </Button>
+        )}
+        {status === 'downloading' && onCancel && (
+          <Button onPress={onCancel} accessibilityLabel="Cancel coach model download" testID="coach-model-card-cancel">
+            Cancel
+          </Button>
+        )}
+        {status === 'error' && onRetry && (
+          <Button onPress={onRetry} accessibilityLabel="Retry coach model download" testID="coach-model-card-retry">
+            Retry
+          </Button>
+        )}
+      </Card.Actions>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginVertical: 8,
+  },
+  progressWrap: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    gap: 4,
+  },
+  progressLabel: {
+    alignSelf: 'flex-end',
+  },
+});

--- a/components/settings/CoachRoutingPreference.tsx
+++ b/components/settings/CoachRoutingPreference.tsx
@@ -1,0 +1,114 @@
+import { StyleSheet, View } from 'react-native';
+import { RadioButton, Text } from 'react-native-paper';
+import type { CoachRoutingPreference as RoutingPref } from '@/lib/services/coach-dispatch';
+
+export interface CoachRoutingPreferenceProps {
+  value: RoutingPref;
+  onChange: (next: RoutingPref) => void;
+  /** When true, disables the local_only option (e.g. model not ready). */
+  localDisabled?: boolean;
+}
+
+interface Option {
+  key: RoutingPref;
+  label: string;
+  description: string;
+}
+
+const OPTIONS: Option[] = [
+  {
+    key: 'cloud_only',
+    label: 'Cloud only',
+    description: 'Always use the cloud coach. Requires internet.',
+  },
+  {
+    key: 'prefer_local',
+    label: 'Prefer on-device (fallback to cloud)',
+    description: 'Use on-device model when ready, otherwise fall back to cloud.',
+  },
+  {
+    key: 'local_only',
+    label: 'On-device only',
+    description: 'Only use the on-device model. No network requests.',
+  },
+];
+
+export function CoachRoutingPreference(props: CoachRoutingPreferenceProps) {
+  const { value, onChange, localDisabled = false } = props;
+
+  return (
+    <View
+      style={styles.container}
+      accessibilityRole="radiogroup"
+      accessibilityLabel="Coach routing preference"
+      testID="coach-routing-preference"
+    >
+      <Text variant="titleSmall" style={styles.heading}>
+        Coach routing
+      </Text>
+      <RadioButton.Group
+        value={value}
+        onValueChange={(next) => {
+          if (next === 'cloud_only' || next === 'prefer_local' || next === 'local_only') {
+            onChange(next);
+          }
+        }}
+      >
+        {OPTIONS.map((opt) => {
+          const disabled = localDisabled && opt.key === 'local_only';
+          const testId = `coach-routing-preference-${opt.key}`;
+          return (
+            <View
+              key={opt.key}
+              style={styles.row}
+              testID={testId}
+              accessibilityLabel={opt.label}
+              accessibilityRole="radio"
+              accessibilityState={{ checked: value === opt.key, disabled }}
+            >
+              <RadioButton
+                value={opt.key}
+                disabled={disabled}
+              />
+              <View style={styles.labelWrap}>
+                <Text variant="bodyMedium" style={disabled ? styles.labelDisabled : undefined}>
+                  {opt.label}
+                </Text>
+                <Text variant="bodySmall" style={disabled ? styles.descDisabled : styles.desc}>
+                  {opt.description}
+                </Text>
+              </View>
+            </View>
+          );
+        })}
+      </RadioButton.Group>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 8,
+  },
+  heading: {
+    marginBottom: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingVertical: 6,
+  },
+  labelWrap: {
+    flex: 1,
+    paddingLeft: 4,
+  },
+  desc: {
+    opacity: 0.7,
+  },
+  descDisabled: {
+    opacity: 0.4,
+  },
+  labelDisabled: {
+    opacity: 0.5,
+  },
+});

--- a/components/settings/CoachRoutingPreference.tsx
+++ b/components/settings/CoachRoutingPreference.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import { RadioButton, Text } from 'react-native-paper';
 import type { CoachRoutingPreference as RoutingPref } from '@/lib/services/coach-dispatch';
 
@@ -58,18 +58,20 @@ export function CoachRoutingPreference(props: CoachRoutingPreferenceProps) {
           const disabled = localDisabled && opt.key === 'local_only';
           const testId = `coach-routing-preference-${opt.key}`;
           return (
-            <View
+            <TouchableOpacity
               key={opt.key}
               style={styles.row}
               testID={testId}
               accessibilityLabel={opt.label}
               accessibilityRole="radio"
               accessibilityState={{ checked: value === opt.key, disabled }}
+              disabled={disabled}
+              onPress={() => {
+                if (!disabled) onChange(opt.key);
+              }}
+              activeOpacity={0.7}
             >
-              <RadioButton
-                value={opt.key}
-                disabled={disabled}
-              />
+              <RadioButton value={opt.key} disabled={disabled} />
               <View style={styles.labelWrap}>
                 <Text variant="bodyMedium" style={disabled ? styles.labelDisabled : undefined}>
                   {opt.label}
@@ -78,7 +80,7 @@ export function CoachRoutingPreference(props: CoachRoutingPreferenceProps) {
                   {opt.description}
                 </Text>
               </View>
-            </View>
+            </TouchableOpacity>
           );
         })}
       </RadioButton.Group>

--- a/lib/services/coach-dispatch.ts
+++ b/lib/services/coach-dispatch.ts
@@ -1,0 +1,134 @@
+/**
+ * coach-dispatch
+ *
+ * Routes `sendCoachPrompt` through cloud or on-device (Gemma) based on a
+ * user-configurable preference, with graceful fallback.
+ *
+ * Preferences:
+ * - `cloud_only`:   Always use cloud. Errors propagate normally.
+ * - `prefer_local`: Try on-device first; fall back to cloud on any failure
+ *                   (model not ready OR generation error). Records a
+ *                   single-time fallback telemetry counter for observability.
+ * - `local_only`:   On-device only. If the model is not ready, throw a
+ *                   typed `CoachDispatchError` with code `local_unavailable`.
+ *
+ * The on-device runtime is provided by the injected `modelManager` arg.
+ * In tests we pass a minimal `{ getStatus }` stub; in production callers
+ * pass the real `coach-model-manager` module. A `localGenerate` callable
+ * is accepted in `opts` — if omitted, `prefer_local` cannot truly run on
+ * device and will fall through to cloud (but still use the preference to
+ * decide).
+ */
+
+import type { CoachMessage, CoachContext } from './coach-service';
+import { sendCoachPrompt } from './coach-service';
+import { recordCounter } from './coach-telemetry';
+
+export type CoachRoutingPreference = 'cloud_only' | 'prefer_local' | 'local_only';
+
+export interface CoachModelStatusSnapshot {
+  status: 'none' | 'downloading' | 'ready' | 'error';
+  progress?: number;
+  errorMessage?: string;
+  modelId?: string;
+}
+
+export interface CoachModelManagerLike {
+  getStatus(): CoachModelStatusSnapshot;
+}
+
+export interface CoachDispatchArgs {
+  messages: CoachMessage[];
+  context?: CoachContext;
+}
+
+export interface CoachDispatchOptions {
+  preference: CoachRoutingPreference;
+  modelManager: CoachModelManagerLike;
+  /**
+   * Optional on-device generation callable. If the preference selects
+   * on-device generation but this is not provided, the dispatcher treats the
+   * local runtime as unavailable (same as model-not-ready).
+   */
+  localGenerate?: (args: CoachDispatchArgs) => Promise<CoachMessage>;
+  /**
+   * Optional cloud sender override (for testing). Defaults to
+   * `sendCoachPrompt` from coach-service.
+   */
+  cloudSend?: (messages: CoachMessage[], context?: CoachContext) => Promise<CoachMessage>;
+}
+
+export type CoachDispatchErrorCode = 'local_unavailable' | 'local_generation_failed';
+
+export class CoachDispatchError extends Error {
+  readonly code: CoachDispatchErrorCode;
+  readonly cause?: unknown;
+
+  constructor(code: CoachDispatchErrorCode, message: string, cause?: unknown) {
+    super(message);
+    this.name = 'CoachDispatchError';
+    this.code = code;
+    this.cause = cause;
+  }
+}
+
+async function runLocal(
+  args: CoachDispatchArgs,
+  opts: CoachDispatchOptions,
+): Promise<CoachMessage> {
+  const status = opts.modelManager.getStatus();
+  if (status.status !== 'ready') {
+    throw new CoachDispatchError(
+      'local_unavailable',
+      `On-device coach model is not ready (status=${status.status}).`,
+    );
+  }
+  if (!opts.localGenerate) {
+    throw new CoachDispatchError(
+      'local_unavailable',
+      'On-device coach runtime is not wired up.',
+    );
+  }
+  try {
+    return await opts.localGenerate(args);
+  } catch (err) {
+    throw new CoachDispatchError(
+      'local_generation_failed',
+      err instanceof Error ? err.message : 'Local generation failed',
+      err,
+    );
+  }
+}
+
+export async function dispatchCoachPrompt(
+  args: CoachDispatchArgs,
+  opts: CoachDispatchOptions,
+): Promise<CoachMessage> {
+  const cloudSend = opts.cloudSend ?? sendCoachPrompt;
+
+  switch (opts.preference) {
+    case 'cloud_only':
+      return cloudSend(args.messages, args.context);
+
+    case 'local_only':
+      return runLocal(args, opts);
+
+    case 'prefer_local': {
+      try {
+        return await runLocal(args, opts);
+      } catch (err) {
+        // Record single fallback event so product can track how often
+        // prefer_local falls through. Counter is additive and never throws.
+        recordCounter('coach_dispatch_prefer_local_fallback');
+        return cloudSend(args.messages, args.context);
+      }
+    }
+
+    default: {
+      // Exhaustiveness guard — unknown preference falls back to cloud.
+      const _exhaustive: never = opts.preference;
+      void _exhaustive;
+      return cloudSend(args.messages, args.context);
+    }
+  }
+}

--- a/lib/services/coach-live-snapshot.ts
+++ b/lib/services/coach-live-snapshot.ts
@@ -1,0 +1,143 @@
+/**
+ * coach-live-snapshot
+ *
+ * Serializes in-memory live session state into a compact, prompt-friendly
+ * payload that the AI coach can use for in-session guidance. This module is
+ * purely in-memory — it never persists anything and expects the caller
+ * (typically the session runner) to hand it freeform session data.
+ *
+ * Design:
+ * - `buildLiveSessionSnapshot` returns `null` when there's nothing useful to
+ *   report (no exercise id/name, no FQI, no faults), so call sites can safely
+ *   spread `...(snapshot ? { liveSession: snapshot } : {})` into a CoachContext.
+ * - `recentFaults` is capped at 3, sorted by count descending — this keeps
+ *   the prompt clause short and focused on the highest-frequency faults.
+ * - `summarizeForPrompt` returns a 1-2 line plaintext summary suitable for
+ *   embedding in a system prompt clause.
+ */
+
+export interface LiveFQIScores {
+  rom?: number;
+  symmetry?: number;
+  tempo?: number;
+  stability?: number;
+}
+
+export interface LiveFaultEntry {
+  id: string;
+  count: number;
+  lastRepNumber?: number;
+}
+
+export interface LiveSessionSnapshot {
+  exerciseId?: string;
+  exerciseName?: string;
+  currentFQI?: LiveFQIScores;
+  recentFaults: LiveFaultEntry[];
+}
+
+export interface LiveSessionInput {
+  exerciseId?: string;
+  exerciseName?: string;
+  currentFQI?: LiveFQIScores;
+  recentFaults?: LiveFaultEntry[];
+}
+
+const MAX_FAULTS = 3;
+
+function hasAnyFQI(fqi?: LiveFQIScores): boolean {
+  if (!fqi) return false;
+  return (
+    typeof fqi.rom === 'number' ||
+    typeof fqi.symmetry === 'number' ||
+    typeof fqi.tempo === 'number' ||
+    typeof fqi.stability === 'number'
+  );
+}
+
+function sanitizeFaults(faults?: LiveFaultEntry[]): LiveFaultEntry[] {
+  if (!faults || faults.length === 0) return [];
+  return faults
+    .filter((f) => f && typeof f.id === 'string' && f.id.length > 0 && typeof f.count === 'number' && f.count > 0)
+    .map((f) => ({
+      id: f.id,
+      count: Math.max(0, Math.floor(f.count)),
+      ...(typeof f.lastRepNumber === 'number' ? { lastRepNumber: f.lastRepNumber } : {}),
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, MAX_FAULTS);
+}
+
+/**
+ * Build a snapshot from freeform in-memory input. Returns null when there's
+ * no meaningful payload (no exercise, no FQI, no faults).
+ */
+export function buildLiveSessionSnapshot(input: LiveSessionInput): LiveSessionSnapshot | null {
+  if (!input) return null;
+
+  const exerciseId = typeof input.exerciseId === 'string' && input.exerciseId.trim() ? input.exerciseId.trim() : undefined;
+  const exerciseName = typeof input.exerciseName === 'string' && input.exerciseName.trim() ? input.exerciseName.trim() : undefined;
+  const hasFQI = hasAnyFQI(input.currentFQI);
+  const recentFaults = sanitizeFaults(input.recentFaults);
+
+  if (!exerciseId && !exerciseName && !hasFQI && recentFaults.length === 0) {
+    return null;
+  }
+
+  const snap: LiveSessionSnapshot = { recentFaults };
+  if (exerciseId) snap.exerciseId = exerciseId;
+  if (exerciseName) snap.exerciseName = exerciseName;
+  if (hasFQI && input.currentFQI) {
+    const fqi: LiveFQIScores = {};
+    if (typeof input.currentFQI.rom === 'number') fqi.rom = input.currentFQI.rom;
+    if (typeof input.currentFQI.symmetry === 'number') fqi.symmetry = input.currentFQI.symmetry;
+    if (typeof input.currentFQI.tempo === 'number') fqi.tempo = input.currentFQI.tempo;
+    if (typeof input.currentFQI.stability === 'number') fqi.stability = input.currentFQI.stability;
+    snap.currentFQI = fqi;
+  }
+  return snap;
+}
+
+function formatFQIScore(value?: number): string | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return value.toFixed(2);
+}
+
+/**
+ * Produce a short plaintext description of the snapshot suitable for a
+ * system-prompt clause. Keeps output to 1-2 lines. Returns empty string if
+ * the snapshot is empty (defensive — callers should gate on null first).
+ */
+export function summarizeForPrompt(snap: LiveSessionSnapshot | null | undefined): string {
+  if (!snap) return '';
+
+  const parts: string[] = [];
+  const name = snap.exerciseName || snap.exerciseId;
+  if (name) {
+    parts.push(`exercise=${name}`);
+  }
+
+  if (snap.currentFQI) {
+    const fqiParts: string[] = [];
+    const rom = formatFQIScore(snap.currentFQI.rom);
+    const sym = formatFQIScore(snap.currentFQI.symmetry);
+    const tempo = formatFQIScore(snap.currentFQI.tempo);
+    const stab = formatFQIScore(snap.currentFQI.stability);
+    if (rom !== null) fqiParts.push(`rom=${rom}`);
+    if (sym !== null) fqiParts.push(`symmetry=${sym}`);
+    if (tempo !== null) fqiParts.push(`tempo=${tempo}`);
+    if (stab !== null) fqiParts.push(`stability=${stab}`);
+    if (fqiParts.length > 0) {
+      parts.push(`FQI(${fqiParts.join(', ')})`);
+    }
+  }
+
+  if (snap.recentFaults.length > 0) {
+    const faultStr = snap.recentFaults
+      .map((f) => (typeof f.lastRepNumber === 'number' ? `${f.id}×${f.count}@rep${f.lastRepNumber}` : `${f.id}×${f.count}`))
+      .join(', ');
+    parts.push(`recent faults: ${faultStr}`);
+  }
+
+  return parts.join('; ');
+}

--- a/lib/services/coach-model-manager.ts
+++ b/lib/services/coach-model-manager.ts
@@ -1,0 +1,56 @@
+/**
+ * coach-model-manager (stub)
+ *
+ * TODO(#431): Replace this stub with the full implementation from
+ * feat/429-gemma-coach-v2 / PR #431. That branch introduces on-device
+ * Gemma model lifecycle management (download, ready, error states). Until
+ * that PR merges, this minimal stub exposes `getStatus()` so that
+ * coach-dispatch and the settings UI can compile and run.
+ *
+ * Intentionally matches the expected shape from #431 so swap-in is trivial.
+ */
+
+export type CoachModelStatus = 'none' | 'downloading' | 'ready' | 'error';
+
+export interface CoachModelState {
+  status: CoachModelStatus;
+  progress?: number; // 0..1 when downloading
+  errorMessage?: string;
+  modelId?: string;
+}
+
+let currentState: CoachModelState = { status: 'none' };
+
+type Listener = (state: CoachModelState) => void;
+const listeners = new Set<Listener>();
+
+export function getStatus(): CoachModelState {
+  return currentState;
+}
+
+export function isModelReady(): boolean {
+  return currentState.status === 'ready';
+}
+
+/**
+ * Test/dev helper — set the status and notify listeners. In the PR #431
+ * implementation this will be driven by the runtime layer; here it's an
+ * overt test hook.
+ */
+export function __setStatusForTesting(next: CoachModelState): void {
+  currentState = next;
+  listeners.forEach((l) => l(currentState));
+}
+
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  listener(currentState);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function __resetForTesting(): void {
+  currentState = { status: 'none' };
+  listeners.clear();
+}

--- a/lib/services/coach-service.ts
+++ b/lib/services/coach-service.ts
@@ -1,6 +1,7 @@
 import { supabase } from '@/lib/supabase';
 import { errorWithTs, warnWithTs } from '@/lib/logger';
 import { createError, logError } from './ErrorHandler';
+import type { LiveSessionSnapshot } from './coach-live-snapshot';
 
 export type CoachRole = 'user' | 'assistant' | 'system';
 
@@ -18,6 +19,13 @@ export interface CoachContext {
   };
   focus?: string;
   sessionId?: string;
+  /**
+   * Optional in-session context passed to the coach edge function. When
+   * present, the edge function appends a short "live session context" clause
+   * to the system prompt. Purely additive — default call sites do not need to
+   * set this.
+   */
+  liveSession?: LiveSessionSnapshot;
 }
 
 interface RawCoachResponse {

--- a/lib/services/coach-telemetry.ts
+++ b/lib/services/coach-telemetry.ts
@@ -1,0 +1,29 @@
+/**
+ * coach-telemetry (stub)
+ *
+ * TODO(#431): PR #431 introduces a richer telemetry module. When it lands,
+ * the helpers here should be merged non-destructively into that module —
+ * they are additive (generic counter only) and do not depend on any
+ * internal of the PR-431 implementation.
+ *
+ * Shape today (extended in a follow-up commit):
+ * - `recordCounter(name, value?)` — generic in-memory counter used by
+ *   coach-dispatch for fallback telemetry.
+ * - `getCounter(name)` — read counter (test helper).
+ * - `resetTelemetry()` — clears all counters.
+ */
+
+const counters = new Map<string, number>();
+
+export function recordCounter(name: string, value: number = 1): void {
+  const prev = counters.get(name) ?? 0;
+  counters.set(name, prev + value);
+}
+
+export function getCounter(name: string): number {
+  return counters.get(name) ?? 0;
+}
+
+export function resetTelemetry(): void {
+  counters.clear();
+}

--- a/lib/services/coach-telemetry.ts
+++ b/lib/services/coach-telemetry.ts
@@ -1,19 +1,31 @@
 /**
- * coach-telemetry (stub)
+ * coach-telemetry
  *
  * TODO(#431): PR #431 introduces a richer telemetry module. When it lands,
  * the helpers here should be merged non-destructively into that module —
- * they are additive (generic counter only) and do not depend on any
- * internal of the PR-431 implementation.
+ * they are additive (generic counter + cue-adoption rate helpers) and do
+ * not depend on any internal of the PR-431 implementation.
  *
- * Shape today (extended in a follow-up commit):
+ * API:
  * - `recordCounter(name, value?)` — generic in-memory counter used by
  *   coach-dispatch for fallback telemetry.
  * - `getCounter(name)` — read counter (test helper).
- * - `resetTelemetry()` — clears all counters.
+ * - `recordCoachCueEmitted(cueId, sessionId)` — emit event for a cue.
+ * - `recordCoachCueAdopted(cueId, sessionId)` — adopt event for a cue.
+ * - `getAdoptionRate()` — adopted unique (cueId, sessionId) / emitted.
+ * - `resetTelemetry()` — clears all counters + emit/adopt state.
  */
 
 const counters = new Map<string, number>();
+
+// Unique cueId::sessionId pairs: a cue emitted multiple times for the same
+// (cue, session) counts once when computing adoption rate.
+const emittedKeys = new Set<string>();
+const adoptedKeys = new Set<string>();
+
+function cueKey(cueId: string, sessionId: string): string {
+  return `${cueId}::${sessionId}`;
+}
 
 export function recordCounter(name: string, value: number = 1): void {
   const prev = counters.get(name) ?? 0;
@@ -24,6 +36,34 @@ export function getCounter(name: string): number {
   return counters.get(name) ?? 0;
 }
 
+export function recordCoachCueEmitted(cueId: string, sessionId: string): void {
+  if (!cueId || !sessionId) return;
+  emittedKeys.add(cueKey(cueId, sessionId));
+  recordCounter('coach_cue_emitted');
+}
+
+export function recordCoachCueAdopted(cueId: string, sessionId: string): void {
+  if (!cueId || !sessionId) return;
+  // Record emission implicitly so callers that only observe adoption still
+  // contribute a valid denominator.
+  const key = cueKey(cueId, sessionId);
+  emittedKeys.add(key);
+  adoptedKeys.add(key);
+  recordCounter('coach_cue_adopted');
+}
+
+/**
+ * Adoption rate = unique adopted (cueId, sessionId) / unique emitted.
+ * Returns 1 on empty data (neutral-best default for a fresh UI).
+ */
+export function getAdoptionRate(): number {
+  const emitted = emittedKeys.size;
+  if (emitted === 0) return 1;
+  return adoptedKeys.size / emitted;
+}
+
 export function resetTelemetry(): void {
   counters.clear();
+  emittedKeys.clear();
+  adoptedKeys.clear();
 }

--- a/supabase/functions/coach/index.ts
+++ b/supabase/functions/coach/index.ts
@@ -8,9 +8,30 @@ interface ChatMessage {
   content: string;
 }
 
+interface LiveFQI {
+  rom?: number;
+  symmetry?: number;
+  tempo?: number;
+  stability?: number;
+}
+
+interface LiveFault {
+  id: string;
+  count: number;
+  lastRepNumber?: number;
+}
+
+interface LiveSessionSnapshot {
+  exerciseId?: string;
+  exerciseName?: string;
+  currentFQI?: LiveFQI;
+  recentFaults?: LiveFault[];
+}
+
 interface CoachContext {
   profile?: { id?: string; name?: string | null; email?: string | null };
   focus?: string;
+  liveSession?: LiveSessionSnapshot;
 }
 
 interface RequestBody {
@@ -103,6 +124,54 @@ function sanitizeName(name: string): string {
   return name.replace(/[^\w\s'-]/g, '').slice(0, 100).trim();
 }
 
+function formatFQIScore(value?: number): string | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return value.toFixed(2);
+}
+
+/** Mirror of lib/services/coach-live-snapshot.ts#summarizeForPrompt for edge use. */
+function summarizeLiveSession(snap?: LiveSessionSnapshot): string {
+  if (!snap) return '';
+
+  const parts: string[] = [];
+  const rawName = snap.exerciseName || snap.exerciseId;
+  if (rawName) {
+    // Reuse sanitizeName to strip any prompt-injection characters from exercise label.
+    parts.push(`exercise=${sanitizeName(rawName)}`);
+  }
+
+  if (snap.currentFQI) {
+    const fqiParts: string[] = [];
+    const rom = formatFQIScore(snap.currentFQI.rom);
+    const sym = formatFQIScore(snap.currentFQI.symmetry);
+    const tempo = formatFQIScore(snap.currentFQI.tempo);
+    const stab = formatFQIScore(snap.currentFQI.stability);
+    if (rom !== null) fqiParts.push(`rom=${rom}`);
+    if (sym !== null) fqiParts.push(`symmetry=${sym}`);
+    if (tempo !== null) fqiParts.push(`tempo=${tempo}`);
+    if (stab !== null) fqiParts.push(`stability=${stab}`);
+    if (fqiParts.length > 0) parts.push(`FQI(${fqiParts.join(', ')})`);
+  }
+
+  if (Array.isArray(snap.recentFaults) && snap.recentFaults.length > 0) {
+    const capped = snap.recentFaults
+      .filter((f) => f && typeof f.id === 'string' && typeof f.count === 'number' && f.count > 0)
+      .slice(0, 3);
+    if (capped.length > 0) {
+      const faultStr = capped
+        .map((f) =>
+          typeof f.lastRepNumber === 'number'
+            ? `${sanitizeName(f.id)}×${f.count}@rep${f.lastRepNumber}`
+            : `${sanitizeName(f.id)}×${f.count}`,
+        )
+        .join(', ');
+      parts.push(`recent faults: ${faultStr}`);
+    }
+  }
+
+  return parts.join('; ');
+}
+
 function buildPrompt(context?: CoachContext) {
   const focus = context?.focus || 'fitness_coach';
   const rawName = context?.profile?.name;
@@ -111,20 +180,29 @@ function buildPrompt(context?: CoachContext) {
     ? `You are coaching ${safeName}.`
     : 'You are coaching the user.';
 
+  const systemLines: string[] = [
+    'You are Form Factor’s AI coach for strength, conditioning, mobility, and nutrition.',
+    userLine,
+    'Stay safe: avoid medical advice, do not invent injuries, and recommend seeing a physician for pain, dizziness, or medical issues.',
+    'Do not mention that you are an AI or language model.',
+    'Outputs must be concise (under ~180 words) and actionable with clear sets/reps, rest, tempo, or food swaps.',
+    'Prefer simple movements with minimal equipment unless the user specifies otherwise.',
+    'Offer 1-2 options max; avoid long lists.',
+    'If user asks for calorie/protein guidance, give estimates and ranges, not exact prescriptions.',
+    `Focus: ${focus}.`,
+  ];
+
+  if (context?.liveSession) {
+    const liveSummary = summarizeLiveSession(context.liveSession);
+    if (liveSummary) {
+      systemLines.push(`Live session context: ${liveSummary}.`);
+    }
+  }
+
   return [
     {
       role: 'system',
-      content: [
-        'You are Form Factor’s AI coach for strength, conditioning, mobility, and nutrition.',
-        userLine,
-        'Stay safe: avoid medical advice, do not invent injuries, and recommend seeing a physician for pain, dizziness, or medical issues.',
-        'Do not mention that you are an AI or language model.',
-        'Outputs must be concise (under ~180 words) and actionable with clear sets/reps, rest, tempo, or food swaps.',
-        'Prefer simple movements with minimal equipment unless the user specifies otherwise.',
-        'Offer 1-2 options max; avoid long lists.',
-        'If user asks for calorie/protein guidance, give estimates and ranges, not exact prescriptions.',
-        `Focus: ${focus}.`,
-      ].join(' '),
+      content: systemLines.join(' '),
     } satisfies ChatMessage,
   ];
 }

--- a/tests/unit/components/settings/coach-model-card.test.tsx
+++ b/tests/unit/components/settings/coach-model-card.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { Provider as PaperProvider } from 'react-native-paper';
+
+import { CoachModelCard } from '@/components/settings/CoachModelCard';
+
+function renderWithProvider(ui: React.ReactElement) {
+  return render(<PaperProvider>{ui}</PaperProvider>);
+}
+
+describe('CoachModelCard', () => {
+  it('renders "none" state with download action and accessibility label', () => {
+    const onStartDownload = jest.fn();
+    const { getByTestId, getByLabelText } = renderWithProvider(
+      <CoachModelCard status="none" onStartDownload={onStartDownload} />,
+    );
+
+    expect(getByLabelText('On-device coach model not downloaded')).toBeTruthy();
+    const downloadBtn = getByTestId('coach-model-card-download');
+    expect(downloadBtn).toBeTruthy();
+    fireEvent.press(downloadBtn);
+    expect(onStartDownload).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders "downloading" state with progress and cancel action', () => {
+    const onCancel = jest.fn();
+    const { getByTestId, getByLabelText, queryByTestId } = renderWithProvider(
+      <CoachModelCard status="downloading" progress={0.42} onCancel={onCancel} />,
+    );
+
+    expect(getByLabelText('On-device coach model is downloading')).toBeTruthy();
+    expect(getByTestId('coach-model-card-progress')).toBeTruthy();
+    expect(queryByTestId('coach-model-card-download')).toBeNull();
+
+    const cancelBtn = getByTestId('coach-model-card-cancel');
+    fireEvent.press(cancelBtn);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders "ready" state without action buttons', () => {
+    const { queryByTestId, getByLabelText } = renderWithProvider(
+      <CoachModelCard status="ready" modelId="gemma-2b-q4" />,
+    );
+
+    expect(getByLabelText('On-device coach model is ready')).toBeTruthy();
+    expect(queryByTestId('coach-model-card-download')).toBeNull();
+    expect(queryByTestId('coach-model-card-cancel')).toBeNull();
+    expect(queryByTestId('coach-model-card-retry')).toBeNull();
+  });
+
+  it('renders "error" state with retry action and surfaces error message', () => {
+    const onRetry = jest.fn();
+    const { getByTestId, getByLabelText, getByText } = renderWithProvider(
+      <CoachModelCard status="error" errorMessage="Disk full" onRetry={onRetry} />,
+    );
+
+    expect(getByLabelText('On-device coach model error')).toBeTruthy();
+    expect(getByText('Disk full')).toBeTruthy();
+    const retryBtn = getByTestId('coach-model-card-retry');
+    fireEvent.press(retryBtn);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('clamps progress to [0, 1] range visually', () => {
+    const { getByTestId } = renderWithProvider(
+      <CoachModelCard status="downloading" progress={1.5} />,
+    );
+    // The progress testID still renders; just ensure no throw.
+    expect(getByTestId('coach-model-card-progress')).toBeTruthy();
+  });
+});

--- a/tests/unit/components/settings/coach-routing-preference.test.tsx
+++ b/tests/unit/components/settings/coach-routing-preference.test.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { Provider as PaperProvider } from 'react-native-paper';
+
+import { CoachRoutingPreference } from '@/components/settings/CoachRoutingPreference';
+import type { CoachRoutingPreference as RoutingPref } from '@/lib/services/coach-dispatch';
+
+function Harness({
+  initial = 'cloud_only',
+  localDisabled = false,
+  onChange,
+}: {
+  initial?: RoutingPref;
+  localDisabled?: boolean;
+  onChange?: (next: RoutingPref) => void;
+}) {
+  const [value, setValue] = useState<RoutingPref>(initial);
+  return (
+    <PaperProvider>
+      <CoachRoutingPreference
+        value={value}
+        onChange={(next) => {
+          setValue(next);
+          onChange?.(next);
+        }}
+        localDisabled={localDisabled}
+      />
+    </PaperProvider>
+  );
+}
+
+describe('CoachRoutingPreference', () => {
+  it('renders all three options with radiogroup role', () => {
+    const { getByTestId } = render(<Harness />);
+    expect(getByTestId('coach-routing-preference')).toBeTruthy();
+    expect(getByTestId('coach-routing-preference-cloud_only')).toBeTruthy();
+    expect(getByTestId('coach-routing-preference-prefer_local')).toBeTruthy();
+    expect(getByTestId('coach-routing-preference-local_only')).toBeTruthy();
+  });
+
+  it('toggles selection when a different option is pressed', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<Harness onChange={onChange} />);
+
+    const preferLocalRow = getByTestId('coach-routing-preference-prefer_local');
+    // The RadioButton inside the row is a pressable; pressing the row
+    // itself in tests routes to onValueChange via RN Paper.
+    fireEvent.press(preferLocalRow);
+    expect(onChange).toHaveBeenCalledWith('prefer_local');
+    expect(preferLocalRow.props.accessibilityState.checked).toBe(true);
+  });
+
+  it('marks local_only accessibilityState.disabled when localDisabled=true', () => {
+    const { getByTestId } = render(<Harness localDisabled />);
+    const localOnlyRow = getByTestId('coach-routing-preference-local_only');
+    expect(localOnlyRow.props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('reflects external value changes in accessibility state', () => {
+    const { getByTestId, rerender } = render(
+      <PaperProvider>
+        <CoachRoutingPreference value="cloud_only" onChange={jest.fn()} />
+      </PaperProvider>,
+    );
+    expect(getByTestId('coach-routing-preference-cloud_only').props.accessibilityState.checked).toBe(true);
+
+    rerender(
+      <PaperProvider>
+        <CoachRoutingPreference value="local_only" onChange={jest.fn()} />
+      </PaperProvider>,
+    );
+    expect(getByTestId('coach-routing-preference-local_only').props.accessibilityState.checked).toBe(true);
+    expect(getByTestId('coach-routing-preference-cloud_only').props.accessibilityState.checked).toBe(false);
+  });
+});

--- a/tests/unit/services/coach-dispatch.test.ts
+++ b/tests/unit/services/coach-dispatch.test.ts
@@ -1,0 +1,193 @@
+import {
+  dispatchCoachPrompt,
+  CoachDispatchError,
+  type CoachDispatchOptions,
+  type CoachModelManagerLike,
+  type CoachModelStatusSnapshot,
+} from '@/lib/services/coach-dispatch';
+import type { CoachMessage } from '@/lib/services/coach-service';
+import { getCounter, resetTelemetry } from '@/lib/services/coach-telemetry';
+
+const messages: CoachMessage[] = [{ role: 'user', content: 'squat cues?' }];
+
+function makeManager(status: CoachModelStatusSnapshot['status']): CoachModelManagerLike {
+  return {
+    getStatus: () => ({ status }),
+  };
+}
+
+describe('coach-dispatch', () => {
+  beforeEach(() => {
+    resetTelemetry();
+  });
+
+  it('cloud_only: routes straight to cloudSend and returns its reply', async () => {
+    const cloudSend = jest.fn().mockResolvedValue({ role: 'assistant', content: 'cloud reply' });
+    const localGenerate = jest.fn();
+
+    const opts: CoachDispatchOptions = {
+      preference: 'cloud_only',
+      modelManager: makeManager('ready'),
+      cloudSend,
+      localGenerate,
+    };
+
+    const result = await dispatchCoachPrompt({ messages }, opts);
+
+    expect(result).toEqual({ role: 'assistant', content: 'cloud reply' });
+    expect(cloudSend).toHaveBeenCalledTimes(1);
+    expect(localGenerate).not.toHaveBeenCalled();
+  });
+
+  it('cloud_only: propagates cloud errors without fallback', async () => {
+    const cloudErr = new Error('Upstream failure');
+    const cloudSend = jest.fn().mockRejectedValue(cloudErr);
+
+    const opts: CoachDispatchOptions = {
+      preference: 'cloud_only',
+      modelManager: makeManager('ready'),
+      cloudSend,
+    };
+
+    await expect(dispatchCoachPrompt({ messages }, opts)).rejects.toBe(cloudErr);
+    expect(cloudSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefer_local: uses local when model is ready', async () => {
+    const cloudSend = jest.fn();
+    const localGenerate = jest.fn().mockResolvedValue({ role: 'assistant', content: 'local reply' });
+
+    const opts: CoachDispatchOptions = {
+      preference: 'prefer_local',
+      modelManager: makeManager('ready'),
+      cloudSend,
+      localGenerate,
+    };
+
+    const result = await dispatchCoachPrompt({ messages }, opts);
+    expect(result).toEqual({ role: 'assistant', content: 'local reply' });
+    expect(localGenerate).toHaveBeenCalledTimes(1);
+    expect(cloudSend).not.toHaveBeenCalled();
+    expect(getCounter('coach_dispatch_prefer_local_fallback')).toBe(0);
+  });
+
+  it('prefer_local: falls back to cloud when model is not ready, logs telemetry', async () => {
+    const cloudSend = jest.fn().mockResolvedValue({ role: 'assistant', content: 'cloud fallback' });
+    const localGenerate = jest.fn();
+
+    const opts: CoachDispatchOptions = {
+      preference: 'prefer_local',
+      modelManager: makeManager('downloading'),
+      cloudSend,
+      localGenerate,
+    };
+
+    const result = await dispatchCoachPrompt({ messages }, opts);
+    expect(result).toEqual({ role: 'assistant', content: 'cloud fallback' });
+    expect(localGenerate).not.toHaveBeenCalled();
+    expect(cloudSend).toHaveBeenCalledTimes(1);
+    expect(getCounter('coach_dispatch_prefer_local_fallback')).toBe(1);
+  });
+
+  it('prefer_local: falls back to cloud when local generation throws', async () => {
+    const cloudSend = jest.fn().mockResolvedValue({ role: 'assistant', content: 'cloud after local fail' });
+    const localGenerate = jest.fn().mockRejectedValue(new Error('gemma crashed'));
+
+    const opts: CoachDispatchOptions = {
+      preference: 'prefer_local',
+      modelManager: makeManager('ready'),
+      cloudSend,
+      localGenerate,
+    };
+
+    const result = await dispatchCoachPrompt({ messages }, opts);
+    expect(result).toEqual({ role: 'assistant', content: 'cloud after local fail' });
+    expect(localGenerate).toHaveBeenCalledTimes(1);
+    expect(cloudSend).toHaveBeenCalledTimes(1);
+    expect(getCounter('coach_dispatch_prefer_local_fallback')).toBe(1);
+  });
+
+  it('prefer_local: only logs fallback telemetry once per dispatch', async () => {
+    const cloudSend = jest.fn().mockResolvedValue({ role: 'assistant', content: 'cloud' });
+    const opts: CoachDispatchOptions = {
+      preference: 'prefer_local',
+      modelManager: makeManager('error'),
+      cloudSend,
+    };
+
+    await dispatchCoachPrompt({ messages }, opts);
+    expect(getCounter('coach_dispatch_prefer_local_fallback')).toBe(1);
+  });
+
+  it('local_only: returns local reply when model is ready', async () => {
+    const cloudSend = jest.fn();
+    const localGenerate = jest.fn().mockResolvedValue({ role: 'assistant', content: 'local only reply' });
+
+    const opts: CoachDispatchOptions = {
+      preference: 'local_only',
+      modelManager: makeManager('ready'),
+      cloudSend,
+      localGenerate,
+    };
+
+    const result = await dispatchCoachPrompt({ messages }, opts);
+    expect(result).toEqual({ role: 'assistant', content: 'local only reply' });
+    expect(cloudSend).not.toHaveBeenCalled();
+  });
+
+  it('local_only: throws CoachDispatchError(local_unavailable) when model is not ready', async () => {
+    const cloudSend = jest.fn();
+    const localGenerate = jest.fn();
+
+    const opts: CoachDispatchOptions = {
+      preference: 'local_only',
+      modelManager: makeManager('none'),
+      cloudSend,
+      localGenerate,
+    };
+
+    await expect(dispatchCoachPrompt({ messages }, opts)).rejects.toBeInstanceOf(CoachDispatchError);
+    await expect(dispatchCoachPrompt({ messages }, opts)).rejects.toMatchObject({
+      code: 'local_unavailable',
+    });
+    expect(cloudSend).not.toHaveBeenCalled();
+    expect(localGenerate).not.toHaveBeenCalled();
+  });
+
+  it('local_only: throws local_unavailable when localGenerate is missing even if ready', async () => {
+    const opts: CoachDispatchOptions = {
+      preference: 'local_only',
+      modelManager: makeManager('ready'),
+      // localGenerate intentionally omitted
+    };
+
+    await expect(dispatchCoachPrompt({ messages }, opts)).rejects.toMatchObject({
+      code: 'local_unavailable',
+    });
+  });
+
+  it('local_only: propagates local generation errors as CoachDispatchError(local_generation_failed)', async () => {
+    const localGenerate = jest.fn().mockRejectedValue(new Error('oom'));
+    const opts: CoachDispatchOptions = {
+      preference: 'local_only',
+      modelManager: makeManager('ready'),
+      localGenerate,
+    };
+
+    await expect(dispatchCoachPrompt({ messages }, opts)).rejects.toMatchObject({
+      code: 'local_generation_failed',
+    });
+  });
+
+  it('threads context through to cloudSend', async () => {
+    const cloudSend = jest.fn().mockResolvedValue({ role: 'assistant', content: 'ok' });
+    const opts: CoachDispatchOptions = {
+      preference: 'cloud_only',
+      modelManager: makeManager('ready'),
+      cloudSend,
+    };
+
+    await dispatchCoachPrompt({ messages, context: { focus: 'squat' } }, opts);
+    expect(cloudSend).toHaveBeenCalledWith(messages, { focus: 'squat' });
+  });
+});

--- a/tests/unit/services/coach-live-snapshot.test.ts
+++ b/tests/unit/services/coach-live-snapshot.test.ts
@@ -1,0 +1,160 @@
+import {
+  buildLiveSessionSnapshot,
+  summarizeForPrompt,
+  type LiveSessionSnapshot,
+} from '@/lib/services/coach-live-snapshot';
+
+describe('coach-live-snapshot', () => {
+  describe('buildLiveSessionSnapshot', () => {
+    it('returns null when input is empty', () => {
+      expect(buildLiveSessionSnapshot({})).toBeNull();
+    });
+
+    it('returns null when input has only whitespace strings', () => {
+      expect(buildLiveSessionSnapshot({ exerciseId: '   ', exerciseName: '' })).toBeNull();
+    });
+
+    it('returns null when faults are all invalid', () => {
+      expect(
+        buildLiveSessionSnapshot({
+          recentFaults: [
+            { id: '', count: 3 },
+            { id: 'fault', count: 0 },
+          ],
+        }),
+      ).toBeNull();
+    });
+
+    it('returns shape with full input', () => {
+      const snap = buildLiveSessionSnapshot({
+        exerciseId: 'squat',
+        exerciseName: 'Back Squat',
+        currentFQI: { rom: 0.9, symmetry: 0.85, tempo: 0.75, stability: 0.8 },
+        recentFaults: [
+          { id: 'knee_valgus', count: 4, lastRepNumber: 7 },
+          { id: 'depth_short', count: 2 },
+        ],
+      });
+      expect(snap).toEqual({
+        exerciseId: 'squat',
+        exerciseName: 'Back Squat',
+        currentFQI: { rom: 0.9, symmetry: 0.85, tempo: 0.75, stability: 0.8 },
+        recentFaults: [
+          { id: 'knee_valgus', count: 4, lastRepNumber: 7 },
+          { id: 'depth_short', count: 2 },
+        ],
+      });
+    });
+
+    it('trims exercise id/name whitespace', () => {
+      const snap = buildLiveSessionSnapshot({
+        exerciseId: '  bench_press ',
+        exerciseName: '  Bench Press  ',
+      });
+      expect(snap?.exerciseId).toBe('bench_press');
+      expect(snap?.exerciseName).toBe('Bench Press');
+    });
+
+    it('returns snapshot with only FQI when no exercise is provided', () => {
+      const snap = buildLiveSessionSnapshot({ currentFQI: { rom: 0.5 } });
+      expect(snap).not.toBeNull();
+      expect(snap?.exerciseId).toBeUndefined();
+      expect(snap?.currentFQI).toEqual({ rom: 0.5 });
+      expect(snap?.recentFaults).toEqual([]);
+    });
+
+    it('caps faults at 3, sorted by count desc', () => {
+      const snap = buildLiveSessionSnapshot({
+        exerciseName: 'Deadlift',
+        recentFaults: [
+          { id: 'fault_a', count: 1 },
+          { id: 'fault_b', count: 5 },
+          { id: 'fault_c', count: 3 },
+          { id: 'fault_d', count: 7 },
+          { id: 'fault_e', count: 2 },
+        ],
+      });
+      expect(snap?.recentFaults).toHaveLength(3);
+      expect(snap?.recentFaults.map((f) => f.id)).toEqual(['fault_d', 'fault_b', 'fault_c']);
+    });
+
+    it('filters out faults with zero or negative count and missing id', () => {
+      const snap = buildLiveSessionSnapshot({
+        exerciseName: 'Row',
+        recentFaults: [
+          { id: 'valid', count: 2 },
+          { id: '', count: 5 },
+          { id: 'neg', count: -1 },
+          { id: 'zero', count: 0 },
+        ],
+      });
+      expect(snap?.recentFaults).toEqual([{ id: 'valid', count: 2 }]);
+    });
+
+    it('ignores non-number FQI fields', () => {
+      const snap = buildLiveSessionSnapshot({
+        exerciseName: 'Squat',
+        currentFQI: { rom: 0.9, symmetry: undefined, tempo: 0.7 },
+      });
+      expect(snap?.currentFQI).toEqual({ rom: 0.9, tempo: 0.7 });
+    });
+
+    it('omits currentFQI entirely when all fields missing', () => {
+      const snap = buildLiveSessionSnapshot({
+        exerciseName: 'Squat',
+        currentFQI: {},
+      });
+      expect(snap?.currentFQI).toBeUndefined();
+    });
+  });
+
+  describe('summarizeForPrompt', () => {
+    it('returns empty string for null snapshot', () => {
+      expect(summarizeForPrompt(null)).toBe('');
+    });
+
+    it('returns empty string for undefined snapshot', () => {
+      expect(summarizeForPrompt(undefined)).toBe('');
+    });
+
+    it('produces expected string for full snapshot', () => {
+      const snap: LiveSessionSnapshot = {
+        exerciseId: 'squat',
+        exerciseName: 'Back Squat',
+        currentFQI: { rom: 0.9, symmetry: 0.85, tempo: 0.75, stability: 0.8 },
+        recentFaults: [
+          { id: 'knee_valgus', count: 4, lastRepNumber: 7 },
+          { id: 'depth_short', count: 2 },
+        ],
+      };
+      expect(summarizeForPrompt(snap)).toBe(
+        'exercise=Back Squat; FQI(rom=0.90, symmetry=0.85, tempo=0.75, stability=0.80); recent faults: knee_valgus×4@rep7, depth_short×2',
+      );
+    });
+
+    it('falls back to exerciseId when exerciseName missing', () => {
+      const snap: LiveSessionSnapshot = {
+        exerciseId: 'row',
+        recentFaults: [],
+      };
+      expect(summarizeForPrompt(snap)).toBe('exercise=row');
+    });
+
+    it('omits FQI clause when no scores present', () => {
+      const snap: LiveSessionSnapshot = {
+        exerciseName: 'Deadlift',
+        recentFaults: [{ id: 'back_round', count: 1 }],
+      };
+      expect(summarizeForPrompt(snap)).toBe('exercise=Deadlift; recent faults: back_round×1');
+    });
+
+    it('omits faults clause when empty', () => {
+      const snap: LiveSessionSnapshot = {
+        exerciseName: 'Plank',
+        currentFQI: { stability: 0.65 },
+        recentFaults: [],
+      };
+      expect(summarizeForPrompt(snap)).toBe('exercise=Plank; FQI(stability=0.65)');
+    });
+  });
+});

--- a/tests/unit/services/coach-service.live-context.test.ts
+++ b/tests/unit/services/coach-service.live-context.test.ts
@@ -1,0 +1,102 @@
+const mockInvoke = jest.fn();
+const mockInsert = jest.fn();
+const mockFrom = jest.fn(() => ({ insert: mockInsert }));
+const mockCreateError = jest.fn(
+  (
+    domain: string,
+    code: string,
+    message: string,
+    opts?: { details?: unknown; retryable?: boolean; severity?: string },
+  ) => ({
+    domain,
+    code,
+    message,
+    retryable: opts?.retryable ?? false,
+    severity: opts?.severity ?? 'error',
+    details: opts?.details,
+  }),
+);
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    functions: { invoke: mockInvoke },
+    from: mockFrom,
+  },
+}));
+
+jest.mock('@/lib/services/ErrorHandler', () => ({
+  createError: mockCreateError,
+  logError: jest.fn(),
+}));
+
+jest.mock('../../../lib/services/ErrorHandler', () => ({
+  createError: mockCreateError,
+  logError: jest.fn(),
+}));
+
+import { buildLiveSessionSnapshot } from '@/lib/services/coach-live-snapshot';
+
+let sendCoachPrompt: typeof import('@/lib/services/coach-service')['sendCoachPrompt'];
+
+describe('coach-service livesession threading', () => {
+  const baseMessages = [{ role: 'user' as const, content: 'Should I deepen my squat?' }];
+
+  beforeAll(() => {
+    ({ sendCoachPrompt } = require('@/lib/services/coach-service'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInvoke.mockResolvedValue({ data: { message: 'Go a touch deeper.' }, error: null });
+    mockInsert.mockResolvedValue({ error: null });
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('includes liveSession in the invoke payload when provided', async () => {
+    const liveSession = buildLiveSessionSnapshot({
+      exerciseId: 'squat',
+      exerciseName: 'Back Squat',
+      currentFQI: { rom: 0.9, symmetry: 0.8 },
+      recentFaults: [{ id: 'knee_valgus', count: 3 }],
+    });
+    expect(liveSession).not.toBeNull();
+
+    await sendCoachPrompt(baseMessages, { focus: 'squat', liveSession: liveSession! });
+
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+    const [, callOpts] = mockInvoke.mock.calls[0]!;
+    expect(callOpts.body.context.liveSession).toEqual(liveSession);
+    expect(callOpts.body.context.focus).toBe('squat');
+  });
+
+  it('omits liveSession from payload when context is undefined', async () => {
+    await sendCoachPrompt(baseMessages);
+
+    const [, callOpts] = mockInvoke.mock.calls[0]!;
+    expect(callOpts.body.context).toBeUndefined();
+  });
+
+  it('omits liveSession from payload when caller does not set it', async () => {
+    await sendCoachPrompt(baseMessages, { focus: 'mobility' });
+
+    const [, callOpts] = mockInvoke.mock.calls[0]!;
+    expect(callOpts.body.context.liveSession).toBeUndefined();
+    expect(callOpts.body.context.focus).toBe('mobility');
+  });
+
+  it('forwards raw liveSession object when caller bypasses builder', async () => {
+    const rawSnap = {
+      exerciseId: 'dl',
+      exerciseName: 'Deadlift',
+      recentFaults: [{ id: 'back_round', count: 2, lastRepNumber: 5 }],
+    };
+    await sendCoachPrompt(baseMessages, { liveSession: rawSnap });
+
+    const [, callOpts] = mockInvoke.mock.calls[0]!;
+    expect(callOpts.body.context.liveSession).toEqual(rawSnap);
+  });
+});

--- a/tests/unit/services/coach-telemetry.adoption.test.ts
+++ b/tests/unit/services/coach-telemetry.adoption.test.ts
@@ -1,0 +1,73 @@
+import {
+  getAdoptionRate,
+  getCounter,
+  recordCoachCueAdopted,
+  recordCoachCueEmitted,
+  resetTelemetry,
+} from '@/lib/services/coach-telemetry';
+
+describe('coach-telemetry cue adoption', () => {
+  beforeEach(() => {
+    resetTelemetry();
+  });
+
+  it('returns 1.0 when nothing has been emitted (neutral default)', () => {
+    expect(getAdoptionRate()).toBe(1);
+  });
+
+  it('returns 0.5 when half of emitted cues were adopted', () => {
+    recordCoachCueEmitted('cue_knee_valgus', 'session-1');
+    recordCoachCueEmitted('cue_depth_short', 'session-1');
+    recordCoachCueAdopted('cue_knee_valgus', 'session-1');
+    expect(getAdoptionRate()).toBeCloseTo(0.5, 5);
+  });
+
+  it('returns 1.0 when every emitted cue was adopted', () => {
+    recordCoachCueEmitted('cue_a', 'session-1');
+    recordCoachCueEmitted('cue_b', 'session-1');
+    recordCoachCueAdopted('cue_a', 'session-1');
+    recordCoachCueAdopted('cue_b', 'session-1');
+    expect(getAdoptionRate()).toBe(1);
+  });
+
+  it('treats repeated emissions of the same (cue, session) as a single denominator unit', () => {
+    recordCoachCueEmitted('cue_a', 'session-1');
+    recordCoachCueEmitted('cue_a', 'session-1');
+    recordCoachCueEmitted('cue_a', 'session-1');
+    recordCoachCueAdopted('cue_a', 'session-1');
+    expect(getAdoptionRate()).toBe(1);
+  });
+
+  it('returns 0.0 on reset followed by emissions only (no adoptions)', () => {
+    recordCoachCueEmitted('cue_a', 'session-1');
+    recordCoachCueAdopted('cue_a', 'session-1');
+    expect(getAdoptionRate()).toBe(1);
+
+    resetTelemetry();
+    recordCoachCueEmitted('cue_b', 'session-2');
+    recordCoachCueEmitted('cue_c', 'session-2');
+    expect(getAdoptionRate()).toBe(0);
+  });
+
+  it('ignores empty ids/sessions', () => {
+    recordCoachCueEmitted('', 'session-1');
+    recordCoachCueEmitted('cue', '');
+    recordCoachCueAdopted('', '');
+    expect(getAdoptionRate()).toBe(1); // no emissions recorded
+  });
+
+  it('increments raw counters in addition to unique-pair tracking', () => {
+    recordCoachCueEmitted('cue_a', 'session-1');
+    recordCoachCueEmitted('cue_a', 'session-1'); // same pair, but still a counter tick
+    recordCoachCueAdopted('cue_a', 'session-1');
+    expect(getCounter('coach_cue_emitted')).toBe(2);
+    expect(getCounter('coach_cue_adopted')).toBe(1);
+  });
+
+  it('counts adoptions across different sessions independently', () => {
+    recordCoachCueEmitted('cue_a', 'session-1');
+    recordCoachCueEmitted('cue_a', 'session-2');
+    recordCoachCueAdopted('cue_a', 'session-2');
+    expect(getAdoptionRate()).toBeCloseTo(0.5, 5);
+  });
+});


### PR DESCRIPTION
## Summary

Makes the coach aware of the current form-tracking session, adds on-device Gemma routing UX with fallback, and introduces cue adoption telemetry.

- **Live-context snapshot**: new `coach-live-snapshot` serializer (exercise, FQI, recent faults) feeding an optional `liveSession` field on `CoachContext`. Edge function renders it as a short "Live session context: …" clause in the system prompt, gated by `if (context.liveSession)` so default call sites are unaffected.
- **On-device routing**: new `coach-dispatch` with three preferences (`cloud_only`, `prefer_local`, `local_only`), typed `CoachDispatchError` on `local_unavailable`, telemetry counter on `prefer_local` cloud fallback.
- **Settings UX**: new `CoachModelCard` (none / downloading / ready / error) and `CoachRoutingPreference` (radio group) wired into a new `app/(modals)/settings-coaching.tsx` route. Preference persists to AsyncStorage at `coach_routing_preference`.
- **Cue adoption telemetry**: extends the stub `coach-telemetry` module with `recordCoachCueEmitted` / `recordCoachCueAdopted` / `getAdoptionRate` over unique (cueId, sessionId) pairs.

## Atomic commits

1. `feat(coach): add coach-live-snapshot serializer for in-session context`
2. `feat(coach): extend CoachContext with optional liveSession field`
3. `feat(coach): edge function recognizes liveSession in system prompt`
4. `test(coach): coach-live-snapshot coverage`
5. `test(coach): CoachContext liveSession threading`
6. `feat(coach): add coach-dispatch for cloud/local routing with fallback`
7. `test(coach): coach-dispatch routing + fallback`
8. `feat(settings): add CoachModelCard and CoachRoutingPreference`
9. `feat(settings): wire Coaching section into settings screen`
10. `feat(telemetry): extend coach-telemetry with cue adoption counters`
11. `test(settings): coach-model-card + coach-routing-preference render`

## PR #431 dependencies (stubbed locally)

PR #431 (`feat/429-gemma-coach-v2`) introduces `coach-model-manager` and `coach-telemetry`. Neither module exists on `main` yet, so this branch ships minimal local stubs so the dispatch/UI compile and run in isolation:

- `lib/services/coach-model-manager.ts` — minimal `getStatus()` / `subscribe()` / `isModelReady()` plus `__setStatusForTesting()` / `__resetForTesting()` hooks. Shape is intentionally compatible with #431 so swap-in should be trivial.
- `lib/services/coach-telemetry.ts` — in-memory `recordCounter` / `getCounter` / `resetTelemetry` plus the new cue-adoption helpers. Additive: when #431 lands, only merge the cue-adoption helpers into its richer module (no destructive edits needed).

Both files carry `TODO(#431)` comments flagging the intended replacement.

## Constraints honored

- No `supabase/migrations/`, `ios/`, `android/`, `.env`, or `.husky/` changes.
- Edge function change in `supabase/functions/coach/index.ts` is additive and gated on `context.liveSession`.
- No new dependencies.
- Did not modify any file owned by PR #431 (`coach-safety.ts`, `coach-rollout.ts`, `coach-prompt.ts`, `coach-context-enricher.ts`).

## Test plan

- [x] `bun run lint` — 0 errors (2 pre-existing warnings in `template-builder.tsx` unrelated to this PR).
- [x] `bun run check:types` — clean.
- [x] `bun test tests/unit/services/coach-live-snapshot.test.ts tests/unit/services/coach-service.live-context.test.ts tests/unit/services/coach-dispatch.test.ts tests/unit/services/coach-telemetry.adoption.test.ts tests/unit/components/settings/` — **48 new tests pass across 6 suites**.
- [x] Existing `tests/unit/services/coach-service.test.ts` (25 tests) still passes.

Closes #439
Refs #429, #297
