### PR TITLE
feat(insights): rep-level + longitudinal analytics — FQI trend, fault heatmap, ROM progression, symmetry, export

### DIFF
--- a/app/(modals)/_layout.tsx
+++ b/app/(modals)/_layout.tsx
@@ -16,6 +16,14 @@ export default function ModalsLayout() {
       <Stack.Screen name="follow-requests" options={{ presentation: 'modal' }} />
       <Stack.Screen name="user-profile" options={{ presentation: 'modal' }} />
       <Stack.Screen name="workout-insights" options={{ presentation: 'modal' }} />
+      <Stack.Screen
+        name="rep-insights"
+        options={{
+          presentation: 'modal',
+          gestureEnabled: true,
+          contentStyle: { backgroundColor: '#0B1626' },
+        }}
+      />
       <Stack.Screen name="help-support" options={{ presentation: 'modal', gestureEnabled: true }} />
       <Stack.Screen name="notifications" options={{ presentation: 'modal', gestureEnabled: true }} />
       <Stack.Screen name="about" options={{ presentation: 'modal', gestureEnabled: true }} />

--- a/app/(modals)/rep-insights.tsx
+++ b/app/(modals)/rep-insights.tsx
@@ -1,0 +1,296 @@
+/**
+ * RepInsightsModal
+ *
+ * Aggregates all rep-level analytics into a single scrollable modal.
+ * Accepts `?exerciseId=` and `?sessionId=` query params:
+ *   - When `sessionId` is present, the fault heatmap and rep rewind are
+ *     scoped to that session; longitudinal cards still use `exerciseId`.
+ *   - When only `exerciseId` is present, all cards show longitudinal views.
+ */
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+
+import { FqiTrendChart } from '@/components/insights/FqiTrendChart';
+import { FaultHeatmap } from '@/components/insights/FaultHeatmap';
+import { RomProgressionCard } from '@/components/insights/RomProgressionCard';
+import { SymmetryCard } from '@/components/insights/SymmetryCard';
+import { RepRewindCarousel } from '@/components/insights/RepRewindCarousel';
+import { shareRepData } from '@/lib/services/rep-export';
+import type { FaultHeatmapScope } from '@/lib/services/rep-analytics';
+
+export default function RepInsightsModal() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ exerciseId?: string; sessionId?: string }>();
+  const exerciseId = typeof params.exerciseId === 'string' ? params.exerciseId : '';
+  const sessionId = typeof params.sessionId === 'string' ? params.sessionId : undefined;
+
+  const [exporting, setExporting] = useState<'csv' | 'json' | null>(null);
+
+  const faultScope = useMemo<FaultHeatmapScope>(
+    () => (sessionId ? { sessionId } : { exerciseId, days: 30 }),
+    [sessionId, exerciseId],
+  );
+
+  const handleExport = useCallback(
+    async (format: 'csv' | 'json') => {
+      if (!exerciseId && !sessionId) {
+        Alert.alert('Nothing to export', 'Open this screen from a session or exercise to enable export.');
+        return;
+      }
+      try {
+        setExporting(format);
+        const result = await shareRepData(
+          sessionId ? { sessionId } : { exerciseId, days: 30 },
+          format,
+        );
+        if (!result.shared) {
+          Alert.alert(
+            'Export ready',
+            result.fileUri
+              ? `File written to:\n${result.fileUri}\n\nSharing is unavailable on this build.`
+              : 'Sharing is unavailable on this build. Data was generated but could not be written to disk.',
+          );
+        }
+      } catch (error) {
+        Alert.alert('Export failed', error instanceof Error ? error.message : 'Unknown error');
+      } finally {
+        setExporting(null);
+      }
+    },
+    [exerciseId, sessionId],
+  );
+
+  if (!exerciseId && !sessionId) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+            <Ionicons name="arrow-back" size={22} color="#F5F7FF" />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>Rep Insights</Text>
+          <View style={styles.headerSpacer} />
+        </View>
+        <View style={styles.centerState}>
+          <Ionicons name="analytics-outline" size={42} color="#6781A6" />
+          <Text style={styles.stateTitle}>Choose an exercise</Text>
+          <Text style={styles.stateText}>
+            Open this screen from an exercise detail or completed session to see its analytics.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backButton} accessibilityRole="button" accessibilityLabel="Close">
+          <Ionicons name="arrow-back" size={22} color="#F5F7FF" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Rep Insights</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      <ScrollView
+        style={styles.content}
+        contentContainerStyle={styles.contentInner}
+        showsVerticalScrollIndicator={false}
+      >
+        {exerciseId ? (
+          <FqiTrendChart exerciseId={exerciseId} />
+        ) : (
+          <View style={styles.inlineNote}>
+            <Text style={styles.inlineNoteText}>FQI trend requires an exercise scope.</Text>
+          </View>
+        )}
+
+        <FaultHeatmap scope={faultScope} />
+
+        {exerciseId && <RomProgressionCard exerciseId={exerciseId} />}
+        {exerciseId && <SymmetryCard exerciseId={exerciseId} />}
+
+        <RepRewindCarousel sessionId={sessionId} exerciseId={exerciseId || undefined} />
+
+        <View style={styles.exportCard}>
+          <Text style={styles.exportTitle}>Export rep data</Text>
+          <Text style={styles.exportSubtitle}>
+            Share your rep telemetry with a coach or import into a spreadsheet.
+          </Text>
+          <View style={styles.exportRow}>
+            <TouchableOpacity
+              style={[styles.exportButton, exporting !== null && styles.exportButtonDisabled]}
+              disabled={exporting !== null}
+              onPress={() => handleExport('csv')}
+              accessibilityRole="button"
+              accessibilityLabel="Export as CSV"
+            >
+              {exporting === 'csv' ? (
+                <ActivityIndicator color="#F5F7FF" size="small" />
+              ) : (
+                <>
+                  <Ionicons name="document-text-outline" size={16} color="#F5F7FF" />
+                  <Text style={styles.exportButtonText}>CSV</Text>
+                </>
+              )}
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.exportButtonGhost, exporting !== null && styles.exportButtonDisabled]}
+              disabled={exporting !== null}
+              onPress={() => handleExport('json')}
+              accessibilityRole="button"
+              accessibilityLabel="Export as JSON"
+            >
+              {exporting === 'json' ? (
+                <ActivityIndicator color="#DCE5F5" size="small" />
+              ) : (
+                <>
+                  <Ionicons name="code-slash-outline" size={16} color="#DCE5F5" />
+                  <Text style={styles.exportButtonGhostText}>JSON</Text>
+                </>
+              )}
+            </TouchableOpacity>
+          </View>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0B1626',
+  },
+  header: {
+    paddingTop: 58,
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(154, 172, 209, 0.18)',
+  },
+  backButton: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(76, 140, 255, 0.2)',
+  },
+  headerTitle: {
+    flex: 1,
+    textAlign: 'center',
+    fontSize: 19,
+    fontWeight: '700',
+    color: '#F5F7FF',
+    marginRight: 34,
+  },
+  headerSpacer: {
+    width: 0,
+  },
+  content: {
+    flex: 1,
+  },
+  contentInner: {
+    padding: 16,
+    gap: 12,
+    paddingBottom: 40,
+  },
+  centerState: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 10,
+    paddingHorizontal: 24,
+  },
+  stateTitle: {
+    color: '#F5F7FF',
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  stateText: {
+    color: '#9AACD1',
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  inlineNote: {
+    backgroundColor: '#12243A',
+    borderRadius: 12,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.16)',
+  },
+  inlineNoteText: {
+    color: '#9AACD1',
+    fontSize: 12,
+    textAlign: 'center',
+  },
+  exportCard: {
+    backgroundColor: '#12243A',
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.16)',
+    padding: 14,
+  },
+  exportTitle: {
+    color: '#F5F7FF',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  exportSubtitle: {
+    color: '#9AACD1',
+    marginTop: 4,
+    marginBottom: 12,
+    fontSize: 12,
+  },
+  exportRow: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+  exportButton: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    backgroundColor: '#4C8CFF',
+    borderRadius: 12,
+    paddingVertical: 10,
+  },
+  exportButtonText: {
+    color: '#F5F7FF',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  exportButtonGhost: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    backgroundColor: '#0F2339',
+    borderRadius: 12,
+    paddingVertical: 10,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.2)',
+  },
+  exportButtonGhostText: {
+    color: '#DCE5F5',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  exportButtonDisabled: {
+    opacity: 0.5,
+  },
+});

--- a/components/insights/FaultHeatmap.tsx
+++ b/components/insights/FaultHeatmap.tsx
@@ -1,0 +1,185 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Dimensions, StyleSheet, Text, View } from 'react-native';
+import { BarChart } from 'react-native-chart-kit';
+import {
+  getFaultHeatmap,
+  type FaultHeatmapEntry,
+  type FaultHeatmapScope,
+} from '@/lib/services/rep-analytics';
+
+interface Props {
+  scope: FaultHeatmapScope;
+  /** Optional pre-fetched data to skip network calls. */
+  initialData?: FaultHeatmapEntry[] | null;
+}
+
+function severityColor(avg: number): string {
+  if (avg >= 1.5) return '#EF4444'; // high
+  if (avg >= 0.5) return '#F59E0B'; // medium
+  return '#3CC8A9'; // low
+}
+
+function severityLabel(avg: number): string {
+  if (avg >= 1.5) return 'high';
+  if (avg >= 0.5) return 'medium';
+  return 'low';
+}
+
+export function FaultHeatmap({ scope, initialData }: Props) {
+  const [data, setData] = useState<FaultHeatmapEntry[] | null>(initialData ?? null);
+  const [loading, setLoading] = useState(!initialData);
+
+  useEffect(() => {
+    if (initialData) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      const next = await getFaultHeatmap(scope);
+      if (!cancelled) {
+        setData(next);
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [scope, initialData]);
+
+  const chartData = useMemo(() => {
+    if (!data || data.length === 0) return null;
+    const top = data.slice(0, 6);
+    return {
+      labels: top.map((d) => d.faultId.replace(/_/g, ' ').slice(0, 10)),
+      datasets: [
+        {
+          data: top.map((d) => d.count),
+        },
+      ],
+    };
+  }, [data]);
+
+  const screenWidth = Dimensions.get('window').width;
+  const chartWidth = Math.max(280, screenWidth - 40);
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.cardTitle}>Fault Heatmap</Text>
+      <Text style={styles.cardSubtitle}>Most-detected form faults across your reps.</Text>
+
+      {loading ? (
+        <View style={styles.empty}>
+          <ActivityIndicator color="#F59E0B" />
+        </View>
+      ) : !chartData ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>No faults detected yet. Nice work.</Text>
+        </View>
+      ) : (
+        <>
+          <BarChart
+            data={chartData}
+            width={chartWidth}
+            height={200}
+            yAxisLabel=""
+            yAxisSuffix=""
+            fromZero
+            showValuesOnTopOfBars
+            chartConfig={{
+              backgroundColor: 'transparent',
+              backgroundGradientFrom: '#0F2339',
+              backgroundGradientTo: '#1B2E4A',
+              decimalPlaces: 0,
+              color: (opacity = 1) => `rgba(245, 158, 11, ${opacity})`,
+              labelColor: (opacity = 1) => `rgba(154, 172, 209, ${opacity})`,
+              propsForBackgroundLines: { stroke: 'rgba(154, 172, 209, 0.15)', strokeWidth: 1 },
+              barPercentage: 0.6,
+            }}
+            style={styles.chart}
+          />
+
+          <View style={styles.legend}>
+            {data?.slice(0, 6).map((entry) => (
+              <View key={entry.faultId} style={styles.legendRow}>
+                <View style={[styles.dot, { backgroundColor: severityColor(entry.severityAvg) }]} />
+                <Text style={styles.legendFault}>{entry.faultId}</Text>
+                <Text style={styles.legendCount}>{entry.count}</Text>
+                <Text style={[styles.legendSeverity, { color: severityColor(entry.severityAvg) }]}>
+                  {severityLabel(entry.severityAvg)}
+                </Text>
+              </View>
+            ))}
+          </View>
+        </>
+      )}
+    </View>
+  );
+}
+
+export default FaultHeatmap;
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#12243A',
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.16)',
+    padding: 14,
+  },
+  cardTitle: {
+    color: '#F5F7FF',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  cardSubtitle: {
+    color: '#9AACD1',
+    marginTop: 4,
+    marginBottom: 10,
+    fontSize: 12,
+  },
+  chart: {
+    borderRadius: 12,
+    marginLeft: -10,
+  },
+  empty: {
+    paddingVertical: 32,
+    alignItems: 'center',
+  },
+  emptyText: {
+    color: '#9AACD1',
+    fontSize: 13,
+  },
+  legend: {
+    marginTop: 10,
+    gap: 6,
+  },
+  legendRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  legendFault: {
+    flex: 1,
+    color: '#F5F7FF',
+    fontSize: 12,
+    textTransform: 'capitalize',
+  },
+  legendCount: {
+    color: '#DCE5F5',
+    fontSize: 12,
+    fontWeight: '700',
+    width: 26,
+    textAlign: 'right',
+  },
+  legendSeverity: {
+    fontSize: 11,
+    fontWeight: '600',
+    textTransform: 'capitalize',
+    width: 58,
+    textAlign: 'right',
+  },
+});

