### PR TITLE
feat(workouts): exercise library expansion — 6 compound lifts (hip-thrust, BSS, row, lat-PD, OHP, DB-curl)

### DIFF
--- a/docs/OVERNIGHT_CHANGELOG.md
+++ b/docs/OVERNIGHT_CHANGELOG.md
@@ -1,0 +1,66 @@
+# Overnight changelog
+
+Non-code changes and cross-PR notes from overnight / parallel-agent work.
+See git log for the atomic commit detail; this file captures the higher-
+level "what wave shipped" narrative for quick reviewer context.
+
+## 2026-04-16 — Exercise library expansion (#459)
+
+Adds 6 compound/accessory form models to `lib/workouts/` following the
+pattern established by #441 (lunge + extended dead-hang):
+
+- `hip_thrust` — 5 faults (shallow_depth / heel_liftoff / incomplete_lockout /
+  asymmetric_extension / hyperextension)
+- `bulgarian_split_squat` — 4 faults (shallow_depth / forward_knee /
+  asymmetric_drive / heel_collapse); unilateral working-leg selection by
+  deeper-knee proxy matching lunge.
+- `barbell_row` — 4 faults (incomplete_lockout / rounded_back via
+  sequenceCheck / asymmetric_pull / elbows_high)
+- `lat_pulldown` — 4 faults (incomplete_lockout / excessive_lean via
+  shoulder delta / asymmetric_pull / elbows_flare at bottom-of-pull)
+- `overhead_press` — 4 faults (incomplete_lockout / excessive_lean /
+  asymmetric_press / core_hyperextension via peak-hip angle)
+- `dumbbell_curl` — 3 faults (swinging via hip-flex delta / incomplete_lockout
+  / asymmetric_curl); forearm supination intentionally not trackable.
+
+### Judgment calls (sparse sensors)
+
+`JointAngles` has no wrist, ankle, foot, or spine channel, so several
+faults use proxies documented inline per-file:
+
+- hip_thrust `heel_liftoff`: knee-angle asymmetry at peak extension stands
+  in for foot-planted-vs-lifted.
+- BSS `heel_collapse`: extreme acute front-knee angle proxies a collapsed arch.
+- barbell_row `rounded_back`: `sequenceCheck(hip-delta, shoulder-delta)`
+  flags spine flexion via relative joint movement.
+- lat_pulldown `excessive_lean` / overhead_press `excessive_lean` /
+  dumbbell_curl `swinging`: all use `clampedDelta(startHip, minHip)` on the
+  hip channel — torso-rotation sensors don't exist in the current fusion.
+- dumbbell_curl: no supination fault (no wrist-rotation sensor).
+
+### Helper reconcile note
+
+`lib/workouts/helpers.ts` landed on this PR as a byte-identical copy of
+`feat/438-form-model-depth` (#441). PR-N / #452 used the same
+copy-then-reconcile pattern for `subject-identity.ts`. Whichever PR merges
+second needs only to drop the TODO(#438) comment — no content changes.
+
+### Coverage delta
+
+- 6 new movement form-model files: `hip-thrust`, `bulgarian-split-squat`,
+  `barbell-row`, `lat-pulldown`, `overhead-press`, `dumbbell-curl`.
+- 6 new per-movement test suites (hip-thrust 22, BSS 19, row 19, lat-PD 19,
+  OHP 19, DB-curl 16 → 114 tests).
+- 1 new parametric harness covering every fault (24 faults × 3 layers
+  [baseline / positive / NaN-guard] = 72 cases + 1 cardinality check = 73).
+- Extended `workouts-factory.test.ts` by +36 assertions across the 6 new
+  modes (getWorkoutByMode / isDetectionMode / isValidWorkoutId /
+  getWorkoutById) and a DetectionMode-cardinality check (14 total modes).
+
+### Deferrals
+
+- Coach-drill (`drills?: FaultDrill[]`) backfill — waits on #434 to
+  introduce the field.
+- Leg press / hack squat / incline variants — separate L-effort PR.
+- Supabase workout-template seeds referencing the new IDs — needs a
+  migration and was intentionally skipped (banned path).

--- a/lib/services/cue-rotator-variants.ts
+++ b/lib/services/cue-rotator-variants.ts
@@ -158,69 +158,88 @@ export const CUE_ROTATION_VARIANTS: CueVariantMap = {
   // ---- Lat pulldown ----
   'Elbows in — drive them down, not out.': [
     'Drive elbows down and keep them tucked.',
+    'Tuck the elbows and drive to the ribs.',
   ],
   'Let the arms extend fully — feel the stretch.': [
     'Full stretch at the top before pulling.',
+    'Reach long at the top and feel the stretch.',
   ],
   'Smooth pull — lats lead, no swinging.': [
     'Lead with the lats, no body swing.',
+    'Pull with the lats and keep the torso quiet.',
   ],
 
   // ---- Dumbbell curl ----
   'Stop swinging — hips stay locked.': [
     'Lock the hips and kill the swing.',
+    'Still hips, strict curl.',
   ],
   'Squeeze all the way up — full biceps contraction.': [
     'Curl higher and squeeze the biceps hard.',
+    'Top squeeze — crush the curl.',
   ],
   'Slow tempo — elbows pinned, control the descent.': [
     'Pin the elbows and lower with control.',
+    'Keep elbows pinned and lower slower.',
   ],
 
   // ---- Hip thrust ----
   'Ribs down — finish with the glutes, not the lower back.': [
     'Keep ribs down and squeeze the glutes.',
+    'Brace the ribs and finish with glutes.',
   ],
   'Drive higher — aim for full hip extension.': [
     'Drive through to full hip lockout.',
+    'Lift higher until the hips fully lock.',
   ],
   'Controlled tempo — squeeze at the top.': [
     'Control the rep and pause at lockout.',
+    'Steady rep — squeeze at the top.',
   ],
 
   // ---- Barbell row ----
   'Tuck elbows down — pull to the lower ribs.': [
     'Keep elbows tucked and row to the ribs.',
+    'Drive elbows down and row low.',
   ],
   'Stay hinged — resist the urge to stand up.': [
     'Hold the hinge and resist standing tall.',
+    'Keep the hinge and fight the urge to rise.',
   ],
   'Smooth pull — squeeze the shoulder blades at the top.': [
     'Pull smooth and pinch the shoulder blades.',
+    'Row smooth and squeeze the upper back.',
   ],
 
   // ---- Bulgarian split squat ----
   'Drop deeper — front thigh parallel to the floor.': [
     'Sink deeper until the front thigh is parallel.',
+    'Go lower until the front thigh is level.',
   ],
   'Shift weight back — keep the front shin vertical.': [
     'Sit back and keep the front shin stacked.',
+    'Move back into the heel and stack the shin.',
   ],
   'Reset your stance, breathe, then repeat.': [
     'Reset the stance, breathe, then go again.',
+    'Rebuild the stance, breathe, repeat.',
   ],
   'Sit into the front leg — stay tall through the hips.': [
     'Load the front leg and stay tall.',
+    'Sink into the front leg and keep hips tall.',
   ],
 
   // ---- Overhead press ----
   'Ribs down — stop arching the lower back.': [
     'Stack the ribs and stop the back arch.',
+    'Keep ribs tucked and press without arching.',
   ],
   'Punch through — arms straight at the top.': [
     'Punch overhead until the elbows lock.',
+    'Finish tall and lock the arms overhead.',
   ],
   'Brace hard — vertical bar path, stay stacked.': [
     'Brace hard and keep the bar vertical.',
+    'Stay braced and keep the bar stacked.',
   ],
 };

--- a/lib/workouts/README.md
+++ b/lib/workouts/README.md
@@ -31,4 +31,38 @@ Each workout lives in its own file (for example `pullup.ts`, `pushup.ts`) and ex
 
 - Prefer keeping **all** workout-specific heuristics inside the workout file (not in `scan-arkit.tsx`).
 - Keep thresholds named and documented (avoid magic numbers sprinkled through the UI).
-- If you need a new metric for UI/telemetry, add it to that workout’s `Metrics` type and compute it in `calculateMetrics`.
+- If you need a new metric for UI/telemetry, add it to that workout's `Metrics` type and compute it in `calculateMetrics`.
+
+## Registered movements (as of #459)
+
+| ID | Category | Faults | Gotchas |
+|---|---|---|---|
+| `pullup` | upper_body | 2 | Bilateral vertical pull |
+| `pushup` | upper_body | 2 | Hip sag via hipDropRatio |
+| `squat` | lower_body | 4 | Parallel depth, knee valgus, hip shift |
+| `deadlift` | full_body | 2 | Sequence-based rounded_back |
+| `rdl` | full_body | 1 | Hinge asymmetry |
+| `benchpress` | upper_body | 5 | Elbow flare, asymmetric press |
+| `dead_hang` | upper_body | 3 (core) + scapular/kipping/grip_shift when merged from #441 | Static hold — no rep boundary |
+| `farmers_walk` | full_body | 1 | Duration-based; lateral lean |
+| `hip_thrust` | lower_body | 5 | Heel-liftoff proxy: knee-angle asymmetry |
+| `bulgarian_split_squat` | lower_body | 4 | Unilateral — deeper-knee = working leg |
+| `barbell_row` | upper_body | 4 | Rounded-back via hip-vs-shoulder sequenceCheck |
+| `lat_pulldown` | upper_body | 4 | Seated — excessive-lean via shoulder delta |
+| `overhead_press` | upper_body | 4 | Core hyperextension via peak-hip angle |
+| `dumbbell_curl` | upper_body | 3 | Swinging via hip-flex delta proxy |
+
+## Coach-drill backfill (follow-up)
+
+`FaultDefinition` does not yet carry a `drills` field. Once #434 lands and
+introduces `drills?: FaultDrill[]`, a follow-up PR will backfill 1-3
+corrective drills per fault across **all** movements (including the 6 new
+ones added here). Until then, the `dynamicCue` string carries the lone
+corrective message for each fault.
+
+## Helper reconcile note (#441 + #459)
+
+`lib/workouts/helpers.ts` is currently duplicated between this PR and
+`feat/438-form-model-depth` (#441). Both PRs carry identical content —
+whichever merges second should delete its TODO(#438) reconcile comment
+but needs no other action because the files are byte-for-byte identical.

--- a/lib/workouts/barbell-row.ts
+++ b/lib/workouts/barbell-row.ts
@@ -1,0 +1,424 @@
+/**
+ * Barbell Row Workout Definition
+ *
+ * Defines all the logic for tracking barbell row form:
+ * - Phases: setup → hinged → pulling → top → lowering
+ * - Rep boundaries: starts at 'pulling', ends at 'hinged'
+ * - Thresholds for elbow-flexion and hip-hinge angles
+ * - Fault detection conditions (4 faults)
+ * - FQI calculation weights
+ *
+ * Horizontal pulling movement. At the bottom ("hinged") the torso is
+ * nearly parallel to the floor (hip angle ~100°) and elbows are
+ * extended (~170°). At the top ("top") the elbows are flexed to ~70°
+ * with shoulders staying retracted.
+ *
+ * Proxies used (documented here because JointAngles is sparse):
+ * - `rounded_back` — no spine sensor; we compare the shoulder-angle
+ *   change vs hip-angle change. If the shoulders sag forward faster
+ *   than the hips rise at peak pull, we treat it as spinal flexion.
+ * - `elbows_high` — high shoulder-abduction angle at top = chicken-winging
+ *   (bar pulled to the chest instead of the lower-ribs).
+ */
+
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type {
+  WorkoutDefinition,
+  PhaseDefinition,
+  RepBoundary,
+  FaultDefinition,
+  FQIWeights,
+  AngleRange,
+  WorkoutMetrics,
+  RepContext,
+  ScoringMetricDefinition,
+} from '@/lib/types/workout-definitions';
+import { asymmetryCheck, sequenceCheck } from './helpers';
+
+// =============================================================================
+// Phase Type
+// =============================================================================
+
+export type BarbellRowPhase = 'setup' | 'hinged' | 'pulling' | 'top' | 'lowering';
+
+// =============================================================================
+// Metrics Type
+// =============================================================================
+
+export interface BarbellRowMetrics extends WorkoutMetrics {
+  avgElbow: number;
+  avgShoulder: number;
+  avgHip: number;
+  armsTracked: boolean;
+}
+
+// =============================================================================
+// Thresholds
+// =============================================================================
+
+export const BARBELL_ROW_THRESHOLDS = {
+  /** Hip-angle at hinge start — torso near parallel */
+  hingedHipMax: 120,
+  /** Elbow near-extended at bottom */
+  bottomElbow: 155,
+  /** Transition to pulling once elbow starts flexing */
+  pullingStart: 140,
+  /** Peak pull — elbow flexed ~70° */
+  topElbow: 80,
+  /** Transition back to lowering */
+  loweringStart: 110,
+  /** Rep considered "incomplete" if top elbow is still above this */
+  incompleteLockoutMin: 100,
+  /** Shoulder angle at top above which = elbows-high / chicken wing */
+  elbowsHighShoulderMax: 115,
+  /** Asymmetric-pull tolerance on elbow angle at top (%) */
+  asymmetricPullMaxPct: 15,
+  /**
+   * Rounded-back check — primary is hip, secondary is shoulder. During a
+   * clean row the hip should move more than the shoulder (lifter stays
+   * hinged). If the shoulder-angle delta exceeds hip-angle delta we flag.
+   * No absolute angle threshold — sequenceCheck is comparative.
+   */
+} as const;
+
+// =============================================================================
+// Angle Ranges
+// =============================================================================
+
+const angleRanges: Record<string, AngleRange> = {
+  elbow: {
+    min: 70,
+    max: 170,
+    optimal: 80,
+    tolerance: 15,
+  },
+  shoulder: {
+    min: 60,
+    max: 120,
+    optimal: 90,
+    tolerance: 15,
+  },
+  hip: {
+    min: 80,
+    max: 130,
+    optimal: 105,
+    tolerance: 15,
+  },
+};
+
+const scoringMetrics: ScoringMetricDefinition[] = [
+  {
+    id: 'elbow',
+    extract: (rep, side) => {
+      if (side === 'left') {
+        return {
+          start: rep.start.leftElbow,
+          end: rep.end.leftElbow,
+          min: rep.min.leftElbow,
+          max: rep.max.leftElbow,
+        };
+      }
+      return {
+        start: rep.start.rightElbow,
+        end: rep.end.rightElbow,
+        min: rep.min.rightElbow,
+        max: rep.max.rightElbow,
+      };
+    },
+  },
+  {
+    id: 'shoulder',
+    extract: (rep, side) => {
+      if (side === 'left') {
+        return {
+          start: rep.start.leftShoulder,
+          end: rep.end.leftShoulder,
+          min: rep.min.leftShoulder,
+          max: rep.max.leftShoulder,
+        };
+      }
+      return {
+        start: rep.start.rightShoulder,
+        end: rep.end.rightShoulder,
+        min: rep.min.rightShoulder,
+        max: rep.max.rightShoulder,
+      };
+    },
+  },
+];
+
+// =============================================================================
+// Phase Definitions
+// =============================================================================
+
+const phases: PhaseDefinition<BarbellRowPhase>[] = [
+  {
+    id: 'setup',
+    displayName: 'Setup',
+    enterCondition: () => true,
+    staticCue: 'Hinge to ~45°, brace, bar over mid-foot.',
+  },
+  {
+    id: 'hinged',
+    displayName: 'Hinged',
+    enterCondition: (angles: JointAngles) => {
+      const avgHip = (angles.leftHip + angles.rightHip) / 2;
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return avgHip <= BARBELL_ROW_THRESHOLDS.hingedHipMax && avgElbow >= BARBELL_ROW_THRESHOLDS.bottomElbow;
+    },
+    staticCue: 'Hold the hinge — keep the back flat, arms long.',
+  },
+  {
+    id: 'pulling',
+    displayName: 'Pulling',
+    enterCondition: (angles: JointAngles, prevPhase: BarbellRowPhase) => {
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return prevPhase === 'hinged' && avgElbow <= BARBELL_ROW_THRESHOLDS.pullingStart;
+    },
+    staticCue: 'Drive the elbows back — bar to the lower ribs.',
+  },
+  {
+    id: 'top',
+    displayName: 'Top',
+    enterCondition: (angles: JointAngles, prevPhase: BarbellRowPhase) => {
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return prevPhase === 'pulling' && avgElbow <= BARBELL_ROW_THRESHOLDS.topElbow + 10;
+    },
+    staticCue: 'Squeeze the blades — brief pause at the top.',
+  },
+  {
+    id: 'lowering',
+    displayName: 'Lowering',
+    enterCondition: (angles: JointAngles, prevPhase: BarbellRowPhase) => {
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return prevPhase === 'top' && avgElbow >= BARBELL_ROW_THRESHOLDS.loweringStart;
+    },
+    staticCue: 'Lower under control — stay hinged.',
+  },
+];
+
+// =============================================================================
+// Rep Boundary
+// =============================================================================
+
+const repBoundary: RepBoundary<BarbellRowPhase> = {
+  startPhase: 'pulling',
+  endPhase: 'hinged',
+  minDurationMs: 700,
+};
+
+// =============================================================================
+// Fault Definitions (4 faults per spec)
+// =============================================================================
+
+const faults: FaultDefinition[] = [
+  {
+    id: 'incomplete_lockout',
+    displayName: 'Incomplete Row',
+    condition: (ctx: RepContext) => {
+      const minElbow = Math.min(ctx.minAngles.leftElbow, ctx.minAngles.rightElbow);
+      if (!Number.isFinite(minElbow)) return false;
+      return minElbow > BARBELL_ROW_THRESHOLDS.incompleteLockoutMin;
+    },
+    severity: 2,
+    dynamicCue: 'Pull higher — bar should touch the lower ribs.',
+    fqiPenalty: 12,
+  },
+  {
+    id: 'rounded_back',
+    displayName: 'Rounded Back',
+    condition: (ctx: RepContext) => {
+      // Hip should move less than the shoulder during a proper row (torso
+      // stays pinned to angle). If the shoulder-angle delta OUTPACES the
+      // hip-angle delta, we flag as spinal flexion. sequenceCheck with
+      // shouldPrimaryRiseFirst=true fires when primary (hip) < secondary (shoulder).
+      const leftHipDelta = Math.abs(ctx.maxAngles.leftHip - ctx.minAngles.leftHip);
+      const rightHipDelta = Math.abs(ctx.maxAngles.rightHip - ctx.minAngles.rightHip);
+      const leftShoulderDelta = Math.abs(ctx.maxAngles.leftShoulder - ctx.minAngles.leftShoulder);
+      const rightShoulderDelta = Math.abs(ctx.maxAngles.rightShoulder - ctx.minAngles.rightShoulder);
+      const hipDelta = Math.max(leftHipDelta, rightHipDelta);
+      const shoulderDelta = Math.max(leftShoulderDelta, rightShoulderDelta);
+      return sequenceCheck(0, hipDelta, 0, shoulderDelta, true) && shoulderDelta > 15;
+    },
+    severity: 3,
+    dynamicCue: 'Brace and keep the back flat — no rounding at the top.',
+    fqiPenalty: 15,
+  },
+  {
+    id: 'asymmetric_pull',
+    displayName: 'Asymmetric Pull',
+    condition: (ctx: RepContext) => {
+      return asymmetryCheck(
+        ctx.minAngles.leftElbow,
+        ctx.minAngles.rightElbow,
+        BARBELL_ROW_THRESHOLDS.asymmetricPullMaxPct
+      );
+    },
+    severity: 1,
+    dynamicCue: 'Pull evenly — both elbows arrive at the ribs together.',
+    fqiPenalty: 8,
+  },
+  {
+    id: 'elbows_high',
+    displayName: 'Elbows Flared High',
+    condition: (ctx: RepContext) => {
+      const maxShoulder = Math.max(ctx.maxAngles.leftShoulder, ctx.maxAngles.rightShoulder);
+      if (!Number.isFinite(maxShoulder)) return false;
+      return maxShoulder > BARBELL_ROW_THRESHOLDS.elbowsHighShoulderMax;
+    },
+    severity: 2,
+    dynamicCue: 'Keep elbows tucked — pull the bar low and tight to the body.',
+    fqiPenalty: 10,
+  },
+];
+
+// =============================================================================
+// FQI Weights
+// =============================================================================
+
+const fqiWeights: FQIWeights = {
+  rom: 0.35,
+  depth: 0.3,
+  faults: 0.35,
+};
+
+// =============================================================================
+// Metrics Calculator
+// =============================================================================
+
+function calculateMetrics(
+  angles: JointAngles,
+  _joints?: Map<string, { x: number; y: number; isTracked: boolean }>
+): BarbellRowMetrics {
+  const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+  const avgShoulder = (angles.leftShoulder + angles.rightShoulder) / 2;
+  const avgHip = (angles.leftHip + angles.rightHip) / 2;
+
+  const armsTracked =
+    angles.leftElbow > 0 && angles.leftElbow < 180 &&
+    angles.rightElbow > 0 && angles.rightElbow < 180;
+
+  return {
+    avgElbow,
+    avgShoulder,
+    avgHip,
+    armsTracked,
+  };
+}
+
+// =============================================================================
+// Phase State Machine
+// =============================================================================
+
+function getNextPhase(
+  currentPhase: BarbellRowPhase,
+  _angles: JointAngles,
+  metrics: BarbellRowMetrics
+): BarbellRowPhase {
+  if (!metrics.armsTracked) {
+    return 'setup';
+  }
+
+  const elbow = metrics.avgElbow;
+  const hip = metrics.avgHip;
+
+  switch (currentPhase) {
+    case 'setup':
+      if (hip <= BARBELL_ROW_THRESHOLDS.hingedHipMax && elbow >= BARBELL_ROW_THRESHOLDS.bottomElbow) {
+        return 'hinged';
+      }
+      return 'setup';
+
+    case 'hinged':
+      if (elbow <= BARBELL_ROW_THRESHOLDS.pullingStart) {
+        return 'pulling';
+      }
+      return 'hinged';
+
+    case 'pulling':
+      if (elbow <= BARBELL_ROW_THRESHOLDS.topElbow + 10) {
+        return 'top';
+      }
+      return 'pulling';
+
+    case 'top':
+      if (elbow >= BARBELL_ROW_THRESHOLDS.loweringStart) {
+        return 'lowering';
+      }
+      return 'top';
+
+    case 'lowering':
+      if (elbow >= BARBELL_ROW_THRESHOLDS.bottomElbow) {
+        return 'hinged';
+      }
+      return 'lowering';
+
+    default:
+      return 'setup';
+  }
+}
+
+// =============================================================================
+// Export Workout Definition
+// =============================================================================
+
+export const barbellRowDefinition: WorkoutDefinition<BarbellRowPhase, BarbellRowMetrics> = {
+  id: 'barbell_row',
+  displayName: 'Barbell Row',
+  description: 'Horizontal pulling movement targeting the mid-back, lats, and rear delts.',
+  category: 'upper_body',
+  difficulty: 'intermediate',
+
+  phases,
+  initialPhase: 'setup',
+  repBoundary,
+  thresholds: BARBELL_ROW_THRESHOLDS,
+  angleRanges,
+  scoringMetrics,
+  faults,
+  fqiWeights,
+
+  ui: {
+    iconName: 'barbell-outline',
+    primaryMetric: { key: 'avgElbowDeg', label: 'Avg Elbow', format: 'deg' },
+    secondaryMetric: { key: 'avgHipDeg', label: 'Avg Hip', format: 'deg' },
+    buildUploadMetrics: (metrics) => ({
+      avgElbowDeg: metrics?.avgElbow ?? null,
+      avgShoulderDeg: metrics?.avgShoulder ?? null,
+      avgHipDeg: metrics?.avgHip ?? null,
+    }),
+    buildWatchMetrics: (metrics) => ({
+      avgElbowDeg: metrics?.avgElbow ?? null,
+    }),
+    getRealtimeCues: ({ phaseId, metrics }) => {
+      const messages: string[] = [];
+
+      if (
+        phaseId === 'top' &&
+        typeof metrics.avgShoulder === 'number' &&
+        metrics.avgShoulder > BARBELL_ROW_THRESHOLDS.elbowsHighShoulderMax
+      ) {
+        messages.push('Tuck elbows down — pull to the lower ribs.');
+      }
+
+      if (
+        phaseId === 'pulling' &&
+        typeof metrics.avgHip === 'number' &&
+        metrics.avgHip > BARBELL_ROW_THRESHOLDS.hingedHipMax + 20
+      ) {
+        messages.push('Stay hinged — resist the urge to stand up.');
+      }
+
+      if (messages.length === 0) {
+        messages.push('Smooth pull — squeeze the shoulder blades at the top.');
+      }
+
+      return messages;
+    },
+  },
+
+  calculateMetrics,
+  getNextPhase,
+};
+
+export default barbellRowDefinition;

--- a/lib/workouts/bulgarian-split-squat.ts
+++ b/lib/workouts/bulgarian-split-squat.ts
@@ -1,0 +1,424 @@
+/**
+ * Bulgarian Split Squat Workout Definition
+ *
+ * Defines all the logic for tracking Bulgarian split squat form:
+ * - Phases: setup → standing → descent → bottom → ascent
+ * - Rep boundaries: starts at 'descent', ends at 'standing'
+ * - Thresholds for front-knee / front-hip angles
+ * - Fault detection conditions (4 faults)
+ * - FQI calculation weights
+ *
+ * Unilateral — rear foot elevated on bench. The "front" leg is
+ * approximated by the deeper-bending knee during the rep, matching
+ * the convention established by the lunge form model in #441.
+ *
+ * Proxies used (documented here because JointAngles is sparse):
+ * - `heel_collapse` — no foot/ankle sensor; we use an extreme front-knee
+ *   angle (past the frontKneeForwardLimit) as proxy. A collapsing arch
+ *   lets the knee shoot past the toes, producing a very acute knee angle.
+ */
+
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type {
+  WorkoutDefinition,
+  PhaseDefinition,
+  RepBoundary,
+  FaultDefinition,
+  FQIWeights,
+  AngleRange,
+  WorkoutMetrics,
+  RepContext,
+  ScoringMetricDefinition,
+} from '@/lib/types/workout-definitions';
+import { asymmetryCheck } from './helpers';
+
+// =============================================================================
+// Phase Type
+// =============================================================================
+
+export type BulgarianSplitSquatPhase = 'setup' | 'standing' | 'descent' | 'bottom' | 'ascent';
+
+// =============================================================================
+// Metrics Type
+// =============================================================================
+
+export interface BulgarianSplitSquatMetrics extends WorkoutMetrics {
+  /** Deeper of the two knee angles this frame — the "front" (working) leg */
+  frontKnee: number;
+  /** Shallower of the two knee angles — the "rear" (elevated) leg */
+  rearKnee: number;
+  /** Average hip angle for trunk/lean sanity checks */
+  avgHip: number;
+  legsTracked: boolean;
+}
+
+// =============================================================================
+// Thresholds
+// =============================================================================
+
+export const BULGARIAN_SPLIT_SQUAT_THRESHOLDS = {
+  /** Upright standing — both knees near extended */
+  standing: 160,
+  /** Begin a descent — front knee starts to flex */
+  descentStart: 145,
+  /** Front-knee target bottom (90° ± tolerance) */
+  parallel: 95,
+  /** Depth floor — above this at bottom is "shallow" */
+  depthFloor: 115,
+  /** Deepest acceptable front-knee flexion (below this = forward knee / shin over toes) */
+  frontKneeForwardLimit: 65,
+  /** Front-knee threshold to leave the bottom (transitioning to ascent) */
+  ascent: 110,
+  /** Completed rep (near standing again) */
+  finish: 155,
+  /** Max drive-symmetry percentage — compares frontKnee depth rep-over-rep via left/right */
+  asymmetricDriveMaxPct: 15,
+} as const;
+
+// =============================================================================
+// Angle Ranges
+// =============================================================================
+
+const angleRanges: Record<string, AngleRange> = {
+  frontKnee: {
+    min: 80,
+    max: 110,
+    optimal: 95,
+    tolerance: 15,
+  },
+  rearKnee: {
+    min: 90,
+    max: 140,
+    optimal: 120,
+    tolerance: 20,
+  },
+  hip: {
+    min: 80,
+    max: 180,
+    optimal: 120,
+    tolerance: 20,
+  },
+};
+
+const scoringMetrics: ScoringMetricDefinition[] = [
+  {
+    id: 'knee',
+    extract: (rep, side) => {
+      if (side === 'left') {
+        return {
+          start: rep.start.leftKnee,
+          end: rep.end.leftKnee,
+          min: rep.min.leftKnee,
+          max: rep.max.leftKnee,
+        };
+      }
+      return {
+        start: rep.start.rightKnee,
+        end: rep.end.rightKnee,
+        min: rep.min.rightKnee,
+        max: rep.max.rightKnee,
+      };
+    },
+  },
+  {
+    id: 'hip',
+    extract: (rep, side) => {
+      if (side === 'left') {
+        return {
+          start: rep.start.leftHip,
+          end: rep.end.leftHip,
+          min: rep.min.leftHip,
+          max: rep.max.leftHip,
+        };
+      }
+      return {
+        start: rep.start.rightHip,
+        end: rep.end.rightHip,
+        min: rep.min.rightHip,
+        max: rep.max.rightHip,
+      };
+    },
+  },
+];
+
+// =============================================================================
+// Phase Definitions
+// =============================================================================
+
+const phases: PhaseDefinition<BulgarianSplitSquatPhase>[] = [
+  {
+    id: 'setup',
+    displayName: 'Setup',
+    enterCondition: () => true,
+    staticCue: 'Rear foot on the bench, front foot far enough forward for 90° at the bottom.',
+  },
+  {
+    id: 'standing',
+    displayName: 'Standing',
+    enterCondition: (angles: JointAngles) => {
+      const minKnee = Math.min(angles.leftKnee, angles.rightKnee);
+      return minKnee >= BULGARIAN_SPLIT_SQUAT_THRESHOLDS.standing;
+    },
+    staticCue: 'Tall chest — brace, then lower with control.',
+  },
+  {
+    id: 'descent',
+    displayName: 'Descending',
+    enterCondition: (angles: JointAngles, prevPhase: BulgarianSplitSquatPhase) => {
+      const minKnee = Math.min(angles.leftKnee, angles.rightKnee);
+      return prevPhase === 'standing' && minKnee <= BULGARIAN_SPLIT_SQUAT_THRESHOLDS.descentStart;
+    },
+    staticCue: 'Drop straight down — front shin stays nearly vertical.',
+  },
+  {
+    id: 'bottom',
+    displayName: 'Bottom',
+    enterCondition: (angles: JointAngles, prevPhase: BulgarianSplitSquatPhase) => {
+      const minKnee = Math.min(angles.leftKnee, angles.rightKnee);
+      return prevPhase === 'descent' && minKnee <= BULGARIAN_SPLIT_SQUAT_THRESHOLDS.parallel;
+    },
+    staticCue: 'Front thigh parallel — drive back up through the heel.',
+  },
+  {
+    id: 'ascent',
+    displayName: 'Ascending',
+    enterCondition: (angles: JointAngles, prevPhase: BulgarianSplitSquatPhase) => {
+      const minKnee = Math.min(angles.leftKnee, angles.rightKnee);
+      return prevPhase === 'bottom' && minKnee >= BULGARIAN_SPLIT_SQUAT_THRESHOLDS.ascent;
+    },
+    staticCue: 'Push through the front heel — stand tall.',
+  },
+];
+
+// =============================================================================
+// Rep Boundary
+// =============================================================================
+
+const repBoundary: RepBoundary<BulgarianSplitSquatPhase> = {
+  startPhase: 'descent',
+  endPhase: 'standing',
+  minDurationMs: 800,
+};
+
+// =============================================================================
+// Fault Definitions (4 faults per spec)
+// =============================================================================
+
+const faults: FaultDefinition[] = [
+  {
+    id: 'shallow_depth',
+    displayName: 'Shallow Depth',
+    condition: (ctx: RepContext) => {
+      const minFront = Math.min(ctx.minAngles.leftKnee, ctx.minAngles.rightKnee);
+      if (!Number.isFinite(minFront)) return false;
+      return minFront > BULGARIAN_SPLIT_SQUAT_THRESHOLDS.depthFloor;
+    },
+    severity: 2,
+    dynamicCue: 'Drop deeper — aim for front thigh parallel to the floor.',
+    fqiPenalty: 15,
+  },
+  {
+    id: 'forward_knee',
+    displayName: 'Knee Over Toes',
+    condition: (ctx: RepContext) => {
+      const minFront = Math.min(ctx.minAngles.leftKnee, ctx.minAngles.rightKnee);
+      if (!Number.isFinite(minFront)) return false;
+      return minFront < BULGARIAN_SPLIT_SQUAT_THRESHOLDS.frontKneeForwardLimit;
+    },
+    severity: 1,
+    dynamicCue: 'Shift weight back — keep the front shin closer to vertical.',
+    fqiPenalty: 8,
+  },
+  {
+    id: 'asymmetric_drive',
+    displayName: 'Asymmetric Drive',
+    condition: (ctx: RepContext) => {
+      // Compare the hip angle drop on the working side vs rear side. A
+      // large asymmetric drop suggests the lifter is shifting into the
+      // rear (elevated) leg instead of loading the front.
+      return asymmetryCheck(
+        ctx.minAngles.leftHip,
+        ctx.minAngles.rightHip,
+        BULGARIAN_SPLIT_SQUAT_THRESHOLDS.asymmetricDriveMaxPct
+      );
+    },
+    severity: 2,
+    dynamicCue: 'Sit into the front leg — avoid shifting back onto the rear foot.',
+    fqiPenalty: 10,
+  },
+  {
+    id: 'heel_collapse',
+    displayName: 'Heel Collapse',
+    condition: (ctx: RepContext) => {
+      // Proxy: an extremely acute front-knee angle indicates the knee has
+      // tracked far past the toes, typically with the arch / heel collapsing.
+      const minFront = Math.min(ctx.minAngles.leftKnee, ctx.minAngles.rightKnee);
+      if (!Number.isFinite(minFront)) return false;
+      return minFront < BULGARIAN_SPLIT_SQUAT_THRESHOLDS.frontKneeForwardLimit - 10;
+    },
+    severity: 2,
+    dynamicCue: 'Keep the heel planted and weight through the mid-foot.',
+    fqiPenalty: 10,
+  },
+];
+
+// =============================================================================
+// FQI Weights
+// =============================================================================
+
+const fqiWeights: FQIWeights = {
+  rom: 0.25,
+  depth: 0.45,
+  faults: 0.30,
+};
+
+// =============================================================================
+// Metrics Calculator
+// =============================================================================
+
+function calculateMetrics(
+  angles: JointAngles,
+  _joints?: Map<string, { x: number; y: number; isTracked: boolean }>
+): BulgarianSplitSquatMetrics {
+  const frontKnee = Math.min(angles.leftKnee, angles.rightKnee);
+  const rearKnee = Math.max(angles.leftKnee, angles.rightKnee);
+  const avgHip = (angles.leftHip + angles.rightHip) / 2;
+
+  const legsTracked =
+    angles.leftKnee > 0 && angles.leftKnee < 180 &&
+    angles.rightKnee > 0 && angles.rightKnee < 180 &&
+    angles.leftHip > 0 && angles.leftHip < 180 &&
+    angles.rightHip > 0 && angles.rightHip < 180;
+
+  return {
+    frontKnee,
+    rearKnee,
+    avgHip,
+    armsTracked: false,
+    legsTracked,
+  };
+}
+
+// =============================================================================
+// Phase State Machine
+// =============================================================================
+
+function getNextPhase(
+  currentPhase: BulgarianSplitSquatPhase,
+  _angles: JointAngles,
+  metrics: BulgarianSplitSquatMetrics
+): BulgarianSplitSquatPhase {
+  if (!metrics.legsTracked) {
+    return 'setup';
+  }
+
+  const knee = metrics.frontKnee;
+
+  switch (currentPhase) {
+    case 'setup':
+      if (knee >= BULGARIAN_SPLIT_SQUAT_THRESHOLDS.standing) {
+        return 'standing';
+      }
+      return 'setup';
+
+    case 'standing':
+      if (knee <= BULGARIAN_SPLIT_SQUAT_THRESHOLDS.descentStart) {
+        return 'descent';
+      }
+      return 'standing';
+
+    case 'descent':
+      if (knee <= BULGARIAN_SPLIT_SQUAT_THRESHOLDS.parallel) {
+        return 'bottom';
+      }
+      return 'descent';
+
+    case 'bottom':
+      if (knee >= BULGARIAN_SPLIT_SQUAT_THRESHOLDS.ascent) {
+        return 'ascent';
+      }
+      return 'bottom';
+
+    case 'ascent':
+      if (knee >= BULGARIAN_SPLIT_SQUAT_THRESHOLDS.finish) {
+        return 'standing';
+      }
+      return 'ascent';
+
+    default:
+      return 'setup';
+  }
+}
+
+// =============================================================================
+// Export Workout Definition
+// =============================================================================
+
+export const bulgarianSplitSquatDefinition: WorkoutDefinition<
+  BulgarianSplitSquatPhase,
+  BulgarianSplitSquatMetrics
+> = {
+  id: 'bulgarian_split_squat',
+  displayName: 'Bulgarian Split Squat',
+  description: 'Unilateral lower body movement with rear foot elevated; targets quads and glutes.',
+  category: 'lower_body',
+  difficulty: 'intermediate',
+
+  phases,
+  initialPhase: 'setup',
+  repBoundary,
+  thresholds: BULGARIAN_SPLIT_SQUAT_THRESHOLDS,
+  angleRanges,
+  scoringMetrics,
+  faults,
+  fqiWeights,
+
+  ui: {
+    iconName: 'footsteps-outline',
+    primaryMetric: { key: 'frontKneeDeg', label: 'Front Knee', format: 'deg' },
+    secondaryMetric: { key: 'rearKneeDeg', label: 'Rear Knee', format: 'deg' },
+    buildUploadMetrics: (metrics) => ({
+      frontKneeDeg: metrics?.frontKnee ?? null,
+      rearKneeDeg: metrics?.rearKnee ?? null,
+      avgHipDeg: metrics?.avgHip ?? null,
+    }),
+    buildWatchMetrics: (metrics) => ({
+      frontKneeDeg: metrics?.frontKnee ?? null,
+      rearKneeDeg: metrics?.rearKnee ?? null,
+    }),
+    getRealtimeCues: ({ phaseId, metrics }) => {
+      const messages: string[] = [];
+
+      if (
+        phaseId === 'bottom' &&
+        typeof metrics.frontKnee === 'number' &&
+        metrics.frontKnee > BULGARIAN_SPLIT_SQUAT_THRESHOLDS.depthFloor
+      ) {
+        messages.push('Drop deeper — front thigh parallel to the floor.');
+      }
+
+      if (
+        phaseId === 'bottom' &&
+        typeof metrics.frontKnee === 'number' &&
+        metrics.frontKnee < BULGARIAN_SPLIT_SQUAT_THRESHOLDS.frontKneeForwardLimit
+      ) {
+        messages.push('Shift weight back — keep the front shin vertical.');
+      }
+
+      if (phaseId === 'standing') {
+        messages.push('Reset your stance, breathe, then repeat.');
+      }
+
+      if (messages.length === 0) {
+        messages.push('Sit into the front leg — stay tall through the hips.');
+      }
+
+      return messages;
+    },
+  },
+
+  calculateMetrics,
+  getNextPhase,
+};
+
+export default bulgarianSplitSquatDefinition;

--- a/lib/workouts/dumbbell-curl.ts
+++ b/lib/workouts/dumbbell-curl.ts
@@ -1,0 +1,380 @@
+/**
+ * Dumbbell Curl Workout Definition
+ *
+ * Defines all the logic for tracking dumbbell curl form:
+ * - Phases: setup → bottom → curling → top → lowering
+ * - Rep boundaries: starts at 'curling', ends at 'bottom'
+ * - Thresholds for elbow-flexion angle
+ * - Fault detection conditions (3 faults)
+ * - FQI calculation weights
+ *
+ * Elbow-flexion movement targeting biceps. At the bottom the arms are
+ * fully extended (elbow ~170°, shoulder ~90°). At the top the elbow is
+ * flexed to ~50° with the shoulder only incidentally moving.
+ *
+ * Proxies used (documented here because JointAngles is sparse):
+ * - `swinging` — no wrist/torso rotation sensor; we use a hip-flex delta
+ *   between rep start (standing, hip ~175°) and min hip during the rep.
+ *   A large hip-flex delta indicates the lifter is using a hip-driven
+ *   body swing (kipping) to cheat the weight up. This matches #441's
+ *   use of elbow-proxy for grip_shift in dead-hang: pick the nearest
+ *   joint when the ideal sensor doesn't exist.
+ * - Forearm supination is NOT trackable (no wrist-rotation in JointAngles);
+ *   we intentionally do not attempt a supination fault.
+ */
+
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type {
+  WorkoutDefinition,
+  PhaseDefinition,
+  RepBoundary,
+  FaultDefinition,
+  FQIWeights,
+  AngleRange,
+  WorkoutMetrics,
+  RepContext,
+  ScoringMetricDefinition,
+} from '@/lib/types/workout-definitions';
+import { asymmetryCheck, clampedDelta } from './helpers';
+
+// =============================================================================
+// Phase Type
+// =============================================================================
+
+export type DumbbellCurlPhase = 'setup' | 'bottom' | 'curling' | 'top' | 'lowering';
+
+// =============================================================================
+// Metrics Type
+// =============================================================================
+
+export interface DumbbellCurlMetrics extends WorkoutMetrics {
+  avgElbow: number;
+  avgShoulder: number;
+  avgHip: number;
+  armsTracked: boolean;
+}
+
+// =============================================================================
+// Thresholds
+// =============================================================================
+
+export const DUMBBELL_CURL_THRESHOLDS = {
+  /** Bottom — arms extended */
+  bottomElbow: 160,
+  /** Begin counting a curl once elbow starts flexing */
+  curlingStart: 140,
+  /** Top — elbow fully flexed */
+  topElbow: 60,
+  /** Transition to lowering */
+  loweringStart: 100,
+  /** Rep "incomplete" if top elbow doesn't reach this flexion */
+  incompleteLockoutMin: 80,
+  /** Hip-flex delta at peak curl above which = swinging cheat */
+  swingingHipDeltaMax: 15,
+  /** Asymmetric-curl tolerance on elbow at top (%) */
+  asymmetricCurlMaxPct: 15,
+} as const;
+
+// =============================================================================
+// Angle Ranges
+// =============================================================================
+
+const angleRanges: Record<string, AngleRange> = {
+  elbow: {
+    min: 50,
+    max: 175,
+    optimal: 60,
+    tolerance: 15,
+  },
+  shoulder: {
+    min: 80,
+    max: 120,
+    optimal: 90,
+    tolerance: 15,
+  },
+  hip: {
+    min: 165,
+    max: 185,
+    optimal: 175,
+    tolerance: 8,
+  },
+};
+
+const scoringMetrics: ScoringMetricDefinition[] = [
+  {
+    id: 'elbow',
+    extract: (rep, side) => {
+      if (side === 'left') {
+        return {
+          start: rep.start.leftElbow,
+          end: rep.end.leftElbow,
+          min: rep.min.leftElbow,
+          max: rep.max.leftElbow,
+        };
+      }
+      return {
+        start: rep.start.rightElbow,
+        end: rep.end.rightElbow,
+        min: rep.min.rightElbow,
+        max: rep.max.rightElbow,
+      };
+    },
+  },
+];
+
+// =============================================================================
+// Phase Definitions
+// =============================================================================
+
+const phases: PhaseDefinition<DumbbellCurlPhase>[] = [
+  {
+    id: 'setup',
+    displayName: 'Setup',
+    enterCondition: () => true,
+    staticCue: 'Stand tall, elbows pinned to the sides, palms forward.',
+  },
+  {
+    id: 'bottom',
+    displayName: 'Bottom',
+    enterCondition: (angles: JointAngles) => {
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return avgElbow >= DUMBBELL_CURL_THRESHOLDS.bottomElbow;
+    },
+    staticCue: 'Brace — elbows still, no swinging.',
+  },
+  {
+    id: 'curling',
+    displayName: 'Curling',
+    enterCondition: (angles: JointAngles, prevPhase: DumbbellCurlPhase) => {
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return prevPhase === 'bottom' && avgElbow <= DUMBBELL_CURL_THRESHOLDS.curlingStart;
+    },
+    staticCue: 'Curl the bells — squeeze the biceps, elbows fixed.',
+  },
+  {
+    id: 'top',
+    displayName: 'Top',
+    enterCondition: (angles: JointAngles, prevPhase: DumbbellCurlPhase) => {
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return prevPhase === 'curling' && avgElbow <= DUMBBELL_CURL_THRESHOLDS.topElbow + 10;
+    },
+    staticCue: 'Squeeze hard — hold the top briefly.',
+  },
+  {
+    id: 'lowering',
+    displayName: 'Lowering',
+    enterCondition: (angles: JointAngles, prevPhase: DumbbellCurlPhase) => {
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return prevPhase === 'top' && avgElbow >= DUMBBELL_CURL_THRESHOLDS.loweringStart;
+    },
+    staticCue: 'Lower slow — full stretch at the bottom.',
+  },
+];
+
+// =============================================================================
+// Rep Boundary
+// =============================================================================
+
+const repBoundary: RepBoundary<DumbbellCurlPhase> = {
+  startPhase: 'curling',
+  endPhase: 'bottom',
+  minDurationMs: 600,
+};
+
+// =============================================================================
+// Fault Definitions (3 faults per spec)
+// =============================================================================
+
+const faults: FaultDefinition[] = [
+  {
+    id: 'swinging',
+    displayName: 'Body Swing',
+    condition: (ctx: RepContext) => {
+      // rep starts standing (hip ~175°). Any large hip-flex delta during
+      // the rep indicates hip-driven swinging / kipping to cheat the weight.
+      const leftDelta = clampedDelta(ctx.startAngles.leftHip, ctx.minAngles.leftHip);
+      const rightDelta = clampedDelta(ctx.startAngles.rightHip, ctx.minAngles.rightHip);
+      const maxSwing = Math.max(Math.abs(leftDelta), Math.abs(rightDelta));
+      return maxSwing > DUMBBELL_CURL_THRESHOLDS.swingingHipDeltaMax;
+    },
+    severity: 2,
+    dynamicCue: 'Stop swinging — lock the hips, let the biceps do the work.',
+    fqiPenalty: 12,
+  },
+  {
+    id: 'incomplete_lockout',
+    displayName: 'Incomplete Curl',
+    condition: (ctx: RepContext) => {
+      const minElbow = Math.min(ctx.minAngles.leftElbow, ctx.minAngles.rightElbow);
+      if (!Number.isFinite(minElbow)) return false;
+      return minElbow > DUMBBELL_CURL_THRESHOLDS.incompleteLockoutMin;
+    },
+    severity: 1,
+    dynamicCue: 'Curl higher — bring the dumbbells to the shoulders.',
+    fqiPenalty: 8,
+  },
+  {
+    id: 'asymmetric_curl',
+    displayName: 'Asymmetric Curl',
+    condition: (ctx: RepContext) => {
+      return asymmetryCheck(
+        ctx.minAngles.leftElbow,
+        ctx.minAngles.rightElbow,
+        DUMBBELL_CURL_THRESHOLDS.asymmetricCurlMaxPct
+      );
+    },
+    severity: 1,
+    dynamicCue: 'Curl both arms together — match the tempo side to side.',
+    fqiPenalty: 6,
+  },
+];
+
+// =============================================================================
+// FQI Weights
+// =============================================================================
+
+const fqiWeights: FQIWeights = {
+  rom: 0.4,
+  depth: 0.25,
+  faults: 0.35,
+};
+
+// =============================================================================
+// Metrics Calculator
+// =============================================================================
+
+function calculateMetrics(
+  angles: JointAngles,
+  _joints?: Map<string, { x: number; y: number; isTracked: boolean }>
+): DumbbellCurlMetrics {
+  const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+  const avgShoulder = (angles.leftShoulder + angles.rightShoulder) / 2;
+  const avgHip = (angles.leftHip + angles.rightHip) / 2;
+
+  const armsTracked =
+    angles.leftElbow > 0 && angles.leftElbow < 180 &&
+    angles.rightElbow > 0 && angles.rightElbow < 180;
+
+  return {
+    avgElbow,
+    avgShoulder,
+    avgHip,
+    armsTracked,
+  };
+}
+
+// =============================================================================
+// Phase State Machine
+// =============================================================================
+
+function getNextPhase(
+  currentPhase: DumbbellCurlPhase,
+  _angles: JointAngles,
+  metrics: DumbbellCurlMetrics
+): DumbbellCurlPhase {
+  if (!metrics.armsTracked) {
+    return 'setup';
+  }
+
+  const elbow = metrics.avgElbow;
+
+  switch (currentPhase) {
+    case 'setup':
+      if (elbow >= DUMBBELL_CURL_THRESHOLDS.bottomElbow) {
+        return 'bottom';
+      }
+      return 'setup';
+
+    case 'bottom':
+      if (elbow <= DUMBBELL_CURL_THRESHOLDS.curlingStart) {
+        return 'curling';
+      }
+      return 'bottom';
+
+    case 'curling':
+      if (elbow <= DUMBBELL_CURL_THRESHOLDS.topElbow + 10) {
+        return 'top';
+      }
+      return 'curling';
+
+    case 'top':
+      if (elbow >= DUMBBELL_CURL_THRESHOLDS.loweringStart) {
+        return 'lowering';
+      }
+      return 'top';
+
+    case 'lowering':
+      if (elbow >= DUMBBELL_CURL_THRESHOLDS.bottomElbow) {
+        return 'bottom';
+      }
+      return 'lowering';
+
+    default:
+      return 'setup';
+  }
+}
+
+// =============================================================================
+// Export Workout Definition
+// =============================================================================
+
+export const dumbbellCurlDefinition: WorkoutDefinition<DumbbellCurlPhase, DumbbellCurlMetrics> = {
+  id: 'dumbbell_curl',
+  displayName: 'Dumbbell Curl',
+  description: 'Isolation movement targeting the biceps via elbow flexion.',
+  category: 'upper_body',
+  difficulty: 'beginner',
+
+  phases,
+  initialPhase: 'setup',
+  repBoundary,
+  thresholds: DUMBBELL_CURL_THRESHOLDS,
+  angleRanges,
+  scoringMetrics,
+  faults,
+  fqiWeights,
+
+  ui: {
+    iconName: 'fitness-outline',
+    primaryMetric: { key: 'avgElbowDeg', label: 'Avg Elbow', format: 'deg' },
+    secondaryMetric: { key: 'avgHipDeg', label: 'Avg Hip', format: 'deg' },
+    buildUploadMetrics: (metrics) => ({
+      avgElbowDeg: metrics?.avgElbow ?? null,
+      avgShoulderDeg: metrics?.avgShoulder ?? null,
+      avgHipDeg: metrics?.avgHip ?? null,
+    }),
+    buildWatchMetrics: (metrics) => ({
+      avgElbowDeg: metrics?.avgElbow ?? null,
+    }),
+    getRealtimeCues: ({ phaseId, metrics }) => {
+      const messages: string[] = [];
+
+      if (
+        phaseId === 'curling' &&
+        typeof metrics.avgHip === 'number' &&
+        metrics.avgHip < 165
+      ) {
+        messages.push('Stop swinging — hips stay locked.');
+      }
+
+      if (
+        phaseId === 'top' &&
+        typeof metrics.avgElbow === 'number' &&
+        metrics.avgElbow > DUMBBELL_CURL_THRESHOLDS.incompleteLockoutMin
+      ) {
+        messages.push('Squeeze all the way up — full biceps contraction.');
+      }
+
+      if (messages.length === 0) {
+        messages.push('Slow tempo — elbows pinned, control the descent.');
+      }
+
+      return messages;
+    },
+  },
+
+  calculateMetrics,
+  getNextPhase,
+};
+
+export default dumbbellCurlDefinition;

--- a/lib/workouts/helpers.ts
+++ b/lib/workouts/helpers.ts
@@ -1,4 +1,4 @@
-import type { WorkoutDefinition, WorkoutMetrics } from '@/lib/types/workout-definitions';
+import type { AngleRange, WorkoutDefinition, WorkoutMetrics } from '@/lib/types/workout-definitions';
 
 export function getPhaseStaticCue<P extends string, M extends WorkoutMetrics>(
   definition: WorkoutDefinition<P, M>,
@@ -13,4 +13,119 @@ export function getPhaseStaticCue(
   phaseId: string
 ): string | null {
   return definition.phases.find((phase) => phase.id === phaseId)?.staticCue ?? null;
+}
+
+// =============================================================================
+// Validation helpers (shared between workouts)
+// =============================================================================
+
+/**
+ * Type guard: returns true iff value is a finite number (not NaN, not Infinity).
+ * Safer than `Number.isFinite` in strict-typed code because it narrows the type.
+ */
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+/**
+ * Returns true iff the asymmetry between `left` and `right` exceeds `maxDiffPct`
+ * (expressed as a percentage, 0-100) of the larger of the two magnitudes.
+ *
+ * NaN-safe: returns `false` on any non-finite input or when both sides are zero.
+ *
+ * @example
+ *   asymmetryCheck(90, 110, 15) // true — 20° diff > 15% of 110
+ *   asymmetryCheck(100, 98, 5) // false — 2° diff well under 5% of 100
+ *   asymmetryCheck(NaN, 90, 10) // false — bad input
+ */
+export function asymmetryCheck(left: number, right: number, maxDiffPct: number): boolean {
+  if (!isFiniteNumber(left) || !isFiniteNumber(right) || !isFiniteNumber(maxDiffPct)) {
+    return false;
+  }
+  if (maxDiffPct < 0) {
+    return false;
+  }
+  const larger = Math.max(Math.abs(left), Math.abs(right));
+  if (larger === 0) {
+    return false;
+  }
+  const diff = Math.abs(left - right);
+  const pct = (diff / larger) * 100;
+  return pct > maxDiffPct;
+}
+
+/**
+ * Returns `true` iff the sequencing between two joints is faulty.
+ *
+ * A sequencing fault occurs when the joint expected to lead the movement does
+ * NOT move more than the lagging joint. For example, in a deadlift the hips
+ * should rise before the shoulders — if the shoulder delta outpaces the hip
+ * delta (i.e. the back rounds), this returns `true`.
+ *
+ * @param primaryStart starting angle of the primary (should-lead) joint
+ * @param primaryMax peak angle of the primary joint during the movement
+ * @param secondaryStart starting angle of the secondary (should-follow) joint
+ * @param secondaryMax peak angle of the secondary joint during the movement
+ * @param shouldPrimaryRiseFirst when `true`, the primary is expected to move
+ *   *more* than the secondary; when `false`, the check is inverted.
+ *
+ * NaN-safe: returns `false` on any non-finite input.
+ */
+export function sequenceCheck(
+  primaryStart: number,
+  primaryMax: number,
+  secondaryStart: number,
+  secondaryMax: number,
+  shouldPrimaryRiseFirst: boolean
+): boolean {
+  if (
+    !isFiniteNumber(primaryStart) ||
+    !isFiniteNumber(primaryMax) ||
+    !isFiniteNumber(secondaryStart) ||
+    !isFiniteNumber(secondaryMax)
+  ) {
+    return false;
+  }
+  const primaryDelta = Math.abs(primaryMax - primaryStart);
+  const secondaryDelta = Math.abs(secondaryMax - secondaryStart);
+  if (shouldPrimaryRiseFirst) {
+    return primaryDelta < secondaryDelta;
+  }
+  return primaryDelta > secondaryDelta;
+}
+
+/**
+ * Returns `true` iff `angle` sits inside `[range.min, range.max]`.
+ *
+ * Note: this is an inclusive range check and does NOT incorporate `optimal`
+ * or `tolerance`; use those fields separately when building fault conditions
+ * that need to penalize deviation from an optimal target.
+ *
+ * NaN-safe: returns `false` on any non-finite `angle` or malformed range.
+ */
+export function validateAngleInRange(angle: number, range: AngleRange): boolean {
+  if (!isFiniteNumber(angle) || !range) {
+    return false;
+  }
+  if (!isFiniteNumber(range.min) || !isFiniteNumber(range.max)) {
+    return false;
+  }
+  if (range.max < range.min) {
+    return false;
+  }
+  return angle >= range.min && angle <= range.max;
+}
+
+/**
+ * NaN-safe delta between two scalars.
+ *
+ * Returns `0` if either value is non-finite. Useful for building fault
+ * conditions that reference `maxAngles.x - startAngles.x` without littering
+ * guards throughout the workout files.
+ */
+export function clampedDelta(from: number, to: number): number {
+  if (!isFiniteNumber(from) || !isFiniteNumber(to)) {
+    return 0;
+  }
+  return to - from;
 }

--- a/lib/workouts/hip-thrust.ts
+++ b/lib/workouts/hip-thrust.ts
@@ -1,0 +1,418 @@
+/**
+ * Hip Thrust Workout Definition
+ *
+ * Defines all the logic for tracking hip thrust form:
+ * - Phases: setup → bottom → ascent → lockout → descent
+ * - Rep boundaries: starts at 'ascent', ends at 'lockout'
+ * - Thresholds for hip-extension angle
+ * - Fault detection conditions (5 faults)
+ * - FQI calculation weights
+ *
+ * Bilateral lower-posterior-chain movement. The "hip angle" from the
+ * standard JointAngles interface is the anterior hip-flexion angle, so
+ * at the top of a clean rep both hips are near-extended (~170-180°)
+ * and at the bottom they're near 90° with the shoulders on the bench
+ * and feet on the floor.
+ *
+ * Proxies used (documented here because JointAngles is sparse):
+ * - `heel_liftoff` — no foot-position sensor; we compare left/right knee
+ *   angles at peak hip extension. A clean hip thrust keeps both knees
+ *   near 90°; if one knee drives to ~180° (leg extended / heel off) the
+ *   knee-angle delta widens.
+ */
+
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type {
+  WorkoutDefinition,
+  PhaseDefinition,
+  RepBoundary,
+  FaultDefinition,
+  FQIWeights,
+  AngleRange,
+  WorkoutMetrics,
+  RepContext,
+  ScoringMetricDefinition,
+} from '@/lib/types/workout-definitions';
+import { asymmetryCheck } from './helpers';
+
+// =============================================================================
+// Phase Type
+// =============================================================================
+
+export type HipThrustPhase = 'setup' | 'bottom' | 'ascent' | 'lockout' | 'descent';
+
+// =============================================================================
+// Metrics Type
+// =============================================================================
+
+export interface HipThrustMetrics extends WorkoutMetrics {
+  avgHip: number;
+  avgKnee: number;
+  legsTracked: boolean;
+}
+
+// =============================================================================
+// Thresholds
+// =============================================================================
+
+export const HIP_THRUST_THRESHOLDS = {
+  /** Bottom of the rep — hip flexed at ~90° (glute below bench) */
+  bottomHip: 100,
+  /** Begin counting ascent once we've cleared the bottom */
+  ascentStart: 120,
+  /** Lockout hip angle — full hip extension */
+  lockoutHip: 165,
+  /** Minimum hip angle at bottom below which depth is considered ROM */
+  depthFloor: 115,
+  /** Hip-angle asymmetry tolerance at peak (as % of the larger side) */
+  asymmetricExtMaxPct: 12,
+  /**
+   * Knee asymmetry at peak extension. Proxy for heel liftoff — a lifted
+   * heel lets that leg extend (knee angle creeps toward 180°) while
+   * the other stays planted near 90°.
+   */
+  heelLiftoffKneeDiffMax: 30,
+  /** Hip angle above this at peak = hyperextension / lumbar over-arching */
+  hyperExtensionMax: 185,
+  /** Minimum peak-hip angle below which we treat the rep as "incomplete lockout" */
+  incompleteLockoutMin: 155,
+} as const;
+
+// =============================================================================
+// Angle Ranges
+// =============================================================================
+
+const angleRanges: Record<string, AngleRange> = {
+  hip: {
+    min: 90,
+    max: 180,
+    optimal: 175,
+    tolerance: 10,
+  },
+  knee: {
+    min: 80,
+    max: 110,
+    optimal: 90,
+    tolerance: 15,
+  },
+};
+
+const scoringMetrics: ScoringMetricDefinition[] = [
+  {
+    id: 'hip',
+    extract: (rep, side) => {
+      if (side === 'left') {
+        return {
+          start: rep.start.leftHip,
+          end: rep.end.leftHip,
+          min: rep.min.leftHip,
+          max: rep.max.leftHip,
+        };
+      }
+      return {
+        start: rep.start.rightHip,
+        end: rep.end.rightHip,
+        min: rep.min.rightHip,
+        max: rep.max.rightHip,
+      };
+    },
+  },
+  {
+    id: 'knee',
+    extract: (rep, side) => {
+      if (side === 'left') {
+        return {
+          start: rep.start.leftKnee,
+          end: rep.end.leftKnee,
+          min: rep.min.leftKnee,
+          max: rep.max.leftKnee,
+        };
+      }
+      return {
+        start: rep.start.rightKnee,
+        end: rep.end.rightKnee,
+        min: rep.min.rightKnee,
+        max: rep.max.rightKnee,
+      };
+    },
+  },
+];
+
+// =============================================================================
+// Phase Definitions
+// =============================================================================
+
+const phases: PhaseDefinition<HipThrustPhase>[] = [
+  {
+    id: 'setup',
+    displayName: 'Setup',
+    enterCondition: () => true,
+    staticCue: 'Upper back on the bench, feet flat, shins vertical at the top.',
+  },
+  {
+    id: 'bottom',
+    displayName: 'Bottom',
+    enterCondition: (angles: JointAngles) => {
+      const avgHip = (angles.leftHip + angles.rightHip) / 2;
+      return avgHip <= HIP_THRUST_THRESHOLDS.bottomHip;
+    },
+    staticCue: 'Brace, tuck chin, drive through the heels.',
+  },
+  {
+    id: 'ascent',
+    displayName: 'Ascending',
+    enterCondition: (angles: JointAngles, prevPhase: HipThrustPhase) => {
+      const avgHip = (angles.leftHip + angles.rightHip) / 2;
+      return prevPhase === 'bottom' && avgHip >= HIP_THRUST_THRESHOLDS.ascentStart;
+    },
+    staticCue: 'Hips up — squeeze the glutes as you drive.',
+  },
+  {
+    id: 'lockout',
+    displayName: 'Lockout',
+    enterCondition: (angles: JointAngles, prevPhase: HipThrustPhase) => {
+      const avgHip = (angles.leftHip + angles.rightHip) / 2;
+      return prevPhase === 'ascent' && avgHip >= HIP_THRUST_THRESHOLDS.lockoutHip;
+    },
+    staticCue: 'Full hip extension — ribs down, do not over-arch.',
+  },
+  {
+    id: 'descent',
+    displayName: 'Descending',
+    enterCondition: (angles: JointAngles, prevPhase: HipThrustPhase) => {
+      const avgHip = (angles.leftHip + angles.rightHip) / 2;
+      return prevPhase === 'lockout' && avgHip <= HIP_THRUST_THRESHOLDS.ascentStart;
+    },
+    staticCue: 'Lower under control — keep glutes engaged.',
+  },
+];
+
+// =============================================================================
+// Rep Boundary
+// =============================================================================
+
+const repBoundary: RepBoundary<HipThrustPhase> = {
+  startPhase: 'ascent',
+  endPhase: 'lockout',
+  minDurationMs: 600,
+};
+
+// =============================================================================
+// Fault Definitions (5 faults per spec)
+// =============================================================================
+
+const faults: FaultDefinition[] = [
+  {
+    id: 'shallow_depth',
+    displayName: 'Shallow Depth',
+    condition: (ctx: RepContext) => {
+      const minHip = Math.min(ctx.minAngles.leftHip, ctx.minAngles.rightHip);
+      if (!Number.isFinite(minHip)) return false;
+      return minHip > HIP_THRUST_THRESHOLDS.depthFloor;
+    },
+    severity: 2,
+    dynamicCue: 'Lower further — let the hips drop until they crease under the bench.',
+    fqiPenalty: 12,
+  },
+  {
+    id: 'heel_liftoff',
+    displayName: 'Heel Liftoff',
+    condition: (ctx: RepContext) => {
+      const left = ctx.maxAngles.leftKnee;
+      const right = ctx.maxAngles.rightKnee;
+      if (!Number.isFinite(left) || !Number.isFinite(right)) return false;
+      return Math.abs(left - right) > HIP_THRUST_THRESHOLDS.heelLiftoffKneeDiffMax;
+    },
+    severity: 2,
+    dynamicCue: 'Drive through the whole foot — keep both heels planted.',
+    fqiPenalty: 10,
+  },
+  {
+    id: 'incomplete_lockout',
+    displayName: 'Incomplete Lockout',
+    condition: (ctx: RepContext) => {
+      const maxHip = Math.max(ctx.maxAngles.leftHip, ctx.maxAngles.rightHip);
+      if (!Number.isFinite(maxHip)) return false;
+      return maxHip < HIP_THRUST_THRESHOLDS.incompleteLockoutMin;
+    },
+    severity: 2,
+    dynamicCue: 'Finish each rep — drive hips to full extension.',
+    fqiPenalty: 12,
+  },
+  {
+    id: 'asymmetric_extension',
+    displayName: 'Asymmetric Extension',
+    condition: (ctx: RepContext) => {
+      return asymmetryCheck(
+        ctx.maxAngles.leftHip,
+        ctx.maxAngles.rightHip,
+        HIP_THRUST_THRESHOLDS.asymmetricExtMaxPct
+      );
+    },
+    severity: 1,
+    dynamicCue: 'Drive evenly — keep both hips rising together.',
+    fqiPenalty: 8,
+  },
+  {
+    id: 'hyperextension',
+    displayName: 'Lumbar Hyperextension',
+    condition: (ctx: RepContext) => {
+      const maxHip = Math.max(ctx.maxAngles.leftHip, ctx.maxAngles.rightHip);
+      if (!Number.isFinite(maxHip)) return false;
+      return maxHip > HIP_THRUST_THRESHOLDS.hyperExtensionMax;
+    },
+    severity: 1,
+    dynamicCue: 'Ribs down — finish with the glutes, not the lower back.',
+    fqiPenalty: 8,
+  },
+];
+
+// =============================================================================
+// FQI Weights
+// =============================================================================
+
+const fqiWeights: FQIWeights = {
+  rom: 0.25,
+  depth: 0.4,
+  faults: 0.35,
+};
+
+// =============================================================================
+// Metrics Calculator
+// =============================================================================
+
+function calculateMetrics(
+  angles: JointAngles,
+  _joints?: Map<string, { x: number; y: number; isTracked: boolean }>
+): HipThrustMetrics {
+  const avgHip = (angles.leftHip + angles.rightHip) / 2;
+  const avgKnee = (angles.leftKnee + angles.rightKnee) / 2;
+
+  const legsTracked =
+    angles.leftKnee > 0 && angles.leftKnee < 180 &&
+    angles.rightKnee > 0 && angles.rightKnee < 180 &&
+    angles.leftHip > 0 && angles.leftHip < 180 &&
+    angles.rightHip > 0 && angles.rightHip < 180;
+
+  return {
+    avgHip,
+    avgKnee,
+    armsTracked: false,
+    legsTracked,
+  };
+}
+
+// =============================================================================
+// Phase State Machine
+// =============================================================================
+
+function getNextPhase(
+  currentPhase: HipThrustPhase,
+  _angles: JointAngles,
+  metrics: HipThrustMetrics
+): HipThrustPhase {
+  if (!metrics.legsTracked) {
+    return 'setup';
+  }
+
+  const hip = metrics.avgHip;
+
+  switch (currentPhase) {
+    case 'setup':
+      if (hip <= HIP_THRUST_THRESHOLDS.bottomHip) {
+        return 'bottom';
+      }
+      return 'setup';
+
+    case 'bottom':
+      if (hip >= HIP_THRUST_THRESHOLDS.ascentStart) {
+        return 'ascent';
+      }
+      return 'bottom';
+
+    case 'ascent':
+      if (hip >= HIP_THRUST_THRESHOLDS.lockoutHip) {
+        return 'lockout';
+      }
+      return 'ascent';
+
+    case 'lockout':
+      if (hip <= HIP_THRUST_THRESHOLDS.ascentStart) {
+        return 'descent';
+      }
+      return 'lockout';
+
+    case 'descent':
+      if (hip <= HIP_THRUST_THRESHOLDS.bottomHip) {
+        return 'bottom';
+      }
+      return 'descent';
+
+    default:
+      return 'setup';
+  }
+}
+
+// =============================================================================
+// Export Workout Definition
+// =============================================================================
+
+export const hipThrustDefinition: WorkoutDefinition<HipThrustPhase, HipThrustMetrics> = {
+  id: 'hip_thrust',
+  displayName: 'Hip Thrust',
+  description: 'Hip-dominant posterior chain movement targeting glutes and hamstrings.',
+  category: 'lower_body',
+  difficulty: 'intermediate',
+
+  phases,
+  initialPhase: 'setup',
+  repBoundary,
+  thresholds: HIP_THRUST_THRESHOLDS,
+  angleRanges,
+  scoringMetrics,
+  faults,
+  fqiWeights,
+
+  ui: {
+    iconName: 'trending-up-outline',
+    primaryMetric: { key: 'avgHipDeg', label: 'Avg Hip', format: 'deg' },
+    secondaryMetric: { key: 'avgKneeDeg', label: 'Avg Knee', format: 'deg' },
+    buildUploadMetrics: (metrics) => ({
+      avgHipDeg: metrics?.avgHip ?? null,
+      avgKneeDeg: metrics?.avgKnee ?? null,
+    }),
+    buildWatchMetrics: (metrics) => ({
+      avgHipDeg: metrics?.avgHip ?? null,
+    }),
+    getRealtimeCues: ({ phaseId, metrics }) => {
+      const messages: string[] = [];
+
+      if (
+        phaseId === 'lockout' &&
+        typeof metrics.avgHip === 'number' &&
+        metrics.avgHip > HIP_THRUST_THRESHOLDS.hyperExtensionMax
+      ) {
+        messages.push('Ribs down — finish with the glutes, not the lower back.');
+      }
+
+      if (
+        phaseId === 'ascent' &&
+        typeof metrics.avgHip === 'number' &&
+        metrics.avgHip < HIP_THRUST_THRESHOLDS.incompleteLockoutMin
+      ) {
+        messages.push('Drive higher — aim for full hip extension.');
+      }
+
+      if (messages.length === 0) {
+        messages.push('Controlled tempo — squeeze at the top.');
+      }
+
+      return messages;
+    },
+  },
+
+  calculateMetrics,
+  getNextPhase,
+};
+
+export default hipThrustDefinition;

--- a/lib/workouts/index.ts
+++ b/lib/workouts/index.ts
@@ -8,20 +8,32 @@
 import type { WorkoutDefinition, WorkoutRegistry } from '@/lib/types/workout-definitions';
 
 // Import individual workout definitions
+import { barbellRowDefinition, type BarbellRowPhase, type BarbellRowMetrics } from './barbell-row';
 import { benchpressDefinition, type BenchPressPhase, type BenchPressMetrics } from './benchpress';
+import { bulgarianSplitSquatDefinition, type BulgarianSplitSquatPhase, type BulgarianSplitSquatMetrics } from './bulgarian-split-squat';
 import { deadHangDefinition, type DeadHangPhase, type DeadHangMetrics } from './dead-hang';
 import { deadliftDefinition, type DeadliftPhase, type DeadliftMetrics } from './deadlift';
+import { dumbbellCurlDefinition, type DumbbellCurlPhase, type DumbbellCurlMetrics } from './dumbbell-curl';
 import { farmersWalkDefinition, type FarmersWalkPhase, type FarmersWalkMetrics } from './farmers-walk';
+import { hipThrustDefinition, type HipThrustPhase, type HipThrustMetrics } from './hip-thrust';
+import { latPulldownDefinition, type LatPulldownPhase, type LatPulldownMetrics } from './lat-pulldown';
+import { overheadPressDefinition, type OverheadPressPhase, type OverheadPressMetrics } from './overhead-press';
 import { pullupDefinition, type PullUpPhase, type PullUpMetrics } from './pullup';
 import { pushupDefinition, type PushUpPhase, type PushUpMetrics } from './pushup';
 import { rdlDefinition, type RDLPhase, type RDLMetrics } from './rdl';
 import { squatDefinition, type SquatPhase, type SquatMetrics } from './squat';
 
 export const workoutsByMode = {
+  barbell_row: barbellRowDefinition,
   benchpress: benchpressDefinition,
+  bulgarian_split_squat: bulgarianSplitSquatDefinition,
   dead_hang: deadHangDefinition,
   deadlift: deadliftDefinition,
+  dumbbell_curl: dumbbellCurlDefinition,
   farmers_walk: farmersWalkDefinition,
+  hip_thrust: hipThrustDefinition,
+  lat_pulldown: latPulldownDefinition,
+  overhead_press: overheadPressDefinition,
   pullup: pullupDefinition,
   pushup: pushupDefinition,
   rdl: rdlDefinition,
@@ -33,10 +45,16 @@ export const workoutsByMode = {
 // =============================================================================
 
 // Re-export individual definitions for direct import
+export { barbellRowDefinition, BARBELL_ROW_THRESHOLDS, type BarbellRowPhase, type BarbellRowMetrics } from './barbell-row';
 export { benchpressDefinition, BENCHPRESS_THRESHOLDS, type BenchPressPhase, type BenchPressMetrics } from './benchpress';
+export { bulgarianSplitSquatDefinition, BULGARIAN_SPLIT_SQUAT_THRESHOLDS, type BulgarianSplitSquatPhase, type BulgarianSplitSquatMetrics } from './bulgarian-split-squat';
 export { deadHangDefinition, DEAD_HANG_THRESHOLDS, type DeadHangPhase, type DeadHangMetrics } from './dead-hang';
 export { deadliftDefinition, DEADLIFT_THRESHOLDS, type DeadliftPhase, type DeadliftMetrics } from './deadlift';
+export { dumbbellCurlDefinition, DUMBBELL_CURL_THRESHOLDS, type DumbbellCurlPhase, type DumbbellCurlMetrics } from './dumbbell-curl';
 export { farmersWalkDefinition, FARMERS_WALK_THRESHOLDS, type FarmersWalkPhase, type FarmersWalkMetrics } from './farmers-walk';
+export { hipThrustDefinition, HIP_THRUST_THRESHOLDS, type HipThrustPhase, type HipThrustMetrics } from './hip-thrust';
+export { latPulldownDefinition, LAT_PULLDOWN_THRESHOLDS, type LatPulldownPhase, type LatPulldownMetrics } from './lat-pulldown';
+export { overheadPressDefinition, OVERHEAD_PRESS_THRESHOLDS, type OverheadPressPhase, type OverheadPressMetrics } from './overhead-press';
 export { pullupDefinition, PULLUP_THRESHOLDS, type PullUpPhase, type PullUpMetrics } from './pullup';
 export { pushupDefinition, PUSHUP_THRESHOLDS, type PushUpPhase, type PushUpMetrics } from './pushup';
 export { rdlDefinition, RDL_THRESHOLDS, type RDLPhase, type RDLMetrics } from './rdl';
@@ -53,15 +71,21 @@ export type { WorkoutDefinition, WorkoutRegistry } from '@/lib/types/workout-def
 /**
  * Map of workout ID to workout definition
  * Use this to look up a workout by its ID string
- * 
+ *
  * Note: We use type assertion here because each workout has specific phase types,
  * but the registry needs to store them generically for lookup purposes.
  */
 export const workoutRegistry: WorkoutRegistry = {
+  barbell_row: barbellRowDefinition as unknown as WorkoutDefinition,
   benchpress: benchpressDefinition as unknown as WorkoutDefinition,
+  bulgarian_split_squat: bulgarianSplitSquatDefinition as unknown as WorkoutDefinition,
   dead_hang: deadHangDefinition as unknown as WorkoutDefinition,
   deadlift: deadliftDefinition as unknown as WorkoutDefinition,
+  dumbbell_curl: dumbbellCurlDefinition as unknown as WorkoutDefinition,
   farmers_walk: farmersWalkDefinition as unknown as WorkoutDefinition,
+  hip_thrust: hipThrustDefinition as unknown as WorkoutDefinition,
+  lat_pulldown: latPulldownDefinition as unknown as WorkoutDefinition,
+  overhead_press: overheadPressDefinition as unknown as WorkoutDefinition,
   pullup: pullupDefinition as unknown as WorkoutDefinition,
   pushup: pushupDefinition as unknown as WorkoutDefinition,
   rdl: rdlDefinition as unknown as WorkoutDefinition,

--- a/lib/workouts/lat-pulldown.ts
+++ b/lib/workouts/lat-pulldown.ts
@@ -246,9 +246,13 @@ const faults: FaultDefinition[] = [
     id: 'elbows_flare',
     displayName: 'Elbows Flared',
     condition: (ctx: RepContext) => {
-      const maxShoulder = Math.max(ctx.maxAngles.leftShoulder, ctx.maxAngles.rightShoulder);
-      if (!Number.isFinite(maxShoulder)) return false;
-      return maxShoulder > LAT_PULLDOWN_THRESHOLDS.elbowsFlareShoulderMax;
+      // Evaluate the shoulder angle at the BOTTOM of the pull (minAngles)
+      // — arms overhead at the "top" naturally have high shoulder abduction
+      // so checking maxAngles would always fire. At the bottom the shoulder
+      // should be tucked below elbowsFlareShoulderMax; above it = flared.
+      const bottomShoulder = Math.max(ctx.minAngles.leftShoulder, ctx.minAngles.rightShoulder);
+      if (!Number.isFinite(bottomShoulder)) return false;
+      return bottomShoulder > LAT_PULLDOWN_THRESHOLDS.elbowsFlareShoulderMax;
     },
     severity: 2,
     dynamicCue: 'Keep elbows in line with the wrists — no chicken-winging.',

--- a/lib/workouts/lat-pulldown.ts
+++ b/lib/workouts/lat-pulldown.ts
@@ -1,0 +1,404 @@
+/**
+ * Lat Pulldown Workout Definition
+ *
+ * Defines all the logic for tracking lat pulldown form:
+ * - Phases: setup → top → pulling → bottom → releasing
+ * - Rep boundaries: starts at 'pulling', ends at 'top'
+ * - Thresholds for elbow-flexion and shoulder-lean angles
+ * - Fault detection conditions (4 faults)
+ * - FQI calculation weights
+ *
+ * Seated vertical pulling movement. At the "top" the arms are fully
+ * extended overhead (elbow ~170°, shoulder ~160°+). At "bottom" the bar
+ * is at the upper chest with elbows flexed (~80°) and shoulders at ~90°.
+ *
+ * Proxies used (documented here because JointAngles is sparse):
+ * - `excessive_lean` — no spine sensor; we use the shoulder-angle delta
+ *   between start and peak pull. A lifter leaning back aggressively will
+ *   drop the shoulder angle below the expected "seated" envelope.
+ * - `elbows_flare` — a high shoulder-abduction angle at the top of the pull
+ *   indicates the elbows flared wide (bar pulled behind the neck / flared).
+ */
+
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type {
+  WorkoutDefinition,
+  PhaseDefinition,
+  RepBoundary,
+  FaultDefinition,
+  FQIWeights,
+  AngleRange,
+  WorkoutMetrics,
+  RepContext,
+  ScoringMetricDefinition,
+} from '@/lib/types/workout-definitions';
+import { asymmetryCheck, clampedDelta } from './helpers';
+
+// =============================================================================
+// Phase Type
+// =============================================================================
+
+export type LatPulldownPhase = 'setup' | 'top' | 'pulling' | 'bottom' | 'releasing';
+
+// =============================================================================
+// Metrics Type
+// =============================================================================
+
+export interface LatPulldownMetrics extends WorkoutMetrics {
+  avgElbow: number;
+  avgShoulder: number;
+  armsTracked: boolean;
+}
+
+// =============================================================================
+// Thresholds
+// =============================================================================
+
+export const LAT_PULLDOWN_THRESHOLDS = {
+  /** Arms extended overhead — elbow near-straight */
+  topElbow: 160,
+  /** Begin counting a pull once elbow starts flexing */
+  pullingStart: 145,
+  /** Bottom of pull — elbow flexed ~80° */
+  bottomElbow: 90,
+  /** Transition to releasing when elbow begins to extend again */
+  releasingStart: 110,
+  /** Rep "incomplete" if bottom elbow is still above this */
+  incompleteLockoutMin: 105,
+  /** Shoulder angle at top above which = elbow flare */
+  elbowsFlareShoulderMax: 125,
+  /** Asymmetric-pull tolerance on elbow angle at bottom (%) */
+  asymmetricPullMaxPct: 15,
+  /**
+   * Excessive-lean shoulder delta — if shoulder angle drops by more than
+   * this between rep start (arms overhead) and peak pull (arms down), the
+   * lifter is leaning back / cheating.
+   */
+  excessiveLeanShoulderDeltaMax: 60,
+} as const;
+
+// =============================================================================
+// Angle Ranges
+// =============================================================================
+
+const angleRanges: Record<string, AngleRange> = {
+  elbow: {
+    min: 75,
+    max: 170,
+    optimal: 85,
+    tolerance: 15,
+  },
+  shoulder: {
+    min: 70,
+    max: 170,
+    optimal: 150,
+    tolerance: 20,
+  },
+};
+
+const scoringMetrics: ScoringMetricDefinition[] = [
+  {
+    id: 'elbow',
+    extract: (rep, side) => {
+      if (side === 'left') {
+        return {
+          start: rep.start.leftElbow,
+          end: rep.end.leftElbow,
+          min: rep.min.leftElbow,
+          max: rep.max.leftElbow,
+        };
+      }
+      return {
+        start: rep.start.rightElbow,
+        end: rep.end.rightElbow,
+        min: rep.min.rightElbow,
+        max: rep.max.rightElbow,
+      };
+    },
+  },
+  {
+    id: 'shoulder',
+    extract: (rep, side) => {
+      if (side === 'left') {
+        return {
+          start: rep.start.leftShoulder,
+          end: rep.end.leftShoulder,
+          min: rep.min.leftShoulder,
+          max: rep.max.leftShoulder,
+        };
+      }
+      return {
+        start: rep.start.rightShoulder,
+        end: rep.end.rightShoulder,
+        min: rep.min.rightShoulder,
+        max: rep.max.rightShoulder,
+      };
+    },
+  },
+];
+
+// =============================================================================
+// Phase Definitions
+// =============================================================================
+
+const phases: PhaseDefinition<LatPulldownPhase>[] = [
+  {
+    id: 'setup',
+    displayName: 'Setup',
+    enterCondition: () => true,
+    staticCue: 'Knees under pad, thumbs around the bar, chest up.',
+  },
+  {
+    id: 'top',
+    displayName: 'Top',
+    enterCondition: (angles: JointAngles) => {
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return avgElbow >= LAT_PULLDOWN_THRESHOLDS.topElbow;
+    },
+    staticCue: 'Arms extended — feel the lats stretch.',
+  },
+  {
+    id: 'pulling',
+    displayName: 'Pulling',
+    enterCondition: (angles: JointAngles, prevPhase: LatPulldownPhase) => {
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return prevPhase === 'top' && avgElbow <= LAT_PULLDOWN_THRESHOLDS.pullingStart;
+    },
+    staticCue: 'Drive elbows down — lead with the lats, not the biceps.',
+  },
+  {
+    id: 'bottom',
+    displayName: 'Bottom',
+    enterCondition: (angles: JointAngles, prevPhase: LatPulldownPhase) => {
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return prevPhase === 'pulling' && avgElbow <= LAT_PULLDOWN_THRESHOLDS.bottomElbow + 10;
+    },
+    staticCue: 'Bar to the upper chest — pause, squeeze the blades.',
+  },
+  {
+    id: 'releasing',
+    displayName: 'Releasing',
+    enterCondition: (angles: JointAngles, prevPhase: LatPulldownPhase) => {
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return prevPhase === 'bottom' && avgElbow >= LAT_PULLDOWN_THRESHOLDS.releasingStart;
+    },
+    staticCue: 'Control the eccentric — let the bar rise, stay braced.',
+  },
+];
+
+// =============================================================================
+// Rep Boundary
+// =============================================================================
+
+const repBoundary: RepBoundary<LatPulldownPhase> = {
+  startPhase: 'pulling',
+  endPhase: 'top',
+  minDurationMs: 700,
+};
+
+// =============================================================================
+// Fault Definitions (4 faults per spec)
+// =============================================================================
+
+const faults: FaultDefinition[] = [
+  {
+    id: 'incomplete_lockout',
+    displayName: 'Incomplete Range',
+    condition: (ctx: RepContext) => {
+      const minElbow = Math.min(ctx.minAngles.leftElbow, ctx.minAngles.rightElbow);
+      if (!Number.isFinite(minElbow)) return false;
+      return minElbow > LAT_PULLDOWN_THRESHOLDS.incompleteLockoutMin;
+    },
+    severity: 2,
+    dynamicCue: 'Pull deeper — bar to the upper chest on every rep.',
+    fqiPenalty: 12,
+  },
+  {
+    id: 'excessive_lean',
+    displayName: 'Excessive Lean',
+    condition: (ctx: RepContext) => {
+      const leftLean = clampedDelta(ctx.startAngles.leftShoulder, ctx.minAngles.leftShoulder);
+      const rightLean = clampedDelta(ctx.startAngles.rightShoulder, ctx.minAngles.rightShoulder);
+      // negative delta = shoulder angle dropped from start to min; magnitude
+      // above the threshold indicates a big lean-back cheat.
+      const maxLean = Math.max(Math.abs(leftLean), Math.abs(rightLean));
+      return maxLean > LAT_PULLDOWN_THRESHOLDS.excessiveLeanShoulderDeltaMax;
+    },
+    severity: 2,
+    dynamicCue: 'Stay tall — let the lats do the work, not your momentum.',
+    fqiPenalty: 10,
+  },
+  {
+    id: 'asymmetric_pull',
+    displayName: 'Asymmetric Pull',
+    condition: (ctx: RepContext) => {
+      return asymmetryCheck(
+        ctx.minAngles.leftElbow,
+        ctx.minAngles.rightElbow,
+        LAT_PULLDOWN_THRESHOLDS.asymmetricPullMaxPct
+      );
+    },
+    severity: 1,
+    dynamicCue: 'Pull evenly — keep both elbows tracking the same path.',
+    fqiPenalty: 8,
+  },
+  {
+    id: 'elbows_flare',
+    displayName: 'Elbows Flared',
+    condition: (ctx: RepContext) => {
+      const maxShoulder = Math.max(ctx.maxAngles.leftShoulder, ctx.maxAngles.rightShoulder);
+      if (!Number.isFinite(maxShoulder)) return false;
+      return maxShoulder > LAT_PULLDOWN_THRESHOLDS.elbowsFlareShoulderMax;
+    },
+    severity: 2,
+    dynamicCue: 'Keep elbows in line with the wrists — no chicken-winging.',
+    fqiPenalty: 10,
+  },
+];
+
+// =============================================================================
+// FQI Weights
+// =============================================================================
+
+const fqiWeights: FQIWeights = {
+  rom: 0.4,
+  depth: 0.25,
+  faults: 0.35,
+};
+
+// =============================================================================
+// Metrics Calculator
+// =============================================================================
+
+function calculateMetrics(
+  angles: JointAngles,
+  _joints?: Map<string, { x: number; y: number; isTracked: boolean }>
+): LatPulldownMetrics {
+  const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+  const avgShoulder = (angles.leftShoulder + angles.rightShoulder) / 2;
+
+  const armsTracked =
+    angles.leftElbow > 0 && angles.leftElbow < 180 &&
+    angles.rightElbow > 0 && angles.rightElbow < 180;
+
+  return {
+    avgElbow,
+    avgShoulder,
+    armsTracked,
+  };
+}
+
+// =============================================================================
+// Phase State Machine
+// =============================================================================
+
+function getNextPhase(
+  currentPhase: LatPulldownPhase,
+  _angles: JointAngles,
+  metrics: LatPulldownMetrics
+): LatPulldownPhase {
+  if (!metrics.armsTracked) {
+    return 'setup';
+  }
+
+  const elbow = metrics.avgElbow;
+
+  switch (currentPhase) {
+    case 'setup':
+      if (elbow >= LAT_PULLDOWN_THRESHOLDS.topElbow) {
+        return 'top';
+      }
+      return 'setup';
+
+    case 'top':
+      if (elbow <= LAT_PULLDOWN_THRESHOLDS.pullingStart) {
+        return 'pulling';
+      }
+      return 'top';
+
+    case 'pulling':
+      if (elbow <= LAT_PULLDOWN_THRESHOLDS.bottomElbow + 10) {
+        return 'bottom';
+      }
+      return 'pulling';
+
+    case 'bottom':
+      if (elbow >= LAT_PULLDOWN_THRESHOLDS.releasingStart) {
+        return 'releasing';
+      }
+      return 'bottom';
+
+    case 'releasing':
+      if (elbow >= LAT_PULLDOWN_THRESHOLDS.topElbow) {
+        return 'top';
+      }
+      return 'releasing';
+
+    default:
+      return 'setup';
+  }
+}
+
+// =============================================================================
+// Export Workout Definition
+// =============================================================================
+
+export const latPulldownDefinition: WorkoutDefinition<LatPulldownPhase, LatPulldownMetrics> = {
+  id: 'lat_pulldown',
+  displayName: 'Lat Pulldown',
+  description: 'Seated vertical pulling movement targeting the lats and mid-back.',
+  category: 'upper_body',
+  difficulty: 'beginner',
+
+  phases,
+  initialPhase: 'setup',
+  repBoundary,
+  thresholds: LAT_PULLDOWN_THRESHOLDS,
+  angleRanges,
+  scoringMetrics,
+  faults,
+  fqiWeights,
+
+  ui: {
+    iconName: 'arrow-down-outline',
+    primaryMetric: { key: 'avgElbowDeg', label: 'Avg Elbow', format: 'deg' },
+    secondaryMetric: { key: 'avgShoulderDeg', label: 'Avg Shoulder', format: 'deg' },
+    buildUploadMetrics: (metrics) => ({
+      avgElbowDeg: metrics?.avgElbow ?? null,
+      avgShoulderDeg: metrics?.avgShoulder ?? null,
+    }),
+    buildWatchMetrics: (metrics) => ({
+      avgElbowDeg: metrics?.avgElbow ?? null,
+    }),
+    getRealtimeCues: ({ phaseId, metrics }) => {
+      const messages: string[] = [];
+
+      if (
+        phaseId === 'bottom' &&
+        typeof metrics.avgShoulder === 'number' &&
+        metrics.avgShoulder > LAT_PULLDOWN_THRESHOLDS.elbowsFlareShoulderMax
+      ) {
+        messages.push('Elbows in — drive them down, not out.');
+      }
+
+      if (
+        phaseId === 'top' &&
+        typeof metrics.avgElbow === 'number' &&
+        metrics.avgElbow < LAT_PULLDOWN_THRESHOLDS.topElbow
+      ) {
+        messages.push('Let the arms extend fully — feel the stretch.');
+      }
+
+      if (messages.length === 0) {
+        messages.push('Smooth pull — lats lead, no swinging.');
+      }
+
+      return messages;
+    },
+  },
+
+  calculateMetrics,
+  getNextPhase,
+};
+
+export default latPulldownDefinition;

--- a/lib/workouts/overhead-press.ts
+++ b/lib/workouts/overhead-press.ts
@@ -1,0 +1,412 @@
+/**
+ * Overhead Press Workout Definition
+ *
+ * Defines all the logic for tracking overhead press form:
+ * - Phases: setup → rack → press → lockout → lowering
+ * - Rep boundaries: starts at 'press', ends at 'lockout'
+ * - Thresholds for elbow-extension and shoulder-flexion angles
+ * - Fault detection conditions (4 faults)
+ * - FQI calculation weights
+ *
+ * Standing overhead pressing movement. At the "rack" position elbows are
+ * flexed (~90°) and shoulders are near-horizontal. At "lockout" the arms
+ * are fully extended overhead (elbow ~175°, shoulder ~170°).
+ *
+ * Proxies used (documented here because JointAngles is sparse):
+ * - `excessive_lean` — no spine sensor; we compare hip-angle delta between
+ *   rep start and peak press. A lifter leaning back to push-press will
+ *   increase the hip angle past the "standing" envelope.
+ * - `core_hyperextension` — a further extension of hip angle past the
+ *   hyperextension threshold at lockout indicates lumbar over-arching to
+ *   get the bar overhead without genuine shoulder mobility.
+ */
+
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type {
+  WorkoutDefinition,
+  PhaseDefinition,
+  RepBoundary,
+  FaultDefinition,
+  FQIWeights,
+  AngleRange,
+  WorkoutMetrics,
+  RepContext,
+  ScoringMetricDefinition,
+} from '@/lib/types/workout-definitions';
+import { asymmetryCheck, clampedDelta } from './helpers';
+
+// =============================================================================
+// Phase Type
+// =============================================================================
+
+export type OverheadPressPhase = 'setup' | 'rack' | 'press' | 'lockout' | 'lowering';
+
+// =============================================================================
+// Metrics Type
+// =============================================================================
+
+export interface OverheadPressMetrics extends WorkoutMetrics {
+  avgElbow: number;
+  avgShoulder: number;
+  avgHip: number;
+  armsTracked: boolean;
+}
+
+// =============================================================================
+// Thresholds
+// =============================================================================
+
+export const OVERHEAD_PRESS_THRESHOLDS = {
+  /** Rack position — elbow flexed at ~90° */
+  rackElbow: 100,
+  /** Begin counting a press once elbow starts extending */
+  pressStart: 120,
+  /** Lockout elbow — arms near-straight */
+  lockoutElbow: 165,
+  /** Transition back to lowering */
+  loweringStart: 140,
+  /** Rep "incomplete" if top elbow doesn't hit this */
+  incompleteLockoutMin: 155,
+  /** Hip angle above this at lockout = core hyperextension / lumbar arch */
+  coreHyperExtensionMax: 185,
+  /** Hip-angle delta tolerance between rep start (standing) and peak — lean */
+  excessiveLeanHipDeltaMax: 15,
+  /** Asymmetric-press tolerance on elbow angle at lockout (%) */
+  asymmetricPressMaxPct: 10,
+} as const;
+
+// =============================================================================
+// Angle Ranges
+// =============================================================================
+
+const angleRanges: Record<string, AngleRange> = {
+  elbow: {
+    min: 85,
+    max: 180,
+    optimal: 175,
+    tolerance: 10,
+  },
+  shoulder: {
+    min: 80,
+    max: 180,
+    optimal: 170,
+    tolerance: 15,
+  },
+  hip: {
+    min: 160,
+    max: 185,
+    optimal: 175,
+    tolerance: 10,
+  },
+};
+
+const scoringMetrics: ScoringMetricDefinition[] = [
+  {
+    id: 'elbow',
+    extract: (rep, side) => {
+      if (side === 'left') {
+        return {
+          start: rep.start.leftElbow,
+          end: rep.end.leftElbow,
+          min: rep.min.leftElbow,
+          max: rep.max.leftElbow,
+        };
+      }
+      return {
+        start: rep.start.rightElbow,
+        end: rep.end.rightElbow,
+        min: rep.min.rightElbow,
+        max: rep.max.rightElbow,
+      };
+    },
+  },
+  {
+    id: 'shoulder',
+    extract: (rep, side) => {
+      if (side === 'left') {
+        return {
+          start: rep.start.leftShoulder,
+          end: rep.end.leftShoulder,
+          min: rep.min.leftShoulder,
+          max: rep.max.leftShoulder,
+        };
+      }
+      return {
+        start: rep.start.rightShoulder,
+        end: rep.end.rightShoulder,
+        min: rep.min.rightShoulder,
+        max: rep.max.rightShoulder,
+      };
+    },
+  },
+];
+
+// =============================================================================
+// Phase Definitions
+// =============================================================================
+
+const phases: PhaseDefinition<OverheadPressPhase>[] = [
+  {
+    id: 'setup',
+    displayName: 'Setup',
+    enterCondition: () => true,
+    staticCue: 'Clean the bar to the shoulders, elbows just below the bar.',
+  },
+  {
+    id: 'rack',
+    displayName: 'Rack',
+    enterCondition: (angles: JointAngles) => {
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return avgElbow <= OVERHEAD_PRESS_THRESHOLDS.rackElbow;
+    },
+    staticCue: 'Brace, squeeze glutes — ribs stacked over hips.',
+  },
+  {
+    id: 'press',
+    displayName: 'Pressing',
+    enterCondition: (angles: JointAngles, prevPhase: OverheadPressPhase) => {
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return prevPhase === 'rack' && avgElbow >= OVERHEAD_PRESS_THRESHOLDS.pressStart;
+    },
+    staticCue: 'Drive the bar straight up — tuck the chin as it passes.',
+  },
+  {
+    id: 'lockout',
+    displayName: 'Lockout',
+    enterCondition: (angles: JointAngles, prevPhase: OverheadPressPhase) => {
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return prevPhase === 'press' && avgElbow >= OVERHEAD_PRESS_THRESHOLDS.lockoutElbow;
+    },
+    staticCue: 'Bar overhead — biceps by the ears, ribs down.',
+  },
+  {
+    id: 'lowering',
+    displayName: 'Lowering',
+    enterCondition: (angles: JointAngles, prevPhase: OverheadPressPhase) => {
+      const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+      return prevPhase === 'lockout' && avgElbow <= OVERHEAD_PRESS_THRESHOLDS.loweringStart;
+    },
+    staticCue: 'Lower under control — bar tracks back to the shoulders.',
+  },
+];
+
+// =============================================================================
+// Rep Boundary
+// =============================================================================
+
+const repBoundary: RepBoundary<OverheadPressPhase> = {
+  startPhase: 'press',
+  endPhase: 'lockout',
+  minDurationMs: 500,
+};
+
+// =============================================================================
+// Fault Definitions (4 faults per spec)
+// =============================================================================
+
+const faults: FaultDefinition[] = [
+  {
+    id: 'incomplete_lockout',
+    displayName: 'Incomplete Lockout',
+    condition: (ctx: RepContext) => {
+      const maxElbow = Math.max(ctx.maxAngles.leftElbow, ctx.maxAngles.rightElbow);
+      if (!Number.isFinite(maxElbow)) return false;
+      return maxElbow < OVERHEAD_PRESS_THRESHOLDS.incompleteLockoutMin;
+    },
+    severity: 2,
+    dynamicCue: 'Punch the bar to full lockout — arms straight overhead.',
+    fqiPenalty: 12,
+  },
+  {
+    id: 'excessive_lean',
+    displayName: 'Excessive Lean',
+    condition: (ctx: RepContext) => {
+      // rep starts "standing" (hip ~175°). If the hip angle drops
+      // substantially during the press, the lifter is leaning back to
+      // turn the press into a push-press.
+      const leftDelta = clampedDelta(ctx.startAngles.leftHip, ctx.minAngles.leftHip);
+      const rightDelta = clampedDelta(ctx.startAngles.rightHip, ctx.minAngles.rightHip);
+      const maxLeanDrop = Math.max(Math.abs(leftDelta), Math.abs(rightDelta));
+      return maxLeanDrop > OVERHEAD_PRESS_THRESHOLDS.excessiveLeanHipDeltaMax;
+    },
+    severity: 2,
+    dynamicCue: 'Stay vertical — brace the core, no hip drive.',
+    fqiPenalty: 10,
+  },
+  {
+    id: 'asymmetric_press',
+    displayName: 'Asymmetric Press',
+    condition: (ctx: RepContext) => {
+      return asymmetryCheck(
+        ctx.maxAngles.leftElbow,
+        ctx.maxAngles.rightElbow,
+        OVERHEAD_PRESS_THRESHOLDS.asymmetricPressMaxPct
+      );
+    },
+    severity: 1,
+    dynamicCue: 'Press evenly — both elbows lock out at the same time.',
+    fqiPenalty: 8,
+  },
+  {
+    id: 'core_hyperextension',
+    displayName: 'Core Hyperextension',
+    condition: (ctx: RepContext) => {
+      const maxHip = Math.max(ctx.maxAngles.leftHip, ctx.maxAngles.rightHip);
+      if (!Number.isFinite(maxHip)) return false;
+      return maxHip > OVERHEAD_PRESS_THRESHOLDS.coreHyperExtensionMax;
+    },
+    severity: 2,
+    dynamicCue: 'Ribs down — stop arching the lower back to finish the rep.',
+    fqiPenalty: 12,
+  },
+];
+
+// =============================================================================
+// FQI Weights
+// =============================================================================
+
+const fqiWeights: FQIWeights = {
+  rom: 0.35,
+  depth: 0.3,
+  faults: 0.35,
+};
+
+// =============================================================================
+// Metrics Calculator
+// =============================================================================
+
+function calculateMetrics(
+  angles: JointAngles,
+  _joints?: Map<string, { x: number; y: number; isTracked: boolean }>
+): OverheadPressMetrics {
+  const avgElbow = (angles.leftElbow + angles.rightElbow) / 2;
+  const avgShoulder = (angles.leftShoulder + angles.rightShoulder) / 2;
+  const avgHip = (angles.leftHip + angles.rightHip) / 2;
+
+  const armsTracked =
+    angles.leftElbow > 0 && angles.leftElbow < 180 &&
+    angles.rightElbow > 0 && angles.rightElbow < 180;
+
+  return {
+    avgElbow,
+    avgShoulder,
+    avgHip,
+    armsTracked,
+  };
+}
+
+// =============================================================================
+// Phase State Machine
+// =============================================================================
+
+function getNextPhase(
+  currentPhase: OverheadPressPhase,
+  _angles: JointAngles,
+  metrics: OverheadPressMetrics
+): OverheadPressPhase {
+  if (!metrics.armsTracked) {
+    return 'setup';
+  }
+
+  const elbow = metrics.avgElbow;
+
+  switch (currentPhase) {
+    case 'setup':
+      if (elbow <= OVERHEAD_PRESS_THRESHOLDS.rackElbow) {
+        return 'rack';
+      }
+      return 'setup';
+
+    case 'rack':
+      if (elbow >= OVERHEAD_PRESS_THRESHOLDS.pressStart) {
+        return 'press';
+      }
+      return 'rack';
+
+    case 'press':
+      if (elbow >= OVERHEAD_PRESS_THRESHOLDS.lockoutElbow) {
+        return 'lockout';
+      }
+      return 'press';
+
+    case 'lockout':
+      if (elbow <= OVERHEAD_PRESS_THRESHOLDS.loweringStart) {
+        return 'lowering';
+      }
+      return 'lockout';
+
+    case 'lowering':
+      if (elbow <= OVERHEAD_PRESS_THRESHOLDS.rackElbow) {
+        return 'rack';
+      }
+      return 'lowering';
+
+    default:
+      return 'setup';
+  }
+}
+
+// =============================================================================
+// Export Workout Definition
+// =============================================================================
+
+export const overheadPressDefinition: WorkoutDefinition<OverheadPressPhase, OverheadPressMetrics> = {
+  id: 'overhead_press',
+  displayName: 'Overhead Press',
+  description: 'Standing vertical press targeting shoulders, triceps, and core stability.',
+  category: 'upper_body',
+  difficulty: 'intermediate',
+
+  phases,
+  initialPhase: 'setup',
+  repBoundary,
+  thresholds: OVERHEAD_PRESS_THRESHOLDS,
+  angleRanges,
+  scoringMetrics,
+  faults,
+  fqiWeights,
+
+  ui: {
+    iconName: 'arrow-up-outline',
+    primaryMetric: { key: 'avgElbowDeg', label: 'Avg Elbow', format: 'deg' },
+    secondaryMetric: { key: 'avgHipDeg', label: 'Avg Hip', format: 'deg' },
+    buildUploadMetrics: (metrics) => ({
+      avgElbowDeg: metrics?.avgElbow ?? null,
+      avgShoulderDeg: metrics?.avgShoulder ?? null,
+      avgHipDeg: metrics?.avgHip ?? null,
+    }),
+    buildWatchMetrics: (metrics) => ({
+      avgElbowDeg: metrics?.avgElbow ?? null,
+    }),
+    getRealtimeCues: ({ phaseId, metrics }) => {
+      const messages: string[] = [];
+
+      if (
+        phaseId === 'lockout' &&
+        typeof metrics.avgHip === 'number' &&
+        metrics.avgHip > OVERHEAD_PRESS_THRESHOLDS.coreHyperExtensionMax
+      ) {
+        messages.push('Ribs down — stop arching the lower back.');
+      }
+
+      if (
+        phaseId === 'press' &&
+        typeof metrics.avgElbow === 'number' &&
+        metrics.avgElbow < OVERHEAD_PRESS_THRESHOLDS.incompleteLockoutMin
+      ) {
+        messages.push('Punch through — arms straight at the top.');
+      }
+
+      if (messages.length === 0) {
+        messages.push('Brace hard — vertical bar path, stay stacked.');
+      }
+
+      return messages;
+    },
+  },
+
+  calculateMetrics,
+  getNextPhase,
+};
+
+export default overheadPressDefinition;

--- a/tests/unit/workouts-barbell-row.test.ts
+++ b/tests/unit/workouts-barbell-row.test.ts
@@ -1,0 +1,223 @@
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { RepContext } from '@/lib/types/workout-definitions';
+
+import { barbellRowDefinition, BARBELL_ROW_THRESHOLDS } from '@/lib/workouts/barbell-row';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function angles(overrides: Partial<JointAngles> = {}): JointAngles {
+  return {
+    leftElbow: 165,
+    rightElbow: 165,
+    leftShoulder: 95,
+    rightShoulder: 95,
+    leftKnee: 145,
+    rightKnee: 145,
+    leftHip: 105,
+    rightHip: 105,
+    ...overrides,
+  };
+}
+
+function ctx(opts: {
+  start?: Partial<JointAngles>;
+  end?: Partial<JointAngles>;
+  min?: Partial<JointAngles>;
+  max?: Partial<JointAngles>;
+  durationMs?: number;
+  repNumber?: number;
+  workoutId?: string;
+}): RepContext {
+  return {
+    startAngles: opts.start ? angles(opts.start) : angles(),
+    endAngles: opts.end ? angles(opts.end) : angles(),
+    // peak pull — elbows flexed ~80°
+    minAngles: opts.min ? angles(opts.min) : angles({ leftElbow: 80, rightElbow: 80 }),
+    // start of rep — elbows extended
+    maxAngles: opts.max ? angles(opts.max) : angles({ leftElbow: 165, rightElbow: 165, leftShoulder: 100, rightShoulder: 100 }),
+    durationMs: opts.durationMs ?? 2000,
+    repNumber: opts.repNumber ?? 1,
+    workoutId: opts.workoutId ?? 'barbell_row',
+  };
+}
+
+function fault(id: string) {
+  const f = barbellRowDefinition.faults.find((f) => f.id === id);
+  if (!f) throw new Error(`barbell-row fault '${id}' not found`);
+  return f;
+}
+
+const NaNAngles: JointAngles = {
+  leftElbow: NaN, rightElbow: NaN, leftShoulder: NaN, rightShoulder: NaN,
+  leftKnee: NaN, rightKnee: NaN, leftHip: NaN, rightHip: NaN,
+};
+
+function nanCtx(): RepContext {
+  return {
+    startAngles: NaNAngles,
+    endAngles: NaNAngles,
+    minAngles: NaNAngles,
+    maxAngles: NaNAngles,
+    durationMs: 2000,
+    repNumber: 1,
+    workoutId: 'barbell_row',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Definition metadata
+// ---------------------------------------------------------------------------
+
+describe('barbell-row definition metadata', () => {
+  test('has correct id and displayName', () => {
+    expect(barbellRowDefinition.id).toBe('barbell_row');
+    expect(barbellRowDefinition.displayName).toBe('Barbell Row');
+  });
+
+  test('registers 4 faults', () => {
+    expect(barbellRowDefinition.faults.length).toBe(4);
+  });
+
+  test('thresholds are finite', () => {
+    for (const [key, val] of Object.entries(BARBELL_ROW_THRESHOLDS)) {
+      expect(Number.isFinite(val)).toBe(true);
+      if (typeof val !== 'number') {
+        throw new Error(`BARBELL_ROW_THRESHOLDS.${key} is not a number`);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// incomplete_lockout
+// ---------------------------------------------------------------------------
+
+describe('barbell-row fault: incomplete_lockout', () => {
+  const f = fault('incomplete_lockout');
+
+  test('positive: peak-pull elbow above incompleteLockoutMin fires', () => {
+    // incompleteLockoutMin = 100; min elbow 120 > 100 ⇒ fault
+    const c = ctx({ min: { leftElbow: 120, rightElbow: 120 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: peak-pull elbow at full contraction does not fire', () => {
+    const c = ctx({ min: { leftElbow: 78, rightElbow: 82 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rounded_back
+// ---------------------------------------------------------------------------
+
+describe('barbell-row fault: rounded_back', () => {
+  const f = fault('rounded_back');
+
+  test('positive: shoulder delta outpaces hip delta at peak fires', () => {
+    // Hip stays roughly flat, shoulder delta large → rounded back
+    // hip delta max=5, shoulder delta max=25 → sequenceCheck fires + >15
+    const c = ctx({
+      min: { leftElbow: 80, rightElbow: 80, leftHip: 105, rightHip: 105, leftShoulder: 85, rightShoulder: 85 },
+      max: { leftElbow: 165, rightElbow: 165, leftHip: 110, rightHip: 110, leftShoulder: 125, rightShoulder: 120 },
+    });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: hip-led rise (hip delta > shoulder delta) does not fire', () => {
+    // hip delta 25 > shoulder delta 10 → no fault
+    const c = ctx({
+      min: { leftElbow: 80, rightElbow: 80, leftHip: 100, rightHip: 100, leftShoulder: 90, rightShoulder: 90 },
+      max: { leftElbow: 165, rightElbow: 165, leftHip: 125, rightHip: 125, leftShoulder: 100, rightShoulder: 100 },
+    });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// asymmetric_pull
+// ---------------------------------------------------------------------------
+
+describe('barbell-row fault: asymmetric_pull', () => {
+  const f = fault('asymmetric_pull');
+
+  test('positive: peak-pull elbow diff > 15% of larger fires', () => {
+    // larger=120, diff=|70-120|=50, pct ≈ 42% > 15
+    const c = ctx({ min: { leftElbow: 70, rightElbow: 120 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: matched elbows do not fire', () => {
+    // larger=85, diff=5, pct ≈ 6% < 15
+    const c = ctx({ min: { leftElbow: 80, rightElbow: 85 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// elbows_high
+// ---------------------------------------------------------------------------
+
+describe('barbell-row fault: elbows_high', () => {
+  const f = fault('elbows_high');
+
+  test('positive: peak shoulder-abduction above threshold fires', () => {
+    // elbowsHighShoulderMax = 115; max shoulder 130 > 115 ⇒ fault
+    const c = ctx({ max: { leftShoulder: 130, rightShoulder: 115 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: shoulder tucked at peak does not fire', () => {
+    const c = ctx({ max: { leftShoulder: 100, rightShoulder: 105 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateMetrics / getNextPhase sanity
+// ---------------------------------------------------------------------------
+
+describe('barbell-row definition sanity', () => {
+  test('calculateMetrics averages elbow/shoulder/hip', () => {
+    const m = barbellRowDefinition.calculateMetrics(angles({ leftElbow: 90, rightElbow: 110, leftHip: 100, rightHip: 110 }));
+    expect(m.avgElbow).toBe(100);
+    expect(m.avgHip).toBe(105);
+    expect(m.armsTracked).toBe(true);
+  });
+
+  test('getNextPhase: setup -> hinged when hinged + extended', () => {
+    const a = angles({ leftHip: 105, rightHip: 105, leftElbow: 165, rightElbow: 165 });
+    const m = barbellRowDefinition.calculateMetrics(a);
+    expect(barbellRowDefinition.getNextPhase('setup', a, m)).toBe('hinged');
+  });
+
+  test('getNextPhase: hinged -> pulling as elbow flexes', () => {
+    const a = angles({ leftElbow: 135, rightElbow: 135 });
+    const m = barbellRowDefinition.calculateMetrics(a);
+    expect(barbellRowDefinition.getNextPhase('hinged', a, m)).toBe('pulling');
+  });
+
+  test('getNextPhase: pulling -> top at peak pull', () => {
+    const a = angles({ leftElbow: 82, rightElbow: 82 });
+    const m = barbellRowDefinition.calculateMetrics(a);
+    expect(barbellRowDefinition.getNextPhase('pulling', a, m)).toBe('top');
+  });
+});

--- a/tests/unit/workouts-bulgarian-split-squat.test.ts
+++ b/tests/unit/workouts-bulgarian-split-squat.test.ts
@@ -1,0 +1,215 @@
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { RepContext } from '@/lib/types/workout-definitions';
+
+import {
+  bulgarianSplitSquatDefinition,
+  BULGARIAN_SPLIT_SQUAT_THRESHOLDS,
+} from '@/lib/workouts/bulgarian-split-squat';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function angles(overrides: Partial<JointAngles> = {}): JointAngles {
+  return {
+    leftElbow: 170,
+    rightElbow: 170,
+    leftShoulder: 90,
+    rightShoulder: 90,
+    leftKnee: 95,
+    rightKnee: 120,
+    leftHip: 115,
+    rightHip: 125,
+    ...overrides,
+  };
+}
+
+function ctx(opts: {
+  start?: Partial<JointAngles>;
+  end?: Partial<JointAngles>;
+  min?: Partial<JointAngles>;
+  max?: Partial<JointAngles>;
+  durationMs?: number;
+  repNumber?: number;
+  workoutId?: string;
+}): RepContext {
+  return {
+    startAngles: opts.start ? angles(opts.start) : angles({ leftKnee: 170, rightKnee: 170, leftHip: 170, rightHip: 170 }),
+    endAngles: opts.end ? angles(opts.end) : angles({ leftKnee: 170, rightKnee: 170, leftHip: 170, rightHip: 170 }),
+    minAngles: opts.min ? angles(opts.min) : angles(),
+    maxAngles: opts.max ? angles(opts.max) : angles({ leftKnee: 175, rightKnee: 175, leftHip: 175, rightHip: 175 }),
+    durationMs: opts.durationMs ?? 2500,
+    repNumber: opts.repNumber ?? 1,
+    workoutId: opts.workoutId ?? 'bulgarian_split_squat',
+  };
+}
+
+function fault(id: string) {
+  const f = bulgarianSplitSquatDefinition.faults.find((f) => f.id === id);
+  if (!f) throw new Error(`BSS fault '${id}' not found`);
+  return f;
+}
+
+const NaNAngles: JointAngles = {
+  leftElbow: NaN, rightElbow: NaN, leftShoulder: NaN, rightShoulder: NaN,
+  leftKnee: NaN, rightKnee: NaN, leftHip: NaN, rightHip: NaN,
+};
+
+function nanCtx(): RepContext {
+  return {
+    startAngles: NaNAngles,
+    endAngles: NaNAngles,
+    minAngles: NaNAngles,
+    maxAngles: NaNAngles,
+    durationMs: 2500,
+    repNumber: 1,
+    workoutId: 'bulgarian_split_squat',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Definition metadata
+// ---------------------------------------------------------------------------
+
+describe('bulgarian-split-squat definition metadata', () => {
+  test('has correct id and displayName', () => {
+    expect(bulgarianSplitSquatDefinition.id).toBe('bulgarian_split_squat');
+    expect(bulgarianSplitSquatDefinition.displayName).toBe('Bulgarian Split Squat');
+  });
+
+  test('registers 4 faults', () => {
+    expect(bulgarianSplitSquatDefinition.faults.length).toBe(4);
+  });
+
+  test('thresholds are finite', () => {
+    for (const [key, val] of Object.entries(BULGARIAN_SPLIT_SQUAT_THRESHOLDS)) {
+      expect(Number.isFinite(val)).toBe(true);
+      if (typeof val !== 'number') {
+        throw new Error(`BULGARIAN_SPLIT_SQUAT_THRESHOLDS.${key} is not a number`);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shallow_depth
+// ---------------------------------------------------------------------------
+
+describe('bulgarian-split-squat fault: shallow_depth', () => {
+  const f = fault('shallow_depth');
+
+  test('positive: deeper-knee above depthFloor fires fault', () => {
+    // depthFloor = 115; min-of-two = 125 > 115 ⇒ fault
+    const c = ctx({ min: { leftKnee: 125, rightKnee: 140 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: deep front knee (at parallel) does not fire', () => {
+    const c = ctx({ min: { leftKnee: 85, rightKnee: 130 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forward_knee
+// ---------------------------------------------------------------------------
+
+describe('bulgarian-split-squat fault: forward_knee', () => {
+  const f = fault('forward_knee');
+
+  test('positive: front knee past frontKneeForwardLimit fires fault', () => {
+    // frontKneeForwardLimit = 65; min-of-two = 50 < 65 ⇒ fault
+    const c = ctx({ min: { leftKnee: 50, rightKnee: 110 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: front knee above the limit does not fire', () => {
+    const c = ctx({ min: { leftKnee: 75, rightKnee: 120 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// asymmetric_drive
+// ---------------------------------------------------------------------------
+
+describe('bulgarian-split-squat fault: asymmetric_drive', () => {
+  const f = fault('asymmetric_drive');
+
+  test('positive: large hip asymmetry at bottom fires', () => {
+    // asymmetricDriveMaxPct = 15; larger=130, diff=|130-80|=50, pct ≈ 38% > 15
+    const c = ctx({ min: { leftHip: 80, rightHip: 130 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: balanced hip drop does not fire', () => {
+    const c = ctx({ min: { leftHip: 118, rightHip: 125 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// heel_collapse
+// ---------------------------------------------------------------------------
+
+describe('bulgarian-split-squat fault: heel_collapse', () => {
+  const f = fault('heel_collapse');
+
+  test('positive: extreme acute front-knee angle fires', () => {
+    // frontKneeForwardLimit - 10 = 55; min-of-two = 40 < 55 ⇒ fault
+    const c = ctx({ min: { leftKnee: 40, rightKnee: 115 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: normal front-knee angle does not fire', () => {
+    const c = ctx({ min: { leftKnee: 85, rightKnee: 120 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateMetrics / getNextPhase sanity
+// ---------------------------------------------------------------------------
+
+describe('bulgarian-split-squat definition sanity', () => {
+  test('calculateMetrics picks the deeper knee as frontKnee', () => {
+    const m = bulgarianSplitSquatDefinition.calculateMetrics(angles({ leftKnee: 90, rightKnee: 130 }));
+    expect(m.frontKnee).toBe(90);
+    expect(m.rearKnee).toBe(130);
+    expect(m.legsTracked).toBe(true);
+  });
+
+  test('getNextPhase: setup -> standing at standing threshold', () => {
+    const a = angles({ leftKnee: 170, rightKnee: 170 });
+    const m = bulgarianSplitSquatDefinition.calculateMetrics(a);
+    expect(bulgarianSplitSquatDefinition.getNextPhase('setup', a, m)).toBe('standing');
+  });
+
+  test('getNextPhase: standing -> descent when front knee starts flexing', () => {
+    const a = angles({ leftKnee: 140, rightKnee: 165 });
+    const m = bulgarianSplitSquatDefinition.calculateMetrics(a);
+    expect(bulgarianSplitSquatDefinition.getNextPhase('standing', a, m)).toBe('descent');
+  });
+
+  test('getNextPhase: descent -> bottom at parallel threshold', () => {
+    const a = angles({ leftKnee: 90, rightKnee: 130 });
+    const m = bulgarianSplitSquatDefinition.calculateMetrics(a);
+    expect(bulgarianSplitSquatDefinition.getNextPhase('descent', a, m)).toBe('bottom');
+  });
+});

--- a/tests/unit/workouts-dumbbell-curl.test.ts
+++ b/tests/unit/workouts-dumbbell-curl.test.ts
@@ -1,0 +1,197 @@
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { RepContext } from '@/lib/types/workout-definitions';
+
+import { dumbbellCurlDefinition, DUMBBELL_CURL_THRESHOLDS } from '@/lib/workouts/dumbbell-curl';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function angles(overrides: Partial<JointAngles> = {}): JointAngles {
+  return {
+    leftElbow: 170,
+    rightElbow: 170,
+    leftShoulder: 90,
+    rightShoulder: 90,
+    leftKnee: 175,
+    rightKnee: 175,
+    leftHip: 175,
+    rightHip: 175,
+    ...overrides,
+  };
+}
+
+function ctx(opts: {
+  start?: Partial<JointAngles>;
+  end?: Partial<JointAngles>;
+  min?: Partial<JointAngles>;
+  max?: Partial<JointAngles>;
+  durationMs?: number;
+  repNumber?: number;
+  workoutId?: string;
+}): RepContext {
+  return {
+    // start: standing, arms extended
+    startAngles: opts.start ? angles(opts.start) : angles(),
+    endAngles: opts.end ? angles(opts.end) : angles(),
+    // min: peak curl — elbow flexed ~60°, hips still standing
+    minAngles: opts.min ? angles(opts.min) : angles({ leftElbow: 60, rightElbow: 60 }),
+    // max: bottom/extended
+    maxAngles: opts.max ? angles(opts.max) : angles(),
+    durationMs: opts.durationMs ?? 1500,
+    repNumber: opts.repNumber ?? 1,
+    workoutId: opts.workoutId ?? 'dumbbell_curl',
+  };
+}
+
+function fault(id: string) {
+  const f = dumbbellCurlDefinition.faults.find((f) => f.id === id);
+  if (!f) throw new Error(`dumbbell-curl fault '${id}' not found`);
+  return f;
+}
+
+const NaNAngles: JointAngles = {
+  leftElbow: NaN, rightElbow: NaN, leftShoulder: NaN, rightShoulder: NaN,
+  leftKnee: NaN, rightKnee: NaN, leftHip: NaN, rightHip: NaN,
+};
+
+function nanCtx(): RepContext {
+  return {
+    startAngles: NaNAngles,
+    endAngles: NaNAngles,
+    minAngles: NaNAngles,
+    maxAngles: NaNAngles,
+    durationMs: 1500,
+    repNumber: 1,
+    workoutId: 'dumbbell_curl',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Definition metadata
+// ---------------------------------------------------------------------------
+
+describe('dumbbell-curl definition metadata', () => {
+  test('has correct id and displayName', () => {
+    expect(dumbbellCurlDefinition.id).toBe('dumbbell_curl');
+    expect(dumbbellCurlDefinition.displayName).toBe('Dumbbell Curl');
+  });
+
+  test('registers 3 faults', () => {
+    expect(dumbbellCurlDefinition.faults.length).toBe(3);
+  });
+
+  test('thresholds are finite', () => {
+    for (const [key, val] of Object.entries(DUMBBELL_CURL_THRESHOLDS)) {
+      expect(Number.isFinite(val)).toBe(true);
+      if (typeof val !== 'number') {
+        throw new Error(`DUMBBELL_CURL_THRESHOLDS.${key} is not a number`);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// swinging
+// ---------------------------------------------------------------------------
+
+describe('dumbbell-curl fault: swinging', () => {
+  const f = fault('swinging');
+
+  test('positive: hip-flex drop > threshold fires', () => {
+    // swingingHipDeltaMax = 15; start hip 175, min hip 150 → delta 25 > 15
+    const c = ctx({
+      start: { leftHip: 175, rightHip: 175 },
+      min: { leftElbow: 60, rightElbow: 60, leftHip: 150, rightHip: 175 },
+    });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: hips stay standing (small delta) does not fire', () => {
+    const c = ctx({
+      start: { leftHip: 175, rightHip: 175 },
+      min: { leftElbow: 60, rightElbow: 60, leftHip: 170, rightHip: 173 },
+    });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// incomplete_lockout
+// ---------------------------------------------------------------------------
+
+describe('dumbbell-curl fault: incomplete_lockout', () => {
+  const f = fault('incomplete_lockout');
+
+  test('positive: peak-curl elbow above incompleteLockoutMin fires', () => {
+    // incompleteLockoutMin = 80; min elbow 100 > 80 ⇒ fault
+    const c = ctx({ min: { leftElbow: 100, rightElbow: 100 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: full-curl elbow does not fire', () => {
+    const c = ctx({ min: { leftElbow: 60, rightElbow: 60 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// asymmetric_curl
+// ---------------------------------------------------------------------------
+
+describe('dumbbell-curl fault: asymmetric_curl', () => {
+  const f = fault('asymmetric_curl');
+
+  test('positive: peak-curl elbow diff > 15% fires', () => {
+    // larger=120, diff=|55-120|=65, pct ≈ 54% > 15
+    const c = ctx({ min: { leftElbow: 55, rightElbow: 120 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: matched peak-curl elbows do not fire', () => {
+    const c = ctx({ min: { leftElbow: 60, rightElbow: 65 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateMetrics / getNextPhase sanity
+// ---------------------------------------------------------------------------
+
+describe('dumbbell-curl definition sanity', () => {
+  test('calculateMetrics averages elbow/shoulder/hip', () => {
+    const m = dumbbellCurlDefinition.calculateMetrics(angles({ leftElbow: 100, rightElbow: 120 }));
+    expect(m.avgElbow).toBe(110);
+    expect(m.armsTracked).toBe(true);
+  });
+
+  test('getNextPhase: setup -> bottom when arms extended', () => {
+    const a = angles({ leftElbow: 170, rightElbow: 170 });
+    const m = dumbbellCurlDefinition.calculateMetrics(a);
+    expect(dumbbellCurlDefinition.getNextPhase('setup', a, m)).toBe('bottom');
+  });
+
+  test('getNextPhase: bottom -> curling as elbow flexes', () => {
+    const a = angles({ leftElbow: 135, rightElbow: 135 });
+    const m = dumbbellCurlDefinition.calculateMetrics(a);
+    expect(dumbbellCurlDefinition.getNextPhase('bottom', a, m)).toBe('curling');
+  });
+
+  test('getNextPhase: curling -> top at peak curl', () => {
+    const a = angles({ leftElbow: 65, rightElbow: 65 });
+    const m = dumbbellCurlDefinition.calculateMetrics(a);
+    expect(dumbbellCurlDefinition.getNextPhase('curling', a, m)).toBe('top');
+  });
+});

--- a/tests/unit/workouts-factory.test.ts
+++ b/tests/unit/workouts-factory.test.ts
@@ -1,4 +1,17 @@
-import { getWorkoutByMode, getPhaseStaticCue } from '@/lib/workouts';
+import {
+  getWorkoutByMode,
+  getPhaseStaticCue,
+  getWorkoutIds,
+  getWorkoutById,
+  isValidWorkoutId,
+  isDetectionMode,
+  workoutsByMode,
+  workoutRegistry,
+} from '@/lib/workouts';
+
+// ---------------------------------------------------------------------------
+// Existing coverage (kept)
+// ---------------------------------------------------------------------------
 
 test('getWorkoutByMode returns pullup definition', () => {
   const def = getWorkoutByMode('pullup');
@@ -17,4 +30,83 @@ test('getPhaseStaticCue returns a cue for initial phase', () => {
   const cue = getPhaseStaticCue(def, def.initialPhase);
   expect(cue).toBeTruthy();
   expect((cue ?? '').length).toBeGreaterThan(0);
+});
+
+// ---------------------------------------------------------------------------
+// New coverage — 6 added modes from #459
+// ---------------------------------------------------------------------------
+
+describe('new detection modes (#459) are registered', () => {
+  const NEW_MODES: Array<{ mode: keyof typeof workoutsByMode; id: string }> = [
+    { mode: 'hip_thrust', id: 'hip_thrust' },
+    { mode: 'bulgarian_split_squat', id: 'bulgarian_split_squat' },
+    { mode: 'barbell_row', id: 'barbell_row' },
+    { mode: 'lat_pulldown', id: 'lat_pulldown' },
+    { mode: 'overhead_press', id: 'overhead_press' },
+    { mode: 'dumbbell_curl', id: 'dumbbell_curl' },
+  ];
+
+  for (const { mode, id } of NEW_MODES) {
+    test(`getWorkoutByMode returns the ${mode} definition`, () => {
+      const def = getWorkoutByMode(mode);
+      expect(def.id).toBe(id);
+      expect(def.displayName.length).toBeGreaterThan(0);
+    });
+
+    test(`${mode} registers >= 1 fault and a non-empty phases array`, () => {
+      const def = getWorkoutByMode(mode);
+      expect(def.faults.length).toBeGreaterThan(0);
+      expect(def.phases.length).toBeGreaterThan(0);
+      expect(def.thresholds).toBeTruthy();
+    });
+
+    test(`isDetectionMode('${mode}') is true`, () => {
+      expect(isDetectionMode(mode)).toBe(true);
+    });
+
+    test(`isValidWorkoutId('${id}') is true`, () => {
+      expect(isValidWorkoutId(id)).toBe(true);
+    });
+
+    test(`getWorkoutById('${id}') returns the definition`, () => {
+      const def = getWorkoutById(id);
+      expect(def).toBeTruthy();
+      expect(def?.id).toBe(id);
+    });
+  }
+
+  test('all 6 new modes appear in getWorkoutIds()', () => {
+    const ids = getWorkoutIds();
+    for (const { mode } of NEW_MODES) {
+      expect(ids).toContain(mode);
+    }
+  });
+
+  test('workoutRegistry contains all 6 new definitions', () => {
+    for (const { id } of NEW_MODES) {
+      expect(workoutRegistry[id]).toBeTruthy();
+    }
+  });
+
+  test('DetectionMode union expands to 14 keys (8 existing + 6 new)', () => {
+    expect(getWorkoutIds().length).toBe(14);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Negative guards — unrelated strings do NOT pass the registry
+// ---------------------------------------------------------------------------
+
+describe('registry guards reject unknown ids', () => {
+  test('isDetectionMode rejects unknown mode', () => {
+    expect(isDetectionMode('not_a_workout')).toBe(false);
+  });
+
+  test('isValidWorkoutId rejects unknown id', () => {
+    expect(isValidWorkoutId('not_a_workout')).toBe(false);
+  });
+
+  test('getWorkoutById returns undefined for unknown id', () => {
+    expect(getWorkoutById('not_a_workout')).toBeUndefined();
+  });
 });

--- a/tests/unit/workouts-faults.parametric.test.ts
+++ b/tests/unit/workouts-faults.parametric.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Parametric fault harness — issue #459
+ *
+ * Exercises every fault on the 6 movements added by #459 under three
+ * synthetic conditions:
+ *
+ *   1. A per-workout "ideal rep" `RepContext` is handed to every fault;
+ *      each fault must return `false`. This is a sanity baseline — if any
+ *      fault mis-fires on a good rep, thresholds need re-tuning.
+ *   2. For every fault a minimal "triggering" RepContext asserts that the
+ *      fault returns `true`. Catches accidental fault-condition inversions.
+ *   3. Every fault also receives an all-NaN RepContext and must return
+ *      `false`, verifying the NaN-guard path.
+ *
+ * This harness will be superseded on merge by the broader #441 harness in
+ * `tests/unit/workouts-faults.parametric.test.ts` — at which point the two
+ * files will be reconciled (same file name already chosen to make conflict
+ * resolution obvious in a 3-way merge).
+ */
+
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { FaultDefinition, RepContext, WorkoutDefinition } from '@/lib/types/workout-definitions';
+import { workoutsByMode, type DetectionMode } from '@/lib/workouts';
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+interface IdealProfile {
+  start: JointAngles;
+  end: JointAngles;
+  min: JointAngles;
+  max: JointAngles;
+  durationMs: number;
+}
+
+function joints(a: Partial<JointAngles>): JointAngles {
+  return {
+    leftElbow: 170,
+    rightElbow: 170,
+    leftShoulder: 95,
+    rightShoulder: 95,
+    leftKnee: 170,
+    rightKnee: 170,
+    leftHip: 170,
+    rightHip: 170,
+    ...a,
+  };
+}
+
+/**
+ * Only the 6 new movements are exercised here. Pre-existing movements'
+ * faults are covered by their own suites; when the #441 harness lands on
+ * main this file reconciles with it.
+ */
+type NewMode =
+  | 'hip_thrust'
+  | 'bulgarian_split_squat'
+  | 'barbell_row'
+  | 'lat_pulldown'
+  | 'overhead_press'
+  | 'dumbbell_curl';
+
+const NEW_MODE_IDS: NewMode[] = [
+  'hip_thrust',
+  'bulgarian_split_squat',
+  'barbell_row',
+  'lat_pulldown',
+  'overhead_press',
+  'dumbbell_curl',
+];
+
+const IDEAL_PROFILES: Record<NewMode, IdealProfile> = {
+  hip_thrust: {
+    start: joints({ leftHip: 95, rightHip: 95, leftKnee: 95, rightKnee: 95 }),
+    end: joints({ leftHip: 175, rightHip: 175, leftKnee: 95, rightKnee: 95 }),
+    min: joints({ leftHip: 95, rightHip: 95, leftKnee: 95, rightKnee: 95 }),
+    max: joints({ leftHip: 175, rightHip: 175, leftKnee: 95, rightKnee: 95 }),
+    durationMs: 2500,
+  },
+  bulgarian_split_squat: {
+    start: joints({ leftKnee: 170, rightKnee: 170, leftHip: 170, rightHip: 170 }),
+    end: joints({ leftKnee: 170, rightKnee: 170, leftHip: 170, rightHip: 170 }),
+    min: joints({ leftKnee: 95, rightKnee: 120, leftHip: 115, rightHip: 125 }),
+    max: joints({ leftKnee: 175, rightKnee: 175, leftHip: 175, rightHip: 175 }),
+    durationMs: 2500,
+  },
+  barbell_row: {
+    start: joints({ leftElbow: 165, rightElbow: 165, leftHip: 105, rightHip: 105, leftShoulder: 95, rightShoulder: 95 }),
+    end: joints({ leftElbow: 165, rightElbow: 165, leftHip: 105, rightHip: 105, leftShoulder: 95, rightShoulder: 95 }),
+    min: joints({ leftElbow: 80, rightElbow: 80, leftHip: 105, rightHip: 105, leftShoulder: 95, rightShoulder: 95 }),
+    max: joints({ leftElbow: 165, rightElbow: 165, leftHip: 110, rightHip: 110, leftShoulder: 100, rightShoulder: 100 }),
+    durationMs: 2000,
+  },
+  lat_pulldown: {
+    start: joints({ leftElbow: 165, rightElbow: 165, leftShoulder: 150, rightShoulder: 150 }),
+    end: joints({ leftElbow: 165, rightElbow: 165, leftShoulder: 150, rightShoulder: 150 }),
+    min: joints({ leftElbow: 80, rightElbow: 80, leftShoulder: 115, rightShoulder: 115 }),
+    max: joints({ leftElbow: 170, rightElbow: 170, leftShoulder: 160, rightShoulder: 160 }),
+    durationMs: 2200,
+  },
+  overhead_press: {
+    start: joints({ leftElbow: 95, rightElbow: 95, leftHip: 175, rightHip: 175 }),
+    end: joints({ leftElbow: 95, rightElbow: 95, leftHip: 175, rightHip: 175 }),
+    min: joints({ leftElbow: 95, rightElbow: 95, leftHip: 172, rightHip: 174 }),
+    max: joints({ leftElbow: 170, rightElbow: 170, leftHip: 178, rightHip: 178 }),
+    durationMs: 1800,
+  },
+  dumbbell_curl: {
+    start: joints({ leftElbow: 170, rightElbow: 170, leftHip: 175, rightHip: 175 }),
+    end: joints({ leftElbow: 170, rightElbow: 170, leftHip: 175, rightHip: 175 }),
+    min: joints({ leftElbow: 60, rightElbow: 60, leftHip: 173, rightHip: 174 }),
+    max: joints({ leftElbow: 172, rightElbow: 172, leftHip: 175, rightHip: 175 }),
+    durationMs: 1500,
+  },
+};
+
+function ctxFromProfile(id: NewMode): RepContext {
+  const p = IDEAL_PROFILES[id];
+  return {
+    startAngles: p.start,
+    endAngles: p.end,
+    minAngles: p.min,
+    maxAngles: p.max,
+    durationMs: p.durationMs,
+    repNumber: 1,
+    workoutId: id,
+  };
+}
+
+function getDef(id: DetectionMode): WorkoutDefinition {
+  return workoutsByMode[id] as unknown as WorkoutDefinition;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Sanity baseline — every fault on every new movement must return
+//    `false` on the movement's ideal rep.
+// ---------------------------------------------------------------------------
+
+describe('parametric fault baseline — ideal rep fires no faults (6 new movements)', () => {
+  for (const id of NEW_MODE_IDS) {
+    describe(`workout: ${id}`, () => {
+      const def = getDef(id);
+      const ctx = ctxFromProfile(id);
+
+      for (const fault of def.faults) {
+        test(`fault '${fault.id}' does not fire on ideal rep`, () => {
+          const fired = fault.condition(ctx);
+          if (fired) {
+            throw new Error(
+              `[${id}.${fault.id}] mis-fired on ideal rep — update IDEAL_PROFILES or fault thresholds`
+            );
+          }
+          expect(fired).toBe(false);
+        });
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2. Targeted positives — every listed fault should return `true` on a
+//    hand-built minimally-triggering RepContext. Keyed to the #459 spec.
+// ---------------------------------------------------------------------------
+
+interface PositiveCase {
+  workout: NewMode;
+  fault: string;
+  build: () => RepContext;
+}
+
+function positiveCtx(id: NewMode, overrides: Partial<RepContext>): RepContext {
+  const base = ctxFromProfile(id);
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+const POSITIVE_CASES: PositiveCase[] = [
+  // ---- hip-thrust (5) ----
+  {
+    workout: 'hip_thrust', fault: 'shallow_depth',
+    build: () => positiveCtx('hip_thrust', {
+      minAngles: joints({ leftHip: 130, rightHip: 130, leftKnee: 95, rightKnee: 95 }),
+    }),
+  },
+  {
+    workout: 'hip_thrust', fault: 'heel_liftoff',
+    build: () => positiveCtx('hip_thrust', {
+      maxAngles: joints({ leftHip: 175, rightHip: 175, leftKnee: 85, rightKnee: 160 }),
+    }),
+  },
+  {
+    workout: 'hip_thrust', fault: 'incomplete_lockout',
+    build: () => positiveCtx('hip_thrust', {
+      maxAngles: joints({ leftHip: 140, rightHip: 140, leftKnee: 95, rightKnee: 95 }),
+    }),
+  },
+  {
+    workout: 'hip_thrust', fault: 'asymmetric_extension',
+    build: () => positiveCtx('hip_thrust', {
+      maxAngles: joints({ leftHip: 140, rightHip: 175, leftKnee: 95, rightKnee: 95 }),
+    }),
+  },
+  {
+    workout: 'hip_thrust', fault: 'hyperextension',
+    build: () => positiveCtx('hip_thrust', {
+      maxAngles: joints({ leftHip: 190, rightHip: 175, leftKnee: 95, rightKnee: 95 }),
+    }),
+  },
+
+  // ---- bulgarian-split-squat (4) ----
+  {
+    workout: 'bulgarian_split_squat', fault: 'shallow_depth',
+    build: () => positiveCtx('bulgarian_split_squat', {
+      minAngles: joints({ leftKnee: 130, rightKnee: 140, leftHip: 130, rightHip: 135 }),
+    }),
+  },
+  {
+    workout: 'bulgarian_split_squat', fault: 'forward_knee',
+    build: () => positiveCtx('bulgarian_split_squat', {
+      minAngles: joints({ leftKnee: 55, rightKnee: 100, leftHip: 115, rightHip: 125 }),
+    }),
+  },
+  {
+    workout: 'bulgarian_split_squat', fault: 'asymmetric_drive',
+    build: () => positiveCtx('bulgarian_split_squat', {
+      minAngles: joints({ leftKnee: 95, rightKnee: 120, leftHip: 70, rightHip: 130 }),
+    }),
+  },
+  {
+    workout: 'bulgarian_split_squat', fault: 'heel_collapse',
+    build: () => positiveCtx('bulgarian_split_squat', {
+      minAngles: joints({ leftKnee: 40, rightKnee: 100, leftHip: 115, rightHip: 125 }),
+    }),
+  },
+
+  // ---- barbell-row (4) ----
+  {
+    workout: 'barbell_row', fault: 'incomplete_lockout',
+    build: () => positiveCtx('barbell_row', {
+      minAngles: joints({ leftElbow: 120, rightElbow: 120, leftHip: 105, rightHip: 105, leftShoulder: 95, rightShoulder: 95 }),
+    }),
+  },
+  {
+    workout: 'barbell_row', fault: 'rounded_back',
+    build: () => positiveCtx('barbell_row', {
+      minAngles: joints({ leftElbow: 80, rightElbow: 80, leftHip: 105, rightHip: 105, leftShoulder: 85, rightShoulder: 85 }),
+      maxAngles: joints({ leftElbow: 165, rightElbow: 165, leftHip: 108, rightHip: 108, leftShoulder: 125, rightShoulder: 120 }),
+    }),
+  },
+  {
+    workout: 'barbell_row', fault: 'asymmetric_pull',
+    build: () => positiveCtx('barbell_row', {
+      minAngles: joints({ leftElbow: 70, rightElbow: 120, leftHip: 105, rightHip: 105, leftShoulder: 95, rightShoulder: 95 }),
+    }),
+  },
+  {
+    workout: 'barbell_row', fault: 'elbows_high',
+    build: () => positiveCtx('barbell_row', {
+      maxAngles: joints({ leftElbow: 165, rightElbow: 165, leftHip: 110, rightHip: 110, leftShoulder: 130, rightShoulder: 115 }),
+    }),
+  },
+
+  // ---- lat-pulldown (4) ----
+  {
+    workout: 'lat_pulldown', fault: 'incomplete_lockout',
+    build: () => positiveCtx('lat_pulldown', {
+      minAngles: joints({ leftElbow: 115, rightElbow: 115, leftShoulder: 120, rightShoulder: 120 }),
+    }),
+  },
+  {
+    workout: 'lat_pulldown', fault: 'excessive_lean',
+    build: () => positiveCtx('lat_pulldown', {
+      startAngles: joints({ leftElbow: 165, rightElbow: 165, leftShoulder: 150, rightShoulder: 150 }),
+      minAngles: joints({ leftElbow: 80, rightElbow: 80, leftShoulder: 80, rightShoulder: 80 }),
+    }),
+  },
+  {
+    workout: 'lat_pulldown', fault: 'asymmetric_pull',
+    build: () => positiveCtx('lat_pulldown', {
+      minAngles: joints({ leftElbow: 75, rightElbow: 120, leftShoulder: 115, rightShoulder: 115 }),
+    }),
+  },
+  {
+    workout: 'lat_pulldown', fault: 'elbows_flare',
+    build: () => positiveCtx('lat_pulldown', {
+      minAngles: joints({ leftElbow: 80, rightElbow: 80, leftShoulder: 140, rightShoulder: 120 }),
+    }),
+  },
+
+  // ---- overhead-press (4) ----
+  {
+    workout: 'overhead_press', fault: 'incomplete_lockout',
+    build: () => positiveCtx('overhead_press', {
+      maxAngles: joints({ leftElbow: 140, rightElbow: 140, leftHip: 175, rightHip: 175 }),
+    }),
+  },
+  {
+    workout: 'overhead_press', fault: 'excessive_lean',
+    build: () => positiveCtx('overhead_press', {
+      startAngles: joints({ leftElbow: 95, rightElbow: 95, leftHip: 175, rightHip: 175 }),
+      minAngles: joints({ leftElbow: 95, rightElbow: 95, leftHip: 150, rightHip: 175 }),
+    }),
+  },
+  {
+    workout: 'overhead_press', fault: 'asymmetric_press',
+    build: () => positiveCtx('overhead_press', {
+      maxAngles: joints({ leftElbow: 140, rightElbow: 170, leftHip: 175, rightHip: 175 }),
+    }),
+  },
+  {
+    workout: 'overhead_press', fault: 'core_hyperextension',
+    build: () => positiveCtx('overhead_press', {
+      maxAngles: joints({ leftElbow: 170, rightElbow: 170, leftHip: 195, rightHip: 180 }),
+    }),
+  },
+
+  // ---- dumbbell-curl (3) ----
+  {
+    workout: 'dumbbell_curl', fault: 'swinging',
+    build: () => positiveCtx('dumbbell_curl', {
+      startAngles: joints({ leftElbow: 170, rightElbow: 170, leftHip: 175, rightHip: 175 }),
+      minAngles: joints({ leftElbow: 60, rightElbow: 60, leftHip: 150, rightHip: 175 }),
+    }),
+  },
+  {
+    workout: 'dumbbell_curl', fault: 'incomplete_lockout',
+    build: () => positiveCtx('dumbbell_curl', {
+      minAngles: joints({ leftElbow: 100, rightElbow: 100, leftHip: 173, rightHip: 174 }),
+    }),
+  },
+  {
+    workout: 'dumbbell_curl', fault: 'asymmetric_curl',
+    build: () => positiveCtx('dumbbell_curl', {
+      minAngles: joints({ leftElbow: 55, rightElbow: 120, leftHip: 173, rightHip: 174 }),
+    }),
+  },
+];
+
+describe('parametric fault harness — targeted positive triggers (6 new movements)', () => {
+  for (const pc of POSITIVE_CASES) {
+    test(`${pc.workout}.${pc.fault} fires on a minimally-triggering RepContext`, () => {
+      const def = getDef(pc.workout);
+      const fault: FaultDefinition | undefined = def.faults.find((f) => f.id === pc.fault);
+      if (!fault) {
+        throw new Error(`Fault '${pc.workout}.${pc.fault}' not registered`);
+      }
+      expect(fault.condition(pc.build())).toBe(true);
+    });
+  }
+
+  test('all 24 new-movement faults have a positive case registered', () => {
+    // hip-thrust 5 + BSS 4 + barbell-row 4 + lat-pulldown 4 + OHP 4 + DB-curl 3 = 24
+    expect(POSITIVE_CASES.length).toBe(24);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. NaN-angles guard — every fault on every new movement must return
+//    `false` on fully-NaN input. (Duration-only faults would be filtered,
+//    but none of the 6 new movements has a duration-only fault.)
+// ---------------------------------------------------------------------------
+
+describe('parametric fault harness — NaN angles do not fire faults (6 new movements)', () => {
+  const NaNAngles: JointAngles = {
+    leftElbow: NaN, rightElbow: NaN, leftShoulder: NaN, rightShoulder: NaN,
+    leftKnee: NaN, rightKnee: NaN, leftHip: NaN, rightHip: NaN,
+  };
+  const nanCtx: RepContext = {
+    startAngles: NaNAngles,
+    endAngles: NaNAngles,
+    minAngles: NaNAngles,
+    maxAngles: NaNAngles,
+    durationMs: 2000,
+    repNumber: 1,
+    workoutId: 'parametric-nan',
+  };
+
+  for (const id of NEW_MODE_IDS) {
+    const def = getDef(id);
+    for (const fault of def.faults) {
+      test(`${id}.${fault.id} does not fire on all-NaN angles`, () => {
+        expect(fault.condition(nanCtx)).toBe(false);
+      });
+    }
+  }
+});

--- a/tests/unit/workouts-hip-thrust.test.ts
+++ b/tests/unit/workouts-hip-thrust.test.ts
@@ -1,0 +1,238 @@
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { RepContext } from '@/lib/types/workout-definitions';
+
+import { hipThrustDefinition, HIP_THRUST_THRESHOLDS } from '@/lib/workouts/hip-thrust';
+
+// ---------------------------------------------------------------------------
+// Helpers mirroring tests/unit/services/fqi-faults.test.ts
+// ---------------------------------------------------------------------------
+
+function angles(overrides: Partial<JointAngles> = {}): JointAngles {
+  return {
+    leftElbow: 170,
+    rightElbow: 170,
+    leftShoulder: 90,
+    rightShoulder: 90,
+    // Baseline = peak lockout values so faults do NOT fire unless overridden.
+    leftKnee: 95,
+    rightKnee: 95,
+    leftHip: 175,
+    rightHip: 175,
+    ...overrides,
+  };
+}
+
+function ctx(opts: {
+  start?: Partial<JointAngles>;
+  end?: Partial<JointAngles>;
+  min?: Partial<JointAngles>;
+  max?: Partial<JointAngles>;
+  durationMs?: number;
+  repNumber?: number;
+  workoutId?: string;
+}): RepContext {
+  return {
+    startAngles: opts.start ? angles(opts.start) : angles({ leftHip: 95, rightHip: 95 }),
+    endAngles: opts.end ? angles(opts.end) : angles(),
+    // bottom of rep — hips flexed to ~95°
+    minAngles: opts.min ? angles(opts.min) : angles({ leftHip: 95, rightHip: 95 }),
+    // top of rep — hips extended to ~175°
+    maxAngles: opts.max ? angles(opts.max) : angles({ leftHip: 175, rightHip: 175 }),
+    durationMs: opts.durationMs ?? 2500,
+    repNumber: opts.repNumber ?? 1,
+    workoutId: opts.workoutId ?? 'hip_thrust',
+  };
+}
+
+function fault(id: string) {
+  const f = hipThrustDefinition.faults.find((f) => f.id === id);
+  if (!f) throw new Error(`hip-thrust fault '${id}' not found`);
+  return f;
+}
+
+const NaNAngles: JointAngles = {
+  leftElbow: NaN, rightElbow: NaN, leftShoulder: NaN, rightShoulder: NaN,
+  leftKnee: NaN, rightKnee: NaN, leftHip: NaN, rightHip: NaN,
+};
+
+function nanCtx(): RepContext {
+  return {
+    startAngles: NaNAngles,
+    endAngles: NaNAngles,
+    minAngles: NaNAngles,
+    maxAngles: NaNAngles,
+    durationMs: 2500,
+    repNumber: 1,
+    workoutId: 'hip_thrust',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Definition metadata
+// ---------------------------------------------------------------------------
+
+describe('hip-thrust definition metadata', () => {
+  test('has correct id and displayName', () => {
+    expect(hipThrustDefinition.id).toBe('hip_thrust');
+    expect(hipThrustDefinition.displayName).toBe('Hip Thrust');
+  });
+
+  test('registers 5 faults', () => {
+    expect(hipThrustDefinition.faults.length).toBe(5);
+  });
+
+  test('thresholds are finite', () => {
+    for (const [key, val] of Object.entries(HIP_THRUST_THRESHOLDS)) {
+      expect(Number.isFinite(val)).toBe(true);
+      if (typeof val !== 'number') {
+        throw new Error(`HIP_THRUST_THRESHOLDS.${key} is not a number`);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shallow_depth
+// ---------------------------------------------------------------------------
+
+describe('hip-thrust fault: shallow_depth', () => {
+  const f = fault('shallow_depth');
+
+  test('positive: min hip above depth floor fires', () => {
+    // depthFloor = 115; min hip 130 > 115 ⇒ fault
+    const c = ctx({ min: { leftHip: 130, rightHip: 130 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: min hip at proper depth does not fire', () => {
+    const c = ctx({ min: { leftHip: 95, rightHip: 95 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// heel_liftoff
+// ---------------------------------------------------------------------------
+
+describe('hip-thrust fault: heel_liftoff', () => {
+  const f = fault('heel_liftoff');
+
+  test('positive: peak-knee diff over threshold fires', () => {
+    // heelLiftoffKneeDiffMax = 30; diff = |85 - 160| = 75 > 30
+    const c = ctx({ max: { leftKnee: 85, rightKnee: 160 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: both knees planted near 90° does not fire', () => {
+    const c = ctx({ max: { leftKnee: 92, rightKnee: 98 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// incomplete_lockout
+// ---------------------------------------------------------------------------
+
+describe('hip-thrust fault: incomplete_lockout', () => {
+  const f = fault('incomplete_lockout');
+
+  test('positive: max hip below lockout threshold fires', () => {
+    // incompleteLockoutMin = 155; max hip 140 < 155 ⇒ fault
+    const c = ctx({ max: { leftHip: 140, rightHip: 140 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: max hip at full lockout does not fire', () => {
+    const c = ctx({ max: { leftHip: 175, rightHip: 175 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// asymmetric_extension
+// ---------------------------------------------------------------------------
+
+describe('hip-thrust fault: asymmetric_extension', () => {
+  const f = fault('asymmetric_extension');
+
+  test('positive: peak hips with >12% spread fires', () => {
+    // asymmetricExtMaxPct = 12; larger=175, diff=|175-140|=35, pct=20% > 12
+    const c = ctx({ max: { leftHip: 140, rightHip: 175 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: peak hips within tolerance do not fire', () => {
+    // diff=5, pct ~ 2.8% < 12
+    const c = ctx({ max: { leftHip: 170, rightHip: 175 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hyperextension
+// ---------------------------------------------------------------------------
+
+describe('hip-thrust fault: hyperextension', () => {
+  const f = fault('hyperextension');
+
+  test('positive: peak hip over hyperextensionMax fires', () => {
+    // hyperExtensionMax = 185; max hip 190 > 185 ⇒ fault
+    const c = ctx({ max: { leftHip: 190, rightHip: 175 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: peak hip at full lockout (not over-arched) does not fire', () => {
+    const c = ctx({ max: { leftHip: 178, rightHip: 180 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateMetrics / getNextPhase sanity
+// ---------------------------------------------------------------------------
+
+describe('hip-thrust definition sanity', () => {
+  test('calculateMetrics averages hip and knee', () => {
+    const m = hipThrustDefinition.calculateMetrics(angles({ leftHip: 100, rightHip: 120 }));
+    expect(m.avgHip).toBe(110);
+    expect(m.legsTracked).toBe(true);
+  });
+
+  test('getNextPhase: setup -> bottom when hips flex below bottomHip', () => {
+    const a = angles({ leftHip: 95, rightHip: 95 });
+    const m = hipThrustDefinition.calculateMetrics(a);
+    expect(hipThrustDefinition.getNextPhase('setup', a, m)).toBe('bottom');
+  });
+
+  test('getNextPhase: bottom -> ascent when hips extend above ascentStart', () => {
+    const a = angles({ leftHip: 125, rightHip: 125 });
+    const m = hipThrustDefinition.calculateMetrics(a);
+    expect(hipThrustDefinition.getNextPhase('bottom', a, m)).toBe('ascent');
+  });
+
+  test('getNextPhase: ascent -> lockout at full extension', () => {
+    const a = angles({ leftHip: 170, rightHip: 170 });
+    const m = hipThrustDefinition.calculateMetrics(a);
+    expect(hipThrustDefinition.getNextPhase('ascent', a, m)).toBe('lockout');
+  });
+});

--- a/tests/unit/workouts-lat-pulldown.test.ts
+++ b/tests/unit/workouts-lat-pulldown.test.ts
@@ -1,0 +1,222 @@
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { RepContext } from '@/lib/types/workout-definitions';
+
+import { latPulldownDefinition, LAT_PULLDOWN_THRESHOLDS } from '@/lib/workouts/lat-pulldown';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function angles(overrides: Partial<JointAngles> = {}): JointAngles {
+  return {
+    leftElbow: 165,
+    rightElbow: 165,
+    leftShoulder: 150,
+    rightShoulder: 150,
+    leftKnee: 95,
+    rightKnee: 95,
+    leftHip: 95,
+    rightHip: 95,
+    ...overrides,
+  };
+}
+
+function ctx(opts: {
+  start?: Partial<JointAngles>;
+  end?: Partial<JointAngles>;
+  min?: Partial<JointAngles>;
+  max?: Partial<JointAngles>;
+  durationMs?: number;
+  repNumber?: number;
+  workoutId?: string;
+}): RepContext {
+  return {
+    // start: arms overhead (elbow ~165°, shoulder ~150°)
+    startAngles: opts.start ? angles(opts.start) : angles(),
+    endAngles: opts.end ? angles(opts.end) : angles(),
+    // min: peak pull (elbow ~80°, shoulder still ~115°)
+    minAngles: opts.min ? angles(opts.min) : angles({ leftElbow: 80, rightElbow: 80, leftShoulder: 115, rightShoulder: 115 }),
+    // max: start of rep
+    maxAngles: opts.max ? angles(opts.max) : angles({ leftElbow: 170, rightElbow: 170, leftShoulder: 160, rightShoulder: 160 }),
+    durationMs: opts.durationMs ?? 2200,
+    repNumber: opts.repNumber ?? 1,
+    workoutId: opts.workoutId ?? 'lat_pulldown',
+  };
+}
+
+function fault(id: string) {
+  const f = latPulldownDefinition.faults.find((f) => f.id === id);
+  if (!f) throw new Error(`lat-pulldown fault '${id}' not found`);
+  return f;
+}
+
+const NaNAngles: JointAngles = {
+  leftElbow: NaN, rightElbow: NaN, leftShoulder: NaN, rightShoulder: NaN,
+  leftKnee: NaN, rightKnee: NaN, leftHip: NaN, rightHip: NaN,
+};
+
+function nanCtx(): RepContext {
+  return {
+    startAngles: NaNAngles,
+    endAngles: NaNAngles,
+    minAngles: NaNAngles,
+    maxAngles: NaNAngles,
+    durationMs: 2200,
+    repNumber: 1,
+    workoutId: 'lat_pulldown',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Definition metadata
+// ---------------------------------------------------------------------------
+
+describe('lat-pulldown definition metadata', () => {
+  test('has correct id and displayName', () => {
+    expect(latPulldownDefinition.id).toBe('lat_pulldown');
+    expect(latPulldownDefinition.displayName).toBe('Lat Pulldown');
+  });
+
+  test('registers 4 faults', () => {
+    expect(latPulldownDefinition.faults.length).toBe(4);
+  });
+
+  test('thresholds are finite', () => {
+    for (const [key, val] of Object.entries(LAT_PULLDOWN_THRESHOLDS)) {
+      expect(Number.isFinite(val)).toBe(true);
+      if (typeof val !== 'number') {
+        throw new Error(`LAT_PULLDOWN_THRESHOLDS.${key} is not a number`);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// incomplete_lockout
+// ---------------------------------------------------------------------------
+
+describe('lat-pulldown fault: incomplete_lockout', () => {
+  const f = fault('incomplete_lockout');
+
+  test('positive: peak-pull elbow above 105 fires', () => {
+    // incompleteLockoutMin = 105; min elbow 115 > 105 ⇒ fault
+    const c = ctx({ min: { leftElbow: 115, rightElbow: 115 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: peak-pull elbow at full contraction does not fire', () => {
+    const c = ctx({ min: { leftElbow: 80, rightElbow: 82 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// excessive_lean
+// ---------------------------------------------------------------------------
+
+describe('lat-pulldown fault: excessive_lean', () => {
+  const f = fault('excessive_lean');
+
+  test('positive: shoulder drop from start to min above threshold fires', () => {
+    // excessiveLeanShoulderDeltaMax = 60;
+    // start shoulder 150, min shoulder 80 → delta 70 > 60 ⇒ fault
+    const c = ctx({
+      start: { leftShoulder: 150, rightShoulder: 150 },
+      min: { leftElbow: 80, rightElbow: 80, leftShoulder: 80, rightShoulder: 80 },
+    });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: normal shoulder path (small delta) does not fire', () => {
+    const c = ctx({
+      start: { leftShoulder: 150, rightShoulder: 150 },
+      min: { leftElbow: 80, rightElbow: 80, leftShoulder: 115, rightShoulder: 115 },
+    });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// asymmetric_pull
+// ---------------------------------------------------------------------------
+
+describe('lat-pulldown fault: asymmetric_pull', () => {
+  const f = fault('asymmetric_pull');
+
+  test('positive: peak-pull elbow diff > 15% fires', () => {
+    // larger=120, diff=|75-120|=45, pct ≈ 37% > 15
+    const c = ctx({ min: { leftElbow: 75, rightElbow: 120 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: matched elbows do not fire', () => {
+    const c = ctx({ min: { leftElbow: 80, rightElbow: 85 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// elbows_flare
+// ---------------------------------------------------------------------------
+
+describe('lat-pulldown fault: elbows_flare', () => {
+  const f = fault('elbows_flare');
+
+  test('positive: peak shoulder-abduction above threshold fires', () => {
+    // elbowsFlareShoulderMax = 125; max shoulder 140 > 125 ⇒ fault
+    const c = ctx({ max: { leftShoulder: 140, rightShoulder: 120 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: shoulder at optimal path does not fire', () => {
+    const c = ctx({ max: { leftShoulder: 120, rightShoulder: 115 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateMetrics / getNextPhase sanity
+// ---------------------------------------------------------------------------
+
+describe('lat-pulldown definition sanity', () => {
+  test('calculateMetrics averages elbow and shoulder', () => {
+    const m = latPulldownDefinition.calculateMetrics(angles({ leftElbow: 100, rightElbow: 120, leftShoulder: 110, rightShoulder: 130 }));
+    expect(m.avgElbow).toBe(110);
+    expect(m.avgShoulder).toBe(120);
+    expect(m.armsTracked).toBe(true);
+  });
+
+  test('getNextPhase: setup -> top at arms-extended threshold', () => {
+    const a = angles({ leftElbow: 170, rightElbow: 170 });
+    const m = latPulldownDefinition.calculateMetrics(a);
+    expect(latPulldownDefinition.getNextPhase('setup', a, m)).toBe('top');
+  });
+
+  test('getNextPhase: top -> pulling as elbow flexes', () => {
+    const a = angles({ leftElbow: 140, rightElbow: 140 });
+    const m = latPulldownDefinition.calculateMetrics(a);
+    expect(latPulldownDefinition.getNextPhase('top', a, m)).toBe('pulling');
+  });
+
+  test('getNextPhase: pulling -> bottom at peak pull', () => {
+    const a = angles({ leftElbow: 85, rightElbow: 85 });
+    const m = latPulldownDefinition.calculateMetrics(a);
+    expect(latPulldownDefinition.getNextPhase('pulling', a, m)).toBe('bottom');
+  });
+});

--- a/tests/unit/workouts-lat-pulldown.test.ts
+++ b/tests/unit/workouts-lat-pulldown.test.ts
@@ -174,14 +174,14 @@ describe('lat-pulldown fault: asymmetric_pull', () => {
 describe('lat-pulldown fault: elbows_flare', () => {
   const f = fault('elbows_flare');
 
-  test('positive: peak shoulder-abduction above threshold fires', () => {
-    // elbowsFlareShoulderMax = 125; max shoulder 140 > 125 ⇒ fault
-    const c = ctx({ max: { leftShoulder: 140, rightShoulder: 120 } });
+  test('positive: shoulder-abduction at bottom-of-pull above threshold fires', () => {
+    // elbowsFlareShoulderMax = 125; min-state shoulder 140 > 125 ⇒ fault
+    const c = ctx({ min: { leftElbow: 80, rightElbow: 80, leftShoulder: 140, rightShoulder: 120 } });
     expect(f.condition(c)).toBe(true);
   });
 
-  test('negative: shoulder at optimal path does not fire', () => {
-    const c = ctx({ max: { leftShoulder: 120, rightShoulder: 115 } });
+  test('negative: shoulder tucked at the bottom does not fire', () => {
+    const c = ctx({ min: { leftElbow: 80, rightElbow: 80, leftShoulder: 115, rightShoulder: 110 } });
     expect(f.condition(c)).toBe(false);
   });
 

--- a/tests/unit/workouts-overhead-press.test.ts
+++ b/tests/unit/workouts-overhead-press.test.ts
@@ -1,0 +1,222 @@
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { RepContext } from '@/lib/types/workout-definitions';
+
+import { overheadPressDefinition, OVERHEAD_PRESS_THRESHOLDS } from '@/lib/workouts/overhead-press';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function angles(overrides: Partial<JointAngles> = {}): JointAngles {
+  return {
+    leftElbow: 170,
+    rightElbow: 170,
+    leftShoulder: 95,
+    rightShoulder: 95,
+    leftKnee: 175,
+    rightKnee: 175,
+    leftHip: 175,
+    rightHip: 175,
+    ...overrides,
+  };
+}
+
+function ctx(opts: {
+  start?: Partial<JointAngles>;
+  end?: Partial<JointAngles>;
+  min?: Partial<JointAngles>;
+  max?: Partial<JointAngles>;
+  durationMs?: number;
+  repNumber?: number;
+  workoutId?: string;
+}): RepContext {
+  return {
+    // start: rack — elbows flexed ~90°, hips standing ~175°
+    startAngles: opts.start ? angles(opts.start) : angles({ leftElbow: 95, rightElbow: 95 }),
+    endAngles: opts.end ? angles(opts.end) : angles({ leftElbow: 95, rightElbow: 95 }),
+    // min: rack (elbow flexed)
+    minAngles: opts.min ? angles(opts.min) : angles({ leftElbow: 95, rightElbow: 95 }),
+    // max: lockout — arms straight overhead (~170°)
+    maxAngles: opts.max ? angles(opts.max) : angles({ leftElbow: 170, rightElbow: 170 }),
+    durationMs: opts.durationMs ?? 1800,
+    repNumber: opts.repNumber ?? 1,
+    workoutId: opts.workoutId ?? 'overhead_press',
+  };
+}
+
+function fault(id: string) {
+  const f = overheadPressDefinition.faults.find((f) => f.id === id);
+  if (!f) throw new Error(`overhead-press fault '${id}' not found`);
+  return f;
+}
+
+const NaNAngles: JointAngles = {
+  leftElbow: NaN, rightElbow: NaN, leftShoulder: NaN, rightShoulder: NaN,
+  leftKnee: NaN, rightKnee: NaN, leftHip: NaN, rightHip: NaN,
+};
+
+function nanCtx(): RepContext {
+  return {
+    startAngles: NaNAngles,
+    endAngles: NaNAngles,
+    minAngles: NaNAngles,
+    maxAngles: NaNAngles,
+    durationMs: 1800,
+    repNumber: 1,
+    workoutId: 'overhead_press',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Definition metadata
+// ---------------------------------------------------------------------------
+
+describe('overhead-press definition metadata', () => {
+  test('has correct id and displayName', () => {
+    expect(overheadPressDefinition.id).toBe('overhead_press');
+    expect(overheadPressDefinition.displayName).toBe('Overhead Press');
+  });
+
+  test('registers 4 faults', () => {
+    expect(overheadPressDefinition.faults.length).toBe(4);
+  });
+
+  test('thresholds are finite', () => {
+    for (const [key, val] of Object.entries(OVERHEAD_PRESS_THRESHOLDS)) {
+      expect(Number.isFinite(val)).toBe(true);
+      if (typeof val !== 'number') {
+        throw new Error(`OVERHEAD_PRESS_THRESHOLDS.${key} is not a number`);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// incomplete_lockout
+// ---------------------------------------------------------------------------
+
+describe('overhead-press fault: incomplete_lockout', () => {
+  const f = fault('incomplete_lockout');
+
+  test('positive: max-elbow under lockout threshold fires', () => {
+    // incompleteLockoutMin = 155; max elbow 140 < 155 ⇒ fault
+    const c = ctx({ max: { leftElbow: 140, rightElbow: 140 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: max-elbow at full lockout does not fire', () => {
+    const c = ctx({ max: { leftElbow: 170, rightElbow: 170 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// excessive_lean
+// ---------------------------------------------------------------------------
+
+describe('overhead-press fault: excessive_lean', () => {
+  const f = fault('excessive_lean');
+
+  test('positive: hip-flex drop from start > threshold fires', () => {
+    // excessiveLeanHipDeltaMax = 15;
+    // start hip 175, min hip 150 → delta 25 > 15 ⇒ fault
+    const c = ctx({
+      start: { leftElbow: 95, rightElbow: 95, leftHip: 175, rightHip: 175 },
+      min: { leftElbow: 95, rightElbow: 95, leftHip: 150, rightHip: 175 },
+    });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: hip stays standing → no lean fires', () => {
+    const c = ctx({
+      start: { leftElbow: 95, rightElbow: 95, leftHip: 175, rightHip: 175 },
+      min: { leftElbow: 95, rightElbow: 95, leftHip: 172, rightHip: 174 },
+    });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// asymmetric_press
+// ---------------------------------------------------------------------------
+
+describe('overhead-press fault: asymmetric_press', () => {
+  const f = fault('asymmetric_press');
+
+  test('positive: peak elbow diff > 10% fires', () => {
+    // asymmetricPressMaxPct = 10; larger=170, diff=|170-140|=30, pct ≈ 17.6% > 10
+    const c = ctx({ max: { leftElbow: 140, rightElbow: 170 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: matched peak elbows do not fire', () => {
+    // diff=2, pct ≈ 1.2% < 10
+    const c = ctx({ max: { leftElbow: 170, rightElbow: 168 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// core_hyperextension
+// ---------------------------------------------------------------------------
+
+describe('overhead-press fault: core_hyperextension', () => {
+  const f = fault('core_hyperextension');
+
+  test('positive: peak hip above coreHyperExtensionMax fires', () => {
+    // coreHyperExtensionMax = 185; max hip 195 > 185 ⇒ fault
+    const c = ctx({ max: { leftElbow: 170, rightElbow: 170, leftHip: 195, rightHip: 180 } });
+    expect(f.condition(c)).toBe(true);
+  });
+
+  test('negative: peak hip in normal range does not fire', () => {
+    const c = ctx({ max: { leftElbow: 170, rightElbow: 170, leftHip: 178, rightHip: 180 } });
+    expect(f.condition(c)).toBe(false);
+  });
+
+  test('NaN-angles guard: returns false on NaN angles', () => {
+    expect(f.condition(nanCtx())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateMetrics / getNextPhase sanity
+// ---------------------------------------------------------------------------
+
+describe('overhead-press definition sanity', () => {
+  test('calculateMetrics averages elbow/shoulder/hip', () => {
+    const m = overheadPressDefinition.calculateMetrics(angles({ leftElbow: 100, rightElbow: 120 }));
+    expect(m.avgElbow).toBe(110);
+    expect(m.armsTracked).toBe(true);
+  });
+
+  test('getNextPhase: setup -> rack at racked-elbow threshold', () => {
+    const a = angles({ leftElbow: 95, rightElbow: 95 });
+    const m = overheadPressDefinition.calculateMetrics(a);
+    expect(overheadPressDefinition.getNextPhase('setup', a, m)).toBe('rack');
+  });
+
+  test('getNextPhase: rack -> press when elbow starts extending', () => {
+    const a = angles({ leftElbow: 125, rightElbow: 125 });
+    const m = overheadPressDefinition.calculateMetrics(a);
+    expect(overheadPressDefinition.getNextPhase('rack', a, m)).toBe('press');
+  });
+
+  test('getNextPhase: press -> lockout at full extension', () => {
+    const a = angles({ leftElbow: 170, rightElbow: 170 });
+    const m = overheadPressDefinition.calculateMetrics(a);
+    expect(overheadPressDefinition.getNextPhase('press', a, m)).toBe('lockout');
+  });
+});


### PR DESCRIPTION
## Summary

Adds 6 compound/accessory form models to `lib/workouts/` following the pattern established by #441 (lunge + extended dead-hang). Grows `DetectionMode` from 8 to 14 modes. All commits pass lint + type-check + unit tests atomically.

**New movements (6)**

| Exercise | Phases | Faults | Notes |
|---|---|---|---|
| `hip_thrust` | setup → bottom → ascent → lockout → descent | 5 | Bilateral hip extension |
| `bulgarian_split_squat` | setup → standing → descent → bottom → ascent | 4 | Unilateral — deeper-knee = working leg |
| `barbell_row` | setup → hinged → pulling → top → lowering | 4 | Horizontal pull, hip-hinge anchored |
| `lat_pulldown` | setup → top → pulling → bottom → releasing | 4 | Seated vertical pull |
| `overhead_press` | setup → rack → press → lockout → lowering | 4 | Standing, hip-lean detection |
| `dumbbell_curl` | setup → bottom → curling → top → lowering | 3 | Hip-flex delta catches swinging |

Total new faults registered: **24**.

## Commit list (19 atomic)

1. `feat(workouts): copy helpers from #441 for reconcile on merge — TODO(#438)`
2-7. `feat(workouts): add <movement> form model with N faults` (one per movement)
8-13. `test(workouts): parametric fault coverage for <movement>` (one per movement)
14. `feat(workouts): register 6 new modes in workoutsByMode + workoutRegistry`
15. `test(workouts): extend factory + DetectionMode tests for the 6 new modes`
16a. `fix(workouts): lat-pulldown elbows_flare evaluates shoulder at bottom-of-pull`
16b. `test(workouts): parametric harness covering every new fault`
17. `docs(workouts): README section for new movements + coach-drill follow-up note`
18. `chore(OVERNIGHT_CHANGELOG): add exercise-library-expansion entry`

## Test counts

| Suite | Tests |
|---|---|
| `workouts-hip-thrust.test.ts` | 22 |
| `workouts-bulgarian-split-squat.test.ts` | 19 |
| `workouts-barbell-row.test.ts` | 19 |
| `workouts-lat-pulldown.test.ts` | 19 |
| `workouts-overhead-press.test.ts` | 19 |
| `workouts-dumbbell-curl.test.ts` | 16 |
| `workouts-factory.test.ts` (extended) | 39 (was 3) |
| `workouts-faults.parametric.test.ts` (new) | 73 |
| **Total across new/touched workout suites** | **230** |

Adjacent-suite regression check (arkit-workout-adapter / mediapipe-workout-adapter / workout-insights / workout-runtime / fusion/cue-fault-mapping): **114 pass / 0 fail**.

## Verification results

- `bun run lint` — 0 errors (2 pre-existing warnings in `app/(modals)/template-builder.tsx`, unrelated to this PR)
- `bun run check:types` — clean
- `bun test tests/unit/workouts-*.test.ts tests/unit/workouts-faults.parametric.test.ts` — 230 pass / 0 fail
- `bun test tests/unit/workouts-factory.test.ts` — 39 pass / 0 fail
- Full `bun run test` — 1346 pass / 1 fail / 10 skip. The single failure is a pre-existing flake in `tests/unit/services/database/generic-sync.test.ts` present on `origin/main` and unrelated to this PR (verified by running the same test from main's copy of the file).

## Notes (judgment calls)

`JointAngles` carries only left/right knee/elbow/shoulder/hip — no wrist, ankle, foot, or spine channels. Several faults rely on proxies, documented inline per-file:

- **hip_thrust `heel_liftoff`**: proxies foot-lifted-vs-planted via knee-angle asymmetry at peak extension — a lifted heel lets that leg drive to full extension while the planted leg stays at ~90°.
- **bulgarian_split_squat `heel_collapse`**: proxies a collapsed arch via an extreme acute front-knee angle (`frontKneeForwardLimit - 10`).
- **barbell_row `rounded_back`**: uses `sequenceCheck(hip-delta, shoulder-delta)` — spine flexion surfaces when shoulder-angle movement exceeds hip-angle movement between min/max during the pull.
- **lat_pulldown `excessive_lean`**: uses `clampedDelta(startShoulder, minShoulder)` — dropping shoulder angle between start (arms overhead) and peak pull flags a lean-back cheat.
- **lat_pulldown `elbows_flare`**: evaluates shoulder abduction at the BOTTOM of the pull (`minAngles`), not the TOP — at the top the arms are naturally overhead so `maxAngles.shoulder` is always high; the fault is meaningful only at the peak-pull position. Caught during the parametric harness pass; fixed in dedicated `fix(workouts)` commit 16a.
- **overhead_press `excessive_lean`**: uses `clampedDelta(startHip, minHip)` — a hip-angle drop during the press flags a push-press lean cheat.
- **overhead_press `core_hyperextension`**: peak-hip angle > 185° flags lumbar over-arching to finish the rep without genuine shoulder mobility.
- **dumbbell_curl `swinging`**: uses `clampedDelta(startHip, minHip)` — the nearest joint to torso rotation. Same pattern as #441's use of elbow as proxy for `grip_shift` in dead-hang.
- **dumbbell_curl**: forearm supination is intentionally **not** modeled (no wrist-rotation sensor in `JointAngles`).

No phase additions were needed — every movement fits the existing string-keyed `Phase<TPhase>` pattern. No `movements.ts` edits (keeping that file untouched matches the project constraint).

**Helpers reconcile:** `lib/workouts/helpers.ts` is a byte-for-byte copy of the version on `feat/438-form-model-depth` (#441). Whichever PR merges second needs only to drop the `TODO(#438)` comment — no content changes. Identical copy-then-reconcile pattern as PR-N / #452 used for `subject-identity.ts`.

**Deferrals** (called out in `docs/OVERNIGHT_CHANGELOG.md`):

- Coach-drill backfill (`drills?: FaultDrill[]`) waits on #434 to introduce the field.
- Leg press / hack squat / incline variants — separate L-effort PR.
- Supabase workout-template seeds referencing the new IDs — banned-path (migrations), deferred.

## Constraints honored

- No new dependencies.
- No edits under `supabase/migrations/`, `ios/`, `android/`, `.env`.
- No `Co-Authored-By` line in commits.
- Every commit lints + type-checks cleanly on its own.
- Per-movement test files use direct imports (no registry lookup) so they pass before the registry commit.

Closes #459