### PR TITLE
fix: cue-engine priority cancellation (#435) + deadlift symmetric hips_rise_first (#436)

### DIFF
--- a/lib/fusion/cue-engine.ts
+++ b/lib/fusion/cue-engine.ts
@@ -10,13 +10,51 @@ export interface CueRule {
   max: number;
   persistMs: number;
   cooldownMs: number;
+  /** Lower numbers are higher priority. Priority 1 beats priority 3. */
   priority: number;
   message: string;
   channels?: CueChannel[];
 }
 
+/**
+ * Audio handle the cue engine uses to cancel an in-flight cue when a
+ * higher-priority one fires. In production this is
+ * {@link AudioSessionManager}; tests can pass a plain object with jest mocks.
+ */
+export interface CueAudioController {
+  cancel: () => void;
+}
+
+/**
+ * Telemetry event emitted when the engine preempts a currently playing
+ * lower-priority cue for a higher-priority one.
+ */
+export interface CueCancellationResult {
+  timestampMs: number;
+  cancelledRuleId: string;
+  cancelledPriority: number;
+  replacedByRuleId: string;
+  replacedByPriority: number;
+}
+
 export interface CueEngineOptions {
   minConfidence: number;
+  /** Optional audio controller used to interrupt mid-utterance playback. */
+  audio?: CueAudioController;
+  /**
+   * Called when a lower-priority cue is interrupted by a higher-priority one.
+   * Kept synchronous and side-effect-free at the engine boundary — consumers
+   * can forward to supabase / console / analytics as they see fit.
+   */
+  onCancellation?: (event: CueCancellationResult) => void;
+  /**
+   * Estimated time it takes a cue to play out. The engine assumes a cue is
+   * still "playing" for this many ms after its emission when deciding whether
+   * to preempt. Defaults to 1500ms which matches a typical ElevenLabs Flash
+   * short phrase. Callers with better knowledge (e.g. actual TTS duration)
+   * can lower it.
+   */
+  estimatedPlaybackMs?: number;
 }
 
 export interface CueEvaluationInput {
@@ -39,12 +77,21 @@ interface RuleRuntimeState {
   lastEmitMs: number | null;
 }
 
+interface PlayingCueState {
+  ruleId: string;
+  priority: number;
+  startedAtMs: number;
+}
+
 export interface CueEngine {
   evaluate(input: CueEvaluationInput): CueEmission[];
 }
 
+const DEFAULT_ESTIMATED_PLAYBACK_MS = 1500;
+
 class DefaultCueEngine implements CueEngine {
   private readonly runtime = new Map<string, RuleRuntimeState>();
+  private currentlyPlaying: PlayingCueState | null = null;
 
   constructor(private readonly rules: CueRule[], private readonly options: CueEngineOptions) {
     for (const rule of rules) {
@@ -105,7 +152,54 @@ class DefaultCueEngine implements CueEngine {
     }
 
     emissions.sort((a, b) => a.priority - b.priority || b.delta - a.delta);
-    return emissions.slice(0, 1);
+    const selected = emissions[0];
+    if (!selected) {
+      return [];
+    }
+
+    this.maybeCancelLowerPriority(selected, input.timestampMs);
+    this.currentlyPlaying = {
+      ruleId: selected.ruleId,
+      priority: selected.priority,
+      startedAtMs: input.timestampMs,
+    };
+
+    return [selected];
+  }
+
+  /**
+   * If a lower-priority cue is mid-playback, interrupt it so the incoming
+   * higher-priority cue can be heard immediately. Equal-priority cues do NOT
+   * cancel — we let the current one finish to avoid stutter when two equally
+   * important rules fire back-to-back.
+   */
+  private maybeCancelLowerPriority(incoming: CueEmission, nowMs: number): void {
+    const playing = this.currentlyPlaying;
+    if (!playing) {
+      return;
+    }
+
+    const playbackMs = this.options.estimatedPlaybackMs ?? DEFAULT_ESTIMATED_PLAYBACK_MS;
+    const elapsed = nowMs - playing.startedAtMs;
+    if (elapsed >= playbackMs) {
+      // Previous cue has almost certainly finished already — nothing to cancel.
+      this.currentlyPlaying = null;
+      return;
+    }
+
+    // Lower priority number = more urgent. Only preempt when strictly higher.
+    if (incoming.priority >= playing.priority) {
+      return;
+    }
+
+    this.options.audio?.cancel();
+    this.options.onCancellation?.({
+      timestampMs: nowMs,
+      cancelledRuleId: playing.ruleId,
+      cancelledPriority: playing.priority,
+      replacedByRuleId: incoming.ruleId,
+      replacedByPriority: incoming.priority,
+    });
   }
 }
 

--- a/lib/services/audio-session-manager.ts
+++ b/lib/services/audio-session-manager.ts
@@ -38,6 +38,7 @@ export class AudioSessionManager {
   private static instance: AudioSessionManager;
   private currentMode: AudioSessionMode = 'idle';
   private listeners: Set<(mode: AudioSessionMode) => void> = new Set();
+  private cancelListeners: Set<() => void> = new Set();
 
   static getInstance(): AudioSessionManager {
     if (!AudioSessionManager.instance) {
@@ -71,6 +72,40 @@ export class AudioSessionManager {
     this.listeners.add(listener);
     return () => {
       this.listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Interrupt any in-flight speech / audio playback.
+   *
+   * Designed as a fan-out: TTS layers (expo-speech, streaming mp3 player, etc.)
+   * register via {@link onCancelRequested} and perform their own stop logic.
+   * The cue-engine calls this when a higher-priority cue needs to preempt a
+   * lower-priority one that is still playing through.
+   *
+   * Listeners run synchronously and any thrown errors are swallowed so one
+   * misbehaving listener can't block the others.
+   */
+  cancel(): void {
+    for (const listener of this.cancelListeners) {
+      try {
+        listener();
+      } catch (err) {
+        console.warn('[AudioSessionManager] cancel listener threw:', err);
+      }
+    }
+  }
+
+  /**
+   * Register a cancel listener. Returns an unsubscribe function.
+   *
+   * Typical wiring: the speech-feedback hook registers a listener that calls
+   * `Speech.stop()` and clears its queue tail.
+   */
+  onCancelRequested(listener: () => void): () => void {
+    this.cancelListeners.add(listener);
+    return () => {
+      this.cancelListeners.delete(listener);
     };
   }
 }

--- a/lib/workouts/deadlift.ts
+++ b/lib/workouts/deadlift.ts
@@ -209,10 +209,34 @@ const faults: FaultDefinition[] = [
     id: 'hips_rise_first',
     displayName: 'Hips Rise First',
     condition: (ctx: RepContext) => {
-      // If hip angle increases significantly before knee angle
-      // This is a simplified check - ideally would track velocity
-      const hipChange = ctx.maxAngles.leftHip - ctx.startAngles.leftHip;
-      const kneeChange = ctx.maxAngles.leftKnee - ctx.startAngles.leftKnee;
+      // Compute hip-rise and knee-rise symmetrically. Taking min() across
+      // left/right is the most conservative signal — the fault represents
+      // "hips as a unit rose before the knees", so a unilateral hip-delta
+      // spike (which is almost always tracking noise from one side being
+      // occluded or at a bad camera angle) must NOT trigger it. See #436.
+      const leftHipDelta = ctx.maxAngles.leftHip - ctx.startAngles.leftHip;
+      const rightHipDelta = ctx.maxAngles.rightHip - ctx.startAngles.rightHip;
+      const leftKneeDelta = ctx.maxAngles.leftKnee - ctx.startAngles.leftKnee;
+      const rightKneeDelta = ctx.maxAngles.rightKnee - ctx.startAngles.rightKnee;
+
+      const hipChange = Math.min(leftHipDelta, rightHipDelta);
+      const kneeChange = Math.min(leftKneeDelta, rightKneeDelta);
+
+      // If the two sides disagree by more than 15°, one leg is almost
+      // certainly miscoded. Log so we can tune later without adding a
+      // dedicated telemetry module for this one event.
+      const hipAsymmetry = Math.abs(leftHipDelta - rightHipDelta);
+      if (hipAsymmetry > 15 && __DEV__) {
+        console.warn('[deadlift] asymmetry_suspected:', {
+          leftHipDelta,
+          rightHipDelta,
+          leftKneeDelta,
+          rightKneeDelta,
+          hipAsymmetry,
+          repNumber: ctx.repNumber,
+        });
+      }
+
       return hipChange > kneeChange + 30;
     },
     severity: 2,

--- a/tests/unit/fusion/cue-engine-priority-cancel.test.ts
+++ b/tests/unit/fusion/cue-engine-priority-cancel.test.ts
@@ -1,0 +1,251 @@
+import {
+  createCueEngine,
+  type CueAudioController,
+  type CueCancellationResult,
+  type CueRule,
+} from '@/lib/fusion/cue-engine';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const BASE_RULE_ID = 'base';
+const HIGH_RULE_ID = 'critical';
+
+function baseRule(overrides: Partial<CueRule> = {}): CueRule {
+  return {
+    id: BASE_RULE_ID,
+    metric: 'leftKnee',
+    phases: ['bottom'],
+    min: 90,
+    max: 100,
+    persistMs: 0,
+    cooldownMs: 0,
+    priority: 3,
+    message: 'Low priority',
+    channels: ['speech'],
+    ...overrides,
+  };
+}
+
+function makeAudioMock(): CueAudioController & { cancel: jest.Mock } {
+  return { cancel: jest.fn() };
+}
+
+// =============================================================================
+// Priority cancellation semantics
+// =============================================================================
+
+describe('cue engine — priority cancellation', () => {
+  test('higher-priority emission cancels the currently playing lower-priority cue', () => {
+    const audio = makeAudioMock();
+    const onCancellation = jest.fn();
+
+    // The low rule watches leftKnee (range 95..105). The high rule watches
+    // rightKnee (range 90..100). Using different metrics isolates which
+    // frames trigger which rule.
+    const low = baseRule({
+      id: 'low',
+      priority: 3,
+      metric: 'leftKnee',
+      min: 95,
+      max: 105,
+      message: 'tempo reminder',
+    });
+    const high = baseRule({
+      id: 'high',
+      priority: 1,
+      metric: 'rightKnee',
+      min: 90,
+      max: 100,
+      message: 'tracking lost',
+    });
+
+    const engine = createCueEngine([low, high], {
+      minConfidence: 0.7,
+      audio,
+      onCancellation,
+    });
+
+    // Emit the low-priority cue first. leftKnee=80 violates low; rightKnee=95
+    // is inside high's range (90..100) so only low fires.
+    const firstEmissions = engine.evaluate({
+      timestampMs: 1_000,
+      phase: 'bottom',
+      confidence: 0.95,
+      metrics: { leftKnee: 80, rightKnee: 95 },
+    });
+    expect(firstEmissions).toHaveLength(1);
+    expect(firstEmissions[0]?.ruleId).toBe('low');
+    expect(audio.cancel).not.toHaveBeenCalled();
+
+    // 500ms later (well inside the 1500ms playback window), rightKnee=80
+    // violates high; leftKnee=100 is inside low's range, so only high fires.
+    // The engine should emit 'high' AND cancel the still-playing 'low'.
+    const secondEmissions = engine.evaluate({
+      timestampMs: 1_500,
+      phase: 'bottom',
+      confidence: 0.95,
+      metrics: { leftKnee: 100, rightKnee: 80 },
+    });
+
+    expect(secondEmissions).toHaveLength(1);
+    expect(secondEmissions[0]?.ruleId).toBe('high');
+    expect(audio.cancel).toHaveBeenCalledTimes(1);
+    expect(onCancellation).toHaveBeenCalledTimes(1);
+
+    const event = onCancellation.mock.calls[0]?.[0] as CueCancellationResult;
+    expect(event.cancelledRuleId).toBe('low');
+    expect(event.cancelledPriority).toBe(3);
+    expect(event.replacedByRuleId).toBe('high');
+    expect(event.replacedByPriority).toBe(1);
+    expect(event.timestampMs).toBe(1_500);
+  });
+
+  test('lower-priority emission does NOT cancel a playing higher-priority cue', () => {
+    const audio = makeAudioMock();
+    const onCancellation = jest.fn();
+
+    // Configure the high-priority rule's cooldown so it can only fire once
+    // within the test window; after it fires we try to fire low.
+    const high = baseRule({
+      id: 'high',
+      priority: 1,
+      min: 90,
+      max: 100,
+      cooldownMs: 10_000,
+      message: 'high priority',
+    });
+    const low = baseRule({
+      id: 'low',
+      priority: 3,
+      min: 95,
+      max: 105,
+      cooldownMs: 0,
+      message: 'low priority',
+    });
+
+    const engine = createCueEngine([high, low], {
+      minConfidence: 0.7,
+      audio,
+      onCancellation,
+    });
+
+    // leftKnee=85 violates BOTH — arbitration picks 'high' (priority 1).
+    engine.evaluate({
+      timestampMs: 1_000,
+      phase: 'bottom',
+      confidence: 0.95,
+      metrics: { leftKnee: 85 },
+    });
+    // leftKnee=92 is inside high's range (90..100) but outside low's (95..105),
+    // so only 'low' fires; high's cooldown also blocks any re-emission.
+    const laterEmissions = engine.evaluate({
+      timestampMs: 1_400,
+      phase: 'bottom',
+      confidence: 0.95,
+      metrics: { leftKnee: 92 },
+    });
+
+    expect(laterEmissions).toHaveLength(1);
+    expect(laterEmissions[0]?.ruleId).toBe('low');
+    // critical: low came in while high is still "playing" — must NOT cancel.
+    expect(audio.cancel).not.toHaveBeenCalled();
+    expect(onCancellation).not.toHaveBeenCalled();
+  });
+
+  test('equal-priority cues do NOT cancel each other (current cue plays to completion)', () => {
+    // Documents the chosen behavior: we only preempt on STRICTLY higher
+    // priority. Two equally important rules back-to-back should not stutter.
+    const audio = makeAudioMock();
+    const onCancellation = jest.fn();
+
+    const ruleA = baseRule({ id: 'a', priority: 2, min: 95, max: 105, message: 'A' });
+    const ruleB = baseRule({
+      id: 'b',
+      priority: 2,
+      metric: 'rightKnee',
+      min: 95,
+      max: 105,
+      message: 'B',
+    });
+
+    const engine = createCueEngine([ruleA, ruleB], {
+      minConfidence: 0.7,
+      audio,
+      onCancellation,
+    });
+
+    // First frame: only A violates (leftKnee=80, rightKnee=100 is inside B).
+    engine.evaluate({
+      timestampMs: 1_000,
+      phase: 'bottom',
+      confidence: 0.95,
+      metrics: { leftKnee: 80, rightKnee: 100 },
+    });
+
+    // Second frame: only B violates.
+    const second = engine.evaluate({
+      timestampMs: 1_400,
+      phase: 'bottom',
+      confidence: 0.95,
+      metrics: { leftKnee: 100, rightKnee: 80 },
+    });
+
+    expect(second).toHaveLength(1);
+    expect(second[0]?.ruleId).toBe('b');
+    expect(audio.cancel).not.toHaveBeenCalled();
+    expect(onCancellation).not.toHaveBeenCalled();
+  });
+
+  test('no cancellation when the playback window has elapsed', () => {
+    const audio = makeAudioMock();
+    const high = baseRule({ id: 'high', priority: 1, min: 90, max: 100, cooldownMs: 0 });
+    const low = baseRule({ id: 'low', priority: 3, min: 95, max: 105, cooldownMs: 0 });
+
+    const engine = createCueEngine([high, low], {
+      minConfidence: 0.7,
+      audio,
+      estimatedPlaybackMs: 500,
+    });
+
+    // Fire low (leftKnee=110 is only outside low's 95..105).
+    engine.evaluate({
+      timestampMs: 1_000,
+      phase: 'bottom',
+      confidence: 0.95,
+      metrics: { leftKnee: 110 },
+    });
+    // Fire high 2000ms later, past the 500ms window.
+    engine.evaluate({
+      timestampMs: 3_000,
+      phase: 'bottom',
+      confidence: 0.95,
+      metrics: { leftKnee: 80 },
+    });
+
+    expect(audio.cancel).not.toHaveBeenCalled();
+  });
+
+  test('engine works without audio controller (optional dependency)', () => {
+    const low = baseRule({ id: 'low', priority: 3, min: 95, max: 105, cooldownMs: 0 });
+    const high = baseRule({ id: 'high', priority: 1, min: 90, max: 100, cooldownMs: 0 });
+
+    const engine = createCueEngine([low, high], { minConfidence: 0.7 });
+
+    expect(() => {
+      engine.evaluate({
+        timestampMs: 1_000,
+        phase: 'bottom',
+        confidence: 0.95,
+        metrics: { leftKnee: 80 },
+      });
+      engine.evaluate({
+        timestampMs: 1_300,
+        phase: 'bottom',
+        confidence: 0.95,
+        metrics: { leftKnee: 85 },
+      });
+    }).not.toThrow();
+  });
+});

--- a/tests/unit/services/audio-session-manager.test.ts
+++ b/tests/unit/services/audio-session-manager.test.ts
@@ -19,6 +19,7 @@ beforeEach(() => {
   // Reset singleton internal state between tests
   (manager as any).currentMode = 'idle';
   (manager as any).listeners = new Set();
+  (manager as any).cancelListeners = new Set();
 });
 
 // =============================================================================
@@ -119,5 +120,50 @@ describe('onModeChange', () => {
     await manager.setMode('coaching');
 
     expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// cancel / onCancelRequested
+// =============================================================================
+
+describe('cancel', () => {
+  it('invokes every registered cancel listener', () => {
+    const a = jest.fn();
+    const b = jest.fn();
+    manager.onCancelRequested(a);
+    manager.onCancelRequested(b);
+
+    manager.cancel();
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribing a cancel listener stops future cancel() fan-out', () => {
+    const listener = jest.fn();
+    const unsubscribe = manager.onCancelRequested(listener);
+    unsubscribe();
+
+    manager.cancel();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('isolates throwing listeners so later listeners still run', () => {
+    const throwing = jest.fn(() => {
+      throw new Error('boom');
+    });
+    const healthy = jest.fn();
+    manager.onCancelRequested(throwing);
+    manager.onCancelRequested(healthy);
+
+    expect(() => manager.cancel()).not.toThrow();
+    expect(throwing).toHaveBeenCalledTimes(1);
+    expect(healthy).toHaveBeenCalledTimes(1);
+  });
+
+  it('no-ops when no cancel listeners are registered', () => {
+    expect(() => manager.cancel()).not.toThrow();
   });
 });

--- a/tests/unit/services/fqi-faults.test.ts
+++ b/tests/unit/services/fqi-faults.test.ts
@@ -390,6 +390,54 @@ describe('deadlift faults', () => {
       });
       expect(f.condition(c)).toBe(false);
     });
+
+    // =========================================================================
+    // #436 — symmetric-delta fix
+    //
+    // Prior to the fix, hips_rise_first read only leftHip / leftKnee deltas.
+    // Camera-angle noise on the right side was enough to trigger the fault
+    // even when actual form was symmetric. The fix takes
+    // min(leftDelta, rightDelta) for both hips and knees.
+    // =========================================================================
+
+    it('[#436] symmetric rise: both hips rise 40°, knees rise 20° — fault DOES fire', () => {
+      // leftHipDelta=rightHipDelta=40, min=40
+      // leftKneeDelta=rightKneeDelta=20, min=20
+      // 40 > 20 + 30 = 50? No — actually falls below threshold.
+      // Bump hips to 60° so we're comfortably over the +30 margin.
+      const c = ctx({
+        start: { leftHip: 80, rightHip: 80, leftKnee: 140, rightKnee: 140 },
+        max: { leftHip: 140, rightHip: 140, leftKnee: 160, rightKnee: 160 },
+      });
+      // hipChange=60, kneeChange=20, 60 > 20+30=50 ✓
+      expect(f.condition(c)).toBe(true);
+    });
+
+    it('[#436] asymmetric tracking noise: left hip 40° / right hip 5° — fault does NOT fire', () => {
+      // leftHipDelta=40, rightHipDelta=5, min=5 (conservative)
+      // leftKneeDelta=rightKneeDelta=20, min=20
+      // 5 > 20+30=50? No — the bug-fix behavior.
+      // Before the fix this hit 40 > 20+30? No; but using the older left-only
+      // read WITH a larger asymmetry (e.g. 90° vs 5°) would have fired
+      // spuriously. Verify the symmetric path clamps to the lower side.
+      const c = ctx({
+        start: { leftHip: 80, rightHip: 80, leftKnee: 140, rightKnee: 140 },
+        max: { leftHip: 170, rightHip: 85, leftKnee: 160, rightKnee: 160 },
+      });
+      // Using min: hipChange=5, kneeChange=20, 5 > 50? No.
+      // If the code still read leftHip-only: hipChange=90, kneeChange=20,
+      // 90 > 50? YES — would have fired. This test pins the new behavior.
+      expect(f.condition(c)).toBe(false);
+    });
+
+    it('[#436] symmetric good form (hips 20°, knees 30°): fault does NOT fire', () => {
+      // hipChange=20, kneeChange=30, 20 > 30+30=60? No.
+      const c = ctx({
+        start: { leftHip: 120, rightHip: 120, leftKnee: 130, rightKnee: 130 },
+        max: { leftHip: 140, rightHip: 140, leftKnee: 160, rightKnee: 160 },
+      });
+      expect(f.condition(c)).toBe(false);
+    });
   });
 
   describe('asymmetric_pull', () => {

--- a/tests/unit/workouts/deadlift.test.ts
+++ b/tests/unit/workouts/deadlift.test.ts
@@ -148,21 +148,23 @@ describe('deadlift: fault conditions', () => {
 
   test('hips_rise_first: hipChange > kneeChange + 30', () => {
     const fault = faultById('hips_rise_first');
-    // start: hip=80, knee=80. max: hip=160, knee=90 -> hipChange=80, kneeChange=10. Diff=70 > 30 -> fire.
+    // Bilateral/min-delta path: both hips rise 60°, knees rise 20°.
+    // minHipChange=60, minKneeChange=20 => 60 > 20 + 30 -> fire.
     expect(
       fault!.condition(
         baseRepContext({
-          startAngles: angles({ leftHip: 80, leftKnee: 80 }),
-          maxAngles: angles({ leftHip: 160, leftKnee: 90 }),
+          startAngles: angles({ leftHip: 80, rightHip: 80, leftKnee: 140, rightKnee: 140 }),
+          maxAngles: angles({ leftHip: 140, rightHip: 140, leftKnee: 160, rightKnee: 160 }),
         })
       )
     ).toBe(true);
-    // Balanced: hipChange=50, kneeChange=40. Diff=10 not > 30 -> no fire.
+    // Symmetric good form: hips rise 20°, knees rise 30°.
+    // minHipChange=20, minKneeChange=30 => 20 > 30 + 30? No.
     expect(
       fault!.condition(
         baseRepContext({
-          startAngles: angles({ leftHip: 80, leftKnee: 80 }),
-          maxAngles: angles({ leftHip: 130, leftKnee: 120 }),
+          startAngles: angles({ leftHip: 120, rightHip: 120, leftKnee: 130, rightKnee: 130 }),
+          maxAngles: angles({ leftHip: 140, rightHip: 140, leftKnee: 160, rightKnee: 160 }),
         })
       )
     ).toBe(false);


### PR DESCRIPTION
## Summary

Two surgical bug fixes shipped together because both were surfaced by
the PR #432 test-coverage expansion, both are tightly-scoped, and
per overnight directive we prefer one PR with atomic commits over
splitting small related fixes.

### Bug 1 — #435: cue-engine priority cancellation

`lib/fusion/cue-engine.ts` had no way to preempt a currently playing
cue. A `critical`-priority cue (tracking-loss) could be queued or
dropped behind a `low` tempo reminder that was still playing through
TTS.

**Fix:** Engine now tracks `currentlyPlaying` (`{ ruleId, priority,
startedAtMs }`). When `evaluate()` produces a new emission with a
strictly higher priority (lower number) and the previous cue is still
inside its playback window, the engine calls `audio.cancel()` on an
injected `CueAudioController` and fires a `CueCancellationResult`
telemetry event. Equal-priority cues do **not** cancel (documented
decision — avoids stutter).

`AudioSessionManager` gained a `cancel()` primitive plus an
`onCancelRequested()` listener API so TTS layers (expo-speech,
streaming mp3 player) can register their own stop logic without the
manager having to import expo-speech directly.

### Bug 2 — #436: deadlift `hips_rise_first` asymmetry

The fault condition read only LEFT hip / LEFT knee deltas. Camera-angle
tracking noise on one side (right hip briefly off-frame) would fire the
fault even when the user's actual form was symmetric.

**Fix:** Take `min(leftHipDelta, rightHipDelta)` for both hips and
knees — the most conservative pair, which matches the intent "hips as a
unit rose first". When `|leftHipDelta - rightHipDelta|` exceeds 15°, a
dev-only `[deadlift] asymmetry_suspected:` warn logs a structured
payload so we can tune later. No new telemetry module added for this
one event.

## Commits (5, atomic)

1. `fix(audio-session-manager): add cancel() primitive for mid-utterance interruption`
2. `fix(cue-engine): cancel lower-priority cue when higher-priority fires (#435)`
3. `test(cue-engine): cover priority cancellation semantics`
4. `fix(deadlift): compute hips_rise_first with symmetric hip delta (#436)`
5. `test(deadlift): cover symmetric vs asymmetric hips_rise_first cases`

## Test plan

- [x] `bun run lint` — clean (2 pre-existing warnings in template-builder.tsx unrelated)
- [x] `bun run check:types` — clean
- [x] `bun run test -- tests/unit/fusion/cue-engine-priority-cancel.test.ts` — 5/5 pass
- [x] `bun run test -- tests/unit/fusion/cue-engine.test.ts` — 4/4 pass (no regression)
- [x] `bun run test -- tests/unit/services/fqi-faults.test.ts` — 87/87 pass (was 84; +3 new deadlift cases)
- [x] `bun run test -- tests/unit/services/audio-session-manager.test.ts` — 14/14 pass (was 10; +4 new cancel cases)
- [x] All 92 fusion tests still pass
- [ ] Manual smoke on iOS device: fire a low-priority cue, force a tracking-loss, verify the critical cue cuts in immediately (follow-up, requires app-layer wiring)

## Judgment calls

1. **audio-session-manager surface:** Issue suggested `cancel()` stops the current utterance directly. In reality, the manager only handles iOS audio MODES — actual TTS playback lives in `hooks/use-speech-feedback.ts` and `hooks/use-streaming-tts.ts`. Rather than pulling `expo-speech` into the manager, I made `cancel()` a fan-out to registered listeners. The speech hooks can subscribe and stop their own queues. Cleaner separation and keeps the manager stack-free.

2. **Cue-engine not yet wired into app code:** `createCueEngine` is currently only consumed by tests — `scan-arkit.tsx` doesn't use it yet. The preemption logic is a pure library change; actual `audio` + `onCancellation` wiring lands in a follow-up when the cue-engine is plumbed into the scan screen.

3. **estimatedPlaybackMs default 1500ms:** Matches a short ElevenLabs Flash utterance. Callers with better TTS duration knowledge can override. Without a "playback done" signal, this is the least-bad way to keep `evaluate()` synchronous and pure.

4. **Deadlift tests location:** Issue suggested `tests/unit/workouts/deadlift.test.ts` but the existing `hips_rise_first` tests live in `tests/unit/services/fqi-faults.test.ts` (where all deadlift fault coverage lives). Per directive "extend existing structure rather than fork a parallel file", new cases went there.

5. **Pre-push hook:** The full `bun test` suite has an unrelated failing test in `tests/unit/services/database/generic-sync.test.ts` on `origin/main`. Not touched by this PR. Pushed with `CI_LOCAL_SKIP=1` per overnight directive.

Closes #435
Closes #436