--- a/components/insights/FqiTrendChart.tsx
+++ b/components/insights/FqiTrendChart.tsx
@@ -1,0 +1,230 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Dimensions, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { LineChart } from 'react-native-chart-kit';
+import {
+  calculateRepFqiTrend,
+  type RepFqiTrend,
+} from '@/lib/services/rep-analytics';
+
+type TimeRange = '30d' | '90d' | 'all';
+
+const RANGE_OPTIONS: { id: TimeRange; label: string; days: number }[] = [
+  { id: '30d', label: '30 days', days: 30 },
+  { id: '90d', label: '90 days', days: 90 },
+  { id: 'all', label: 'All time', days: 3650 },
+];
+
+interface Props {
+  exerciseId: string;
+  /** Optional pre-fetched snapshot to skip network calls (used for previews/tests). */
+  initialSnapshot?: RepFqiTrend | null;
+  /** Default range selection. */
+  defaultRange?: TimeRange;
+}
+
+export function FqiTrendChart({ exerciseId, initialSnapshot, defaultRange = '30d' }: Props) {
+  const [range, setRange] = useState<TimeRange>(defaultRange);
+  const [snapshot, setSnapshot] = useState<RepFqiTrend | null>(initialSnapshot ?? null);
+  const [loading, setLoading] = useState(!initialSnapshot);
+
+  useEffect(() => {
+    if (initialSnapshot) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      const days = RANGE_OPTIONS.find((o) => o.id === range)?.days ?? 30;
+      const next = await calculateRepFqiTrend(exerciseId, days);
+      if (!cancelled) {
+        setSnapshot(next);
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [exerciseId, range, initialSnapshot]);
+
+  const chartData = useMemo(() => {
+    if (!snapshot || snapshot.dataPoints.length === 0) return null;
+    const points = snapshot.dataPoints;
+    const stride = Math.max(1, Math.ceil(points.length / 6));
+    return {
+      labels: points.map((p, i) => (i % stride === 0 || i === points.length - 1 ? new Date(p.ts).toISOString().slice(5, 10) : '')),
+      datasets: [
+        {
+          data: points.map((p) => p.fqi),
+          color: (opacity = 1) => `rgba(76, 140, 255, ${opacity})`,
+          strokeWidth: 2,
+        },
+      ],
+    };
+  }, [snapshot]);
+
+  const screenWidth = Dimensions.get('window').width;
+  const chartWidth = Math.max(280, screenWidth - 40);
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.cardTitle}>FQI Trend</Text>
+      <Text style={styles.cardSubtitle}>Form quality across your last sessions.</Text>
+
+      <View style={styles.tabs}>
+        {RANGE_OPTIONS.map((opt) => (
+          <TouchableOpacity
+            key={opt.id}
+            style={[styles.tab, range === opt.id && styles.tabActive]}
+            onPress={() => setRange(opt.id)}
+          >
+            <Text style={[styles.tabText, range === opt.id && styles.tabTextActive]}>{opt.label}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      {loading ? (
+        <View style={styles.empty}>
+          <ActivityIndicator color="#4C8CFF" />
+        </View>
+      ) : !chartData ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>No rep data in this window yet.</Text>
+        </View>
+      ) : (
+        <>
+          <View style={styles.summaryRow}>
+            <View style={styles.summaryPill}>
+              <Text style={styles.summaryLabel}>Avg</Text>
+              <Text style={styles.summaryValue}>{snapshot?.avgFqi ?? '--'}</Text>
+            </View>
+            <View style={styles.summaryPill}>
+              <Text style={styles.summaryLabel}>Slope</Text>
+              <Text style={styles.summaryValue}>
+                {snapshot?.slope === null || snapshot?.slope === undefined
+                  ? '--'
+                  : `${snapshot.slope > 0 ? '+' : ''}${snapshot.slope.toFixed(2)}/d`}
+              </Text>
+            </View>
+            <View style={styles.summaryPill}>
+              <Text style={styles.summaryLabel}>R²</Text>
+              <Text style={styles.summaryValue}>
+                {snapshot?.rSquared === null || snapshot?.rSquared === undefined
+                  ? '--'
+                  : snapshot.rSquared.toFixed(2)}
+              </Text>
+            </View>
+            <View style={styles.summaryPill}>
+              <Text style={styles.summaryLabel}>Reps</Text>
+              <Text style={styles.summaryValue}>{snapshot?.dataPoints.length ?? 0}</Text>
+            </View>
+          </View>
+
+          <LineChart
+            data={chartData}
+            width={chartWidth}
+            height={200}
+            chartConfig={{
+              backgroundColor: 'transparent',
+              backgroundGradientFrom: '#0F2339',
+              backgroundGradientTo: '#1B2E4A',
+              decimalPlaces: 0,
+              color: (opacity = 1) => `rgba(76, 140, 255, ${opacity})`,
+              labelColor: (opacity = 1) => `rgba(154, 172, 209, ${opacity})`,
+              propsForBackgroundLines: { stroke: 'rgba(154, 172, 209, 0.15)', strokeWidth: 1 },
+              propsForDots: { r: '2', strokeWidth: '0' },
+            }}
+            withDots
+            withInnerLines
+            withOuterLines={false}
+            withVerticalLines={false}
+            bezier
+            style={styles.chart}
+          />
+        </>
+      )}
+    </View>
+  );
+}
+
+export default FqiTrendChart;
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#12243A',
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.16)',
+    padding: 14,
+  },
+  cardTitle: {
+    color: '#F5F7FF',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  cardSubtitle: {
+    color: '#9AACD1',
+    marginTop: 4,
+    marginBottom: 10,
+    fontSize: 12,
+  },
+  tabs: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 12,
+  },
+  tab: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.2)',
+    backgroundColor: '#0F2339',
+  },
+  tabActive: {
+    backgroundColor: '#4C8CFF',
+    borderColor: '#4C8CFF',
+  },
+  tabText: {
+    color: '#9AACD1',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  tabTextActive: {
+    color: '#F5F7FF',
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 10,
+    flexWrap: 'wrap',
+  },
+  summaryPill: {
+    flex: 1,
+    minWidth: '22%',
+    backgroundColor: '#0F2339',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.14)',
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+  },
+  summaryLabel: {
+    color: '#9AACD1',
+    fontSize: 11,
+  },
+  summaryValue: {
+    color: '#F5F7FF',
+    fontWeight: '600',
+    marginTop: 3,
+  },
+  chart: {
+    borderRadius: 12,
+    marginLeft: -10,
+  },
+  empty: {
+    paddingVertical: 32,
+    alignItems: 'center',
+  },
+  emptyText: {
+    color: '#9AACD1',
+    fontSize: 13,
+  },
+});

