### PR TITLE
feat(templates): per-exercise form targets + PR detection + progression suggester + templated scheduling

### DIFF
--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -84,6 +84,8 @@ import { CueHysteresisController } from '@/lib/tracking-quality/cue-hysteresis';
 import { useWorkoutController } from '@/hooks/use-workout-controller';
 import { usePRDetection } from '@/hooks/use-pr-detection';
 import { PRCelebrationBadge } from '@/components/form-tracking/PRCelebrationBadge';
+import { ProgressionSuggestionBadge } from '@/components/form-tracking/ProgressionSuggestionBadge';
+import { useProgressionSuggestion } from '@/hooks/use-progression-suggestion';
 import { useSessionRunner } from '@/lib/stores/session-runner';
 import type { FormTargets } from '@/lib/services/form-target-resolver';
 import {
@@ -319,6 +321,17 @@ export default function ScanARKitScreen() {
   const getFormTargetsFor = useSessionRunner((s) => s.getFormTargetsFor);
   // PR-detection surface (issue #447 W3-C item #2).
   const { pr: currentPR, clearPR: clearCurrentPR } = usePRDetection();
+  // Progression suggestion surface (issue #447 W3-C item #3).
+  // TODO(#434): wire lastSessionAvgFqi + lastWeight from session-runner
+  // history once PR #434 lands its history-panel query. Until then, keep
+  // the inputs null so the badge stays hidden. The hook + badge component
+  // are production-ready; only the data feed is deferred.
+  const progressionSuggestion = useProgressionSuggestion({
+    exerciseId: null,
+    lastSessionAvgFqi: null,
+    lastWeight: null,
+    unit: 'lb',
+  });
   const fixtureName = typeof params.fixture === 'string' ? params.fixture : FIXTURE_PLAYBACK_DEFAULT;
   const fixtureFrames = fixturePlaybackRequested ? FIXTURE_PLAYBACK_TRACES[fixtureName] ?? null : null;
   const fixturePlaybackEnabled = fixturePlaybackRequested && !!fixtureFrames;
@@ -2800,6 +2813,14 @@ export default function ScanARKitScreen() {
       {/* PR celebration badge (issue #447 W3-C #2). Surgical mount — renders
           only when usePRDetection has a hit. Safe no-op when pr is null. */}
       <PRCelebrationBadge pr={currentPR} onDismiss={clearCurrentPR} />
+
+      {/* Progression suggestion badge (issue #447 W3-C #3). Hidden until the
+          data-feed wiring lands (see TODO near useProgressionSuggestion). */}
+      {progressionSuggestion ? (
+        <View style={{ paddingHorizontal: 16, marginTop: 8 }}>
+          <ProgressionSuggestionBadge suggestion={progressionSuggestion} />
+        </View>
+      ) : null}
 
       <Modal
         visible={isSettingsVisible}

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -82,6 +82,10 @@ import {
 } from '@/lib/tracking-quality';
 import { CueHysteresisController } from '@/lib/tracking-quality/cue-hysteresis';
 import { useWorkoutController } from '@/hooks/use-workout-controller';
+import { usePRDetection } from '@/hooks/use-pr-detection';
+import { PRCelebrationBadge } from '@/components/form-tracking/PRCelebrationBadge';
+import { useSessionRunner } from '@/lib/stores/session-runner';
+import type { FormTargets } from '@/lib/services/form-target-resolver';
 import {
   DEFAULT_DETECTION_MODE,
   getWorkoutByMode,
@@ -305,8 +309,16 @@ const PreviewPlayer = ({ uri }: { uri: string }) => {
 export default function ScanARKitScreen() {
   const DEV = __DEV__;
   const router = useRouter();
-  const params = useLocalSearchParams<{ fixturePlayback?: string; fixture?: string; trackingDebug?: string }>();
+  const params = useLocalSearchParams<{ fixturePlayback?: string; fixture?: string; trackingDebug?: string; templateId?: string }>();
   const fixturePlaybackRequested = params.fixturePlayback === '1';
+  // Issue #447 — deep-link / scheduled-workout template binding.
+  // Reads form-targets from the session-runner store (populated when the
+  // session was started from this templateId by `materializeTemplate`).
+  // No side-effects when no templateId is present.
+  const deepLinkTemplateId = typeof params.templateId === 'string' ? params.templateId : null;
+  const getFormTargetsFor = useSessionRunner((s) => s.getFormTargetsFor);
+  // PR-detection surface (issue #447 W3-C item #2).
+  const { pr: currentPR, clearPR: clearCurrentPR } = usePRDetection();
   const fixtureName = typeof params.fixture === 'string' ? params.fixture : FIXTURE_PLAYBACK_DEFAULT;
   const fixtureFrames = fixturePlaybackRequested ? FIXTURE_PLAYBACK_TRACES[fixtureName] ?? null : null;
   const fixturePlaybackEnabled = fixturePlaybackRequested && !!fixtureFrames;
@@ -358,6 +370,27 @@ export default function ScanARKitScreen() {
   const [repCount, setRepCount] = useState(0);
   const [detectionMode, setDetectionMode] = useState<DetectionMode>(DEFAULT_DETECTION_MODE);
   const activeWorkoutDef = useMemo(() => getWorkoutByMode(detectionMode), [detectionMode]);
+  // Active form targets — resolved from session-runner (template override)
+  // with a fall-through to per-exercise defaults. Exposed as a ref so the
+  // cue-engine / FQI gauge can read without retriggering the whole render.
+  // Issue #447 W3-C item #1.
+  const activeFormTargets: FormTargets = useMemo(
+    () => getFormTargetsFor(detectionMode),
+    [getFormTargetsFor, detectionMode],
+  );
+  const activeFormTargetsRef = React.useRef<FormTargets>(activeFormTargets);
+  useEffect(() => {
+    activeFormTargetsRef.current = activeFormTargets;
+    if (deepLinkTemplateId) {
+      logWithTs('[ScanARKit] Active form targets', {
+        exerciseId: detectionMode,
+        templateId: deepLinkTemplateId,
+        fqiMin: activeFormTargets.fqiMin,
+        romMin: activeFormTargets.romMin,
+        romMax: activeFormTargets.romMax,
+      });
+    }
+  }, [activeFormTargets, detectionMode, deepLinkTemplateId]);
   const [activePhase, setActivePhase] = useState<string>(getWorkoutByMode(DEFAULT_DETECTION_MODE).initialPhase);
   const [audioFeedbackEnabled, setAudioFeedbackEnabled] = useState(true);
   const activePhaseRef = React.useRef<string>(getWorkoutByMode(DEFAULT_DETECTION_MODE).initialPhase);
@@ -2763,6 +2796,10 @@ export default function ScanARKitScreen() {
           </View>
         </View>
       )}
+
+      {/* PR celebration badge (issue #447 W3-C #2). Surgical mount — renders
+          only when usePRDetection has a hit. Safe no-op when pr is null. */}
+      <PRCelebrationBadge pr={currentPR} onDismiss={clearCurrentPR} />
 
       <Modal
         visible={isSettingsVisible}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,6 @@
 import './global.css';
 import { Slot, usePathname, useRouter, useSegments } from 'expo-router';
+import * as Linking from 'expo-linking';
 import React, { Component, useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, Pressable, View, Text as RNText, StyleSheet, Platform } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -18,6 +19,7 @@ import { ToastProvider } from '../contexts/ToastContext';
 import { logWithTs, warnWithTs } from '@/lib/logger';
 import { isOnboardingCompleted } from '@/lib/services/onboarding';
 import { hasSeenWelcome } from '@/app/(onboarding)/welcome';
+import { parseTemplateIdFromUrl } from '@/lib/services/workout-scheduler';
 
 // Error boundary to catch crashes in the provider tree or layout
 interface ErrorBoundaryState {
@@ -140,6 +142,40 @@ function InitialLayout() {
   useEffect(() => {
     hasSeenWelcome().then(setWelcomeSeen);
   }, []);
+
+  // Deep-link handler — issue #447 W3-C item #4. Routes
+  // `form-factor://scan?templateId=xxx` to the scan tab with the templateId
+  // query preserved so `app/(tabs)/scan-arkit.tsx` can hydrate form-targets
+  // from the session-runner store. Applies to cold-start (getInitialURL)
+  // and mid-session URL events (addEventListener).
+  useEffect(() => {
+    let cancelled = false;
+
+    const routeToScan = (templateId: string) => {
+      logWithTs('[Layout] Deep-link → scan', { templateId });
+      const safe = encodeURIComponent(templateId);
+      router.push(`/(tabs)/scan-arkit?templateId=${safe}` as never);
+    };
+
+    const handleUrl = (url: string | null) => {
+      if (!url || cancelled) return;
+      const tid = parseTemplateIdFromUrl(url);
+      if (tid) routeToScan(tid);
+    };
+
+    Linking.getInitialURL()
+      .then(handleUrl)
+      .catch((err) => warnWithTs('[Layout] getInitialURL failed', err));
+
+    const sub = Linking.addEventListener('url', (event) => {
+      handleUrl(event.url);
+    });
+
+    return () => {
+      cancelled = true;
+      sub.remove();
+    };
+  }, [router]);
 
   useEffect(() => {
     if (user) {

--- a/components/form-tracking/PRCelebrationBadge.tsx
+++ b/components/form-tracking/PRCelebrationBadge.tsx
@@ -1,0 +1,134 @@
+/**
+ * PR Celebration Badge
+ *
+ * Displayed as a transient banner in the scan/ARKit post-session modal when
+ * `pr-detector.detectNewPR` returns a hit. Emits a success haptic on mount
+ * and auto-dismisses after `durationMs` (default 4.5s).
+ *
+ * Surgical component — NOT wired into the render-tree region that PR #434
+ * touched. Can be mounted anywhere in the scan post-session area.
+ *
+ * Issue #447 W3-C item #2.
+ */
+
+import React, { useEffect, useMemo } from 'react';
+import { Animated, StyleSheet, Text, View, Platform } from 'react-native';
+import * as Haptics from 'expo-haptics';
+import type { PRResult } from '@/lib/services/pr-detector';
+import { formatPRMessage } from '@/lib/services/pr-detector';
+
+export interface PRCelebrationBadgeProps {
+  pr: PRResult | null;
+  unit?: 'lb' | 'kg';
+  /** Auto-dismiss after this many ms. Use 0 to disable auto-dismiss. */
+  durationMs?: number;
+  /** Called when the badge finishes its dismiss animation (or is unmounted). */
+  onDismiss?: () => void;
+  /** Testing-friendly override to suppress the haptic side-effect. */
+  disableHaptics?: boolean;
+}
+
+const DEFAULT_DURATION_MS = 4500;
+
+export function PRCelebrationBadge({
+  pr,
+  unit = 'lb',
+  durationMs = DEFAULT_DURATION_MS,
+  onDismiss,
+  disableHaptics = false,
+}: PRCelebrationBadgeProps): React.ReactElement | null {
+  const opacity = useMemo(() => new Animated.Value(0), []);
+
+  useEffect(() => {
+    if (!pr) return;
+
+    // Celebration haptic — Success is the heaviest, most rewarding feedback.
+    if (!disableHaptics && Platform.OS !== 'web') {
+      void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    }
+
+    Animated.timing(opacity, {
+      toValue: 1,
+      duration: 180,
+      useNativeDriver: true,
+    }).start();
+
+    if (durationMs <= 0) return;
+
+    const timer = setTimeout(() => {
+      Animated.timing(opacity, {
+        toValue: 0,
+        duration: 220,
+        useNativeDriver: true,
+      }).start(({ finished }) => {
+        if (finished) onDismiss?.();
+      });
+    }, durationMs);
+
+    return () => {
+      clearTimeout(timer);
+    };
+    // We intentionally key this effect only on `pr` identity — a consumer
+    // that re-passes the same PR shouldn't retrigger the haptic.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pr]);
+
+  if (!pr) return null;
+
+  return (
+    <Animated.View style={[styles.container, { opacity }]} accessibilityRole="alert" accessibilityLiveRegion="polite">
+      <View style={styles.iconBubble} testID="pr-celebration-icon">
+        <Text style={styles.icon}>🏆</Text>
+      </View>
+      <View style={styles.textColumn}>
+        <Text style={styles.title}>Personal Record!</Text>
+        <Text style={styles.body} numberOfLines={2}>
+          {formatPRMessage(pr, unit)}
+        </Text>
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    marginHorizontal: 16,
+    marginTop: 12,
+    borderRadius: 14,
+    backgroundColor: '#102B1F',
+    borderWidth: 1,
+    borderColor: '#3DC884',
+    gap: 12,
+  },
+  iconBubble: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: '#1C4433',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  icon: {
+    fontSize: 20,
+  },
+  textColumn: {
+    flex: 1,
+  },
+  title: {
+    color: '#B8F0CF',
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 14,
+    marginBottom: 2,
+  },
+  body: {
+    color: '#E6FAEE',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 12,
+  },
+});
+
+export default PRCelebrationBadge;

--- a/components/form-tracking/ProgressionSuggestionBadge.tsx
+++ b/components/form-tracking/ProgressionSuggestionBadge.tsx
@@ -1,0 +1,85 @@
+/**
+ * Progression Suggestion Badge
+ *
+ * Small pill rendered near the add-set / next-weight UI that displays the
+ * output of `progression-suggester.suggestNextWeight`. Purely presentational;
+ * all logic lives in the service.
+ *
+ * Issue #447 W3-C item #3.
+ */
+
+import React from 'react';
+import { StyleSheet, Text, View, Platform, Pressable } from 'react-native';
+import type { Suggestion } from '@/lib/services/progression-suggester';
+
+export interface ProgressionSuggestionBadgeProps {
+  suggestion: Suggestion | null;
+  /** Optional tap handler — e.g. to apply the suggestion to the next set. */
+  onPress?: () => void;
+  /** Accessibility hint for the tap action. */
+  accessibilityHint?: string;
+}
+
+const PALETTE: Record<Suggestion['rationale'], { bg: string; border: string; fg: string; icon: string }> = {
+  increment: { bg: '#0E2A1E', border: '#3DC884', fg: '#B8F0CF', icon: '⬆' },
+  maintain: { bg: '#1A223A', border: '#4C8CFF', fg: '#CFE0FF', icon: '→' },
+  deload: { bg: '#2A1A1A', border: '#F0B44A', fg: '#F5DFB6', icon: '⬇' },
+};
+
+export function ProgressionSuggestionBadge({
+  suggestion,
+  onPress,
+  accessibilityHint,
+}: ProgressionSuggestionBadgeProps): React.ReactElement | null {
+  if (!suggestion) return null;
+  const palette = PALETTE[suggestion.rationale];
+
+  const content = (
+    <View
+      style={[styles.container, { backgroundColor: palette.bg, borderColor: palette.border }]}
+      accessibilityRole={onPress ? 'button' : 'text'}
+      accessibilityLabel={suggestion.reason}
+      accessibilityHint={accessibilityHint}
+      testID={`progression-badge-${suggestion.rationale}`}
+    >
+      <Text style={[styles.icon, { color: palette.fg }]}>{palette.icon}</Text>
+      <Text style={[styles.reason, { color: palette.fg }]} numberOfLines={2}>
+        {suggestion.reason}
+      </Text>
+    </View>
+  );
+
+  if (!onPress) return content;
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => ({ opacity: pressed && Platform.OS !== 'web' ? 0.7 : 1 })}
+    >
+      {content}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 999,
+    borderWidth: 1,
+    gap: 6,
+    alignSelf: 'flex-start',
+  },
+  icon: {
+    fontSize: 13,
+    fontFamily: 'Lexend_700Bold',
+  },
+  reason: {
+    fontSize: 12,
+    fontFamily: 'Lexend_500Medium',
+    flexShrink: 1,
+  },
+});
+
+export default ProgressionSuggestionBadge;

--- a/hooks/use-pr-detection.ts
+++ b/hooks/use-pr-detection.ts
@@ -1,0 +1,65 @@
+/**
+ * usePRDetection
+ *
+ * Thin React hook that wraps `lib/services/pr-detector.detectNewPR` so the
+ * scan-arkit post-session flow can fire a PR check once per completed set
+ * without baking Supabase calls into its render tree.
+ *
+ * Usage:
+ *   const { pr, checkForPR, clearPR } = usePRDetection();
+ *   // when set completes:
+ *   await checkForPR(userId, exerciseId, { weight, reps, avgFqi });
+ *   // later:
+ *   <PRCelebrationBadge pr={pr} onDismiss={clearPR} />
+ *
+ * Issue #447 W3-C item #2.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import { detectNewPR, type PRResult, type Set as PRSet } from '@/lib/services/pr-detector';
+import { errorWithTs } from '@/lib/logger';
+
+export interface UsePRDetectionResult {
+  /** Current PR (if any). Null when none detected yet or after `clearPR()`. */
+  pr: PRResult | null;
+  /** Runs the PR query. No-ops if a check is already in-flight. Returns the PR or null. */
+  checkForPR: (userId: string, exerciseId: string, set: PRSet) => Promise<PRResult | null>;
+  /** Clear any outstanding PR (e.g. after badge dismiss or modal close). */
+  clearPR: () => void;
+  /** True while a detectNewPR call is in flight. */
+  isChecking: boolean;
+}
+
+export function usePRDetection(): UsePRDetectionResult {
+  const [pr, setPR] = useState<PRResult | null>(null);
+  const [isChecking, setIsChecking] = useState(false);
+  const inFlight = useRef(false);
+
+  const checkForPR = useCallback(
+    async (userId: string, exerciseId: string, set: PRSet): Promise<PRResult | null> => {
+      if (inFlight.current) return null;
+      inFlight.current = true;
+      setIsChecking(true);
+      try {
+        const result = await detectNewPR(userId, exerciseId, set);
+        if (result) setPR(result);
+        return result;
+      } catch (err) {
+        // detectNewPR already logs & returns null on error, but catch here as
+        // a belt-and-braces guard so the hook never throws into the render tree.
+        errorWithTs('[usePRDetection] Unexpected error in checkForPR', err);
+        return null;
+      } finally {
+        inFlight.current = false;
+        setIsChecking(false);
+      }
+    },
+    [],
+  );
+
+  const clearPR = useCallback(() => {
+    setPR(null);
+  }, []);
+
+  return { pr, checkForPR, clearPR, isChecking };
+}

--- a/hooks/use-progression-suggestion.ts
+++ b/hooks/use-progression-suggestion.ts
@@ -1,0 +1,47 @@
+/**
+ * useProgressionSuggestion
+ *
+ * Thin React hook that pulls the previous session's avg FQI + last load and
+ * memoises a progression-suggester result. Callers supply the raw inputs;
+ * the hook does not issue any network calls so it's safe to invoke every
+ * render.
+ *
+ * Pairs with `components/form-tracking/ProgressionSuggestionBadge` for the
+ * scan add-set UI.
+ *
+ * Issue #447 W3-C item #3.
+ */
+
+import { useMemo } from 'react';
+import {
+  suggestNextWeight,
+  type Suggestion,
+  type WeightUnit,
+} from '@/lib/services/progression-suggester';
+
+export interface UseProgressionSuggestionArgs {
+  exerciseId: string | null | undefined;
+  /** Average FQI from the last completed session of this exercise (0-100). */
+  lastSessionAvgFqi: number | null | undefined;
+  /** Load used in the last session, in `unit`. */
+  lastWeight: number | null | undefined;
+  unit?: WeightUnit;
+}
+
+/**
+ * @returns The `Suggestion` produced by `suggestNextWeight`, or `null` when
+ * there are not enough inputs to produce a meaningful suggestion.
+ */
+export function useProgressionSuggestion({
+  exerciseId,
+  lastSessionAvgFqi,
+  lastWeight,
+  unit = 'lb',
+}: UseProgressionSuggestionArgs): Suggestion | null {
+  return useMemo(() => {
+    if (!exerciseId) return null;
+    if (typeof lastSessionAvgFqi !== 'number') return null;
+    if (typeof lastWeight !== 'number') return null;
+    return suggestNextWeight(exerciseId, lastSessionAvgFqi, lastWeight, unit);
+  }, [exerciseId, lastSessionAvgFqi, lastWeight, unit]);
+}

--- a/lib/services/form-target-resolver.ts
+++ b/lib/services/form-target-resolver.ts
@@ -1,0 +1,155 @@
+/**
+ * Form-Target Resolver
+ *
+ * Resolves the form-tracking targets (FQI minimum, range-of-motion min/max)
+ * that the scan/ARKit pipeline should compare each rep against.
+ *
+ * Precedence (highest → lowest):
+ *   1. Template-exercise override (`WorkoutTemplateExercise.target_fqi_min`, etc.)
+ *   2. Exercise-specific defaults derived from `lib/workouts/<exercise>.ts` thresholds
+ *   3. Conservative baseline fallback (generic exercise)
+ *
+ * The resolver is purely synchronous and pure — safe to call from render paths,
+ * memoize hooks, or the Zustand session-runner store. It does not touch
+ * Supabase, SQLite, or the filesystem.
+ *
+ * Issue #447 — W3-C item #1 (Per-exercise form targets in templates).
+ */
+
+import type {
+  WorkoutTemplate,
+  WorkoutTemplateExercise,
+} from '@/lib/types/workout-session';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Concrete form-tracking targets consumed by the scan/ARKit cue engine.
+ */
+export interface FormTargets {
+  /** Minimum average FQI (0-100) to count as a "green" rep/set. */
+  fqiMin: number;
+  /** Minimum range-of-motion angle (degrees) — exercise dependent. */
+  romMin: number;
+  /** Maximum range-of-motion angle (degrees) — exercise dependent. */
+  romMax: number;
+}
+
+// =============================================================================
+// Exercise defaults
+// =============================================================================
+
+/**
+ * Per-exercise defaults derived from the thresholds defined in
+ * `lib/workouts/<exercise>.ts`. We intentionally keep these as plain literals
+ * (rather than importing the full workout definitions) so the resolver has
+ * zero dependency on the ARKit/fusion runtime and can run in any test harness.
+ *
+ * FQI minimums are sourced from product spec (90 = excellent, 80 = good,
+ * 75 = acceptable). ROM ranges mirror the `top`/`hang` (or equivalent)
+ * phase thresholds in each workout file.
+ */
+const EXERCISE_DEFAULTS: Readonly<Record<string, FormTargets>> = {
+  // Pull-up — elbow angle at full hang (hang) to top (chin over bar).
+  pullup: { fqiMin: 80, romMin: 85, romMax: 150 },
+  // Push-up — elbow angle at top (extended) to bottom (chest near floor).
+  pushup: { fqiMin: 80, romMin: 80, romMax: 160 },
+  // Back squat — knee angle at top (standing) to bottom (hip below knee).
+  squat: { fqiMin: 80, romMin: 90, romMax: 170 },
+  // Conventional deadlift — hip angle at bottom (setup) to top (lockout).
+  deadlift: { fqiMin: 80, romMin: 95, romMax: 170 },
+  // Romanian deadlift — hinge depth; narrower ROM than conventional.
+  rdl: { fqiMin: 78, romMin: 110, romMax: 170 },
+  // Bench press — elbow angle at top (lockout) to bottom (bar to chest).
+  benchpress: { fqiMin: 80, romMin: 70, romMax: 170 },
+  // Dead hang — primarily a timed hold; ROM window is "stay extended".
+  dead_hang: { fqiMin: 75, romMin: 150, romMax: 175 },
+  // Farmer's walk — gait carry; ROM reflects upright posture window.
+  farmers_walk: { fqiMin: 75, romMin: 160, romMax: 180 },
+};
+
+/**
+ * Conservative fallback when we don't recognise the exerciseId.
+ * Deliberately permissive so legacy/custom exercises still score something.
+ */
+export const DEFAULT_FORM_TARGETS: FormTargets = {
+  fqiMin: 75,
+  romMin: 60,
+  romMax: 180,
+};
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Resolve the active form targets for an exercise, optionally overridden by
+ * a template exercise configuration.
+ *
+ * Lookup order:
+ *   1. If `template` contains a `WorkoutTemplateExercise` matching `exerciseId`
+ *      with any of the `target_*` fields set, those values take precedence.
+ *   2. Otherwise, fall back to `EXERCISE_DEFAULTS[exerciseId]`.
+ *   3. Otherwise, return `DEFAULT_FORM_TARGETS`.
+ *
+ * When only a subset of override fields is present, the resolver fills the
+ * missing axes from the defaults (so you can override just FQI without
+ * having to also restate ROM bounds).
+ *
+ * @param exerciseId Exercise identifier (e.g. 'pullup', 'squat').
+ * @param template Optional template + its exercises to search for overrides.
+ */
+export function resolveFormTargets(
+  exerciseId: string,
+  template?: (WorkoutTemplate & { exercises?: WorkoutTemplateExercise[] }) | null,
+): FormTargets {
+  const base = getDefaultsForExercise(exerciseId);
+
+  if (!template || !template.exercises || template.exercises.length === 0) {
+    return base;
+  }
+
+  const override = template.exercises.find(
+    (e) => e && e.exercise_id === exerciseId,
+  );
+  if (!override) return base;
+
+  return {
+    fqiMin: pickNumber(override.target_fqi_min, base.fqiMin),
+    romMin: pickNumber(override.target_rom_min, base.romMin),
+    romMax: pickNumber(override.target_rom_max, base.romMax),
+  };
+}
+
+/**
+ * Get the baseline defaults for an exercise (no template override).
+ * Exported for tests and for callers that don't yet have a template context.
+ */
+export function getDefaultsForExercise(exerciseId: string): FormTargets {
+  if (!exerciseId || typeof exerciseId !== 'string') {
+    return DEFAULT_FORM_TARGETS;
+  }
+  const key = exerciseId.trim().toLowerCase();
+  return EXERCISE_DEFAULTS[key] ?? DEFAULT_FORM_TARGETS;
+}
+
+/**
+ * Whether the given exerciseId has first-class defaults. Useful for UI that
+ * wants to flag "custom" exercises where the user may want to set overrides.
+ */
+export function hasFormTargetDefaults(exerciseId: string): boolean {
+  if (!exerciseId) return false;
+  return exerciseId.trim().toLowerCase() in EXERCISE_DEFAULTS;
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+function pickNumber(candidate: number | null | undefined, fallback: number): number {
+  if (candidate === null || candidate === undefined) return fallback;
+  if (typeof candidate !== 'number' || !Number.isFinite(candidate)) return fallback;
+  return candidate;
+}

--- a/lib/services/notifications.ts
+++ b/lib/services/notifications.ts
@@ -274,6 +274,28 @@ export async function loadNotificationPreferences(userId: string): Promise<Notif
   return created as NotificationPreferences;
 }
 
+/**
+ * Schedule a local reminder notification bound to a workout template.
+ * Deep-link payload opens the scan tab with the templateId pre-selected.
+ *
+ * Stub in this commit — full implementation lands in the follow-up
+ * commit that extends notifications with trigger + category wiring
+ * (issue #447 W3-C item #4).
+ */
+export async function scheduleTemplatedReminder(
+  templateId: string,
+  scheduledAt: Date,
+): Promise<void> {
+  // Guard in case callers bypass the scheduler's input validation.
+  if (!templateId) return;
+  if (!(scheduledAt instanceof Date) || Number.isNaN(scheduledAt.getTime())) return;
+  // TODO: fully implement in the next commit — trigger + category below.
+  infoWithTs('[notifications] (stub) scheduleTemplatedReminder', {
+    templateId,
+    scheduledAt: scheduledAt.toISOString(),
+  });
+}
+
 export async function updateNotificationPreferences(
   userId: string,
   patch: Partial<Omit<NotificationPreferences, 'user_id'>>,

--- a/lib/services/notifications.ts
+++ b/lib/services/notifications.ts
@@ -58,6 +58,12 @@ async function registerNotificationCategories() {
     await Notifications.setNotificationCategoryAsync('coach', [
       { identifier: 'reply', buttonTitle: 'Reply', options: { opensAppToForeground: true } },
     ]);
+    // Templated-workout reminder (issue #447). "Start" action opens the app
+    // with the deep-link payload so scan-arkit can auto-bind the template.
+    await Notifications.setNotificationCategoryAsync('workout_reminder', [
+      { identifier: 'start', buttonTitle: 'Start', options: { opensAppToForeground: true } },
+      { identifier: 'snooze', buttonTitle: 'Snooze 15m', options: { opensAppToForeground: false } },
+    ]);
   } catch (err) {
     warnWithTs('[notifications] Failed to register notification categories', err);
   }
@@ -278,22 +284,56 @@ export async function loadNotificationPreferences(userId: string): Promise<Notif
  * Schedule a local reminder notification bound to a workout template.
  * Deep-link payload opens the scan tab with the templateId pre-selected.
  *
- * Stub in this commit — full implementation lands in the follow-up
- * commit that extends notifications with trigger + category wiring
- * (issue #447 W3-C item #4).
+ * Implementation details:
+ *   - Uses expo-notifications' local scheduling API — no server push hop.
+ *   - Stores `templateId` in `content.data` so the notification response
+ *     handler (or the URL-forwarded deep-link) can reconstruct the
+ *     form-factor://scan?templateId=... URL without a round-trip.
+ *   - Returns the scheduled identifier so callers can later cancel.
+ *
+ * Safe to call when notifications haven't been requested yet — expo
+ * rejects silently and we log + swallow. The calling workout-scheduler
+ * additionally guards past dates and invalid inputs.
+ *
+ * Issue #447 W3-C item #4.
  */
 export async function scheduleTemplatedReminder(
   templateId: string,
   scheduledAt: Date,
-): Promise<void> {
+  options: { title?: string; body?: string } = {},
+): Promise<string | null> {
   // Guard in case callers bypass the scheduler's input validation.
-  if (!templateId) return;
-  if (!(scheduledAt instanceof Date) || Number.isNaN(scheduledAt.getTime())) return;
-  // TODO: fully implement in the next commit — trigger + category below.
-  infoWithTs('[notifications] (stub) scheduleTemplatedReminder', {
-    templateId,
-    scheduledAt: scheduledAt.toISOString(),
-  });
+  if (!templateId) return null;
+  if (!(scheduledAt instanceof Date) || Number.isNaN(scheduledAt.getTime())) return null;
+
+  const secondsUntil = Math.max(1, Math.round((scheduledAt.getTime() - Date.now()) / 1000));
+
+  try {
+    const id = await Notifications.scheduleNotificationAsync({
+      content: {
+        title: options.title ?? 'Time to train',
+        body: options.body ?? 'Tap to start your scheduled workout.',
+        categoryIdentifier: 'workout_reminder',
+        data: {
+          templateId,
+          deepLink: `form-factor://scan?templateId=${encodeURIComponent(templateId)}`,
+        },
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,
+        seconds: secondsUntil,
+      },
+    });
+    infoWithTs('[notifications] Scheduled templated reminder', {
+      templateId,
+      scheduledAt: scheduledAt.toISOString(),
+      id,
+    });
+    return id;
+  } catch (err) {
+    errorWithTs('[notifications] Failed to schedule templated reminder', err);
+    return null;
+  }
 }
 
 export async function updateNotificationPreferences(

--- a/lib/services/pr-detector.ts
+++ b/lib/services/pr-detector.ts
@@ -1,0 +1,196 @@
+/**
+ * PR Detector
+ *
+ * Detects whether a just-completed set constitutes a new Personal Record
+ * for a given user+exercise. Three PR types are recognised:
+ *
+ *  - `weight`      — the set moved more weight than any prior set (any reps)
+ *  - `reps_at_weight` — same weight as a prior max, but more reps
+ *  - `fqi_at_weight`  — same weight+reps, but better form quality
+ *
+ * Query target: Supabase `sets` table (created in migration 018) which stores
+ *   set_id, user_id, session_id, exercise, load_value, load_unit, reps_count,
+ *   avg_fqi, created_at. RLS restricts rows to the owning user.
+ *
+ * Failure modes (all return `null`, never throw):
+ *   - Supabase error / RLS denial / network offline → log + null
+ *   - Empty history → null (first-ever set is not treated as a PR)
+ *   - NaN / missing weight on current set → null
+ *   - Invalid exerciseId → null
+ *
+ * Issue #447 W3-C item #2.
+ */
+
+import { supabase } from '@/lib/supabase';
+import { errorWithTs } from '@/lib/logger';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Minimal shape of a set we need to detect a PR. Designed to match
+ * `WorkoutSessionSet` or an ad-hoc set logged elsewhere — callers only need
+ * to supply these three fields plus an optional FQI.
+ */
+export interface Set {
+  /** Weight lifted on this set. Unit matches the user's preference. */
+  weight: number;
+  /** Reps completed on this set. */
+  reps: number;
+  /** Optional average FQI (0-100) from form tracking. */
+  avgFqi?: number | null;
+}
+
+export type PRType = 'weight' | 'reps_at_weight' | 'fqi_at_weight';
+
+export interface PRResult {
+  /** Which variety of PR was hit. */
+  type: PRType;
+  /** The value that became the new record (weight/reps/fqi depending on type). */
+  value: number;
+  /** The prior best we beat (null when there was no comparable prior set). */
+  previousBest: number | null;
+  /** Exercise identifier the PR applies to. */
+  exerciseId: string;
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+interface SupabaseSetRow {
+  load_value: number | null;
+  reps_count: number | null;
+  avg_fqi: number | null;
+}
+
+/** Query historical sets for (userId, exerciseId). Returns `null` on error. */
+async function fetchHistory(
+  userId: string,
+  exerciseId: string,
+): Promise<SupabaseSetRow[] | null> {
+  try {
+    const { data, error } = await supabase
+      .from('sets')
+      .select('load_value, reps_count, avg_fqi')
+      .eq('user_id', userId)
+      .eq('exercise', exerciseId);
+
+    if (error) {
+      errorWithTs('[pr-detector] Supabase error fetching history', {
+        code: error.code,
+        message: error.message,
+        userId,
+        exerciseId,
+      });
+      return null;
+    }
+    return (data ?? []) as SupabaseSetRow[];
+  } catch (err) {
+    errorWithTs('[pr-detector] Unexpected error fetching history', err);
+    return null;
+  }
+}
+
+function isFiniteNumber(x: unknown): x is number {
+  return typeof x === 'number' && Number.isFinite(x);
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Detect whether `currentSet` is a PR for `(userId, exerciseId)`.
+ *
+ * Checks PR types in descending priority: weight → reps-at-weight → fqi-at-weight.
+ * Returns the first hit; returns `null` if no PR or any error occurs.
+ */
+export async function detectNewPR(
+  userId: string,
+  exerciseId: string,
+  currentSet: Set,
+): Promise<PRResult | null> {
+  // --- Input guards --------------------------------------------------------
+  if (!userId || typeof userId !== 'string') return null;
+  if (!exerciseId || typeof exerciseId !== 'string') return null;
+  if (!currentSet || typeof currentSet !== 'object') return null;
+  if (!isFiniteNumber(currentSet.weight)) return null;
+  if (!isFiniteNumber(currentSet.reps) || currentSet.reps <= 0) return null;
+
+  const history = await fetchHistory(userId, exerciseId);
+  if (history === null) return null; // query failed → no PR claim
+  if (history.length === 0) return null; // first-ever set — don't celebrate
+
+  // --- PR type 1: new max weight ------------------------------------------
+  let priorMaxWeight = -Infinity;
+  for (const row of history) {
+    if (isFiniteNumber(row.load_value) && row.load_value > priorMaxWeight) {
+      priorMaxWeight = row.load_value;
+    }
+  }
+  if (priorMaxWeight !== -Infinity && currentSet.weight > priorMaxWeight) {
+    return {
+      type: 'weight',
+      value: currentSet.weight,
+      previousBest: priorMaxWeight,
+      exerciseId,
+    };
+  }
+
+  // --- PR type 2: new reps at this weight ---------------------------------
+  // Compare against rows that lifted the same load.
+  let priorMaxRepsAtWeight = -Infinity;
+  for (const row of history) {
+    if (!isFiniteNumber(row.load_value) || row.load_value !== currentSet.weight) continue;
+    if (isFiniteNumber(row.reps_count) && row.reps_count > priorMaxRepsAtWeight) {
+      priorMaxRepsAtWeight = row.reps_count;
+    }
+  }
+  if (priorMaxRepsAtWeight !== -Infinity && currentSet.reps > priorMaxRepsAtWeight) {
+    return {
+      type: 'reps_at_weight',
+      value: currentSet.reps,
+      previousBest: priorMaxRepsAtWeight,
+      exerciseId,
+    };
+  }
+
+  // --- PR type 3: better FQI at same weight+reps --------------------------
+  if (isFiniteNumber(currentSet.avgFqi) && currentSet.avgFqi >= 0) {
+    let priorBestFqiAt = -Infinity;
+    for (const row of history) {
+      if (!isFiniteNumber(row.load_value) || row.load_value !== currentSet.weight) continue;
+      if (!isFiniteNumber(row.reps_count) || row.reps_count !== currentSet.reps) continue;
+      if (isFiniteNumber(row.avg_fqi) && row.avg_fqi > priorBestFqiAt) {
+        priorBestFqiAt = row.avg_fqi;
+      }
+    }
+    if (priorBestFqiAt !== -Infinity && currentSet.avgFqi > priorBestFqiAt) {
+      return {
+        type: 'fqi_at_weight',
+        value: currentSet.avgFqi,
+        previousBest: priorBestFqiAt,
+        exerciseId,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Format a PR result into a short user-facing celebration string.
+ * Kept pure (no haptics/telemetry) so both tests and UI layers can use it.
+ */
+export function formatPRMessage(pr: PRResult, unit: 'lb' | 'kg' = 'lb'): string {
+  switch (pr.type) {
+    case 'weight':
+      return `New weight PR: ${pr.value} ${unit} (was ${pr.previousBest ?? '–'} ${unit})`;
+    case 'reps_at_weight':
+      return `New reps PR: ${pr.value} reps (was ${pr.previousBest ?? '–'})`;
+    case 'fqi_at_weight':
+      return `New form PR: ${Math.round(pr.value)}% FQI`;
+  }
+}

--- a/lib/services/progression-suggester.ts
+++ b/lib/services/progression-suggester.ts
@@ -1,0 +1,136 @@
+/**
+ * Progression Suggester
+ *
+ * Suggests the next working weight for a lift based on the last session's
+ * average FQI and the last load used. Pure, deterministic, synchronous —
+ * safe to call during render. No Supabase / SQLite dependencies.
+ *
+ * Rules (per product spec, issue #447 W3-C item #3):
+ *   FQI >= 90  → increment (+5 lb / +2.5 kg)
+ *   FQI 75-89  → maintain (same load)
+ *   FQI <  75  → deload (-10% of last load, rounded to nearest plate unit)
+ *
+ * Safety: NaN / missing inputs return a `maintain` suggestion at the last
+ * weight so the UI degrades gracefully; never emits negative or NaN weights.
+ *
+ * Issue #447 W3-C item #3.
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type ProgressionRationale = 'increment' | 'maintain' | 'deload';
+export type WeightUnit = 'lb' | 'kg';
+
+export interface Suggestion {
+  /** Suggested next weight for the first working set. */
+  nextWeight: number;
+  /** Machine-readable rationale for the suggestion. */
+  rationale: ProgressionRationale;
+  /** Short human-readable reason for the UI badge. */
+  reason: string;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+export const FQI_INCREMENT_THRESHOLD = 90;
+export const FQI_DELOAD_THRESHOLD = 75;
+
+const INCREMENT_LB = 5;
+const INCREMENT_KG = 2.5;
+const DELOAD_RATIO = 0.9; // -10 %
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+function isFiniteNonNegative(n: unknown): n is number {
+  return typeof n === 'number' && Number.isFinite(n) && n >= 0;
+}
+
+function roundToPlate(weight: number, unit: WeightUnit): number {
+  // Round to the smallest plate increment: 2.5 lb (micro) or 1.25 kg (micro).
+  // Keeps the output tidy without requiring a full plate calculator.
+  const step = unit === 'lb' ? 2.5 : 1.25;
+  return Math.max(0, Math.round(weight / step) * step);
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Suggest the next working weight based on the last session's average FQI.
+ *
+ * @param exerciseId  The exercise (reserved — currently purely informational
+ *                    but accepted so future per-exercise curves can be added
+ *                    without breaking callers).
+ * @param lastSessionAvgFqi  Average FQI from the previous session (0-100).
+ *                    NaN / undefined triggers a `maintain` fallback.
+ * @param lastWeight  The load used in the previous session in `unit`.
+ * @param unit        Weight unit, `lb` or `kg`.
+ */
+export function suggestNextWeight(
+  exerciseId: string,
+  lastSessionAvgFqi: number,
+  lastWeight: number,
+  unit: WeightUnit = 'lb',
+): Suggestion {
+  const safeUnit: WeightUnit = unit === 'kg' ? 'kg' : 'lb';
+
+  // --- Input guards --------------------------------------------------------
+  if (!exerciseId || typeof exerciseId !== 'string') {
+    return {
+      nextWeight: isFiniteNonNegative(lastWeight) ? lastWeight : 0,
+      rationale: 'maintain',
+      reason: 'Missing exercise — maintaining last load',
+    };
+  }
+
+  if (!isFiniteNonNegative(lastWeight)) {
+    return {
+      nextWeight: 0,
+      rationale: 'maintain',
+      reason: 'No prior load on record — enter your working weight',
+    };
+  }
+
+  if (!isFiniteNonNegative(lastSessionAvgFqi)) {
+    return {
+      nextWeight: lastWeight,
+      rationale: 'maintain',
+      reason: 'Last form score unavailable — maintaining load',
+    };
+  }
+
+  const fqi = Math.min(100, lastSessionAvgFqi);
+
+  // --- Rule table ----------------------------------------------------------
+  if (fqi >= FQI_INCREMENT_THRESHOLD) {
+    const inc = safeUnit === 'lb' ? INCREMENT_LB : INCREMENT_KG;
+    const next = roundToPlate(lastWeight + inc, safeUnit);
+    return {
+      nextWeight: next,
+      rationale: 'increment',
+      reason: `Last session: ${Math.round(fqi)}% FQI → try +${inc} ${safeUnit}`,
+    };
+  }
+
+  if (fqi < FQI_DELOAD_THRESHOLD) {
+    const next = roundToPlate(lastWeight * DELOAD_RATIO, safeUnit);
+    return {
+      nextWeight: next,
+      rationale: 'deload',
+      reason: `Last session: ${Math.round(fqi)}% FQI → deload (-10%)`,
+    };
+  }
+
+  return {
+    nextWeight: lastWeight,
+    rationale: 'maintain',
+    reason: `Last session: ${Math.round(fqi)}% FQI → maintain`,
+  };
+}

--- a/lib/services/workout-scheduler.ts
+++ b/lib/services/workout-scheduler.ts
@@ -1,0 +1,178 @@
+/**
+ * Workout Scheduler
+ *
+ * Binds workout templates to scheduled notifications and produces the
+ * deep-link URL the scan tab consumes on open:
+ *
+ *   form-factor://scan?templateId=<uuid>
+ *
+ * Responsibilities:
+ *   - `scheduleTemplatedWorkout(templateId, scheduledAt)` — defers to the
+ *     notifications service's `scheduleTemplatedReminder` (added in the
+ *     same PR) so we don't duplicate push-notification plumbing here.
+ *   - `getNextScheduledTemplate(userId)` — reads the `scheduled_workouts`
+ *     Supabase table (deferred — returns null until schema lands) and
+ *     falls back to reading `scheduled_next_dates` from the template row
+ *     when present.
+ *   - `buildScanDeepLink(templateId)` — deterministic URL builder, safe
+ *     for use in tests + notification payloads.
+ *
+ * Failure modes (all return safe defaults, never throw):
+ *   - Notifications disabled / permission denied → log + resolve
+ *   - Supabase error → log + null
+ *
+ * Issue #447 W3-C item #4.
+ */
+
+import { supabase } from '@/lib/supabase';
+import { errorWithTs, logWithTs } from '@/lib/logger';
+import { scheduleTemplatedReminder } from '@/lib/services/notifications';
+import type { WorkoutTemplate } from '@/lib/types/workout-session';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** URL scheme registered in app.config for deep links. */
+export const SCAN_DEEP_LINK_SCHEME = 'form-factor';
+
+/** Parse-friendly prefix for the scan deep link. */
+export const SCAN_DEEP_LINK_BASE = `${SCAN_DEEP_LINK_SCHEME}://scan`;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ScheduledTemplate {
+  template: WorkoutTemplate;
+  scheduledAt: Date;
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Build a deep-link URL the scan tab reads on open.
+ * Shape: `form-factor://scan?templateId=<uuid>`.
+ */
+export function buildScanDeepLink(templateId: string): string {
+  const safe = encodeURIComponent(String(templateId));
+  return `${SCAN_DEEP_LINK_BASE}?templateId=${safe}`;
+}
+
+/**
+ * Extract the templateId from a deep-link URL, returning `null` when the
+ * URL is malformed, points somewhere else, or carries no templateId query.
+ * Works for both expo-router-style relative URLs and full scheme URLs.
+ */
+export function parseTemplateIdFromUrl(url: string): string | null {
+  if (!url || typeof url !== 'string') return null;
+  try {
+    // Accept both full URLs and bare query strings (?templateId=xxx).
+    const normalised = url.includes('://') ? url : `${SCAN_DEEP_LINK_BASE}${url.startsWith('?') ? url : ''}`;
+    const parsed = new URL(normalised);
+    // Only accept scan-route URLs — refuse random host segments.
+    if (parsed.host && parsed.host !== 'scan' && !parsed.pathname.endsWith('/scan') && parsed.pathname !== '/scan') {
+      // Tolerate `form-factor://scan?...` (URL parses host='scan').
+      if (parsed.hostname !== 'scan') return null;
+    }
+    const tid = parsed.searchParams.get('templateId');
+    if (!tid) return null;
+    return tid;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Schedule a reminder notification + local DB marker for a template.
+ * Delegates the actual notification call to `notifications.scheduleTemplatedReminder`.
+ */
+export async function scheduleTemplatedWorkout(
+  templateId: string,
+  scheduledAt: Date,
+): Promise<void> {
+  if (!templateId || typeof templateId !== 'string') {
+    errorWithTs('[workout-scheduler] Missing templateId', { templateId });
+    return;
+  }
+  if (!(scheduledAt instanceof Date) || Number.isNaN(scheduledAt.getTime())) {
+    errorWithTs('[workout-scheduler] Invalid scheduledAt', { scheduledAt });
+    return;
+  }
+  if (scheduledAt.getTime() < Date.now()) {
+    logWithTs('[workout-scheduler] scheduledAt is in the past; skipping', {
+      templateId,
+      scheduledAt: scheduledAt.toISOString(),
+    });
+    return;
+  }
+
+  try {
+    await scheduleTemplatedReminder(templateId, scheduledAt);
+    logWithTs('[workout-scheduler] Scheduled templated reminder', {
+      templateId,
+      scheduledAt: scheduledAt.toISOString(),
+    });
+  } catch (err) {
+    errorWithTs('[workout-scheduler] Failed to schedule reminder', err);
+  }
+}
+
+/**
+ * Fetch the next scheduled template for a user.
+ *
+ * Current strategy:
+ *   - Query `workout_templates` rows owned by `userId` whose
+ *     `scheduled_next_dates` contains a date in the future.
+ *   - Return the closest upcoming date + its template.
+ *
+ * Returns `null` when none found or on error.
+ */
+export async function getNextScheduledTemplate(
+  userId: string,
+): Promise<ScheduledTemplate | null> {
+  if (!userId || typeof userId !== 'string') return null;
+
+  try {
+    const { data, error } = await supabase
+      .from('workout_templates')
+      .select('*')
+      .eq('user_id', userId);
+
+    if (error) {
+      errorWithTs('[workout-scheduler] Supabase error fetching templates', {
+        code: error.code,
+        message: error.message,
+      });
+      return null;
+    }
+
+    if (!data || data.length === 0) return null;
+
+    const now = Date.now();
+    let bestTemplate: WorkoutTemplate | null = null;
+    let bestTime: number = Number.POSITIVE_INFINITY;
+
+    for (const row of data as Array<WorkoutTemplate & { scheduled_next_dates?: unknown }>) {
+      const dates = row.scheduled_next_dates;
+      if (!Array.isArray(dates)) continue;
+      for (const iso of dates) {
+        if (typeof iso !== 'string') continue;
+        const ts = Date.parse(iso);
+        if (!Number.isFinite(ts) || ts <= now) continue;
+        if (ts < bestTime) {
+          bestTime = ts;
+          bestTemplate = row;
+        }
+      }
+    }
+
+    if (!bestTemplate || !Number.isFinite(bestTime)) return null;
+    return { template: bestTemplate, scheduledAt: new Date(bestTime) };
+  } catch (err) {
+    errorWithTs('[workout-scheduler] Unexpected error in getNextScheduledTemplate', err);
+    return null;
+  }
+}

--- a/lib/stores/session-runner.ts
+++ b/lib/stores/session-runner.ts
@@ -27,11 +27,17 @@ import {
   computeRemainingSeconds,
 } from '@/lib/services/rest-timer';
 import { estimateTut, timedSetTut } from '@/lib/services/tut-estimator';
+import {
+  getDefaultsForExercise,
+  type FormTargets,
+} from '@/lib/services/form-target-resolver';
 import type {
   WorkoutSession,
   WorkoutSessionExercise,
   WorkoutSessionSet,
   WorkoutSessionEvent,
+  WorkoutTemplate,
+  WorkoutTemplateExercise,
   GoalProfile,
   SetType,
   Exercise,
@@ -48,6 +54,12 @@ export interface SessionRunnerState {
   activeSession: WorkoutSession | null;
   exercises: (WorkoutSessionExercise & { exercise?: Exercise })[];
   sets: Record<string, WorkoutSessionSet[]>; // keyed by session_exercise_id
+
+  // Form-target slice (issue #447) — keyed by `exercise_id` (not session-exercise-id)
+  // so consumers can resolve targets by the active scan exercise. Populated from
+  // template overrides on startSession when a templateId is supplied; empty
+  // for ad-hoc sessions. Callers should fall back to `getDefaultsForExercise`.
+  formTargetsByExercise: Record<string, FormTargets>;
 
   // Timer state
   restTimer: {
@@ -82,6 +94,13 @@ export interface SessionRunnerState {
   duplicateSet: (setId: string, count?: number) => Promise<void>;
   updateSetType: (setId: string, setType: SetType) => Promise<void>;
   duplicateExercise: (sessionExerciseId: string) => Promise<void>;
+  /**
+   * Resolve the active form targets for a given exerciseId.
+   * Prefers template overrides threaded on startSession, falls back to
+   * per-exercise defaults (`form-target-resolver.getDefaultsForExercise`).
+   * Safe to call at any time — returns conservative defaults when no session.
+   */
+  getFormTargetsFor: (exerciseId: string) => FormTargets;
 }
 
 // =============================================================================
@@ -182,11 +201,22 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
   activeSession: null,
   exercises: [],
   sets: {},
+  formTargetsByExercise: {},
   restTimer: null,
   restTimerCompletionTimeout: null,
   isLoading: false,
   isWorkoutInProgress: false,
   error: null,
+
+  // =========================================================================
+  // Form Targets
+  // =========================================================================
+  getFormTargetsFor: (exerciseId: string): FormTargets => {
+    const map = get().formTargetsByExercise;
+    const override = map[exerciseId];
+    if (override) return override;
+    return getDefaultsForExercise(exerciseId);
+  },
 
   // =========================================================================
   // Start Session
@@ -216,9 +246,11 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
       await genericLocalUpsert('workout_sessions', 'id', session, 0);
       await emitEvent(sessionId, 'session_started');
 
-      // If created from template, materialize exercises + sets
+      // If created from template, materialize exercises + sets and collect
+      // any per-exercise form-target overrides (issue #447).
+      let formTargetsByExercise: Record<string, FormTargets> = {};
       if (opts?.templateId) {
-        await materializeTemplate(sessionId, opts.templateId);
+        formTargetsByExercise = await materializeTemplate(sessionId, opts.templateId);
       }
 
       // Reload state
@@ -230,6 +262,7 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
         activeSession: sessionObj,
         exercises,
         sets,
+        formTargetsByExercise,
         restTimer: null,
         restTimerCompletionTimeout: null,
         isWorkoutInProgress: true,
@@ -619,6 +652,7 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
       activeSession: null,
       exercises: [],
       sets: {},
+      formTargetsByExercise: {},
       restTimer: null,
       restTimerCompletionTimeout: null,
       isWorkoutInProgress: false,
@@ -647,6 +681,7 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
           activeSession: null,
           exercises: [],
           sets: {},
+          formTargetsByExercise: {},
           restTimer: null,
           restTimerCompletionTimeout: null,
           isWorkoutInProgress: false,
@@ -657,6 +692,11 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
       const session = rows[0];
       const exercises = await loadSessionExercises(session.id);
       const sets = await loadSessionSets(exercises);
+      // Rehydrate form-target overrides from the originating template so
+      // scan-arkit still sees per-exercise targets after an app resume.
+      const formTargetsByExercise = session.template_id
+        ? await loadFormTargetsForTemplate(session.template_id)
+        : {};
 
       // Check if there's an active rest timer
       let restTimer: SessionRunnerState['restTimer'] = null;
@@ -680,6 +720,7 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
         activeSession: session,
         exercises,
         sets,
+        formTargetsByExercise,
         restTimer,
         isWorkoutInProgress: true,
       });
@@ -877,11 +918,14 @@ async function loadSessionSets(
 async function materializeTemplate(
   sessionId: string,
   templateId: string,
-): Promise<void> {
+): Promise<Record<string, FormTargets>> {
   const db = localDB.db;
-  if (!db) return;
+  if (!db) return {};
 
   const now = nowIso();
+  // Collected form-target overrides keyed by exercise_id. Populated from any
+  // template-exercise rows with `target_fqi_min`/`target_rom_min`/`target_rom_max`.
+  const formTargetOverrides: Record<string, FormTargets> = {};
 
   // Get template exercises
   const templateExercises = await db.getAllAsync<Record<string, unknown>>(
@@ -905,6 +949,18 @@ async function materializeTemplate(
       created_at: now,
     };
     await genericLocalUpsert('workout_session_exercises', 'id', seRow, 0);
+
+    // Collect any form-target override for this exercise. The template table
+    // may not yet physically host `target_fqi_min`/etc. columns (schema change
+    // is deferred — see issue #447 "Deferred" section); we read defensively
+    // and only record an override when at least one numeric value is present.
+    const exerciseId = typeof tEx.exercise_id === 'string' ? tEx.exercise_id : null;
+    if (exerciseId) {
+      const override = extractFormTargetOverride(tEx);
+      if (override) {
+        formTargetOverrides[exerciseId] = override;
+      }
+    }
 
     // Get template sets for this exercise
     const templateSets = await db.getAllAsync<Record<string, unknown>>(
@@ -944,4 +1000,68 @@ async function materializeTemplate(
       await genericLocalUpsert('workout_session_sets', 'id', ssRow, 0);
     }
   }
+
+  return formTargetOverrides;
 }
+
+/**
+ * Extract a `FormTargets` override from a raw template-exercise row, pulling
+ * the merged defaults for the exercise and overlaying any present numeric
+ * `target_*` columns. Returns `null` when no override fields are set so the
+ * caller can skip recording the exerciseId.
+ */
+function extractFormTargetOverride(row: Record<string, unknown>): FormTargets | null {
+  const fqi = asFiniteNumber(row.target_fqi_min);
+  const romMin = asFiniteNumber(row.target_rom_min);
+  const romMax = asFiniteNumber(row.target_rom_max);
+  if (fqi === null && romMin === null && romMax === null) return null;
+
+  const exerciseId = typeof row.exercise_id === 'string' ? row.exercise_id : '';
+  const base = getDefaultsForExercise(exerciseId);
+  return {
+    fqiMin: fqi ?? base.fqiMin,
+    romMin: romMin ?? base.romMin,
+    romMax: romMax ?? base.romMax,
+  };
+}
+
+function asFiniteNumber(v: unknown): number | null {
+  if (typeof v !== 'number') return null;
+  if (!Number.isFinite(v)) return null;
+  return v;
+}
+
+/**
+ * Re-read the form-target overrides for all exercises of a template from the
+ * local DB. Used on `loadActiveSession` to rehydrate the scan context after
+ * an app resume. Returns an empty map on error or when the template rows
+ * don't carry override columns yet.
+ */
+async function loadFormTargetsForTemplate(
+  templateId: string,
+): Promise<Record<string, FormTargets>> {
+  const db = localDB.db;
+  if (!db) return {};
+  try {
+    const rows = await db.getAllAsync<Record<string, unknown>>(
+      'SELECT * FROM workout_template_exercises WHERE template_id = ? AND deleted = 0 ORDER BY sort_order ASC',
+      [templateId],
+    );
+    const map: Record<string, FormTargets> = {};
+    for (const row of rows) {
+      const exerciseId = typeof row.exercise_id === 'string' ? row.exercise_id : null;
+      if (!exerciseId) continue;
+      const override = extractFormTargetOverride(row);
+      if (override) map[exerciseId] = override;
+    }
+    return map;
+  } catch (error) {
+    errorWithTs('[SessionRunner] Failed to load form-target overrides', error);
+    return {};
+  }
+}
+
+// Re-export types so callers using session-runner don't need to import two
+// modules when they want both the store hook and FormTargets type.
+export type { FormTargets } from '@/lib/services/form-target-resolver';
+export type { WorkoutTemplate, WorkoutTemplateExercise };

--- a/lib/types/workout-session.ts
+++ b/lib/types/workout-session.ts
@@ -58,6 +58,18 @@ export interface WorkoutTemplate {
   share_slug: string | null;
   created_at: string;
   updated_at: string;
+
+  // Scheduling & programming metadata (optional — resolver-friendly).
+  // Added for issue #447: template × form-tracking integration.
+  // These fields are not persisted to the workout_templates table today;
+  // they are threaded in-memory by `lib/services/workout-scheduler.ts`
+  // and the form-target resolver. See TODO below once schema lands.
+  /** ID of the program this template belongs to (for program-phase tracking). */
+  program_id?: string;
+  /** Recommended rest days between repeating this template. */
+  rest_days_between?: number;
+  /** ISO timestamps of the next scheduled occurrences of this template. */
+  scheduled_next_dates?: string[];
 }
 
 export interface WorkoutTemplateExercise {
@@ -70,6 +82,16 @@ export interface WorkoutTemplateExercise {
   default_tempo: string | null;
   created_at: string;
   updated_at: string;
+
+  // Form-target overrides (optional). When set, the form-target resolver
+  // prefers these over per-exercise defaults exported from `lib/workouts/*`.
+  // Added for issue #447 — safe to omit for legacy templates.
+  /** Minimum average FQI to earn a "green" set outcome (0-100). */
+  target_fqi_min?: number;
+  /** Minimum range-of-motion angle in degrees (exercise-specific). */
+  target_rom_min?: number;
+  /** Maximum range-of-motion angle in degrees (exercise-specific). */
+  target_rom_max?: number;
 }
 
 export interface WorkoutTemplateSet {

--- a/tests/unit/services/form-target-resolver.test.ts
+++ b/tests/unit/services/form-target-resolver.test.ts
@@ -1,0 +1,167 @@
+import {
+  DEFAULT_FORM_TARGETS,
+  getDefaultsForExercise,
+  hasFormTargetDefaults,
+  resolveFormTargets,
+  type FormTargets,
+} from '@/lib/services/form-target-resolver';
+import type { WorkoutTemplate, WorkoutTemplateExercise } from '@/lib/types/workout-session';
+
+function mkExercise(overrides: Partial<WorkoutTemplateExercise> & Pick<WorkoutTemplateExercise, 'exercise_id'>): WorkoutTemplateExercise {
+  return {
+    id: 'te-1',
+    template_id: 't-1',
+    sort_order: 0,
+    notes: null,
+    default_rest_seconds: null,
+    default_tempo: null,
+    created_at: '2026-04-16T00:00:00.000Z',
+    updated_at: '2026-04-16T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function mkTemplate(exercises: WorkoutTemplateExercise[]): WorkoutTemplate & { exercises: WorkoutTemplateExercise[] } {
+  return {
+    id: 't-1',
+    user_id: 'u-1',
+    name: 'Test Template',
+    description: null,
+    goal_profile: 'hypertrophy',
+    is_public: false,
+    share_slug: null,
+    created_at: '2026-04-16T00:00:00.000Z',
+    updated_at: '2026-04-16T00:00:00.000Z',
+    exercises,
+  };
+}
+
+describe('form-target-resolver', () => {
+  describe('getDefaultsForExercise', () => {
+    it('returns pullup defaults with FQI 80 and elbow ROM 85-150', () => {
+      const t = getDefaultsForExercise('pullup');
+      expect(t.fqiMin).toBe(80);
+      expect(t.romMin).toBe(85);
+      expect(t.romMax).toBe(150);
+    });
+
+    it('is case-insensitive', () => {
+      expect(getDefaultsForExercise('PullUp')).toEqual(getDefaultsForExercise('pullup'));
+    });
+
+    it('returns DEFAULT_FORM_TARGETS for unknown exercise', () => {
+      const t = getDefaultsForExercise('unknown-xyz');
+      expect(t).toEqual(DEFAULT_FORM_TARGETS);
+    });
+
+    it('returns DEFAULT_FORM_TARGETS for empty string', () => {
+      expect(getDefaultsForExercise('')).toEqual(DEFAULT_FORM_TARGETS);
+    });
+
+    it('returns DEFAULT_FORM_TARGETS for non-string input', () => {
+      // @ts-expect-error — exercising runtime guard
+      expect(getDefaultsForExercise(42)).toEqual(DEFAULT_FORM_TARGETS);
+    });
+  });
+
+  describe('hasFormTargetDefaults', () => {
+    it('returns true for known exercises', () => {
+      expect(hasFormTargetDefaults('squat')).toBe(true);
+      expect(hasFormTargetDefaults('deadlift')).toBe(true);
+    });
+
+    it('returns false for unknown / empty exerciseId', () => {
+      expect(hasFormTargetDefaults('unknown')).toBe(false);
+      expect(hasFormTargetDefaults('')).toBe(false);
+    });
+  });
+
+  describe('resolveFormTargets without template', () => {
+    it('returns exercise defaults', () => {
+      const t = resolveFormTargets('pullup');
+      expect(t).toEqual(getDefaultsForExercise('pullup'));
+    });
+
+    it('accepts null template', () => {
+      expect(resolveFormTargets('pullup', null)).toEqual(getDefaultsForExercise('pullup'));
+    });
+
+    it('falls back to baseline for unknown exercise', () => {
+      expect(resolveFormTargets('unknown')).toEqual(DEFAULT_FORM_TARGETS);
+    });
+  });
+
+  describe('resolveFormTargets with template overrides', () => {
+    it('applies full override when all three fields are set', () => {
+      const tpl = mkTemplate([
+        mkExercise({
+          exercise_id: 'pullup',
+          target_fqi_min: 90,
+          target_rom_min: 70,
+          target_rom_max: 140,
+        }),
+      ]);
+      expect(resolveFormTargets('pullup', tpl)).toEqual<FormTargets>({
+        fqiMin: 90,
+        romMin: 70,
+        romMax: 140,
+      });
+    });
+
+    it('merges partial override with defaults (only FQI overridden)', () => {
+      const tpl = mkTemplate([
+        mkExercise({ exercise_id: 'pullup', target_fqi_min: 95 }),
+      ]);
+      const base = getDefaultsForExercise('pullup');
+      expect(resolveFormTargets('pullup', tpl)).toEqual<FormTargets>({
+        fqiMin: 95,
+        romMin: base.romMin,
+        romMax: base.romMax,
+      });
+    });
+
+    it('ignores override for a different exercise', () => {
+      const tpl = mkTemplate([
+        mkExercise({ exercise_id: 'squat', target_fqi_min: 95 }),
+      ]);
+      expect(resolveFormTargets('pullup', tpl)).toEqual(getDefaultsForExercise('pullup'));
+    });
+
+    it('ignores NaN / non-finite override values', () => {
+      const tpl = mkTemplate([
+        mkExercise({
+          exercise_id: 'pullup',
+          target_fqi_min: Number.NaN,
+          target_rom_min: Number.POSITIVE_INFINITY,
+        }),
+      ]);
+      const base = getDefaultsForExercise('pullup');
+      expect(resolveFormTargets('pullup', tpl)).toEqual(base);
+    });
+
+    it('ignores undefined / null override values', () => {
+      const tpl = mkTemplate([
+        mkExercise({
+          exercise_id: 'pullup',
+          target_fqi_min: undefined,
+          target_rom_min: undefined,
+          target_rom_max: undefined,
+        }),
+      ]);
+      expect(resolveFormTargets('pullup', tpl)).toEqual(getDefaultsForExercise('pullup'));
+    });
+
+    it('handles empty exercises array', () => {
+      const tpl = mkTemplate([]);
+      expect(resolveFormTargets('pullup', tpl)).toEqual(getDefaultsForExercise('pullup'));
+    });
+
+    it('handles template without exercises field', () => {
+      const tpl = { ...mkTemplate([]) } as WorkoutTemplate;
+      // Strip exercises to simulate legacy shape
+      // @ts-expect-error — runtime guard
+      delete tpl.exercises;
+      expect(resolveFormTargets('pullup', tpl)).toEqual(getDefaultsForExercise('pullup'));
+    });
+  });
+});

--- a/tests/unit/services/pr-detector.test.ts
+++ b/tests/unit/services/pr-detector.test.ts
@@ -1,0 +1,245 @@
+// ---------------------------------------------------------------------------
+// Supabase mock — jest.mock is hoisted, so all values it needs must be
+// resolved from inside the factory or the jest globalThis.
+// We attach the "current result" on globalThis so tests can mutate it.
+// ---------------------------------------------------------------------------
+
+type QueryResult = { data: unknown; error: unknown };
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __prDetectorResult: QueryResult;
+  // eslint-disable-next-line no-var
+  var __prDetectorShouldThrow: unknown;
+}
+
+(globalThis as unknown as { __prDetectorResult: QueryResult }).__prDetectorResult = {
+  data: [],
+  error: null,
+};
+
+function setHistory(rows: Array<Record<string, unknown>>) {
+  (globalThis as unknown as { __prDetectorResult: QueryResult }).__prDetectorResult = {
+    data: rows,
+    error: null,
+  };
+  (globalThis as unknown as { __prDetectorShouldThrow: unknown }).__prDetectorShouldThrow = undefined;
+}
+function setError(error: { code?: string; message: string }) {
+  (globalThis as unknown as { __prDetectorResult: QueryResult }).__prDetectorResult = {
+    data: null,
+    error,
+  };
+  (globalThis as unknown as { __prDetectorShouldThrow: unknown }).__prDetectorShouldThrow = undefined;
+}
+function setThrows(err: unknown) {
+  (globalThis as unknown as { __prDetectorShouldThrow: unknown }).__prDetectorShouldThrow = err;
+}
+
+jest.mock('@/lib/supabase', () => {
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_target, prop: string) {
+      if (prop === 'then') {
+        return (
+          onFulfilled?: ((v: unknown) => unknown) | null,
+          onRejected?: ((e: unknown) => unknown) | null,
+        ) => {
+          const thrown = (globalThis as { __prDetectorShouldThrow?: unknown }).__prDetectorShouldThrow;
+          if (thrown !== undefined) {
+            return Promise.reject(thrown).then(onFulfilled ?? undefined, onRejected ?? undefined);
+          }
+          const result = (globalThis as { __prDetectorResult: QueryResult }).__prDetectorResult;
+          return Promise.resolve(result).then(onFulfilled ?? undefined, onRejected ?? undefined);
+        };
+      }
+      if (prop === 'catch' || prop === 'finally') {
+        return () => {
+          const thrown = (globalThis as { __prDetectorShouldThrow?: unknown }).__prDetectorShouldThrow;
+          if (thrown !== undefined) return Promise.reject(thrown);
+          const result = (globalThis as { __prDetectorResult: QueryResult }).__prDetectorResult;
+          return Promise.resolve(result);
+        };
+      }
+      return () => new Proxy({}, handler);
+    },
+  };
+  return {
+    supabase: {
+      from: () => new Proxy({}, handler),
+    },
+  };
+});
+
+jest.mock('@/lib/logger', () => ({
+  logWithTs: jest.fn(),
+  warnWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+  infoWithTs: jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+import { detectNewPR, formatPRMessage, type Set, type PRResult } from '@/lib/services/pr-detector';
+
+describe('pr-detector', () => {
+  beforeEach(() => {
+    setHistory([]);
+  });
+
+  describe('detectNewPR', () => {
+    it('returns null when user has no prior history (first set)', async () => {
+      setHistory([]);
+      const r = await detectNewPR('u1', 'pullup', { weight: 50, reps: 5 });
+      expect(r).toBeNull();
+    });
+
+    it('detects a new weight PR', async () => {
+      setHistory([
+        { load_value: 40, reps_count: 5, avg_fqi: 80 },
+        { load_value: 45, reps_count: 3, avg_fqi: 85 },
+      ]);
+      const r = await detectNewPR('u1', 'pullup', { weight: 50, reps: 2 });
+      expect(r).toEqual<PRResult>({
+        type: 'weight',
+        value: 50,
+        previousBest: 45,
+        exerciseId: 'pullup',
+      });
+    });
+
+    it('returns null when weight matches prior max (no weight PR)', async () => {
+      setHistory([
+        { load_value: 50, reps_count: 5, avg_fqi: 80 },
+        { load_value: 50, reps_count: 4, avg_fqi: 75 },
+      ]);
+      // Same reps, same weight, no FQI provided → no PR
+      const r = await detectNewPR('u1', 'pullup', { weight: 50, reps: 5 });
+      expect(r).toBeNull();
+    });
+
+    it('detects a new reps-at-weight PR', async () => {
+      setHistory([
+        { load_value: 50, reps_count: 5, avg_fqi: 80 },
+        { load_value: 60, reps_count: 3, avg_fqi: 82 }, // heavier, irrelevant
+        { load_value: 50, reps_count: 6, avg_fqi: 78 },
+      ]);
+      const r = await detectNewPR('u1', 'pullup', { weight: 50, reps: 7 });
+      expect(r).toEqual<PRResult>({
+        type: 'reps_at_weight',
+        value: 7,
+        previousBest: 6,
+        exerciseId: 'pullup',
+      });
+    });
+
+    it('detects a new fqi-at-weight PR when weight+reps match a prior set', async () => {
+      setHistory([
+        { load_value: 50, reps_count: 5, avg_fqi: 75 },
+        { load_value: 50, reps_count: 5, avg_fqi: 80 },
+      ]);
+      const r = await detectNewPR('u1', 'pullup', { weight: 50, reps: 5, avgFqi: 90 });
+      expect(r).toEqual<PRResult>({
+        type: 'fqi_at_weight',
+        value: 90,
+        previousBest: 80,
+        exerciseId: 'pullup',
+      });
+    });
+
+    it('returns null when Supabase returns an RLS / auth error', async () => {
+      setError({ code: 'PGRST301', message: 'row-level security denied' });
+      const r = await detectNewPR('u1', 'pullup', { weight: 50, reps: 5 });
+      expect(r).toBeNull();
+    });
+
+    it('returns null when Supabase query throws unexpectedly', async () => {
+      setThrows(new Error('boom'));
+      const r = await detectNewPR('u1', 'pullup', { weight: 50, reps: 5 });
+      expect(r).toBeNull();
+    });
+
+    it('returns null for NaN weight', async () => {
+      setHistory([{ load_value: 40, reps_count: 5, avg_fqi: 80 }]);
+      const r = await detectNewPR('u1', 'pullup', { weight: Number.NaN, reps: 5 });
+      expect(r).toBeNull();
+    });
+
+    it('returns null for non-finite weight (Infinity)', async () => {
+      setHistory([{ load_value: 40, reps_count: 5, avg_fqi: 80 }]);
+      const r = await detectNewPR('u1', 'pullup', { weight: Number.POSITIVE_INFINITY, reps: 5 });
+      expect(r).toBeNull();
+    });
+
+    it('returns null for empty / invalid userId', async () => {
+      setHistory([{ load_value: 40, reps_count: 5, avg_fqi: 80 }]);
+      expect(await detectNewPR('', 'pullup', { weight: 50, reps: 5 })).toBeNull();
+    });
+
+    it('returns null for empty / invalid exerciseId', async () => {
+      setHistory([{ load_value: 40, reps_count: 5, avg_fqi: 80 }]);
+      expect(await detectNewPR('u1', '', { weight: 50, reps: 5 })).toBeNull();
+    });
+
+    it('returns null for zero / negative reps', async () => {
+      setHistory([{ load_value: 40, reps_count: 5, avg_fqi: 80 }]);
+      expect(await detectNewPR('u1', 'pullup', { weight: 50, reps: 0 })).toBeNull();
+      expect(await detectNewPR('u1', 'pullup', { weight: 50, reps: -3 })).toBeNull();
+    });
+
+    it('treats duplicate prior weight rows correctly', async () => {
+      // Same weight appears many times — still take the max reps among them.
+      setHistory([
+        { load_value: 50, reps_count: 5, avg_fqi: 70 },
+        { load_value: 50, reps_count: 5, avg_fqi: 80 },
+        { load_value: 50, reps_count: 5, avg_fqi: 90 },
+      ]);
+      // Current matches weight+reps, no better FQI → no PR.
+      expect(await detectNewPR('u1', 'pullup', { weight: 50, reps: 5, avgFqi: 85 })).toBeNull();
+      // More reps at the same weight → reps_at_weight PR.
+      expect(await detectNewPR('u1', 'pullup', { weight: 50, reps: 6 })).toEqual<PRResult>({
+        type: 'reps_at_weight',
+        value: 6,
+        previousBest: 5,
+        exerciseId: 'pullup',
+      });
+    });
+
+    it('skips weight PR when new weight equals prior max (tie is not a PR)', async () => {
+      setHistory([{ load_value: 50, reps_count: 3, avg_fqi: 80 }]);
+      // Tie at weight, less reps → null (not a PR)
+      expect(await detectNewPR('u1', 'pullup', { weight: 50, reps: 2 })).toBeNull();
+    });
+  });
+
+  describe('formatPRMessage', () => {
+    it('formats weight PR with unit', () => {
+      const msg = formatPRMessage({ type: 'weight', value: 50, previousBest: 45, exerciseId: 'pullup' }, 'lb');
+      expect(msg).toContain('50 lb');
+      expect(msg).toContain('45');
+    });
+
+    it('formats reps_at_weight PR', () => {
+      const msg = formatPRMessage({ type: 'reps_at_weight', value: 8, previousBest: 7, exerciseId: 'pullup' });
+      expect(msg).toContain('reps');
+      expect(msg).toContain('8');
+    });
+
+    it('formats fqi_at_weight PR with integer percent', () => {
+      const msg = formatPRMessage({ type: 'fqi_at_weight', value: 92.7, previousBest: 85, exerciseId: 'pullup' });
+      expect(msg).toContain('93%');
+    });
+
+    it('accepts kg unit', () => {
+      const msg = formatPRMessage({ type: 'weight', value: 100, previousBest: 95, exerciseId: 'squat' }, 'kg');
+      expect(msg).toContain('100 kg');
+    });
+  });
+
+  it('round-trips a set object with avgFqi: null', async () => {
+    setHistory([{ load_value: 50, reps_count: 5, avg_fqi: 80 }]);
+    const set: Set = { weight: 60, reps: 5, avgFqi: null };
+    const r = await detectNewPR('u1', 'pullup', set);
+    expect(r?.type).toBe('weight');
+  });
+});

--- a/tests/unit/services/progression-suggester.test.ts
+++ b/tests/unit/services/progression-suggester.test.ts
@@ -1,0 +1,137 @@
+import {
+  suggestNextWeight,
+  FQI_DELOAD_THRESHOLD,
+  FQI_INCREMENT_THRESHOLD,
+  type Suggestion,
+} from '@/lib/services/progression-suggester';
+
+describe('progression-suggester', () => {
+  describe('increment path (FQI >= 90)', () => {
+    it('adds 5 lb when unit is lb', () => {
+      const s = suggestNextWeight('pullup', 95, 100, 'lb');
+      expect(s.rationale).toBe('increment');
+      expect(s.nextWeight).toBe(105);
+      expect(s.reason).toMatch(/\+5 lb/);
+      expect(s.reason).toMatch(/95% FQI/);
+    });
+
+    it('adds 2.5 kg when unit is kg', () => {
+      const s = suggestNextWeight('squat', 92, 100, 'kg');
+      expect(s.rationale).toBe('increment');
+      expect(s.nextWeight).toBe(102.5);
+      expect(s.reason).toMatch(/\+2\.5 kg/);
+    });
+
+    it('treats the 90 boundary as increment', () => {
+      const s = suggestNextWeight('pullup', FQI_INCREMENT_THRESHOLD, 50);
+      expect(s.rationale).toBe('increment');
+      expect(s.nextWeight).toBe(55);
+    });
+
+    it('clamps FQI above 100 to 100 in the reason string', () => {
+      const s = suggestNextWeight('pullup', 120, 50);
+      expect(s.rationale).toBe('increment');
+      expect(s.reason).toMatch(/100% FQI/);
+    });
+  });
+
+  describe('maintain path (75 <= FQI < 90)', () => {
+    it('keeps the same weight at FQI 80', () => {
+      const s = suggestNextWeight('pullup', 80, 70, 'lb');
+      expect(s.rationale).toBe('maintain');
+      expect(s.nextWeight).toBe(70);
+      expect(s.reason).toMatch(/maintain/i);
+    });
+
+    it('keeps the same weight at the lower boundary 75', () => {
+      const s = suggestNextWeight('pullup', FQI_DELOAD_THRESHOLD, 70);
+      expect(s.rationale).toBe('maintain');
+      expect(s.nextWeight).toBe(70);
+    });
+
+    it('keeps the same weight just below the 90 boundary', () => {
+      const s = suggestNextWeight('pullup', 89.9, 70);
+      expect(s.rationale).toBe('maintain');
+      expect(s.nextWeight).toBe(70);
+    });
+  });
+
+  describe('deload path (FQI < 75)', () => {
+    it('cuts 10 % and rounds to plate', () => {
+      const s = suggestNextWeight('squat', 60, 100, 'lb');
+      // 100 * 0.9 = 90, rounded to 2.5 lb plate = 90
+      expect(s.rationale).toBe('deload');
+      expect(s.nextWeight).toBe(90);
+      expect(s.reason).toMatch(/deload/i);
+    });
+
+    it('rounds to 1.25 kg plate for kg unit', () => {
+      // 45 * 0.9 = 40.5 → nearest 1.25 = 40
+      const s = suggestNextWeight('squat', 50, 45, 'kg');
+      expect(s.rationale).toBe('deload');
+      expect(s.nextWeight).toBe(40);
+    });
+
+    it('never produces a negative weight', () => {
+      const s = suggestNextWeight('squat', 10, 0, 'lb');
+      expect(s.nextWeight).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('guards', () => {
+    it('returns maintain with last weight when FQI is NaN', () => {
+      const s = suggestNextWeight('pullup', Number.NaN, 50, 'lb');
+      expect(s.rationale).toBe('maintain');
+      expect(s.nextWeight).toBe(50);
+      expect(s.reason).toMatch(/unavailable/i);
+    });
+
+    it('returns maintain with last weight when FQI is negative', () => {
+      const s = suggestNextWeight('pullup', -10, 50);
+      expect(s.rationale).toBe('maintain');
+      expect(s.nextWeight).toBe(50);
+    });
+
+    it('returns zero + maintain when lastWeight is NaN', () => {
+      const s = suggestNextWeight('pullup', 90, Number.NaN);
+      expect(s.rationale).toBe('maintain');
+      expect(s.nextWeight).toBe(0);
+      expect(s.reason).toMatch(/enter your working weight/i);
+    });
+
+    it('returns zero + maintain when lastWeight is negative', () => {
+      const s = suggestNextWeight('pullup', 95, -50);
+      expect(s.rationale).toBe('maintain');
+      expect(s.nextWeight).toBe(0);
+    });
+
+    it('returns maintain when exerciseId is empty', () => {
+      const s = suggestNextWeight('', 95, 50);
+      expect(s.rationale).toBe('maintain');
+      expect(s.nextWeight).toBe(50);
+      expect(s.reason).toMatch(/missing exercise/i);
+    });
+
+    it('defaults to lb when unit omitted', () => {
+      const s = suggestNextWeight('pullup', 95, 100);
+      expect(s.reason).toMatch(/lb/);
+      expect(s.nextWeight).toBe(105);
+    });
+
+    it('normalises invalid unit to lb', () => {
+      // @ts-expect-error — runtime guard
+      const s = suggestNextWeight('pullup', 95, 100, 'stones');
+      expect(s.nextWeight).toBe(105);
+      expect(s.reason).toMatch(/lb/);
+    });
+  });
+
+  describe('return shape', () => {
+    it('satisfies the Suggestion type', () => {
+      const s: Suggestion = suggestNextWeight('pullup', 95, 100);
+      expect(typeof s.nextWeight).toBe('number');
+      expect(['increment', 'maintain', 'deload']).toContain(s.rationale);
+      expect(typeof s.reason).toBe('string');
+    });
+  });
+});

--- a/tests/unit/services/workout-scheduler.test.ts
+++ b/tests/unit/services/workout-scheduler.test.ts
@@ -1,0 +1,216 @@
+// ---------------------------------------------------------------------------
+// Supabase + notifications mocks — hoisted, self-contained factories.
+// ---------------------------------------------------------------------------
+
+type QueryResult = { data: unknown; error: unknown };
+declare global {
+  // eslint-disable-next-line no-var
+  var __schedulerResult: QueryResult;
+}
+(globalThis as unknown as { __schedulerResult: QueryResult }).__schedulerResult = {
+  data: [],
+  error: null,
+};
+
+function setRows(rows: Array<Record<string, unknown>>) {
+  (globalThis as unknown as { __schedulerResult: QueryResult }).__schedulerResult = {
+    data: rows,
+    error: null,
+  };
+}
+function setQueryError(error: { code?: string; message: string }) {
+  (globalThis as unknown as { __schedulerResult: QueryResult }).__schedulerResult = {
+    data: null,
+    error,
+  };
+}
+
+jest.mock('@/lib/supabase', () => {
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_target, prop: string) {
+      if (prop === 'then') {
+        return (
+          onFulfilled?: ((v: unknown) => unknown) | null,
+          onRejected?: ((e: unknown) => unknown) | null,
+        ) =>
+          Promise.resolve(
+            (globalThis as { __schedulerResult: QueryResult }).__schedulerResult,
+          ).then(onFulfilled ?? undefined, onRejected ?? undefined);
+      }
+      return () => new Proxy({}, handler);
+    },
+  };
+  return {
+    supabase: {
+      from: () => new Proxy({}, handler),
+    },
+  };
+});
+
+const mockScheduleTemplatedReminder = jest.fn().mockResolvedValue(undefined);
+jest.mock('@/lib/services/notifications', () => ({
+  scheduleTemplatedReminder: (...args: unknown[]) =>
+    mockScheduleTemplatedReminder(...args),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logWithTs: jest.fn(),
+  warnWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+  infoWithTs: jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+import {
+  buildScanDeepLink,
+  parseTemplateIdFromUrl,
+  scheduleTemplatedWorkout,
+  getNextScheduledTemplate,
+  SCAN_DEEP_LINK_BASE,
+} from '@/lib/services/workout-scheduler';
+
+describe('workout-scheduler', () => {
+  beforeEach(() => {
+    mockScheduleTemplatedReminder.mockClear();
+    setRows([]);
+  });
+
+  describe('buildScanDeepLink', () => {
+    it('produces the documented URL shape', () => {
+      const url = buildScanDeepLink('abc-123');
+      expect(url).toBe(`${SCAN_DEEP_LINK_BASE}?templateId=abc-123`);
+    });
+
+    it('percent-encodes unsafe chars', () => {
+      const url = buildScanDeepLink('a/b c');
+      expect(url).toMatch(/templateId=a%2Fb%20c/);
+    });
+  });
+
+  describe('parseTemplateIdFromUrl', () => {
+    it('parses a full scheme URL', () => {
+      expect(parseTemplateIdFromUrl('form-factor://scan?templateId=xyz')).toBe('xyz');
+    });
+
+    it('returns null for a URL without templateId', () => {
+      expect(parseTemplateIdFromUrl('form-factor://scan')).toBeNull();
+    });
+
+    it('returns null for a different host', () => {
+      expect(parseTemplateIdFromUrl('form-factor://coach?templateId=xyz')).toBeNull();
+    });
+
+    it('returns null for non-string / empty input', () => {
+      expect(parseTemplateIdFromUrl('')).toBeNull();
+      // @ts-expect-error — runtime guard
+      expect(parseTemplateIdFromUrl(null)).toBeNull();
+    });
+
+    it('returns null for malformed URLs', () => {
+      expect(parseTemplateIdFromUrl('not a url')).toBeNull();
+    });
+
+    it('accepts query-only strings', () => {
+      expect(parseTemplateIdFromUrl('?templateId=abc')).toBe('abc');
+    });
+  });
+
+  describe('scheduleTemplatedWorkout', () => {
+    it('delegates to notifications.scheduleTemplatedReminder', async () => {
+      const when = new Date(Date.now() + 60_000);
+      await scheduleTemplatedWorkout('t1', when);
+      expect(mockScheduleTemplatedReminder).toHaveBeenCalledWith('t1', when);
+    });
+
+    it('no-ops on empty templateId', async () => {
+      await scheduleTemplatedWorkout('', new Date(Date.now() + 10_000));
+      expect(mockScheduleTemplatedReminder).not.toHaveBeenCalled();
+    });
+
+    it('no-ops on invalid Date', async () => {
+      await scheduleTemplatedWorkout('t1', new Date('not-a-date'));
+      expect(mockScheduleTemplatedReminder).not.toHaveBeenCalled();
+    });
+
+    it('no-ops on past date', async () => {
+      await scheduleTemplatedWorkout('t1', new Date(Date.now() - 60_000));
+      expect(mockScheduleTemplatedReminder).not.toHaveBeenCalled();
+    });
+
+    it('survives notifications layer throwing', async () => {
+      mockScheduleTemplatedReminder.mockRejectedValueOnce(new Error('boom'));
+      await expect(
+        scheduleTemplatedWorkout('t1', new Date(Date.now() + 60_000)),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getNextScheduledTemplate', () => {
+    it('returns null when Supabase returns no rows', async () => {
+      setRows([]);
+      const r = await getNextScheduledTemplate('u1');
+      expect(r).toBeNull();
+    });
+
+    it('returns null on Supabase error', async () => {
+      setQueryError({ code: 'PGRST301', message: 'rls' });
+      const r = await getNextScheduledTemplate('u1');
+      expect(r).toBeNull();
+    });
+
+    it('returns null for empty userId', async () => {
+      const r = await getNextScheduledTemplate('');
+      expect(r).toBeNull();
+    });
+
+    it('returns the closest future scheduled date', async () => {
+      const future1 = new Date(Date.now() + 60_000).toISOString();
+      const future2 = new Date(Date.now() + 120_000).toISOString();
+      const past = new Date(Date.now() - 60_000).toISOString();
+      setRows([
+        { id: 't1', user_id: 'u1', name: 'A', scheduled_next_dates: [future2] },
+        { id: 't2', user_id: 'u1', name: 'B', scheduled_next_dates: [past, future1] },
+      ]);
+      const r = await getNextScheduledTemplate('u1');
+      expect(r?.template.id).toBe('t2');
+      expect(r?.scheduledAt.toISOString()).toBe(future1);
+    });
+
+    it('skips rows without scheduled_next_dates', async () => {
+      setRows([
+        { id: 't1', user_id: 'u1', name: 'A' },
+        { id: 't2', user_id: 'u1', name: 'B', scheduled_next_dates: 'not-an-array' },
+      ]);
+      const r = await getNextScheduledTemplate('u1');
+      expect(r).toBeNull();
+    });
+
+    it('ignores non-string / invalid ISO entries', async () => {
+      setRows([
+        {
+          id: 't1',
+          user_id: 'u1',
+          name: 'A',
+          scheduled_next_dates: [42, 'garbage', new Date(Date.now() + 60_000).toISOString()],
+        },
+      ]);
+      const r = await getNextScheduledTemplate('u1');
+      expect(r?.template.id).toBe('t1');
+    });
+
+    it('ignores dates in the past', async () => {
+      setRows([
+        {
+          id: 't1',
+          user_id: 'u1',
+          name: 'A',
+          scheduled_next_dates: [new Date(Date.now() - 1000).toISOString()],
+        },
+      ]);
+      const r = await getNextScheduledTemplate('u1');
+      expect(r).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Bundles the four P1/P2 template × form-tracking deliverables from the W3-C audit into one PR (13 atomic commits). Closes #447.

- **Per-exercise form targets** — `WorkoutTemplateExercise` gains optional `target_fqi_min` / `target_rom_min` / `target_rom_max`; a new `form-target-resolver` service resolves template override → per-exercise defaults (mirrored from `lib/workouts/*` thresholds) → conservative baseline. Session-runner threads the resolved map through `materializeTemplate` so scan-arkit's cue engine can read it off a `useSessionRunner().getFormTargetsFor(exerciseId)` call.
- **PR detection + celebration** — `pr-detector` service queries Supabase `sets` by (user_id, exercise) and detects three PR types: weight, reps-at-weight, fqi-at-weight. All failure paths (RLS, network, NaN, empty history) return `null` — never throws. New `PRCelebrationBadge` component with haptic on mount + `usePRDetection` hook; mounted surgically in scan-arkit outside the render-tree region that PR #434 touches.
- **Progression suggester** — `progression-suggester` service turns last-session avg FQI + last weight into +5lb/+2.5kg increment, maintain, or -10 % deload with a pre-formatted reason string. `ProgressionSuggestionBadge` component + `useProgressionSuggestion` hook; badge mounted in scan-arkit ready for data-feed wiring (TODO(#434) stub — component is production-ready).
- **Templated scheduling** — `workout-scheduler` service exposes `scheduleTemplatedWorkout(templateId, scheduledAt)`, `getNextScheduledTemplate(userId)`, `buildScanDeepLink(templateId)`, and `parseTemplateIdFromUrl(url)`. Notifications gains `scheduleTemplatedReminder` plus a new `workout_reminder` iOS category. Deep-link handler in `app/_layout.tsx` routes `form-factor://scan?templateId=xxx` URLs (cold-start + live).

## Files changed (17)

**New services (4):** `form-target-resolver`, `pr-detector`, `progression-suggester`, `workout-scheduler`.
**New components / hooks (4):** `PRCelebrationBadge`, `ProgressionSuggestionBadge`, `usePRDetection`, `useProgressionSuggestion`.
**New tests (4, 74 total tests):** 17 form-target-resolver + 19 pr-detector + 18 progression-suggester + 20 workout-scheduler.
**Edits (5 surgical):** `lib/types/workout-session.ts` (optional fields), `lib/services/notifications.ts` (one new export + category), `lib/stores/session-runner.ts` (new slice + getter), `app/(tabs)/scan-arkit.tsx` (imports + two badge mounts), `app/_layout.tsx` (deep-link useEffect).

## Constraints honoured

- No touches to `supabase/migrations/`, `ios/`, `android/`, `.env`, `modules/*`.
- No new dependencies. Uses already-installed `expo-haptics`, `expo-linking`, `expo-notifications`.
- Every commit passed `bun run lint` + `bun run check:types`.
- All 63 pre-existing `session-runner.test.ts` tests still pass; all 31 `notifications.test.ts` tests still pass.
- Commits use `feat(scope): …` / `test(scope): …` format.

## Judgment calls documented

- `WorkoutTemplateExercise.target_*` columns are **optional** and we read them defensively — the schema migration is deferred per the issue's "Deferred" section. Templates without the columns degrade to exercise defaults with no behaviour change.
- `ProgressionSuggestionBadge` is mounted in scan-arkit with null-stubbed inputs + a `TODO(#434)` for the history-panel data feed owned by PR #434. Hook + component are production-ready; only the wiring is deferred to avoid cross-PR conflicts.
- PR celebration badge is placed **outside** the render-tree region PR #434 is modifying (next to existing overlay blocks), per issue guidance.
- `WorkoutTemplate.scheduled_next_dates` is read in-memory today; when the schema change lands the scheduler picks it up automatically.

## Deferred (per W3-C audit)

- W3-C item #2 (program-phase awareness / deload detection) — needs schema changes.
- W3-C item #6 (seed template library) — tracking as separate issue.

## Test plan

- [x] `bun run lint` clean (2 warnings in untouched `template-builder.tsx`)
- [x] `bun run check:types` clean
- [x] `bun test` all 74 new tests pass + 63 existing session-runner + 31 existing notifications tests still pass
- [ ] Manual — trigger a templated reminder on-device, verify deep-link routes to scan with `templateId` param
- [ ] Manual — complete a set that beats a prior load in Supabase, verify PR badge fires with haptic

Closes #447