--- a/components/insights/RepRewindCarousel.tsx
+++ b/components/insights/RepRewindCarousel.tsx
@@ -1,0 +1,301 @@
+import React, { useEffect, useState } from 'react';
+import { ActivityIndicator, FlatList, StyleSheet, Text, View } from 'react-native';
+import { supabase } from '@/lib/supabase';
+import { errorWithTs } from '@/lib/logger';
+
+// NOTE: Video scrubbing per rep is intentionally deferred until #434
+// (PostSessionSummaryCard + media capture wiring) merges. This carousel
+// currently renders metrics-only cards.
+
+export interface RepRewindItem {
+  repId: string;
+  repIndex: number;
+  fqi: number | null;
+  romDeg: number | null;
+  durationMs: number;
+  faults: string[];
+  side: string | null;
+  startTs: string;
+}
+
+interface Props {
+  /** Limit to a single session when provided. Otherwise falls back to exerciseId + recent window. */
+  sessionId?: string;
+  exerciseId?: string;
+  /** Max number of cards to render. Default 20. */
+  limit?: number;
+  /** Optional pre-fetched data for preview/tests. */
+  initialData?: RepRewindItem[] | null;
+}
+
+function featureNumber(features: unknown, key: string): number | null {
+  if (!features || typeof features !== 'object') return null;
+  const rec = features as Record<string, unknown>;
+  const v = rec[key];
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  return null;
+}
+
+async function loadReps(scope: { sessionId?: string; exerciseId?: string }, limit: number): Promise<RepRewindItem[]> {
+  try {
+    let query = supabase
+      .from('reps')
+      .select('rep_id,rep_index,fqi,start_ts,end_ts,features,faults_detected,side');
+
+    if (scope.sessionId) {
+      query = query.eq('session_id', scope.sessionId);
+    }
+    if (scope.exerciseId) {
+      query = query.eq('exercise', scope.exerciseId);
+    }
+
+    const { data, error } = await query.order('start_ts', { ascending: false }).limit(limit);
+    if (error) throw error;
+
+    const rows = (data ?? []) as {
+      rep_id: string;
+      rep_index: number;
+      fqi: number | null;
+      start_ts: string;
+      end_ts: string;
+      features: unknown;
+      faults_detected: string[] | null;
+      side: string | null;
+    }[];
+
+    return rows.map((r) => ({
+      repId: r.rep_id,
+      repIndex: r.rep_index,
+      fqi: typeof r.fqi === 'number' ? r.fqi : null,
+      romDeg: featureNumber(r.features, 'romDeg') ?? featureNumber(r.features, 'rom_deg'),
+      durationMs: Math.max(0, new Date(r.end_ts).getTime() - new Date(r.start_ts).getTime()),
+      faults: Array.isArray(r.faults_detected) ? r.faults_detected : [],
+      side: r.side,
+      startTs: r.start_ts,
+    }));
+  } catch (error) {
+    errorWithTs('[RepRewindCarousel] loadReps failed', error);
+    return [];
+  }
+}
+
+function fqiColor(fqi: number | null): string {
+  if (fqi === null) return '#6781A6';
+  if (fqi >= 80) return '#3CC8A9';
+  if (fqi >= 60) return '#F59E0B';
+  return '#EF4444';
+}
+
+export function RepRewindCarousel({ sessionId, exerciseId, limit = 20, initialData }: Props) {
+  const [data, setData] = useState<RepRewindItem[] | null>(initialData ?? null);
+  const [loading, setLoading] = useState(!initialData);
+
+  useEffect(() => {
+    if (initialData) return;
+    if (!sessionId && !exerciseId) {
+      setData([]);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      const next = await loadReps({ sessionId, exerciseId }, limit);
+      if (!cancelled) {
+        setData(next);
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, exerciseId, limit, initialData]);
+
+  const renderItem = React.useCallback(({ item }: { item: RepRewindItem }) => {
+    return (
+      <View style={styles.card}>
+        <View style={styles.headerRow}>
+          <Text style={styles.repNumber}>Rep {item.repIndex}</Text>
+          {item.side && <Text style={styles.side}>{item.side}</Text>}
+        </View>
+        <Text style={[styles.fqi, { color: fqiColor(item.fqi) }]}>{item.fqi ?? '--'}</Text>
+        <Text style={styles.fqiLabel}>FQI</Text>
+
+        <View style={styles.statRow}>
+          <View style={styles.statCol}>
+            <Text style={styles.statLabel}>ROM</Text>
+            <Text style={styles.statValue}>
+              {item.romDeg === null ? '--' : `${item.romDeg.toFixed(0)}°`}
+            </Text>
+          </View>
+          <View style={styles.statCol}>
+            <Text style={styles.statLabel}>Time</Text>
+            <Text style={styles.statValue}>
+              {item.durationMs === 0 ? '--' : `${(item.durationMs / 1000).toFixed(1)}s`}
+            </Text>
+          </View>
+        </View>
+
+        {item.faults.length > 0 ? (
+          <View style={styles.faultRow}>
+            {item.faults.slice(0, 2).map((f) => (
+              <View key={f} style={styles.faultChip}>
+                <Text style={styles.faultText}>{f}</Text>
+              </View>
+            ))}
+            {item.faults.length > 2 && <Text style={styles.faultMore}>+{item.faults.length - 2}</Text>}
+          </View>
+        ) : (
+          <View style={styles.faultRow}>
+            <Text style={styles.cleanText}>Clean rep</Text>
+          </View>
+        )}
+      </View>
+    );
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.headerOuter}>
+        <Text style={styles.title}>Rep Rewind</Text>
+        <Text style={styles.subtitle}>Scroll through recent reps. Tap to coach (video coming in #434).</Text>
+      </View>
+
+      {loading ? (
+        <View style={styles.empty}>
+          <ActivityIndicator color="#4C8CFF" />
+        </View>
+      ) : !data || data.length === 0 ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>No reps to rewind in this scope.</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={data}
+          keyExtractor={(item) => item.repId}
+          renderItem={renderItem}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.listContent}
+        />
+      )}
+    </View>
+  );
+}
+
+export default RepRewindCarousel;
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 10,
+  },
+  headerOuter: {
+    paddingHorizontal: 14,
+  },
+  title: {
+    color: '#F5F7FF',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  subtitle: {
+    color: '#9AACD1',
+    marginTop: 4,
+    fontSize: 12,
+  },
+  listContent: {
+    paddingHorizontal: 14,
+    gap: 10,
+  },
+  card: {
+    backgroundColor: '#12243A',
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.16)',
+    padding: 14,
+    width: 148,
+    marginRight: 10,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  repNumber: {
+    color: '#DCE5F5',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  side: {
+    color: '#9AACD1',
+    fontSize: 11,
+    textTransform: 'uppercase',
+    fontWeight: '600',
+  },
+  fqi: {
+    fontSize: 36,
+    fontWeight: '800',
+    marginTop: 6,
+  },
+  fqiLabel: {
+    color: '#9AACD1',
+    fontSize: 11,
+    marginTop: -4,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  statRow: {
+    flexDirection: 'row',
+    marginTop: 12,
+    gap: 8,
+  },
+  statCol: {
+    flex: 1,
+  },
+  statLabel: {
+    color: '#9AACD1',
+    fontSize: 10,
+    textTransform: 'uppercase',
+  },
+  statValue: {
+    color: '#F5F7FF',
+    fontWeight: '700',
+    marginTop: 2,
+  },
+  faultRow: {
+    marginTop: 10,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 4,
+    alignItems: 'center',
+  },
+  faultChip: {
+    backgroundColor: 'rgba(239, 68, 68, 0.2)',
+    borderRadius: 8,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  faultText: {
+    color: '#F8D7D7',
+    fontSize: 10,
+    fontWeight: '600',
+    textTransform: 'capitalize',
+  },
+  faultMore: {
+    color: '#9AACD1',
+    fontSize: 10,
+    fontWeight: '700',
+  },
+  cleanText: {
+    color: '#3CC8A9',
+    fontSize: 11,
+    fontWeight: '700',
+  },
+  empty: {
+    paddingVertical: 32,
+    alignItems: 'center',
+  },
+  emptyText: {
+    color: '#9AACD1',
+    fontSize: 13,
+  },
+});

--- a/components/insights/RomProgressionCard.tsx
+++ b/components/insights/RomProgressionCard.tsx
@@ -1,0 +1,270 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Dimensions, StyleSheet, Text, View } from 'react-native';
+import { LineChart } from 'react-native-chart-kit';
+import { supabase } from '@/lib/supabase';
+import { errorWithTs } from '@/lib/logger';
+
+interface Props {
+  exerciseId: string;
+  /** Number of weeks of history to show. Defaults to 8. */
+  weeks?: number;
+  /** Optional pre-fetched data for preview/tests. */
+  initialData?: RomWeekBucket[] | null;
+}
+
+export interface RomWeekBucket {
+  /** ISO date string for the Monday of this week (UTC). */
+  weekStart: string;
+  /** Short label for the x-axis, e.g. "Mar 25". */
+  label: string;
+  /** Mean ROM across all reps that week (degrees). `null` when no data. */
+  leftAvgRom: number | null;
+  rightAvgRom: number | null;
+  bilateralAvgRom: number | null;
+  repCount: number;
+}
+
+function startOfUtcWeek(ts: string): string {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return ts.slice(0, 10);
+  const day = d.getUTCDay();
+  const diff = day === 0 ? -6 : 1 - day; // Monday start
+  d.setUTCDate(d.getUTCDate() + diff);
+  d.setUTCHours(0, 0, 0, 0);
+  return d.toISOString().slice(0, 10);
+}
+
+function shortLabelFor(weekStart: string): string {
+  const d = new Date(`${weekStart}T00:00:00.000Z`);
+  if (Number.isNaN(d.getTime())) return weekStart;
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function featureRom(features: unknown): number | null {
+  if (!features || typeof features !== 'object') return null;
+  const rec = features as Record<string, unknown>;
+  const v = rec.romDeg ?? rec.rom_deg;
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+async function loadWeeklyRom(exerciseId: string, weeks: number): Promise<RomWeekBucket[]> {
+  try {
+    const cutoff = new Date();
+    cutoff.setUTCDate(cutoff.getUTCDate() - weeks * 7);
+
+    const { data, error } = await supabase
+      .from('reps')
+      .select('side,features,start_ts')
+      .eq('exercise', exerciseId)
+      .gte('start_ts', cutoff.toISOString())
+      .order('start_ts', { ascending: true })
+      .limit(3000);
+
+    if (error) throw error;
+
+    const rows = (data ?? []) as { side: 'left' | 'right' | null; features: unknown; start_ts: string }[];
+    if (rows.length === 0) return [];
+
+    const buckets = new Map<string, { left: number[]; right: number[]; bilateral: number[] }>();
+    for (const row of rows) {
+      const rom = featureRom(row.features);
+      if (rom === null) continue;
+      const weekStart = startOfUtcWeek(row.start_ts);
+      const bucket = buckets.get(weekStart) ?? { left: [], right: [], bilateral: [] };
+      if (row.side === 'left') bucket.left.push(rom);
+      else if (row.side === 'right') bucket.right.push(rom);
+      else bucket.bilateral.push(rom);
+      buckets.set(weekStart, bucket);
+    }
+
+    return [...buckets.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([weekStart, b]) => {
+        const avg = (xs: number[]): number | null =>
+          xs.length === 0 ? null : Number((xs.reduce((a, c) => a + c, 0) / xs.length).toFixed(2));
+        return {
+          weekStart,
+          label: shortLabelFor(weekStart),
+          leftAvgRom: avg(b.left),
+          rightAvgRom: avg(b.right),
+          bilateralAvgRom: avg(b.bilateral),
+          repCount: b.left.length + b.right.length + b.bilateral.length,
+        };
+      });
+  } catch (error) {
+    errorWithTs('[RomProgressionCard] loadWeeklyRom failed', error);
+    return [];
+  }
+}
+
+export function RomProgressionCard({ exerciseId, weeks = 8, initialData }: Props) {
+  const [data, setData] = useState<RomWeekBucket[] | null>(initialData ?? null);
+  const [loading, setLoading] = useState(!initialData);
+
+  useEffect(() => {
+    if (initialData) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      const next = await loadWeeklyRom(exerciseId, weeks);
+      if (!cancelled) {
+        setData(next);
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [exerciseId, weeks, initialData]);
+
+  const chartData = useMemo(() => {
+    if (!data || data.length === 0) return null;
+
+    const hasSideData = data.some((d) => d.leftAvgRom !== null || d.rightAvgRom !== null);
+    const labelStride = Math.max(1, Math.ceil(data.length / 4));
+    const labels = data.map((d, i) => (i % labelStride === 0 || i === data.length - 1 ? d.label : ''));
+
+    const datasets: {
+      data: number[];
+      color?: (opacity?: number) => string;
+      strokeWidth?: number;
+    }[] = [];
+
+    if (hasSideData) {
+      datasets.push({
+        data: data.map((d) => d.leftAvgRom ?? d.bilateralAvgRom ?? 0),
+        color: (opacity = 1) => `rgba(76, 140, 255, ${opacity})`,
+        strokeWidth: 2,
+      });
+      datasets.push({
+        data: data.map((d) => d.rightAvgRom ?? d.bilateralAvgRom ?? 0),
+        color: (opacity = 1) => `rgba(60, 200, 169, ${opacity})`,
+        strokeWidth: 2,
+      });
+    } else {
+      datasets.push({
+        data: data.map((d) => d.bilateralAvgRom ?? 0),
+        color: (opacity = 1) => `rgba(76, 140, 255, ${opacity})`,
+        strokeWidth: 2,
+      });
+    }
+
+    return {
+      labels,
+      datasets,
+      legend: hasSideData ? ['Left', 'Right'] : ['ROM'],
+    };
+  }, [data]);
+
+  const latestDelta = useMemo(() => {
+    if (!data || data.length < 2) return null;
+    const first = data[0];
+    const last = data[data.length - 1];
+    const firstAvg = first.bilateralAvgRom ?? ((first.leftAvgRom ?? 0) + (first.rightAvgRom ?? 0)) / 2;
+    const lastAvg = last.bilateralAvgRom ?? ((last.leftAvgRom ?? 0) + (last.rightAvgRom ?? 0)) / 2;
+    if (!Number.isFinite(firstAvg) || !Number.isFinite(lastAvg) || firstAvg === 0) return null;
+    return Number((lastAvg - firstAvg).toFixed(1));
+  }, [data]);
+
+  const screenWidth = Dimensions.get('window').width;
+  const chartWidth = Math.max(280, screenWidth - 40);
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.headerRow}>
+        <Text style={styles.cardTitle}>ROM Progression</Text>
+        {latestDelta !== null && (
+          <Text style={[styles.delta, latestDelta >= 0 ? styles.deltaUp : styles.deltaDown]}>
+            {latestDelta > 0 ? '+' : ''}
+            {latestDelta.toFixed(1)}°
+          </Text>
+        )}
+      </View>
+      <Text style={styles.cardSubtitle}>Week-over-week range-of-motion trend.</Text>
+
+      {loading ? (
+        <View style={styles.empty}>
+          <ActivityIndicator color="#4C8CFF" />
+        </View>
+      ) : !chartData ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>Not enough reps to compute a weekly trend.</Text>
+        </View>
+      ) : (
+        <LineChart
+          data={chartData}
+          width={chartWidth}
+          height={180}
+          chartConfig={{
+            backgroundColor: 'transparent',
+            backgroundGradientFrom: '#0F2339',
+            backgroundGradientTo: '#1B2E4A',
+            decimalPlaces: 0,
+            color: (opacity = 1) => `rgba(245, 247, 255, ${opacity})`,
+            labelColor: (opacity = 1) => `rgba(154, 172, 209, ${opacity})`,
+            propsForBackgroundLines: { stroke: 'rgba(154, 172, 209, 0.15)', strokeWidth: 1 },
+            propsForDots: { r: '2', strokeWidth: '0' },
+          }}
+          withDots
+          withInnerLines
+          withOuterLines={false}
+          withVerticalLines={false}
+          bezier
+          style={styles.chart}
+        />
+      )}
+    </View>
+  );
+}
+
+export default RomProgressionCard;
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#12243A',
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.16)',
+    padding: 14,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  cardTitle: {
+    color: '#F5F7FF',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  cardSubtitle: {
+    color: '#9AACD1',
+    marginTop: 4,
+    marginBottom: 10,
+    fontSize: 12,
+  },
+  delta: {
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  deltaUp: {
+    color: '#3CC8A9',
+  },
+  deltaDown: {
+    color: '#EF4444',
+  },
+  chart: {
+    borderRadius: 12,
+    marginLeft: -10,
+  },
+  empty: {
+    paddingVertical: 32,
+    alignItems: 'center',
+  },
+  emptyText: {
+    color: '#9AACD1',
+    fontSize: 13,
+    textAlign: 'center',
+    paddingHorizontal: 12,
+  },
+});

--- a/components/insights/SymmetryCard.tsx
+++ b/components/insights/SymmetryCard.tsx
@@ -1,0 +1,198 @@
+import React, { useEffect, useState } from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import {
+  getSymmetryTrend,
+  type SymmetryTrendResult,
+  type SymmetryTrend,
+} from '@/lib/services/rep-analytics';
+
+interface Props {
+  exerciseId: string;
+  days?: number;
+  /** Optional pre-fetched data for preview/tests. */
+  initialData?: SymmetryTrendResult | null;
+}
+
+function trendIcon(trend: SymmetryTrend): React.ComponentProps<typeof Ionicons>['name'] {
+  if (trend === 'improving') return 'trending-down';
+  if (trend === 'worsening') return 'trending-up';
+  if (trend === 'stable') return 'remove';
+  return 'help';
+}
+
+function trendColor(trend: SymmetryTrend): string {
+  if (trend === 'improving') return '#3CC8A9';
+  if (trend === 'worsening') return '#EF4444';
+  if (trend === 'stable') return '#9AACD1';
+  return '#6781A6';
+}
+
+function trendLabel(trend: SymmetryTrend, asymmetryRatio: number | null): string {
+  if (asymmetryRatio === null) return 'Insufficient bilateral data';
+  const pct = (asymmetryRatio * 100).toFixed(1);
+  if (trend === 'improving') return `Gap shrinking (${pct}%)`;
+  if (trend === 'worsening') return `Gap widening (${pct}%)`;
+  if (trend === 'stable') return `Holding steady at ${pct}%`;
+  return `Current gap: ${pct}%`;
+}
+
+export function SymmetryCard({ exerciseId, days = 30, initialData }: Props) {
+  const [data, setData] = useState<SymmetryTrendResult | null>(initialData ?? null);
+  const [loading, setLoading] = useState(!initialData);
+
+  useEffect(() => {
+    if (initialData) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      const next = await getSymmetryTrend(exerciseId, days);
+      if (!cancelled) {
+        setData(next);
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [exerciseId, days, initialData]);
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.headerRow}>
+        <Text style={styles.cardTitle}>Left / Right Symmetry</Text>
+        {data && (
+          <View style={styles.trendPill}>
+            <Ionicons name={trendIcon(data.trend)} size={14} color={trendColor(data.trend)} />
+            <Text style={[styles.trendText, { color: trendColor(data.trend) }]}>{data.trend}</Text>
+          </View>
+        )}
+      </View>
+      <Text style={styles.cardSubtitle}>Bilateral ROM comparison over the last {days} days.</Text>
+
+      {loading ? (
+        <View style={styles.empty}>
+          <ActivityIndicator color="#4C8CFF" />
+        </View>
+      ) : !data ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>No bilateral data yet.</Text>
+        </View>
+      ) : (
+        <>
+          <View style={styles.statsRow}>
+            <View style={styles.statCol}>
+              <Text style={styles.statLabel}>Left avg</Text>
+              <Text style={[styles.statValue, styles.leftColor]}>
+                {data.leftAvgRom === null ? '--' : `${data.leftAvgRom.toFixed(1)}°`}
+              </Text>
+            </View>
+            <View style={styles.statCol}>
+              <Text style={styles.statLabel}>Right avg</Text>
+              <Text style={[styles.statValue, styles.rightColor]}>
+                {data.rightAvgRom === null ? '--' : `${data.rightAvgRom.toFixed(1)}°`}
+              </Text>
+            </View>
+            <View style={styles.statCol}>
+              <Text style={styles.statLabel}>Asymmetry</Text>
+              <Text style={styles.statValue}>
+                {data.asymmetryRatio === null ? '--' : `${(data.asymmetryRatio * 100).toFixed(1)}%`}
+              </Text>
+            </View>
+          </View>
+
+          <Text style={[styles.trendSummary, { color: trendColor(data.trend) }]}>
+            {trendLabel(data.trend, data.asymmetryRatio)}
+          </Text>
+        </>
+      )}
+    </View>
+  );
+}
+
+export default SymmetryCard;
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#12243A',
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.16)',
+    padding: 14,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  cardTitle: {
+    color: '#F5F7FF',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  cardSubtitle: {
+    color: '#9AACD1',
+    marginTop: 4,
+    marginBottom: 12,
+    fontSize: 12,
+  },
+  trendPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    backgroundColor: '#0F2339',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.2)',
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+  },
+  trendText: {
+    fontSize: 11,
+    fontWeight: '700',
+    textTransform: 'capitalize',
+  },
+  statsRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  statCol: {
+    flex: 1,
+    backgroundColor: '#0F2339',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.14)',
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    alignItems: 'flex-start',
+  },
+  statLabel: {
+    color: '#9AACD1',
+    fontSize: 11,
+  },
+  statValue: {
+    color: '#F5F7FF',
+    fontSize: 18,
+    fontWeight: '700',
+    marginTop: 4,
+  },
+  leftColor: {
+    color: '#4C8CFF',
+  },
+  rightColor: {
+    color: '#3CC8A9',
+  },
+  trendSummary: {
+    marginTop: 12,
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  empty: {
+    paddingVertical: 24,
+    alignItems: 'center',
+  },
+  emptyText: {
+    color: '#9AACD1',
+    fontSize: 13,
+  },
+});

--- a/lib/services/rep-analytics.ts
+++ b/lib/services/rep-analytics.ts
@@ -1,0 +1,521 @@
+/**
+ * Rep Analytics Service
+ *
+ * Longitudinal and per-session analytics over rep-level telemetry.
+ *
+ * Data source: the `reps` table (see supabase/migrations/018_create_reps_sets_labels.sql).
+ * Per the codebase's existing pattern (`lib/services/workout-insights.ts`), rep telemetry
+ * is read from Supabase because the on-device `local-db.ts` does not mirror the `reps`
+ * table. Supabase RLS (`reps read own`) scopes all queries to the signed-in user, so
+ * these functions are safe to call without additional `user_id` filtering.
+ *
+ * All functions are defensive:
+ *   - Guard against empty result sets (return typed empty shapes)
+ *   - Guard against NaN / divide-by-zero (return `null` for ratios, `0` for counts)
+ *   - Never throw for missing/empty data — only for network/auth errors from Supabase
+ */
+import { supabase } from '@/lib/supabase';
+import { errorWithTs } from '@/lib/logger';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface RepFqiTrend {
+  /** Least-squares slope (FQI points per day). `null` when <2 points. */
+  slope: number | null;
+  /** Coefficient of determination (0-1). `null` when <2 points or zero variance. */
+  rSquared: number | null;
+  /** Mean FQI across the window. `null` when no data. */
+  avgFqi: number | null;
+  /** Per-rep data points used in the regression. */
+  dataPoints: { ts: string; fqi: number }[];
+}
+
+export type TempoTrend = 'improving' | 'declining' | 'stable' | 'unknown';
+
+export interface TempoStability {
+  /** Mean rep duration in milliseconds. `null` when no data. */
+  avgDurationMs: number | null;
+  /** Population standard deviation of rep durations (ms). `null` when <2 data points. */
+  stdDev: number | null;
+  /** CV = stdDev / mean. `null` when mean is 0/null. */
+  coefficientOfVariation: number | null;
+  /** First-half vs second-half CV delta; "improving" = CV went down. */
+  trend: TempoTrend;
+}
+
+export type SymmetryTrend = 'improving' | 'worsening' | 'stable' | 'unknown';
+
+export interface SymmetryTrendResult {
+  /** Mean ROM for side="left". `null` when no left reps. */
+  leftAvgRom: number | null;
+  /** Mean ROM for side="right". `null` when no right reps. */
+  rightAvgRom: number | null;
+  /**
+   * |left - right| / max(left, right). `null` when either side is missing or both are 0.
+   * 0.0 = perfect symmetry, 1.0 = total imbalance.
+   */
+  asymmetryRatio: number | null;
+  /** First-half vs second-half asymmetry delta; "improving" = smaller gap over time. */
+  trend: SymmetryTrend;
+}
+
+export type FaultSeverity = 'low' | 'medium' | 'high';
+
+export interface FaultHeatmapEntry {
+  faultId: string;
+  count: number;
+  /** Average severity bucket index (0=low, 1=medium, 2=high) across reps. */
+  severityAvg: number;
+}
+
+export interface FaultHeatmapScope {
+  sessionId?: string;
+  exerciseId?: string;
+  days?: number;
+}
+
+export interface CueAdoptionStats {
+  totalCuesEmitted: number;
+  /** Fraction 0-1; `null` when no cues emitted. */
+  adoptionRate: number | null;
+  /** Cue type most often adopted. `null` when none adopted. */
+  mostAdopted: string | null;
+  /** Cue type most often ignored. `null` when none emitted. */
+  leastAdopted: string | null;
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+/** ISO timestamp for `now - days` */
+function cutoffIso(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString();
+}
+
+/** Simple linear regression slope + R^2. Returns nulls on degenerate input. */
+function linearRegression(xs: number[], ys: number[]): { slope: number | null; rSquared: number | null } {
+  if (xs.length !== ys.length || xs.length < 2) {
+    return { slope: null, rSquared: null };
+  }
+  const n = xs.length;
+  const meanX = xs.reduce((a, b) => a + b, 0) / n;
+  const meanY = ys.reduce((a, b) => a + b, 0) / n;
+
+  let ssxx = 0;
+  let ssxy = 0;
+  let ssyy = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = xs[i] - meanX;
+    const dy = ys[i] - meanY;
+    ssxx += dx * dx;
+    ssxy += dx * dy;
+    ssyy += dy * dy;
+  }
+
+  if (ssxx === 0 || !Number.isFinite(ssxx)) return { slope: null, rSquared: null };
+  const slope = ssxy / ssxx;
+  const rSquared = ssyy === 0 ? null : Math.min(1, Math.max(0, (ssxy * ssxy) / (ssxx * ssyy)));
+  if (!Number.isFinite(slope)) return { slope: null, rSquared };
+  return { slope: Number(slope.toFixed(6)), rSquared: rSquared === null ? null : Number(rSquared.toFixed(4)) };
+}
+
+function mean(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const total = values.reduce((a, b) => a + b, 0);
+  if (!Number.isFinite(total)) return null;
+  return total / values.length;
+}
+
+function populationStdDev(values: number[]): number | null {
+  if (values.length < 2) return null;
+  const m = mean(values);
+  if (m === null) return null;
+  const variance = values.reduce((sum, v) => sum + (v - m) * (v - m), 0) / values.length;
+  if (!Number.isFinite(variance) || variance < 0) return null;
+  return Math.sqrt(variance);
+}
+
+function safeRomFromFeatures(features: unknown): number | null {
+  if (!features || typeof features !== 'object') return null;
+  const rec = features as Record<string, unknown>;
+  const v = rec.romDeg ?? rec.rom_deg;
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  return null;
+}
+
+function severityBucket(fault: string): number {
+  // Lightweight severity heuristic — aligns with fqi-calculator fault categories.
+  const major = /collapse|valgus|lumbar|extreme|severe|hyper/i;
+  const moderate = /shallow|forward|shift|asymmetry/i;
+  if (major.test(fault)) return 2;
+  if (moderate.test(fault)) return 1;
+  return 0;
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Linear regression of FQI vs. time for a given exercise, over the last `days`.
+ * Slope is expressed in FQI-points per day (positive = improving).
+ */
+export async function calculateRepFqiTrend(
+  exerciseId: string,
+  days: number = 30,
+): Promise<RepFqiTrend> {
+  const emptyShape: RepFqiTrend = {
+    slope: null,
+    rSquared: null,
+    avgFqi: null,
+    dataPoints: [],
+  };
+
+  if (!exerciseId || !Number.isFinite(days) || days <= 0) {
+    return emptyShape;
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('reps')
+      .select('fqi,start_ts')
+      .eq('exercise', exerciseId)
+      .gte('start_ts', cutoffIso(days))
+      .order('start_ts', { ascending: true })
+      .limit(2000);
+
+    if (error) throw error;
+
+    const rows = (data ?? []) as { fqi: number | null; start_ts: string }[];
+    const dataPoints = rows
+      .filter((r): r is { fqi: number; start_ts: string } =>
+        typeof r.fqi === 'number' && Number.isFinite(r.fqi) && typeof r.start_ts === 'string',
+      )
+      .map((r) => ({ ts: r.start_ts, fqi: r.fqi }));
+
+    if (dataPoints.length === 0) return emptyShape;
+
+    const avgFqi = mean(dataPoints.map((p) => p.fqi));
+    if (dataPoints.length < 2) {
+      return {
+        slope: null,
+        rSquared: null,
+        avgFqi: avgFqi === null ? null : Number(avgFqi.toFixed(2)),
+        dataPoints,
+      };
+    }
+
+    const base = new Date(dataPoints[0].ts).getTime();
+    const xs = dataPoints.map((p) => (new Date(p.ts).getTime() - base) / (1000 * 60 * 60 * 24));
+    const ys = dataPoints.map((p) => p.fqi);
+    const reg = linearRegression(xs, ys);
+
+    return {
+      slope: reg.slope,
+      rSquared: reg.rSquared,
+      avgFqi: avgFqi === null ? null : Number(avgFqi.toFixed(2)),
+      dataPoints,
+    };
+  } catch (error) {
+    errorWithTs('[rep-analytics] calculateRepFqiTrend failed', error);
+    return emptyShape;
+  }
+}
+
+/**
+ * Mean/std-dev of per-rep durations (ms) for a given exercise over the last `weeks`.
+ * `trend` compares the first half of the window to the second half.
+ */
+export async function calculateTempoStability(
+  exerciseId: string,
+  weeks: number = 4,
+): Promise<TempoStability> {
+  const emptyShape: TempoStability = {
+    avgDurationMs: null,
+    stdDev: null,
+    coefficientOfVariation: null,
+    trend: 'unknown',
+  };
+
+  if (!exerciseId || !Number.isFinite(weeks) || weeks <= 0) {
+    return emptyShape;
+  }
+
+  const days = Math.round(weeks * 7);
+
+  try {
+    const { data, error } = await supabase
+      .from('reps')
+      .select('start_ts,end_ts')
+      .eq('exercise', exerciseId)
+      .gte('start_ts', cutoffIso(days))
+      .order('start_ts', { ascending: true })
+      .limit(2000);
+
+    if (error) throw error;
+
+    const rows = (data ?? []) as { start_ts: string; end_ts: string }[];
+    const durations = rows
+      .map((r) => new Date(r.end_ts).getTime() - new Date(r.start_ts).getTime())
+      .filter((v) => Number.isFinite(v) && v > 0);
+
+    if (durations.length === 0) return emptyShape;
+
+    const avgDurationMs = mean(durations);
+    const stdDev = populationStdDev(durations);
+    const cv = avgDurationMs && avgDurationMs > 0 && stdDev !== null ? stdDev / avgDurationMs : null;
+
+    let trend: TempoTrend = 'unknown';
+    if (durations.length >= 4) {
+      const mid = Math.floor(durations.length / 2);
+      const firstHalf = durations.slice(0, mid);
+      const secondHalf = durations.slice(mid);
+      const m1 = mean(firstHalf);
+      const m2 = mean(secondHalf);
+      const s1 = populationStdDev(firstHalf);
+      const s2 = populationStdDev(secondHalf);
+      const cv1 = m1 && m1 > 0 && s1 !== null ? s1 / m1 : null;
+      const cv2 = m2 && m2 > 0 && s2 !== null ? s2 / m2 : null;
+      if (cv1 !== null && cv2 !== null) {
+        const delta = cv2 - cv1;
+        if (Math.abs(delta) < 0.02) trend = 'stable';
+        else trend = delta < 0 ? 'improving' : 'declining';
+      }
+    }
+
+    return {
+      avgDurationMs: avgDurationMs === null ? null : Math.round(avgDurationMs),
+      stdDev: stdDev === null ? null : Math.round(stdDev),
+      coefficientOfVariation: cv === null ? null : Number(cv.toFixed(4)),
+      trend,
+    };
+  } catch (error) {
+    errorWithTs('[rep-analytics] calculateTempoStability failed', error);
+    return emptyShape;
+  }
+}
+
+/**
+ * Left vs right ROM comparison for unilateral exercises over the last `days`.
+ */
+export async function getSymmetryTrend(
+  exerciseId: string,
+  days: number = 30,
+): Promise<SymmetryTrendResult> {
+  const emptyShape: SymmetryTrendResult = {
+    leftAvgRom: null,
+    rightAvgRom: null,
+    asymmetryRatio: null,
+    trend: 'unknown',
+  };
+
+  if (!exerciseId || !Number.isFinite(days) || days <= 0) {
+    return emptyShape;
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('reps')
+      .select('side,features,start_ts')
+      .eq('exercise', exerciseId)
+      .gte('start_ts', cutoffIso(days))
+      .order('start_ts', { ascending: true })
+      .limit(2000);
+
+    if (error) throw error;
+
+    const rows = (data ?? []) as {
+      side: 'left' | 'right' | null;
+      features: unknown;
+      start_ts: string;
+    }[];
+
+    const leftRoms: number[] = [];
+    const rightRoms: number[] = [];
+    const halfSize = Math.floor(rows.length / 2);
+    const firstHalfLeft: number[] = [];
+    const firstHalfRight: number[] = [];
+    const secondHalfLeft: number[] = [];
+    const secondHalfRight: number[] = [];
+
+    rows.forEach((row, idx) => {
+      const rom = safeRomFromFeatures(row.features);
+      if (rom === null) return;
+      if (row.side === 'left') {
+        leftRoms.push(rom);
+        (idx < halfSize ? firstHalfLeft : secondHalfLeft).push(rom);
+      } else if (row.side === 'right') {
+        rightRoms.push(rom);
+        (idx < halfSize ? firstHalfRight : secondHalfRight).push(rom);
+      }
+    });
+
+    const leftAvg = mean(leftRoms);
+    const rightAvg = mean(rightRoms);
+
+    const computeRatio = (l: number | null, r: number | null): number | null => {
+      if (l === null || r === null) return null;
+      const denom = Math.max(Math.abs(l), Math.abs(r));
+      if (denom === 0) return null;
+      return Number((Math.abs(l - r) / denom).toFixed(4));
+    };
+
+    const asymmetryRatio = computeRatio(leftAvg, rightAvg);
+
+    let trend: SymmetryTrend = 'unknown';
+    if (firstHalfLeft.length && firstHalfRight.length && secondHalfLeft.length && secondHalfRight.length) {
+      const r1 = computeRatio(mean(firstHalfLeft), mean(firstHalfRight));
+      const r2 = computeRatio(mean(secondHalfLeft), mean(secondHalfRight));
+      if (r1 !== null && r2 !== null) {
+        const delta = r2 - r1;
+        if (Math.abs(delta) < 0.02) trend = 'stable';
+        else trend = delta < 0 ? 'improving' : 'worsening';
+      }
+    }
+
+    return {
+      leftAvgRom: leftAvg === null ? null : Number(leftAvg.toFixed(2)),
+      rightAvgRom: rightAvg === null ? null : Number(rightAvg.toFixed(2)),
+      asymmetryRatio,
+      trend,
+    };
+  } catch (error) {
+    errorWithTs('[rep-analytics] getSymmetryTrend failed', error);
+    return emptyShape;
+  }
+}
+
+/**
+ * Aggregate fault occurrences (count + severity average) across a scope.
+ * Scope can be any combination of sessionId, exerciseId, and a day window.
+ */
+export async function getFaultHeatmap(scope: FaultHeatmapScope): Promise<FaultHeatmapEntry[]> {
+  try {
+    let query = supabase.from('reps').select('faults_detected,start_ts');
+    if (scope.sessionId) {
+      query = query.eq('session_id', scope.sessionId);
+    }
+    if (scope.exerciseId) {
+      query = query.eq('exercise', scope.exerciseId);
+    }
+    if (scope.days && Number.isFinite(scope.days) && scope.days > 0) {
+      query = query.gte('start_ts', cutoffIso(scope.days));
+    }
+    query = query.limit(2000);
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    const rows = (data ?? []) as { faults_detected: string[] | null }[];
+
+    const aggregates = new Map<string, { count: number; severitySum: number }>();
+    for (const row of rows) {
+      const faults = Array.isArray(row.faults_detected) ? row.faults_detected : [];
+      for (const fault of faults) {
+        if (!fault || typeof fault !== 'string') continue;
+        const existing = aggregates.get(fault) ?? { count: 0, severitySum: 0 };
+        existing.count += 1;
+        existing.severitySum += severityBucket(fault);
+        aggregates.set(fault, existing);
+      }
+    }
+
+    return [...aggregates.entries()]
+      .map(([faultId, agg]) => ({
+        faultId,
+        count: agg.count,
+        severityAvg: agg.count === 0 ? 0 : Number((agg.severitySum / agg.count).toFixed(3)),
+      }))
+      .sort((a, b) => b.count - a.count);
+  } catch (error) {
+    errorWithTs('[rep-analytics] getFaultHeatmap failed', error);
+    return [];
+  }
+}
+
+/**
+ * Cue adoption stats: fraction of cues that the user adopted within 3 reps.
+ * Most/least adopted cue types bubble up for coaching review.
+ */
+export async function getRepCueAdoptionStats(
+  exerciseId: string,
+  days: number = 30,
+): Promise<CueAdoptionStats> {
+  const emptyShape: CueAdoptionStats = {
+    totalCuesEmitted: 0,
+    adoptionRate: null,
+    mostAdopted: null,
+    leastAdopted: null,
+  };
+
+  if (!exerciseId || !Number.isFinite(days) || days <= 0) {
+    return emptyShape;
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('reps')
+      .select('cues_emitted,adopted_within_3_reps')
+      .eq('exercise', exerciseId)
+      .gte('start_ts', cutoffIso(days))
+      .limit(2000);
+
+    if (error) throw error;
+
+    const rows = (data ?? []) as {
+      cues_emitted: { type: string }[] | null;
+      adopted_within_3_reps: boolean | null;
+    }[];
+
+    // Count cue emissions + adoption per type
+    const perType = new Map<string, { emitted: number; adopted: number }>();
+    let totalEmitted = 0;
+    let adoptedReps = 0;
+    let repsWithCues = 0;
+
+    for (const row of rows) {
+      const cues = Array.isArray(row.cues_emitted) ? row.cues_emitted : [];
+      if (cues.length === 0) continue;
+
+      repsWithCues += 1;
+      if (row.adopted_within_3_reps === true) adoptedReps += 1;
+
+      for (const cue of cues) {
+        const type = typeof cue?.type === 'string' ? cue.type : null;
+        if (!type) continue;
+        totalEmitted += 1;
+        const entry = perType.get(type) ?? { emitted: 0, adopted: 0 };
+        entry.emitted += 1;
+        if (row.adopted_within_3_reps === true) entry.adopted += 1;
+        perType.set(type, entry);
+      }
+    }
+
+    if (totalEmitted === 0) return emptyShape;
+
+    const adoptionRate = repsWithCues === 0 ? null : Number((adoptedReps / repsWithCues).toFixed(4));
+
+    const ranked = [...perType.entries()]
+      .filter(([, v]) => v.emitted > 0)
+      .map(([type, v]) => ({ type, rate: v.adopted / v.emitted, emitted: v.emitted }))
+      .sort((a, b) => b.rate - a.rate);
+
+    const mostAdopted = ranked.length > 0 ? ranked[0].type : null;
+    const leastAdopted = ranked.length > 0 ? ranked[ranked.length - 1].type : null;
+
+    return {
+      totalCuesEmitted: totalEmitted,
+      adoptionRate,
+      mostAdopted,
+      leastAdopted,
+    };
+  } catch (error) {
+    errorWithTs('[rep-analytics] getRepCueAdoptionStats failed', error);
+    return emptyShape;
+  }
+}

--- a/lib/services/rep-export.ts
+++ b/lib/services/rep-export.ts
@@ -1,0 +1,271 @@
+/**
+ * Rep Export Service
+ *
+ * Serialises rep-level telemetry to CSV or JSON and (when available) hands it to
+ * the platform share sheet via `expo-sharing`.
+ *
+ * NOTE: `expo-sharing` is not currently in `package.json`, so `shareRepData`
+ * falls back to writing a temp file via `expo-file-system` and returning its
+ * uri. The consumer component can then render a "Copy link" / "Open" fallback.
+ * Once `expo-sharing` is added as a dependency, the dynamic import inside
+ * `shareRepData` will Just Work.
+ */
+import * as FileSystem from 'expo-file-system/legacy';
+import { supabase } from '@/lib/supabase';
+import { errorWithTs } from '@/lib/logger';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type ExportFormat = 'csv' | 'json';
+
+export interface RepExportScope {
+  sessionId?: string;
+  exerciseId?: string;
+  /** Day window when sessionId is not provided. Defaults to 30. */
+  days?: number;
+}
+
+export interface ExportedRepRow {
+  rep_id: string;
+  session_id: string;
+  exercise: string;
+  rep_index: number;
+  side: string | null;
+  start_ts: string;
+  end_ts: string;
+  duration_ms: number;
+  fqi: number | null;
+  rom_deg: number | null;
+  depth_ratio: number | null;
+  peak_velocity: number | null;
+  valgus_peak: number | null;
+  lumbar_flexion_peak: number | null;
+  faults_detected: string;
+  cues_emitted: string;
+}
+
+export interface ShareResult {
+  /** The serialised payload (always returned). */
+  payload: string;
+  /** Absolute file uri (always returned when FileSystem is available). */
+  fileUri: string | null;
+  /**
+   * True when the platform share sheet was actually invoked. False when
+   * `expo-sharing` is not installed or sharing is unavailable on the current
+   * platform.
+   */
+  shared: boolean;
+  filename: string;
+  mimeType: string;
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+/** ISO timestamp for `now - days` */
+function cutoffIso(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString();
+}
+
+function csvEscape(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (/[",\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function featureNumber(features: unknown, key: string): number | null {
+  if (!features || typeof features !== 'object') return null;
+  const rec = features as Record<string, unknown>;
+  const v = rec[key];
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  return null;
+}
+
+function toExportRow(raw: Record<string, unknown>): ExportedRepRow {
+  const start = typeof raw.start_ts === 'string' ? raw.start_ts : '';
+  const end = typeof raw.end_ts === 'string' ? raw.end_ts : '';
+  const duration = start && end ? new Date(end).getTime() - new Date(start).getTime() : 0;
+  return {
+    rep_id: typeof raw.rep_id === 'string' ? raw.rep_id : '',
+    session_id: typeof raw.session_id === 'string' ? raw.session_id : '',
+    exercise: typeof raw.exercise === 'string' ? raw.exercise : '',
+    rep_index: typeof raw.rep_index === 'number' ? raw.rep_index : 0,
+    side: typeof raw.side === 'string' ? raw.side : null,
+    start_ts: start,
+    end_ts: end,
+    duration_ms: Number.isFinite(duration) && duration > 0 ? duration : 0,
+    fqi: typeof raw.fqi === 'number' ? raw.fqi : null,
+    rom_deg: featureNumber(raw.features, 'romDeg') ?? featureNumber(raw.features, 'rom_deg'),
+    depth_ratio: featureNumber(raw.features, 'depthRatio') ?? featureNumber(raw.features, 'depth_ratio'),
+    peak_velocity: featureNumber(raw.features, 'peakVelocity') ?? featureNumber(raw.features, 'peak_velocity'),
+    valgus_peak: featureNumber(raw.features, 'valgusPeak') ?? featureNumber(raw.features, 'valgus_peak'),
+    lumbar_flexion_peak:
+      featureNumber(raw.features, 'lumbarFlexionPeak') ?? featureNumber(raw.features, 'lumbar_flexion_peak'),
+    faults_detected: Array.isArray(raw.faults_detected) ? (raw.faults_detected as string[]).join('|') : '',
+    cues_emitted: Array.isArray(raw.cues_emitted)
+      ? (raw.cues_emitted as { type?: string }[])
+          .map((c) => (typeof c?.type === 'string' ? c.type : ''))
+          .filter(Boolean)
+          .join('|')
+      : '',
+  };
+}
+
+async function fetchReps(scope: RepExportScope): Promise<ExportedRepRow[]> {
+  let query = supabase
+    .from('reps')
+    .select('rep_id,session_id,exercise,rep_index,side,start_ts,end_ts,fqi,features,faults_detected,cues_emitted');
+
+  if (scope.sessionId) {
+    query = query.eq('session_id', scope.sessionId);
+  } else {
+    const days = Number.isFinite(scope.days) && scope.days! > 0 ? (scope.days as number) : 30;
+    query = query.gte('start_ts', cutoffIso(days));
+  }
+  if (scope.exerciseId) {
+    query = query.eq('exercise', scope.exerciseId);
+  }
+
+  const { data, error } = await query.order('start_ts', { ascending: true }).limit(5000);
+  if (error) throw error;
+
+  return (data ?? []).map((raw) => toExportRow(raw as Record<string, unknown>));
+}
+
+export const CSV_COLUMNS: (keyof ExportedRepRow)[] = [
+  'rep_id',
+  'session_id',
+  'exercise',
+  'rep_index',
+  'side',
+  'start_ts',
+  'end_ts',
+  'duration_ms',
+  'fqi',
+  'rom_deg',
+  'depth_ratio',
+  'peak_velocity',
+  'valgus_peak',
+  'lumbar_flexion_peak',
+  'faults_detected',
+  'cues_emitted',
+];
+
+export function serializeCsv(rows: ExportedRepRow[]): string {
+  const header = CSV_COLUMNS.join(',');
+  const body = rows
+    .map((row) => CSV_COLUMNS.map((col) => csvEscape(row[col] as string | number | null)).join(','))
+    .join('\n');
+  return body.length === 0 ? `${header}\n` : `${header}\n${body}\n`;
+}
+
+export function serializeJson(rows: ExportedRepRow[], scope: RepExportScope): string {
+  return JSON.stringify(
+    {
+      exportedAt: new Date().toISOString(),
+      scope,
+      rowCount: rows.length,
+      rows,
+    },
+    null,
+    2,
+  );
+}
+
+export function buildFilename(scope: RepExportScope, format: ExportFormat): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const scopeParts: string[] = [];
+  if (scope.sessionId) scopeParts.push(`session-${scope.sessionId.slice(0, 8)}`);
+  if (scope.exerciseId) scopeParts.push(`ex-${scope.exerciseId.slice(0, 12)}`);
+  if (!scopeParts.length) scopeParts.push(`last-${scope.days ?? 30}d`);
+  return `reps-${scopeParts.join('-')}-${timestamp}.${format}`;
+}
+
+export function mimeTypeFor(format: ExportFormat): string {
+  return format === 'csv' ? 'text/csv' : 'application/json';
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Fetch reps matching `scope` and return the serialised payload.
+ */
+export async function exportRepData(scope: RepExportScope, format: ExportFormat): Promise<string> {
+  try {
+    const rows = await fetchReps(scope);
+    return format === 'csv' ? serializeCsv(rows) : serializeJson(rows, scope);
+  } catch (error) {
+    errorWithTs('[rep-export] exportRepData failed', error);
+    // Return a valid empty payload rather than throwing so callers can
+    // still show a user-visible "no data" state without crashing.
+    return format === 'csv' ? `${CSV_COLUMNS.join(',')}\n` : serializeJson([], scope);
+  }
+}
+
+/**
+ * Serialise + write to a temp file, then try to open the share sheet.
+ * When `expo-sharing` is not installed the function still returns the file uri
+ * so the consumer UI can render a copy/open fallback.
+ */
+export async function shareRepData(scope: RepExportScope, format: ExportFormat): Promise<ShareResult> {
+  const payload = await exportRepData(scope, format);
+  const filename = buildFilename(scope, format);
+  const mimeType = mimeTypeFor(format);
+
+  let fileUri: string | null = null;
+  try {
+    const dir = FileSystem.cacheDirectory ?? FileSystem.documentDirectory;
+    if (dir) {
+      fileUri = `${dir}${filename}`;
+      await FileSystem.writeAsStringAsync(fileUri, payload, { encoding: 'utf8' as FileSystem.EncodingType });
+    }
+  } catch (error) {
+    errorWithTs('[rep-export] writeAsStringAsync failed', error);
+    fileUri = null;
+  }
+
+  let shared = false;
+  try {
+    // Use a dynamic require so the bundler does not fail when expo-sharing
+    // is absent. We still narrow the type to a minimal shape.
+    const sharing = (() => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        return require('expo-sharing') as {
+          isAvailableAsync?: () => Promise<boolean>;
+          shareAsync?: (url: string, options?: { mimeType?: string }) => Promise<void>;
+        };
+      } catch {
+        return null;
+      }
+    })();
+
+    if (sharing && fileUri && typeof sharing.isAvailableAsync === 'function' && typeof sharing.shareAsync === 'function') {
+      const available = await sharing.isAvailableAsync();
+      if (available) {
+        await sharing.shareAsync(fileUri, { mimeType });
+        shared = true;
+      }
+    }
+  } catch (error) {
+    errorWithTs('[rep-export] share invocation failed', error);
+  }
+
+  return {
+    payload,
+    fileUri,
+    shared,
+    filename,
+    mimeType,
+  };
+}

--- a/tests/unit/services/rep-analytics.test.ts
+++ b/tests/unit/services/rep-analytics.test.ts
@@ -1,0 +1,309 @@
+import { supabase } from '@/lib/supabase';
+import {
+  calculateRepFqiTrend,
+  calculateTempoStability,
+  getSymmetryTrend,
+  getFaultHeatmap,
+  getRepCueAdoptionStats,
+} from '@/lib/services/rep-analytics';
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+  },
+}));
+
+const mockFrom = supabase.from as jest.Mock;
+
+function createMockQuery(data: any, error: any = null) {
+  const resolved = { data, error };
+  const query: Record<string, any> = {};
+  ['select', 'eq', 'lt', 'gte', 'order', 'limit'].forEach((method) => {
+    query[method] = jest.fn().mockReturnValue(query);
+  });
+  Object.defineProperty(query, 'then', {
+    value: (onFulfilled: any, onRejected?: any) =>
+      Promise.resolve(resolved).then(onFulfilled, onRejected),
+  });
+  return query;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// =============================================================================
+// calculateRepFqiTrend
+// =============================================================================
+
+describe('calculateRepFqiTrend', () => {
+  it('returns empty shape when exerciseId is blank or invalid days', async () => {
+    const none = await calculateRepFqiTrend('', 30);
+    expect(none).toEqual({ slope: null, rSquared: null, avgFqi: null, dataPoints: [] });
+
+    const badDays = await calculateRepFqiTrend('squat', 0);
+    expect(badDays).toEqual({ slope: null, rSquared: null, avgFqi: null, dataPoints: [] });
+
+    const nanDays = await calculateRepFqiTrend('squat', Number.NaN);
+    expect(nanDays).toEqual({ slope: null, rSquared: null, avgFqi: null, dataPoints: [] });
+
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('computes a positive slope for improving FQI over time', async () => {
+    const rows = [
+      { fqi: 60, start_ts: '2026-04-01T00:00:00.000Z' },
+      { fqi: 70, start_ts: '2026-04-05T00:00:00.000Z' },
+      { fqi: 80, start_ts: '2026-04-09T00:00:00.000Z' },
+      { fqi: 90, start_ts: '2026-04-13T00:00:00.000Z' },
+    ];
+    mockFrom.mockReturnValue(createMockQuery(rows));
+
+    const result = await calculateRepFqiTrend('squat', 30);
+
+    expect(mockFrom).toHaveBeenCalledWith('reps');
+    expect(result.dataPoints).toHaveLength(4);
+    expect(result.avgFqi).toBeCloseTo(75, 2);
+    expect(result.slope).not.toBeNull();
+    expect(result.slope!).toBeGreaterThan(0);
+    expect(result.rSquared).not.toBeNull();
+    expect(result.rSquared!).toBeCloseTo(1, 2);
+  });
+
+  it('returns single data point without slope when only one rep exists', async () => {
+    mockFrom.mockReturnValue(createMockQuery([{ fqi: 75, start_ts: '2026-04-10T00:00:00.000Z' }]));
+
+    const result = await calculateRepFqiTrend('squat', 30);
+
+    expect(result.dataPoints).toHaveLength(1);
+    expect(result.avgFqi).toBe(75);
+    expect(result.slope).toBeNull();
+    expect(result.rSquared).toBeNull();
+  });
+
+  it('filters out NaN / null FQI values', async () => {
+    const rows = [
+      { fqi: 80, start_ts: '2026-04-01T00:00:00.000Z' },
+      { fqi: null, start_ts: '2026-04-02T00:00:00.000Z' },
+      { fqi: Number.NaN, start_ts: '2026-04-03T00:00:00.000Z' },
+      { fqi: 90, start_ts: '2026-04-04T00:00:00.000Z' },
+    ];
+    mockFrom.mockReturnValue(createMockQuery(rows));
+
+    const result = await calculateRepFqiTrend('squat', 30);
+    expect(result.dataPoints).toHaveLength(2);
+    expect(result.avgFqi).toBe(85);
+  });
+
+  it('returns empty shape on supabase error', async () => {
+    mockFrom.mockReturnValue(createMockQuery(null, new Error('network')));
+    const result = await calculateRepFqiTrend('squat', 30);
+    expect(result.dataPoints).toHaveLength(0);
+    expect(result.slope).toBeNull();
+    expect(result.avgFqi).toBeNull();
+  });
+});
+
+// =============================================================================
+// calculateTempoStability
+// =============================================================================
+
+describe('calculateTempoStability', () => {
+  it('computes mean, stdDev and coefficient of variation', async () => {
+    const rows = [
+      { start_ts: '2026-04-01T00:00:00.000Z', end_ts: '2026-04-01T00:00:02.000Z' }, // 2000
+      { start_ts: '2026-04-01T00:01:00.000Z', end_ts: '2026-04-01T00:01:02.500Z' }, // 2500
+      { start_ts: '2026-04-01T00:02:00.000Z', end_ts: '2026-04-01T00:02:02.200Z' }, // 2200
+      { start_ts: '2026-04-01T00:03:00.000Z', end_ts: '2026-04-01T00:03:02.300Z' }, // 2300
+    ];
+    mockFrom.mockReturnValue(createMockQuery(rows));
+
+    const result = await calculateTempoStability('squat', 4);
+
+    expect(mockFrom).toHaveBeenCalledWith('reps');
+    expect(result.avgDurationMs).toBe(2250);
+    expect(result.stdDev).not.toBeNull();
+    expect(result.stdDev!).toBeGreaterThan(0);
+    expect(result.coefficientOfVariation).not.toBeNull();
+    expect(result.coefficientOfVariation!).toBeCloseTo(result.stdDev! / result.avgDurationMs!, 3);
+    expect(['improving', 'declining', 'stable', 'unknown']).toContain(result.trend);
+  });
+
+  it('returns empty shape when no rep durations', async () => {
+    mockFrom.mockReturnValue(createMockQuery([]));
+    const result = await calculateTempoStability('squat', 4);
+    expect(result).toEqual({
+      avgDurationMs: null,
+      stdDev: null,
+      coefficientOfVariation: null,
+      trend: 'unknown',
+    });
+  });
+
+  it('filters out zero-duration reps', async () => {
+    const rows = [
+      { start_ts: '2026-04-01T00:00:00.000Z', end_ts: '2026-04-01T00:00:00.000Z' }, // 0ms
+      { start_ts: '2026-04-01T00:01:00.000Z', end_ts: '2026-04-01T00:00:59.000Z' }, // negative
+      { start_ts: '2026-04-01T00:02:00.000Z', end_ts: '2026-04-01T00:02:01.500Z' }, // 1500
+    ];
+    mockFrom.mockReturnValue(createMockQuery(rows));
+
+    const result = await calculateTempoStability('squat', 4);
+    expect(result.avgDurationMs).toBe(1500);
+  });
+});
+
+// =============================================================================
+// getSymmetryTrend
+// =============================================================================
+
+describe('getSymmetryTrend', () => {
+  it('computes asymmetry ratio from left vs right ROM', async () => {
+    const rows = [
+      { side: 'left', features: { romDeg: 120 }, start_ts: '2026-04-01T00:00:00.000Z' },
+      { side: 'right', features: { romDeg: 100 }, start_ts: '2026-04-01T00:00:30.000Z' },
+      { side: 'left', features: { romDeg: 118 }, start_ts: '2026-04-02T00:00:00.000Z' },
+      { side: 'right', features: { romDeg: 102 }, start_ts: '2026-04-02T00:00:30.000Z' },
+    ];
+    mockFrom.mockReturnValue(createMockQuery(rows));
+
+    const result = await getSymmetryTrend('pullup', 30);
+
+    expect(result.leftAvgRom).toBeCloseTo(119, 1);
+    expect(result.rightAvgRom).toBeCloseTo(101, 1);
+    expect(result.asymmetryRatio).toBeCloseTo(18 / 119, 3);
+  });
+
+  it('returns null asymmetry ratio when one side has no data', async () => {
+    const rows = [
+      { side: 'left', features: { romDeg: 120 }, start_ts: '2026-04-01T00:00:00.000Z' },
+      { side: 'left', features: { romDeg: 118 }, start_ts: '2026-04-02T00:00:00.000Z' },
+    ];
+    mockFrom.mockReturnValue(createMockQuery(rows));
+
+    const result = await getSymmetryTrend('pullup', 30);
+
+    expect(result.leftAvgRom).toBe(119);
+    expect(result.rightAvgRom).toBeNull();
+    expect(result.asymmetryRatio).toBeNull();
+    expect(result.trend).toBe('unknown');
+  });
+
+  it('returns empty shape when ROM is 0 / missing in features', async () => {
+    const rows = [
+      { side: 'left', features: { romDeg: 0 }, start_ts: '2026-04-01T00:00:00.000Z' },
+      { side: 'right', features: { romDeg: 0 }, start_ts: '2026-04-01T00:00:30.000Z' },
+    ];
+    mockFrom.mockReturnValue(createMockQuery(rows));
+
+    const result = await getSymmetryTrend('pullup', 30);
+    // Both sides have mean 0, so denom is 0 -> ratio null
+    expect(result.asymmetryRatio).toBeNull();
+  });
+
+  it('detects worsening trend when second half is more asymmetric', async () => {
+    const rows = [
+      { side: 'left', features: { romDeg: 100 }, start_ts: '2026-04-01T00:00:00.000Z' },
+      { side: 'right', features: { romDeg: 99 }, start_ts: '2026-04-01T00:00:30.000Z' },
+      { side: 'left', features: { romDeg: 100 }, start_ts: '2026-04-02T00:00:00.000Z' },
+      { side: 'right', features: { romDeg: 99 }, start_ts: '2026-04-02T00:00:30.000Z' },
+      { side: 'left', features: { romDeg: 120 }, start_ts: '2026-04-09T00:00:00.000Z' },
+      { side: 'right', features: { romDeg: 80 }, start_ts: '2026-04-09T00:00:30.000Z' },
+      { side: 'left', features: { romDeg: 120 }, start_ts: '2026-04-10T00:00:00.000Z' },
+      { side: 'right', features: { romDeg: 80 }, start_ts: '2026-04-10T00:00:30.000Z' },
+    ];
+    mockFrom.mockReturnValue(createMockQuery(rows));
+
+    const result = await getSymmetryTrend('pullup', 30);
+
+    expect(result.trend).toBe('worsening');
+  });
+});
+
+// =============================================================================
+// getFaultHeatmap
+// =============================================================================
+
+describe('getFaultHeatmap', () => {
+  it('aggregates fault counts and severities across reps, sorted by count', async () => {
+    const rows = [
+      { faults_detected: ['valgus_collapse', 'shallow_depth'] },
+      { faults_detected: ['valgus_collapse'] },
+      { faults_detected: ['shallow_depth', 'forward_lean'] },
+      { faults_detected: [] },
+      { faults_detected: null },
+    ];
+    mockFrom.mockReturnValue(createMockQuery(rows));
+
+    const result = await getFaultHeatmap({ sessionId: 'sess-1' });
+
+    expect(mockFrom).toHaveBeenCalledWith('reps');
+    expect(result).toHaveLength(3);
+    // sorted by count desc
+    expect(result[0].faultId).toBe('valgus_collapse');
+    expect(result[0].count).toBe(2);
+    // 'valgus_collapse' matches major pattern => severity 2
+    expect(result[0].severityAvg).toBe(2);
+    // 'shallow_depth' matches moderate pattern => severity 1
+    expect(result.find((e) => e.faultId === 'shallow_depth')?.severityAvg).toBe(1);
+  });
+
+  it('returns empty array when nothing matches', async () => {
+    mockFrom.mockReturnValue(createMockQuery([]));
+    const result = await getFaultHeatmap({ days: 30 });
+    expect(result).toEqual([]);
+  });
+});
+
+// =============================================================================
+// getRepCueAdoptionStats
+// =============================================================================
+
+describe('getRepCueAdoptionStats', () => {
+  it('computes adoption rate and ranks cue types by adoption', async () => {
+    const rows = [
+      {
+        cues_emitted: [{ type: 'knee_push' }, { type: 'chest_up' }],
+        adopted_within_3_reps: true,
+      },
+      {
+        cues_emitted: [{ type: 'knee_push' }],
+        adopted_within_3_reps: true,
+      },
+      {
+        cues_emitted: [{ type: 'chest_up' }],
+        adopted_within_3_reps: false,
+      },
+      {
+        cues_emitted: [],
+        adopted_within_3_reps: null,
+      },
+    ];
+    mockFrom.mockReturnValue(createMockQuery(rows));
+
+    const result = await getRepCueAdoptionStats('squat', 30);
+
+    expect(mockFrom).toHaveBeenCalledWith('reps');
+    expect(result.totalCuesEmitted).toBe(4);
+    // 2 reps with cues adopted out of 3 reps-with-cues => 0.6667
+    expect(result.adoptionRate).toBeCloseTo(2 / 3, 3);
+    expect(result.mostAdopted).toBe('knee_push');
+    expect(result.leastAdopted).toBe('chest_up');
+  });
+
+  it('returns empty shape when no cues were emitted', async () => {
+    const rows = [
+      { cues_emitted: [], adopted_within_3_reps: null },
+      { cues_emitted: null, adopted_within_3_reps: null },
+    ];
+    mockFrom.mockReturnValue(createMockQuery(rows));
+
+    const result = await getRepCueAdoptionStats('squat', 30);
+    expect(result).toEqual({
+      totalCuesEmitted: 0,
+      adoptionRate: null,
+      mostAdopted: null,
+      leastAdopted: null,
+    });
+  });
+});

--- a/tests/unit/services/rep-export.test.ts
+++ b/tests/unit/services/rep-export.test.ts
@@ -1,0 +1,199 @@
+import { supabase } from '@/lib/supabase';
+import {
+  exportRepData,
+  shareRepData,
+  serializeCsv,
+  serializeJson,
+  buildFilename,
+  CSV_COLUMNS,
+} from '@/lib/services/rep-export';
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+  },
+}));
+
+const mockWriteAsStringAsync = jest.fn();
+jest.mock('expo-file-system/legacy', () => ({
+  cacheDirectory: 'file:///tmp/test/',
+  documentDirectory: 'file:///tmp/test-doc/',
+  writeAsStringAsync: (...args: unknown[]) => mockWriteAsStringAsync(...args),
+  EncodingType: { UTF8: 'utf8' },
+}));
+
+const mockShareAsync = jest.fn();
+const mockIsAvailableAsync = jest.fn();
+jest.mock('expo-sharing', () => ({
+  shareAsync: (...args: unknown[]) => mockShareAsync(...args),
+  isAvailableAsync: () => mockIsAvailableAsync(),
+}), { virtual: true });
+
+const mockFrom = supabase.from as jest.Mock;
+
+function createMockQuery(data: any, error: any = null) {
+  const resolved = { data, error };
+  const query: Record<string, any> = {};
+  ['select', 'eq', 'gte', 'order', 'limit'].forEach((method) => {
+    query[method] = jest.fn().mockReturnValue(query);
+  });
+  Object.defineProperty(query, 'then', {
+    value: (onFulfilled: any, onRejected?: any) =>
+      Promise.resolve(resolved).then(onFulfilled, onRejected),
+  });
+  return query;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockWriteAsStringAsync.mockResolvedValue(undefined);
+  mockIsAvailableAsync.mockResolvedValue(true);
+  mockShareAsync.mockResolvedValue(undefined);
+});
+
+// =============================================================================
+// exportRepData — CSV
+// =============================================================================
+
+describe('exportRepData (csv)', () => {
+  it('emits the full column header even when there are no rows', async () => {
+    mockFrom.mockReturnValue(createMockQuery([]));
+
+    const out = await exportRepData({ sessionId: 'sess-1' }, 'csv');
+
+    expect(out.startsWith(CSV_COLUMNS.join(','))).toBe(true);
+    // No data rows -> just header + newline
+    expect(out.trim().split('\n')).toHaveLength(1);
+  });
+
+  it('flattens features and joins faults/cues with pipe delimiter', async () => {
+    const row = {
+      rep_id: 'rep-1',
+      session_id: 'sess-1',
+      exercise: 'squat',
+      rep_index: 1,
+      side: null,
+      start_ts: '2026-04-01T00:00:00.000Z',
+      end_ts: '2026-04-01T00:00:02.500Z',
+      fqi: 82,
+      features: { romDeg: 112, depthRatio: 0.95, peakVelocity: 1.2, valgusPeak: 4.5 },
+      faults_detected: ['valgus_collapse', 'shallow_depth'],
+      cues_emitted: [{ type: 'knee_push', ts: '2026-04-01T00:00:01.000Z' }],
+    };
+    mockFrom.mockReturnValue(createMockQuery([row]));
+
+    const out = await exportRepData({ sessionId: 'sess-1' }, 'csv');
+
+    const lines = out.trim().split('\n');
+    expect(lines).toHaveLength(2);
+    const header = lines[0].split(',');
+    const values = lines[1].split(',');
+    const get = (col: string) => values[header.indexOf(col)];
+
+    expect(get('rep_id')).toBe('rep-1');
+    expect(get('fqi')).toBe('82');
+    expect(get('rom_deg')).toBe('112');
+    expect(get('depth_ratio')).toBe('0.95');
+    expect(get('peak_velocity')).toBe('1.2');
+    expect(get('valgus_peak')).toBe('4.5');
+    expect(get('duration_ms')).toBe('2500');
+    // pipe-joined with quotes only if special chars present; our faults have no commas
+    expect(get('faults_detected')).toBe('valgus_collapse|shallow_depth');
+    expect(get('cues_emitted')).toBe('knee_push');
+  });
+});
+
+// =============================================================================
+// exportRepData — JSON
+// =============================================================================
+
+describe('exportRepData (json)', () => {
+  it('wraps rows in an envelope with scope + rowCount + exportedAt', async () => {
+    const row = {
+      rep_id: 'rep-1',
+      session_id: 'sess-1',
+      exercise: 'squat',
+      rep_index: 1,
+      side: 'left',
+      start_ts: '2026-04-01T00:00:00.000Z',
+      end_ts: '2026-04-01T00:00:02.000Z',
+      fqi: 80,
+      features: { romDeg: 100 },
+      faults_detected: [],
+      cues_emitted: [],
+    };
+    mockFrom.mockReturnValue(createMockQuery([row]));
+
+    const out = await exportRepData({ exerciseId: 'squat', days: 14 }, 'json');
+    const parsed = JSON.parse(out);
+
+    expect(parsed.scope).toEqual({ exerciseId: 'squat', days: 14 });
+    expect(parsed.rowCount).toBe(1);
+    expect(parsed.rows).toHaveLength(1);
+    expect(parsed.rows[0].rep_id).toBe('rep-1');
+    expect(parsed.rows[0].rom_deg).toBe(100);
+    expect(parsed.rows[0].duration_ms).toBe(2000);
+    expect(typeof parsed.exportedAt).toBe('string');
+  });
+
+  it('serializeCsv + serializeJson helpers round-trip cleanly on zero rows', () => {
+    expect(serializeCsv([]).trim()).toBe(CSV_COLUMNS.join(','));
+    const json = JSON.parse(serializeJson([], { sessionId: 'sess-abc' }));
+    expect(json.rowCount).toBe(0);
+    expect(json.rows).toEqual([]);
+  });
+});
+
+// =============================================================================
+// shareRepData
+// =============================================================================
+
+describe('shareRepData', () => {
+  it('writes the payload to disk and invokes expo-sharing when available', async () => {
+    mockFrom.mockReturnValue(createMockQuery([]));
+
+    const result = await shareRepData({ sessionId: 'sess-1' }, 'csv');
+
+    expect(mockWriteAsStringAsync).toHaveBeenCalledTimes(1);
+    const [uri, payload, opts] = mockWriteAsStringAsync.mock.calls[0];
+    expect(typeof uri).toBe('string');
+    expect(uri.endsWith('.csv')).toBe(true);
+    expect(payload.startsWith(CSV_COLUMNS.join(','))).toBe(true);
+    expect(opts).toEqual({ encoding: 'utf8' });
+
+    expect(mockIsAvailableAsync).toHaveBeenCalledTimes(1);
+    expect(mockShareAsync).toHaveBeenCalledTimes(1);
+    expect(result.shared).toBe(true);
+    expect(result.filename.endsWith('.csv')).toBe(true);
+    expect(result.mimeType).toBe('text/csv');
+  });
+
+  it('still returns a payload when sharing is unavailable', async () => {
+    mockIsAvailableAsync.mockResolvedValueOnce(false);
+    mockFrom.mockReturnValue(createMockQuery([]));
+
+    const result = await shareRepData({ exerciseId: 'squat', days: 7 }, 'json');
+
+    expect(result.shared).toBe(false);
+    expect(mockShareAsync).not.toHaveBeenCalled();
+    expect(result.payload.length).toBeGreaterThan(0);
+    expect(result.mimeType).toBe('application/json');
+  });
+});
+
+// =============================================================================
+// buildFilename
+// =============================================================================
+
+describe('buildFilename', () => {
+  it('includes scope hint in the filename', () => {
+    const sessionFile = buildFilename({ sessionId: 'abcdef123456' }, 'csv');
+    expect(sessionFile).toMatch(/^reps-session-abcdef12-.*\.csv$/);
+
+    const exerciseFile = buildFilename({ exerciseId: 'squat' }, 'json');
+    expect(exerciseFile).toMatch(/^reps-ex-squat-.*\.json$/);
+
+    const rollingFile = buildFilename({ days: 14 }, 'csv');
+    expect(rollingFile).toMatch(/^reps-last-14d-.*\.csv$/);
+  });
+});


### PR DESCRIPTION
## Summary

- New `lib/services/rep-analytics.ts` with FQI trend, tempo stability, symmetry trend, fault heatmap, and cue adoption metrics — all guarded against empty/NaN inputs and returning typed empty shapes on no data.
- New `lib/services/rep-export.ts` for CSV/JSON export of rep telemetry, writing to disk via `expo-file-system` and handing off to `expo-sharing` when available.
- Five new visual components in `components/insights/` (FqiTrendChart, FaultHeatmap, RomProgressionCard, SymmetryCard, RepRewindCarousel), rendered by the new `app/(modals)/rep-insights.tsx` modal route registered in the modals `_layout`.
- 23 new unit tests (16 + 7) across `tests/unit/services/rep-analytics.test.ts` and `tests/unit/services/rep-export.test.ts`.

## Atomic commit list

1. `feat(analytics): add rep-analytics service with FQI/tempo/symmetry/ROM trends`
2. `feat(analytics): add rep-export service for CSV/JSON share`
3. `feat(insights): add FqiTrendChart over 30/90/all-time`
4. `feat(insights): add FaultHeatmap BarChart`
5. `feat(insights): add RomProgressionCard week-over-week`
6. `feat(insights): add SymmetryCard with bilateral asymmetry %`
7. `feat(insights): add RepRewindCarousel for per-rep cards`
8. `feat(insights): add rep-insights modal wiring all analytics`
9. `test(analytics): rep-analytics service coverage`
10. `test(analytics): rep-export csv/json coverage`

No commits were skipped. No squashes.

## Verification

- `bun run lint` — clean on every commit (pre-existing 2 warnings in `template-builder.tsx`, zero errors).
- `bun run check:types` — green on every commit.
- `bun run test -- tests/unit/services/rep-analytics.test.ts tests/unit/services/rep-export.test.ts` → **23 passed, 23 total** (16 analytics + 7 export).

```
PASS tests/unit/services/rep-analytics.test.ts
PASS tests/unit/services/rep-export.test.ts

Test Suites: 2 passed, 2 total
Tests:       23 passed, 23 total
```

The full test suite has pre-existing unrelated failures owned by #422 and was intentionally not run end-to-end.

## File-overlap note

No overlap with branches `feat/427`, `feat/428`, `feat/429`, or `test/430`. All new paths:

- `lib/services/rep-analytics.ts`
- `lib/services/rep-export.ts`
- `components/insights/*` (new directory)
- `app/(modals)/rep-insights.tsx`
- `tests/unit/services/rep-analytics.test.ts`
- `tests/unit/services/rep-export.test.ts`

Only one pre-existing file was touched: `app/(modals)/_layout.tsx` — a single append adding the new `rep-insights` screen registration. No changes to `lib/workouts/*`, `supabase/migrations/`, `ios/`, `android/`, `.env`, `.husky/`, or CI workflows.

## Dependency notes

- `react-native-chart-kit@6.12.0` is already in `package.json` — used directly for Line/Bar charts.
- `expo-sharing` is **not** currently in `package.json`. Per the overnight HARD RULE 3 (no new deps), `shareRepData` loads it via a safe `require()` inside a try/catch. When the dep is missing the function still generates the payload and writes it to disk, returning `{ shared: false, fileUri, payload }` so the UI can fall back. Adding `expo-sharing` later requires zero code changes — the dynamic require will just start succeeding.

## Data-source note

The issue description mentioned reading from `local-db.ts`, but the `reps` table only exists in Supabase (`supabase/migrations/018_create_reps_sets_labels.sql`) and is not mirrored into local SQLite. This PR follows the existing `lib/services/workout-insights.ts` pattern of reading reps directly from Supabase, which is scoped to the current user via RLS (`reps read own`). All service functions are defensive — on Supabase errors they log via `errorWithTs` and return typed empty shapes so UI components stay stable.

## Acceptance

- [x] Analytics service returns typed results with NaN/empty guards on every path.
- [x] All components render with realistic fixture data (components accept optional `initialData`/`initialSnapshot` props for preview).
- [x] `bun run lint` and `bun run check:types` pass.
- [x] `bun run test -- tests/unit/services/rep-analytics.test.ts` passes (16/16).
- [x] `bun run test -- tests/unit/services/rep-export.test.ts` passes (7/7).
- [x] No file overlap with feat/427, feat/428, feat/429, test/430.

Closes #437
