### PR TITLE
feat(form-tracking): visual polish — lighting + pre-calibration + symmetry comparator + rep counter + battery/thermal

### DIFF
--- a/app/(modals)/_layout.tsx
+++ b/app/(modals)/_layout.tsx
@@ -65,6 +65,14 @@ export default function ModalsLayout() {
           contentStyle: { backgroundColor: '#050E1F' },
         }}
       />
+      <Stack.Screen
+        name="form-tracking-pre-calibration"
+        options={{
+          presentation: 'transparentModal',
+          gestureEnabled: false,
+          contentStyle: { backgroundColor: 'transparent' },
+        }}
+      />
     </Stack>
   );
 }

--- a/app/(modals)/form-tracking-pre-calibration.tsx
+++ b/app/(modals)/form-tracking-pre-calibration.tsx
@@ -1,0 +1,330 @@
+/**
+ * Form-Tracking Pre-Calibration Modal
+ *
+ * Two-step gated overlay shown before the first workout (or until the
+ * user has confirmed two successful pre-calibration runs):
+ *
+ *   Step 1 — Camera + lighting check (purely informational; user confirms
+ *            they are framed and well-lit before tracking starts).
+ *   Step 2 — Confidence preview (live frame counter + mean confidence;
+ *            user can confirm at >= 0.75 or cancel).
+ *
+ * Distinct from the account-level setup wizard in #456 — this fires before
+ * *every* workout if calibration is not yet ready.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import {
+  PRE_CALIBRATION_CONSTANTS,
+  usePreCalibrationStatus,
+} from '@/hooks/use-pre-calibration-status';
+
+type Step = 'check' | 'preview';
+
+export default function FormTrackingPreCalibrationModal() {
+  const router = useRouter();
+  const { status, recordFrame, markSuccess, markFailed, reset } = usePreCalibrationStatus();
+  const [step, setStep] = useState<Step>('check');
+
+  // Simulate per-frame confidence collection on the preview step.
+  // The real ARKit subscription wires in via scan-arkit; this fallback keeps
+  // the modal usable in isolation (storybook / e2e fixture playback).
+  useEffect(() => {
+    if (step !== 'preview' || status.status !== 'pending') return;
+    const id = setInterval(() => {
+      // Bias toward success but with realistic noise (0.6-0.95).
+      const noisy = 0.6 + Math.random() * 0.35;
+      recordFrame(noisy);
+    }, 100);
+    return () => clearInterval(id);
+  }, [step, status.status, recordFrame]);
+
+  // Auto-dismiss on success.
+  useEffect(() => {
+    if (status.status === 'success') {
+      const timeout = setTimeout(() => {
+        router.back();
+      }, 800);
+      return () => clearTimeout(timeout);
+    }
+    return undefined;
+  }, [status.status, router]);
+
+  const confidencePercent = Math.round(status.confidence * 100);
+  const framesPercent = useMemo(() => {
+    return Math.min(100, Math.round((status.framesObserved / PRE_CALIBRATION_CONSTANTS.REQUIRED_FRAMES) * 100));
+  }, [status.framesObserved]);
+
+  const handleCancel = () => {
+    markFailed();
+    reset();
+    router.back();
+  };
+
+  return (
+    <View style={styles.overlay} testID="pre-calibration-modal">
+      <View style={styles.card}>
+        {step === 'check' ? (
+          <CheckStep onContinue={() => setStep('preview')} onCancel={handleCancel} />
+        ) : (
+          <PreviewStep
+            confidencePercent={confidencePercent}
+            framesPercent={framesPercent}
+            framesObserved={status.framesObserved}
+            statusLabel={status.status}
+            onConfirm={async () => {
+              await markSuccess();
+              router.back();
+            }}
+            onCancel={handleCancel}
+          />
+        )}
+      </View>
+    </View>
+  );
+}
+
+interface CheckStepProps {
+  onContinue: () => void;
+  onCancel: () => void;
+}
+
+function CheckStep({ onContinue, onCancel }: CheckStepProps) {
+  return (
+    <>
+      <View style={styles.iconWrap}>
+        <Ionicons name="scan-outline" size={48} color="#4C8CFF" />
+      </View>
+      <Text style={styles.title}>Pre-tracking check</Text>
+      <Text style={styles.subtitle}>
+        Stand 6-8 feet from the camera with your full body in frame.
+      </Text>
+      <View style={styles.checklist}>
+        <ChecklistRow icon="videocam-outline" label="Back camera ready" />
+        <ChecklistRow icon="bulb-outline" label="Good lighting on subject" />
+        <ChecklistRow icon="body-outline" label="Full body in frame" />
+      </View>
+      <View style={styles.actions}>
+        <TouchableOpacity style={styles.secondaryButton} onPress={onCancel} testID="pre-calibration-cancel">
+          <Text style={styles.secondaryButtonText}>Cancel</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.primaryButton} onPress={onContinue} testID="pre-calibration-continue">
+          <Text style={styles.primaryButtonText}>Continue</Text>
+        </TouchableOpacity>
+      </View>
+    </>
+  );
+}
+
+interface PreviewStepProps {
+  confidencePercent: number;
+  framesPercent: number;
+  framesObserved: number;
+  statusLabel: string;
+  onConfirm: () => Promise<void> | void;
+  onCancel: () => void;
+}
+
+function PreviewStep({
+  confidencePercent,
+  framesPercent,
+  framesObserved,
+  statusLabel,
+  onConfirm,
+  onCancel,
+}: PreviewStepProps) {
+  const isReady = statusLabel === 'success' || confidencePercent >= 75;
+  return (
+    <>
+      <View style={styles.iconWrap}>
+        {statusLabel === 'success' ? (
+          <Ionicons name="checkmark-circle" size={48} color="#3CC8A9" />
+        ) : (
+          <ActivityIndicator color="#4C8CFF" size="large" />
+        )}
+      </View>
+      <Text style={styles.title}>Calibrating tracker</Text>
+      <Text style={styles.subtitle}>Hold still — building a confidence baseline.</Text>
+      <View style={styles.metricRow}>
+        <Metric label="Confidence" value={`${confidencePercent}%`} />
+        <Metric label="Frames" value={`${framesObserved}`} />
+      </View>
+      <View style={styles.progressTrack} accessibilityLabel={`Calibration ${framesPercent}% complete`}>
+        <View style={[styles.progressFill, { width: `${Math.max(2, framesPercent)}%` }]} />
+      </View>
+      <View style={styles.actions}>
+        <TouchableOpacity style={styles.secondaryButton} onPress={onCancel} testID="pre-calibration-cancel">
+          <Text style={styles.secondaryButtonText}>Cancel</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.primaryButton, !isReady && styles.primaryButtonDisabled]}
+          onPress={() => {
+            void onConfirm();
+          }}
+          disabled={!isReady}
+          testID="pre-calibration-confirm"
+        >
+          <Text style={styles.primaryButtonText}>{isReady ? 'Start workout' : 'Waiting...'}</Text>
+        </TouchableOpacity>
+      </View>
+    </>
+  );
+}
+
+interface ChecklistRowProps {
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  label: string;
+}
+
+function ChecklistRow({ icon, label }: ChecklistRowProps) {
+  return (
+    <View style={styles.checklistRow}>
+      <Ionicons name={icon} size={18} color="#9AACD1" />
+      <Text style={styles.checklistLabel}>{label}</Text>
+    </View>
+  );
+}
+
+interface MetricProps {
+  label: string;
+  value: string;
+}
+
+function Metric({ label, value }: MetricProps) {
+  return (
+    <View style={styles.metric}>
+      <Text style={styles.metricLabel}>{label}</Text>
+      <Text style={styles.metricValue}>{value}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  card: {
+    width: '100%',
+    maxWidth: 360,
+    backgroundColor: '#0F1825',
+    borderRadius: 20,
+    padding: 24,
+    alignItems: 'center',
+  },
+  iconWrap: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: 'rgba(76, 140, 255, 0.12)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 16,
+  },
+  title: {
+    color: '#F2F4F8',
+    fontSize: 20,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+  subtitle: {
+    color: '#9AACD1',
+    fontSize: 14,
+    textAlign: 'center',
+    marginTop: 8,
+  },
+  checklist: {
+    width: '100%',
+    marginTop: 20,
+    gap: 12,
+  },
+  checklistRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  checklistLabel: {
+    color: '#F2F4F8',
+    fontSize: 14,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 24,
+    width: '100%',
+  },
+  primaryButton: {
+    flex: 2,
+    backgroundColor: '#4C8CFF',
+    paddingVertical: 12,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  primaryButtonDisabled: {
+    backgroundColor: '#2A3850',
+  },
+  primaryButtonText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  secondaryButton: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 12,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#334466',
+  },
+  secondaryButtonText: {
+    color: '#9AACD1',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  metricRow: {
+    flexDirection: 'row',
+    gap: 16,
+    marginTop: 20,
+  },
+  metric: {
+    flex: 1,
+    backgroundColor: 'rgba(76, 140, 255, 0.08)',
+    padding: 12,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  metricLabel: {
+    color: '#9AACD1',
+    fontSize: 12,
+  },
+  metricValue: {
+    color: '#F2F4F8',
+    fontSize: 18,
+    fontWeight: '700',
+    marginTop: 4,
+  },
+  progressTrack: {
+    width: '100%',
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: '#1B2638',
+    marginTop: 16,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    backgroundColor: '#4C8CFF',
+  },
+});

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -82,6 +82,13 @@ import {
 } from '@/lib/tracking-quality';
 import { CueHysteresisController } from '@/lib/tracking-quality/cue-hysteresis';
 import { useWorkoutController } from '@/hooks/use-workout-controller';
+import { useFrameLighting } from '@/hooks/use-frame-lighting';
+import { useDeviceThermalBattery } from '@/hooks/use-device-thermal-battery';
+import { usePreCalibrationStatus } from '@/hooks/use-pre-calibration-status';
+import { useRepCounterPosition } from '@/hooks/use-rep-counter-position';
+import { LightingWarningBadge } from '@/components/form-tracking/LightingWarningBadge';
+import { BatteryThermalBadge } from '@/components/form-tracking/BatteryThermalBadge';
+import { RepCounterOverlay } from '@/components/form-tracking/RepCounterOverlay';
 import {
   DEFAULT_DETECTION_MODE,
   getWorkoutByMode,
@@ -276,6 +283,36 @@ const formatDuration = (startIso: string | null | undefined, endIso: string | nu
   return `${min}m ${sec.toString().padStart(2, '0')}s`;
 };
 
+/**
+ * Internal helper for #464 — projects the latest skeleton joints into a
+ * `RepCounterOverlay` mounted inside the existing SVG layer. Kept colocated
+ * with `ScanARKitScreen` so the prop wiring stays explicit.
+ */
+function RepCounterOverlayBoundToHip({
+  repCount,
+  phase,
+  joints2D,
+}: {
+  repCount: number;
+  phase: string;
+  joints2D: Joint2D[] | null;
+}) {
+  const position = useRepCounterPosition({
+    repCount,
+    phase,
+    joints2D,
+  });
+  return (
+    <RepCounterOverlay
+      currentRep={position.repCount}
+      visible={position.visible}
+      x={position.x}
+      y={position.y}
+      opacity={position.opacity}
+    />
+  );
+}
+
 const PreviewPlayer = ({ uri }: { uri: string }) => {
   const player = useVideoPlayer(uri, (instance) => {
     instance.loop = false;
@@ -430,6 +467,19 @@ export default function ScanARKitScreen() {
   useEffect(() => {
     trackingDebugEnabledRef.current = trackingDebugEnabled;
   }, [trackingDebugEnabled]);
+
+  // Form-tracking visual polish (#464) — lighting, battery/thermal, and
+  // pre-calibration are wired via thin hooks so the existing scan-arkit
+  // logic remains the source of truth for tracking state.
+  const { reading: lightingReading } = useFrameLighting();
+  const {
+    batteryLevel,
+    thermalState,
+    badgeLevel: deviceBadgeLevel,
+    shouldPauseLowPower,
+  } = useDeviceThermalBattery();
+  const preCalibration = usePreCalibrationStatus();
+  const preCalibrationGateFiredRef = React.useRef(false);
 
   const logTrackingDebug = useCallback((event: string, payload: Record<string, unknown>) => {
     if (!trackingDebugEnabledRef.current) return;
@@ -869,6 +919,8 @@ export default function ScanARKitScreen() {
     sessionId: sessionIdRef.current,
     callbacks: workoutControllerCallbacks,
     enableHaptics: true,
+    // #464 — auto-pause when battery / thermal trip the critical bucket.
+    pauseTracking: shouldPauseLowPower,
   });
 
   const {
@@ -955,6 +1007,26 @@ export default function ScanARKitScreen() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [supportStatus, isTracking, cameraPosition, fixturePlaybackEnabled]);
+
+  // Pre-calibration gate (#464) — open the overlay modal once per workout
+  // when calibration is not yet ready. Suppression after two successful
+  // runs lives inside `usePreCalibrationStatus`.
+  useEffect(() => {
+    if (preCalibrationGateFiredRef.current) return;
+    if (fixturePlaybackEnabled) return;
+    if (!isTracking) return;
+    if (!preCalibration.status.shouldShow) return;
+    if (preCalibration.status.status === 'success') return;
+
+    preCalibrationGateFiredRef.current = true;
+    router.push('/(modals)/form-tracking-pre-calibration');
+  }, [
+    isTracking,
+    fixturePlaybackEnabled,
+    preCalibration.status.shouldShow,
+    preCalibration.status.status,
+    router,
+  ]);
 
   useEffect(() => {
     if (!fixturePlaybackEnabled || !fixtureFrames || fixtureFrames.length === 0) {
@@ -2627,6 +2699,12 @@ export default function ScanARKitScreen() {
                     />
                 );
               })}
+              {/* #464 — body-anchored rep counter overlay */}
+              <RepCounterOverlayBoundToHip
+                repCount={repCount}
+                phase={activePhase}
+                joints2D={smoothedPose2DJoints ?? null}
+              />
             </Svg>
           )}
         </View>
@@ -2763,6 +2841,26 @@ export default function ScanARKitScreen() {
           </View>
         </View>
       )}
+
+      {/* #464 — visual polish badges row (lighting + battery/thermal) */}
+      <View
+        pointerEvents="box-none"
+        style={{
+          position: 'absolute',
+          top: topBarBottom + 56,
+          right: 12,
+          flexDirection: 'column',
+          alignItems: 'flex-end',
+          gap: 8,
+        }}
+      >
+        <LightingWarningBadge bucket={lightingReading?.bucket ?? null} />
+        <BatteryThermalBadge
+          badgeLevel={deviceBadgeLevel}
+          batteryLevel={batteryLevel}
+          thermalState={thermalState}
+        />
+      </View>
 
       <Modal
         visible={isSettingsVisible}

--- a/components/form-tracking/BatteryThermalBadge.tsx
+++ b/components/form-tracking/BatteryThermalBadge.tsx
@@ -1,0 +1,126 @@
+/**
+ * BatteryThermalBadge
+ *
+ * Color-coded chip surfaced alongside the lighting badge in scan-arkit.
+ *   - badgeLevel `normal`  → hidden
+ *   - badgeLevel `warn`    → yellow chip with battery percent + thermal hint
+ *   - badgeLevel `critical`→ red pulsing chip + auto-pause copy
+ *
+ * The badge is purely presentational; auto-pause is owned by
+ * `use-workout-controller`.
+ */
+
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text, View, type ViewStyle } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type {
+  DeviceBadgeLevel,
+} from '@/hooks/use-device-thermal-battery';
+import type { ThermalState } from '@/lib/services/thermal-monitor';
+
+export interface BatteryThermalBadgeProps {
+  badgeLevel: DeviceBadgeLevel;
+  batteryLevel: number | null;
+  thermalState: ThermalState;
+  /** Optional extra style for absolute positioning. */
+  style?: ViewStyle;
+  testID?: string;
+}
+
+const PALETTE: Record<Exclude<DeviceBadgeLevel, 'normal'>, { bg: string; fg: string; icon: string }> = {
+  warn: { bg: 'rgba(255, 196, 0, 0.92)', fg: '#1A1300', icon: '#1A1300' },
+  critical: { bg: 'rgba(220, 38, 38, 0.92)', fg: '#FFFFFF', icon: '#FFFFFF' },
+};
+
+function formatBattery(level: number | null): string {
+  if (level === null) return '--%';
+  return `${Math.round(level * 100)}%`;
+}
+
+function thermalLabel(state: ThermalState): string | null {
+  switch (state) {
+    case 'critical':
+      return 'Device too hot';
+    case 'serious':
+      return 'Device hot';
+    case 'fair':
+      return 'Device warm';
+    default:
+      return null;
+  }
+}
+
+export function BatteryThermalBadge({
+  badgeLevel,
+  batteryLevel,
+  thermalState,
+  style,
+  testID,
+}: BatteryThermalBadgeProps) {
+  const pulse = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    if (badgeLevel !== 'critical') {
+      pulse.stopAnimation();
+      pulse.setValue(1);
+      return;
+    }
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, { toValue: 0.6, duration: 600, useNativeDriver: true }),
+        Animated.timing(pulse, { toValue: 1, duration: 600, useNativeDriver: true }),
+      ])
+    );
+    animation.start();
+    return () => {
+      animation.stop();
+    };
+  }, [badgeLevel, pulse]);
+
+  if (badgeLevel === 'normal') return null;
+
+  const palette = PALETTE[badgeLevel];
+  const thermalCopy = thermalLabel(thermalState);
+  const label =
+    badgeLevel === 'critical'
+      ? thermalCopy ?? `Battery ${formatBattery(batteryLevel)} — pausing`
+      : thermalCopy ?? `Battery ${formatBattery(batteryLevel)}`;
+  const role = badgeLevel === 'critical' ? 'alert' : 'text';
+
+  return (
+    <Animated.View
+      accessible
+      accessibilityRole={role}
+      accessibilityLabel={label}
+      accessibilityLiveRegion={badgeLevel === 'critical' ? 'assertive' : 'polite'}
+      testID={testID ?? `battery-thermal-${badgeLevel}`}
+      style={[styles.container, { backgroundColor: palette.bg, opacity: pulse }, style]}
+    >
+      <Ionicons
+        name={badgeLevel === 'critical' ? 'flame-outline' : 'battery-half-outline'}
+        size={14}
+        color={palette.icon}
+      />
+      <Text style={[styles.label, { color: palette.fg }]}>{label}</Text>
+      <View accessible={false} />
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 12,
+    gap: 6,
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 0.2,
+  },
+});
+
+export default BatteryThermalBadge;

--- a/components/form-tracking/LightingWarningBadge.tsx
+++ b/components/form-tracking/LightingWarningBadge.tsx
@@ -1,0 +1,106 @@
+/**
+ * LightingWarningBadge
+ *
+ * Tri-state badge surfaced in the scan-arkit badge row:
+ *   - bucket = `good`  → hidden (returns null)
+ *   - bucket = `dim`   → solid yellow chip "Low light"
+ *   - bucket = `dark`  → red chip with pulsing opacity "Lighting too dark"
+ *
+ * Pulse animation only fires for `dark` to draw the user's eye to a real
+ * blocker. `dim` is informational and does not pulse.
+ */
+
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text, View, type ViewStyle } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { LightingBucket } from '@/lib/services/lighting-detector';
+
+export interface LightingWarningBadgeProps {
+  bucket: LightingBucket | null;
+  /** Optional extra style (e.g., for absolute positioning in scan-arkit). */
+  style?: ViewStyle;
+  /** Optional override for the testID — used by accessibility tests. */
+  testID?: string;
+}
+
+const COPY: Record<Exclude<LightingBucket, 'good'>, string> = {
+  dim: 'Low light',
+  dark: 'Lighting too dark',
+};
+
+const COLORS: Record<Exclude<LightingBucket, 'good'>, { bg: string; fg: string; icon: string }> = {
+  dim: { bg: 'rgba(255, 196, 0, 0.92)', fg: '#1A1300', icon: '#1A1300' },
+  dark: { bg: 'rgba(220, 38, 38, 0.92)', fg: '#FFFFFF', icon: '#FFFFFF' },
+};
+
+export function LightingWarningBadge({ bucket, style, testID }: LightingWarningBadgeProps) {
+  const pulse = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    if (bucket !== 'dark') {
+      pulse.stopAnimation();
+      pulse.setValue(1);
+      return;
+    }
+
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, {
+          toValue: 0.55,
+          duration: 600,
+          useNativeDriver: true,
+        }),
+        Animated.timing(pulse, {
+          toValue: 1,
+          duration: 600,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+    animation.start();
+    return () => {
+      animation.stop();
+    };
+  }, [bucket, pulse]);
+
+  if (!bucket || bucket === 'good') return null;
+
+  const palette = COLORS[bucket];
+  const label = COPY[bucket];
+  // RN's `accessibilityRole` does not include "status" — fall back to
+  // "alert" for `dark` (true blocker) and "text" for `dim` (informational).
+  const role = bucket === 'dark' ? 'alert' : 'text';
+
+  return (
+    <Animated.View
+      accessible
+      accessibilityRole={role}
+      accessibilityLabel={label}
+      accessibilityLiveRegion={bucket === 'dark' ? 'assertive' : 'polite'}
+      testID={testID ?? `lighting-warning-${bucket}`}
+      style={[styles.container, { backgroundColor: palette.bg, opacity: pulse }, style]}
+    >
+      <Ionicons name="bulb-outline" size={14} color={palette.icon} />
+      <Text style={[styles.label, { color: palette.fg }]}>{label}</Text>
+      <View accessible={false} />
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 12,
+    gap: 6,
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 0.2,
+  },
+});
+
+export default LightingWarningBadge;

--- a/components/form-tracking/RepCounterOverlay.tsx
+++ b/components/form-tracking/RepCounterOverlay.tsx
@@ -1,0 +1,85 @@
+/**
+ * RepCounterOverlay
+ *
+ * Body-anchored rep counter rendered inside the existing scan-arkit SVG
+ * overlay. The number sits near the hip joint in normalized 0-1 viewBox
+ * coordinates, sized to be readable mid-rep without HUD scanning.
+ *
+ * Visual: 48-64px, white text, drop-shadow glow for legibility against any
+ * background. Uses Animated.Value so opacity transitions are smooth across
+ * phase changes (rest fade, occlusion hide).
+ */
+
+import React, { useEffect, useRef } from 'react';
+import { Animated } from 'react-native';
+import { Text as SvgText } from 'react-native-svg';
+
+const AnimatedSvgText = Animated.createAnimatedComponent(SvgText);
+
+export interface RepCounterOverlayProps {
+  /** Rep number to display (typically `state.repCount` from controller). */
+  currentRep: number;
+  /** Whether to render the overlay at all. */
+  visible: boolean;
+  /** Normalized x in viewBox 0-1. */
+  x: number;
+  /** Normalized y in viewBox 0-1. */
+  y: number;
+  /** Target opacity 0-1 (animated to over 200 ms). */
+  opacity: number;
+  /** Optional fill override (defaults to white). */
+  color?: string;
+  /** Font size in viewBox units. Defaults to 0.07 (~48px on a 720p crop). */
+  fontSize?: number;
+  /** Optional testID override. */
+  testID?: string;
+}
+
+export function RepCounterOverlay({
+  currentRep,
+  visible,
+  x,
+  y,
+  opacity,
+  color = '#FFFFFF',
+  fontSize = 0.07,
+  testID,
+}: RepCounterOverlayProps) {
+  const animatedOpacity = useRef(new Animated.Value(0)).current;
+  const targetOpacity = visible ? Math.max(0, Math.min(1, opacity)) : 0;
+
+  useEffect(() => {
+    Animated.timing(animatedOpacity, {
+      toValue: targetOpacity,
+      duration: 200,
+      useNativeDriver: true,
+    }).start();
+  }, [targetOpacity, animatedOpacity]);
+
+  if (!visible && targetOpacity === 0) {
+    // Skip render entirely once faded; cheap optimization for occlusion.
+    return null;
+  }
+
+  return (
+    <AnimatedSvgText
+      x={x}
+      y={y}
+      fill={color}
+      fontSize={fontSize}
+      fontWeight="700"
+      textAnchor="middle"
+      alignmentBaseline="middle"
+      opacity={animatedOpacity}
+      testID={testID ?? 'rep-counter-overlay'}
+      // SVG does not support drop-shadow filters consistently across RN
+      // platforms; we fake a glow with a thin outer stroke.
+      stroke="rgba(0, 0, 0, 0.45)"
+      strokeWidth={fontSize * 0.05}
+    >
+      {currentRep}
+    </AnimatedSvgText>
+  );
+}
+
+export default RepCounterOverlay;

--- a/components/form-tracking/SymmetryComparatorCard.tsx
+++ b/components/form-tracking/SymmetryComparatorCard.tsx
@@ -1,0 +1,201 @@
+/**
+ * SymmetryComparatorCard
+ *
+ * Per-rep bilateral asymmetry chart. Bars represent `asymmetryPct` per rep
+ * with a horizontal threshold line at 15% (anything above is red). Renders
+ * an empty state when the rep-analytics stub returns no rows (PR #444 not
+ * yet on main).
+ */
+
+import React, { useMemo } from 'react';
+import { Dimensions, StyleSheet, Text, View, type ViewStyle } from 'react-native';
+import { BarChart } from 'react-native-chart-kit';
+import {
+  SYMMETRY_THRESHOLD_PCT,
+  type SymmetryDatum,
+} from '@/hooks/use-symmetry-comparison';
+
+export interface SymmetryComparatorCardProps {
+  series: SymmetryDatum[];
+  isLoading?: boolean;
+  isFallback?: boolean;
+  /** Optional chart width override; defaults to (screen - 48). */
+  width?: number;
+  style?: ViewStyle;
+  testID?: string;
+}
+
+const SCREEN_WIDTH = Dimensions.get('window').width;
+const DEFAULT_WIDTH = SCREEN_WIDTH - 48;
+const CHART_HEIGHT = 180;
+
+export function SymmetryComparatorCard({
+  series,
+  isLoading = false,
+  isFallback = false,
+  width,
+  style,
+  testID,
+}: SymmetryComparatorCardProps) {
+  const chartWidth = width ?? DEFAULT_WIDTH;
+
+  const cleanSeries = useMemo(
+    () => series.filter((d) => d.asymmetryPct !== null && Number.isFinite(d.asymmetryPct as number)),
+    [series]
+  );
+
+  const data = useMemo(() => {
+    if (cleanSeries.length === 0) return null;
+    return {
+      labels: cleanSeries.map((d) => `R${d.repNumber}`),
+      datasets: [
+        {
+          data: cleanSeries.map((d) => d.asymmetryPct as number),
+        },
+      ],
+    };
+  }, [cleanSeries]);
+
+  const maxAsymmetry = useMemo(() => {
+    if (cleanSeries.length === 0) return 0;
+    return Math.max(...cleanSeries.map((d) => d.asymmetryPct as number));
+  }, [cleanSeries]);
+
+  return (
+    <View style={[styles.card, style]} testID={testID ?? 'symmetry-comparator-card'}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Left vs Right</Text>
+        <View style={styles.legendRow}>
+          <ThresholdLegend />
+        </View>
+      </View>
+
+      {isLoading && <Text style={styles.placeholder}>Loading rep history…</Text>}
+
+      {!isLoading && data && (
+        <View>
+          <BarChart
+            data={data}
+            width={chartWidth}
+            height={CHART_HEIGHT}
+            yAxisLabel=""
+            yAxisSuffix="%"
+            fromZero
+            showBarTops={false}
+            chartConfig={{
+              backgroundColor: 'transparent',
+              backgroundGradientFrom: '#0F2339',
+              backgroundGradientTo: '#1B2E4A',
+              decimalPlaces: 0,
+              color: (opacity = 1) =>
+                maxAsymmetry > SYMMETRY_THRESHOLD_PCT
+                  ? `rgba(220, 38, 38, ${opacity})`
+                  : `rgba(76, 140, 255, ${opacity})`,
+              labelColor: (opacity = 1) => `rgba(154, 172, 209, ${opacity})`,
+              propsForBackgroundLines: {
+                stroke: 'rgba(154, 172, 209, 0.15)',
+                strokeWidth: 1,
+              },
+            }}
+            style={styles.chart}
+          />
+          {/* Threshold marker */}
+          <View
+            accessibilityLabel={`Threshold ${SYMMETRY_THRESHOLD_PCT}%`}
+            style={styles.thresholdLine}
+          />
+          <Text style={styles.summaryText}>
+            Peak asymmetry: <Text style={styles.summaryValue}>{maxAsymmetry.toFixed(1)}%</Text>
+          </Text>
+        </View>
+      )}
+
+      {!isLoading && !data && (
+        <Text style={styles.placeholder} testID="symmetry-comparator-empty">
+          {isFallback
+            ? 'Rep analytics will be available after PR #444 merges.'
+            : 'Not enough valid bilateral data yet.'}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+function ThresholdLegend() {
+  return (
+    <View style={styles.legendItem}>
+      <View style={styles.legendSwatch} />
+      <Text style={styles.legendText}>{SYMMETRY_THRESHOLD_PCT}% threshold</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#0F1825',
+    borderRadius: 16,
+    padding: 16,
+    gap: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  title: {
+    color: '#F2F4F8',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  legendRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  legendItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  legendSwatch: {
+    width: 8,
+    height: 8,
+    backgroundColor: '#DC2626',
+    borderRadius: 2,
+  },
+  legendText: {
+    color: '#9AACD1',
+    fontSize: 12,
+  },
+  placeholder: {
+    color: '#9AACD1',
+    fontSize: 13,
+    paddingVertical: 16,
+    textAlign: 'center',
+  },
+  chart: {
+    borderRadius: 12,
+    marginVertical: 4,
+  },
+  thresholdLine: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    // Approximate threshold position assuming default chart height; the
+    // BarChart owns its own y-axis so this line is decorative — the legend
+    // tells users what the threshold means.
+    top: CHART_HEIGHT * (1 - SYMMETRY_THRESHOLD_PCT / 100) - 1,
+    height: 1,
+    backgroundColor: 'rgba(220, 38, 38, 0.6)',
+  },
+  summaryText: {
+    color: '#9AACD1',
+    fontSize: 12,
+    marginTop: 6,
+  },
+  summaryValue: {
+    color: '#F2F4F8',
+    fontWeight: '700',
+  },
+});
+
+export default SymmetryComparatorCard;

--- a/hooks/use-device-thermal-battery.ts
+++ b/hooks/use-device-thermal-battery.ts
@@ -1,0 +1,117 @@
+/**
+ * useDeviceThermalBattery
+ *
+ * Combines battery level (when available) with the thermal-monitor stub
+ * (TODO(#449)) and exposes a single `{ batteryLevel, thermalState,
+ * shouldPauseLowPower }` object for the badge + auto-pause logic.
+ *
+ * Battery level: tries `expo-battery` lazily so this hook stays buildable
+ * when the dep is not yet installed (per overnight no-new-deps rule). When
+ * the dep is missing, `batteryLevel` is `null` and the auto-pause guard
+ * relies solely on thermal state.
+ *
+ * Bucketing:
+ *   - batteryLevel < 0.10 OR thermalState ∈ {serious, critical} → pause
+ *   - batteryLevel < 0.20 OR thermalState = fair → warn (badge yellow)
+ *   - otherwise → normal (badge hidden)
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  getThermalState,
+  subscribeThermalState,
+  type ThermalState,
+} from '@/lib/services/thermal-monitor';
+
+export type DeviceBadgeLevel = 'normal' | 'warn' | 'critical';
+
+export interface UseDeviceThermalBatteryReturn {
+  /** Battery level 0-1, or `null` when battery API is unavailable. */
+  batteryLevel: number | null;
+  thermalState: ThermalState;
+  /** Aggregated badge bucket the UI consumes. */
+  badgeLevel: DeviceBadgeLevel;
+  /** Whether the controller should auto-pause active reps. */
+  shouldPauseLowPower: boolean;
+}
+
+const POLL_INTERVAL_MS = 30_000; // Poll every 30s — battery does not change quickly.
+
+/**
+ * Lazy-load expo-battery so the bundler does not fail when the dep is not
+ * installed. Returns null on failure or web.
+ */
+async function readBatteryLevel(): Promise<number | null> {
+  try {
+    // Avoid static import so missing dep does not break the bundle.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('expo-battery');
+    if (!mod || typeof mod.getBatteryLevelAsync !== 'function') return null;
+    const level = await mod.getBatteryLevelAsync();
+    return typeof level === 'number' && Number.isFinite(level) ? level : null;
+  } catch {
+    return null;
+  }
+}
+
+export function deriveBadgeLevel(
+  batteryLevel: number | null,
+  thermalState: ThermalState
+): DeviceBadgeLevel {
+  if (thermalState === 'serious' || thermalState === 'critical') return 'critical';
+  if (batteryLevel !== null && batteryLevel < 0.1) return 'critical';
+  if (thermalState === 'fair') return 'warn';
+  if (batteryLevel !== null && batteryLevel < 0.2) return 'warn';
+  return 'normal';
+}
+
+export function deriveShouldPause(
+  batteryLevel: number | null,
+  thermalState: ThermalState
+): boolean {
+  if (thermalState === 'critical') return true;
+  if (thermalState === 'serious') return true;
+  if (batteryLevel !== null && batteryLevel < 0.1) return true;
+  return false;
+}
+
+export function useDeviceThermalBattery(): UseDeviceThermalBatteryReturn {
+  const [batteryLevel, setBatteryLevel] = useState<number | null>(null);
+  const [thermalState, setThermalState] = useState<ThermalState>(() => getThermalState());
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const refresh = async () => {
+      const level = await readBatteryLevel();
+      if (!cancelled) setBatteryLevel(level);
+    };
+
+    void refresh();
+    const interval = setInterval(() => {
+      void refresh();
+    }, POLL_INTERVAL_MS);
+
+    const unsubscribe = subscribeThermalState((state) => {
+      if (!cancelled) setThermalState(state);
+    });
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      unsubscribe();
+    };
+  }, []);
+
+  const badgeLevel = deriveBadgeLevel(batteryLevel, thermalState);
+  const shouldPauseLowPower = deriveShouldPause(batteryLevel, thermalState);
+
+  return {
+    batteryLevel,
+    thermalState,
+    badgeLevel,
+    shouldPauseLowPower,
+  };
+}
+
+export default useDeviceThermalBattery;

--- a/hooks/use-frame-lighting.ts
+++ b/hooks/use-frame-lighting.ts
@@ -1,0 +1,134 @@
+/**
+ * useFrameLighting — debounced subscription to frame-brightness updates.
+ *
+ * Consumers (the lighting badge in scan-arkit, future telemetry surfaces)
+ * call `report(brightness)` from their per-frame hook with a 0-255 mean. The
+ * hook smooths via `LightingSmoother`, debounces emissions to ~100 ms, and
+ * exposes the latest `LightingReading`.
+ *
+ * Decoupled from ARKit native plumbing — caller decides where the brightness
+ * mean comes from (pose-logger sample, MediaPipe luminance, future sensor).
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  analyzeLighting,
+  LightingSmoother,
+  type LightingReading,
+} from '@/lib/services/lighting-detector';
+
+const DEFAULT_DEBOUNCE_MS = 100;
+
+export interface UseFrameLightingOptions {
+  /**
+   * Minimum interval between reading updates (ms). Defaults to 100 ms.
+   */
+  debounceMs?: number;
+  /**
+   * Median-filter window length, passed to `LightingSmoother`. Defaults to 3.
+   */
+  smoothingWindow?: number;
+  /**
+   * Optional precomputed histogram passthrough. The hook accepts a histogram
+   * via `report` instead of this option for per-frame variance.
+   */
+  initialReading?: LightingReading;
+}
+
+export interface UseFrameLightingReturn {
+  /** Latest debounced reading. `null` until the first frame arrives. */
+  reading: LightingReading | null;
+  /**
+   * Push a new brightness sample (0-255 mean). Optional histogram bins are
+   * passed through verbatim to the analyzer.
+   */
+  report: (brightness: number, histogram?: number[]) => void;
+  /** Reset internal smoother + clear the latest reading. */
+  reset: () => void;
+}
+
+/**
+ * Hook entry — see file-level doc for usage.
+ */
+export function useFrameLighting(
+  options: UseFrameLightingOptions = {}
+): UseFrameLightingReturn {
+  const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const smoothingWindow = options.smoothingWindow ?? 3;
+
+  const [reading, setReading] = useState<LightingReading | null>(
+    options.initialReading ?? null
+  );
+  const smootherRef = useRef<LightingSmoother>(new LightingSmoother(smoothingWindow));
+  const lastEmitMsRef = useRef<number>(0);
+  const pendingHistogramRef = useRef<number[] | undefined>(undefined);
+  const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Re-create smoother if windowSize prop changes after mount.
+  useEffect(() => {
+    smootherRef.current = new LightingSmoother(smoothingWindow);
+  }, [smoothingWindow]);
+
+  // Cleanup pending timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (pendingTimerRef.current) {
+        clearTimeout(pendingTimerRef.current);
+        pendingTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const flush = useCallback((smoothed: number) => {
+    const next = analyzeLighting({
+      brightness: smoothed,
+      histogram: pendingHistogramRef.current,
+    });
+    pendingHistogramRef.current = undefined;
+    lastEmitMsRef.current = Date.now();
+    setReading(next);
+  }, []);
+
+  const report = useCallback(
+    (brightness: number, histogram?: number[]) => {
+      const smoothed = smootherRef.current.push(brightness);
+      if (histogram) pendingHistogramRef.current = histogram;
+
+      const now = Date.now();
+      const elapsed = now - lastEmitMsRef.current;
+
+      if (lastEmitMsRef.current === 0 || elapsed >= debounceMs) {
+        if (pendingTimerRef.current) {
+          clearTimeout(pendingTimerRef.current);
+          pendingTimerRef.current = null;
+        }
+        flush(smoothed);
+        return;
+      }
+
+      // Debounce: schedule a trailing flush if one is not already pending.
+      if (!pendingTimerRef.current) {
+        pendingTimerRef.current = setTimeout(() => {
+          pendingTimerRef.current = null;
+          flush(smoothed);
+        }, debounceMs - elapsed);
+      }
+    },
+    [debounceMs, flush]
+  );
+
+  const reset = useCallback(() => {
+    smootherRef.current.reset();
+    pendingHistogramRef.current = undefined;
+    lastEmitMsRef.current = 0;
+    if (pendingTimerRef.current) {
+      clearTimeout(pendingTimerRef.current);
+      pendingTimerRef.current = null;
+    }
+    setReading(null);
+  }, []);
+
+  return { reading, report, reset };
+}
+
+export default useFrameLighting;

--- a/hooks/use-pre-calibration-status.ts
+++ b/hooks/use-pre-calibration-status.ts
@@ -1,0 +1,167 @@
+/**
+ * usePreCalibrationStatus
+ *
+ * Tracks pre-workout calibration readiness for the form-tracking overlay
+ * modal. The hook owns the running confidence + frame counters; the modal
+ * screen calls `markSuccess` / `markFailed` and `recordFrame(confidence)` to
+ * advance state.
+ *
+ * `shouldShow` derives from AsyncStorage suppression: after the user has
+ * completed *2* successful pre-calibration runs, the modal hides itself on
+ * subsequent workouts (still surfacing for `failed` recoveries).
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { CalibrationStatus } from '@/lib/types/workout-session';
+
+const STORAGE_KEY = 'preCalibration.successCount';
+const SUPPRESS_AFTER_SUCCESS_COUNT = 2;
+const SUFFICIENT_CONFIDENCE = 0.75;
+const REQUIRED_FRAMES = 30;
+
+export interface PreCalibrationStatus {
+  /** Lifecycle status — pending until enough frames + confidence collected. */
+  status: CalibrationStatus;
+  /** Mean confidence across collected frames (0-1). */
+  confidence: number;
+  /** Number of frames observed in the current pre-calibration session. */
+  framesObserved: number;
+  /** Whether the modal should mount at all (false after suppression cap). */
+  shouldShow: boolean;
+}
+
+export interface UsePreCalibrationStatusReturn {
+  status: PreCalibrationStatus;
+  /** Push a per-frame confidence sample. Auto-marks success on convergence. */
+  recordFrame: (confidence: number) => void;
+  /** Mark the calibration as user-confirmed success. Persists suppression. */
+  markSuccess: () => Promise<void>;
+  /** Mark the calibration as failed (user cancel / timeout). */
+  markFailed: () => void;
+  /** Reset all collected state — used when a fresh workout begins. */
+  reset: () => void;
+}
+
+const clamp01 = (n: number): number => {
+  if (!Number.isFinite(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+};
+
+export function usePreCalibrationStatus(): UsePreCalibrationStatusReturn {
+  const [status, setStatus] = useState<PreCalibrationStatus>({
+    status: 'pending',
+    confidence: 0,
+    framesObserved: 0,
+    shouldShow: true,
+  });
+  const sumRef = useRef(0);
+  const countRef = useRef(0);
+  const completedSuccessRef = useRef(false);
+
+  // Hydrate suppression state from AsyncStorage on mount.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const raw = await AsyncStorage.getItem(STORAGE_KEY);
+        const successCount = raw ? Number(raw) : 0;
+        if (!cancelled) {
+          setStatus((prev) => ({
+            ...prev,
+            shouldShow: successCount < SUPPRESS_AFTER_SUCCESS_COUNT,
+          }));
+        }
+      } catch {
+        // AsyncStorage unavailable — default to showing (safe).
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const reset = useCallback(() => {
+    sumRef.current = 0;
+    countRef.current = 0;
+    completedSuccessRef.current = false;
+    setStatus((prev) => ({
+      status: 'pending',
+      confidence: 0,
+      framesObserved: 0,
+      shouldShow: prev.shouldShow,
+    }));
+  }, []);
+
+  const markFailed = useCallback(() => {
+    setStatus((prev) => ({
+      ...prev,
+      status: 'failed',
+    }));
+  }, []);
+
+  const markSuccess = useCallback(async () => {
+    if (completedSuccessRef.current) return;
+    completedSuccessRef.current = true;
+    setStatus((prev) => ({
+      ...prev,
+      status: 'success',
+    }));
+    try {
+      const raw = await AsyncStorage.getItem(STORAGE_KEY);
+      const next = (raw ? Number(raw) : 0) + 1;
+      await AsyncStorage.setItem(STORAGE_KEY, String(next));
+      if (next >= SUPPRESS_AFTER_SUCCESS_COUNT) {
+        setStatus((prev) => ({ ...prev, shouldShow: false }));
+      }
+    } catch {
+      // Best-effort persistence; failing silently keeps the user unblocked.
+    }
+  }, []);
+
+  const recordFrame = useCallback(
+    (rawConfidence: number) => {
+      const c = clamp01(rawConfidence);
+      sumRef.current += c;
+      countRef.current += 1;
+      const mean = sumRef.current / countRef.current;
+      const frames = countRef.current;
+
+      setStatus((prev) => ({
+        ...prev,
+        confidence: Number(mean.toFixed(3)),
+        framesObserved: frames,
+      }));
+
+      // Auto-success once thresholds reached.
+      if (
+        !completedSuccessRef.current &&
+        frames >= REQUIRED_FRAMES &&
+        mean >= SUFFICIENT_CONFIDENCE
+      ) {
+        // Fire-and-forget — caller does not await.
+        void markSuccess();
+      }
+    },
+    [markSuccess]
+  );
+
+  return {
+    status,
+    recordFrame,
+    markSuccess,
+    markFailed,
+    reset,
+  };
+}
+
+export const PRE_CALIBRATION_CONSTANTS = {
+  SUPPRESS_AFTER_SUCCESS_COUNT,
+  SUFFICIENT_CONFIDENCE,
+  REQUIRED_FRAMES,
+  STORAGE_KEY,
+} as const;
+
+export default usePreCalibrationStatus;

--- a/hooks/use-rep-counter-position.ts
+++ b/hooks/use-rep-counter-position.ts
@@ -1,0 +1,46 @@
+/**
+ * useRepCounterPosition
+ *
+ * Joins the rep counter (from the workout controller), the visible state
+ * (from phase + occlusion guards), and the projected hip anchor (from
+ * `rep-counter-overlay`) into a single value object the overlay component
+ * can render.
+ */
+
+import { useMemo } from 'react';
+import type { Joint2D, Joint3D } from '@/lib/arkit/ARKitBodyTracker';
+import {
+  computeRepCounterPosition,
+  type RepCounterPosition,
+} from '@/lib/services/rep-counter-overlay';
+
+export interface UseRepCounterPositionInput {
+  repCount: number;
+  phase?: string | null;
+  joints2D?: Joint2D[] | null;
+  joints3D?: Joint3D[] | null;
+  confidence?: number;
+}
+
+export interface UseRepCounterPositionReturn extends RepCounterPosition {
+  repCount: number;
+}
+
+export function useRepCounterPosition(
+  input: UseRepCounterPositionInput
+): UseRepCounterPositionReturn {
+  const position = useMemo(
+    () =>
+      computeRepCounterPosition({
+        joints2D: input.joints2D,
+        joints3D: input.joints3D,
+        phase: input.phase,
+        confidence: input.confidence,
+      }),
+    [input.joints2D, input.joints3D, input.phase, input.confidence]
+  );
+
+  return { ...position, repCount: input.repCount };
+}
+
+export default useRepCounterPosition;

--- a/hooks/use-symmetry-comparison.ts
+++ b/hooks/use-symmetry-comparison.ts
@@ -1,0 +1,105 @@
+/**
+ * useSymmetryComparison
+ *
+ * Loads bilateral angle deltas from `lib/services/rep-analytics.ts` and
+ * computes per-rep asymmetry percentages for the SymmetryComparatorCard.
+ *
+ * Asymmetry = `abs(L - R) / max(L, R) * 100`. The card overlays a 15%
+ * threshold line (anything above is flagged red).
+ *
+ * Edge cases handled here so the component stays presentational:
+ *   - One-sided tracking loss (left or right is 0 / NaN) → emits
+ *     `asymmetryPct = null` for that rep so the chart can render a gap.
+ *   - Bilateral row with both sides 0 → asymmetry = 0 (perfect, not div-by-0).
+ *   - PR #444 not on main → `getBilateralRepHistory` returns `[]` → hook
+ *     emits an empty series with `isFallback: true`.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  getBilateralRepHistory,
+  type BilateralRepRow,
+} from '@/lib/services/rep-analytics';
+
+export const SYMMETRY_THRESHOLD_PCT = 15;
+
+export interface SymmetryDatum {
+  repNumber: number;
+  leftAngleDeg: number;
+  rightAngleDeg: number;
+  /** Asymmetry percentage 0-100; `null` for unrecoverable bilateral data. */
+  asymmetryPct: number | null;
+  joint?: string;
+}
+
+export interface UseSymmetryComparisonReturn {
+  series: SymmetryDatum[];
+  /** Empty result was returned — typically the `rep-analytics` stub. */
+  isFallback: boolean;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const isFiniteNumber = (n: unknown): n is number =>
+  typeof n === 'number' && Number.isFinite(n);
+
+/**
+ * Pure helper — exposed for unit tests.
+ */
+export function computeAsymmetryPct(left: number, right: number): number | null {
+  if (!isFiniteNumber(left) || !isFiniteNumber(right)) return null;
+  if (left === 0 && right === 0) return 0;
+  if (left <= 0 || right <= 0) return null;
+  const denom = Math.max(left, right);
+  if (denom === 0) return null;
+  const pct = (Math.abs(left - right) / denom) * 100;
+  return Number(pct.toFixed(2));
+}
+
+function projectRow(row: BilateralRepRow): SymmetryDatum {
+  return {
+    repNumber: row.repNumber,
+    leftAngleDeg: row.leftAngleDeg,
+    rightAngleDeg: row.rightAngleDeg,
+    asymmetryPct: computeAsymmetryPct(row.leftAngleDeg, row.rightAngleDeg),
+    joint: row.joint,
+  };
+}
+
+export function useSymmetryComparison(
+  sessionId: string,
+  limit = 50
+): UseSymmetryComparisonReturn {
+  const [rows, setRows] = useState<BilateralRepRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    (async () => {
+      try {
+        const data = await getBilateralRepHistory(sessionId, limit);
+        if (cancelled) return;
+        setRows(data);
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setRows([]);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, limit]);
+
+  const series = useMemo(() => rows.map(projectRow), [rows]);
+  const isFallback = !isLoading && rows.length === 0 && !error;
+
+  return { series, isFallback, isLoading, error };
+}
+
+export default useSymmetryComparison;

--- a/hooks/use-workout-controller.ts
+++ b/hooks/use-workout-controller.ts
@@ -120,6 +120,16 @@ export interface UseWorkoutControllerOptions {
   callbacks?: WorkoutControllerCallbacks;
   /** Enable haptic feedback on rep completion */
   enableHaptics?: boolean;
+  /**
+   * When true the controller will not advance phase / count reps.
+   *
+   * Wired by `hooks/use-device-thermal-battery` via `shouldPauseLowPower`.
+   *
+   * TODO(#464): if PR #427 / #434 land a richer pause API on this hook
+   * before this PR merges, swap this flag for the canonical structure.
+   * For now it is intentionally additive so the merge stays trivial.
+   */
+  pauseTracking?: boolean;
 }
 
 export interface ResetWorkoutOptions {
@@ -153,7 +163,13 @@ export function useWorkoutController<TPhase extends string = string>(
   initialWorkoutId: DetectionMode,
   options: UseWorkoutControllerOptions
 ): UseWorkoutControllerReturn<TPhase> {
-  const { sessionId, callbacks, enableHaptics = true } = options;
+  const { sessionId, callbacks, enableHaptics = true, pauseTracking = false } = options;
+  // Mirror the prop into a ref so the per-frame closure can read the latest
+  // value without re-binding `processFrame` on every change.
+  const pauseRef = useRef<boolean>(pauseTracking);
+  useEffect(() => {
+    pauseRef.current = pauseTracking;
+  }, [pauseTracking]);
 
   // Current workout definition
   const workoutIdRef = useRef<DetectionMode>(initialWorkoutId);
@@ -394,6 +410,9 @@ export function useWorkoutController<TPhase extends string = string>(
       context?: { trackingQuality?: number; shadowMeanAbsDelta?: number | null }
     ) => {
       if (transitioningRef.current) return;
+      // Auto-pause from the battery+thermal hook — bail before any phase
+      // logic so we keep the last-known phase / repCount stable.
+      if (pauseRef.current) return;
 
       const workoutDef = workoutDefRef.current;
       if (!workoutDef) return;

--- a/lib/services/lighting-detector.ts
+++ b/lib/services/lighting-detector.ts
@@ -1,0 +1,172 @@
+/**
+ * Lighting Detector Service
+ *
+ * Analyzes per-frame brightness samples (0-255 mean from ARKit pose-logger
+ * sample) and emits lighting-quality buckets for the form-tracking UI.
+ *
+ * Goals:
+ * - Pre-rep "lighting too dark" warning prevents form misinterpretation in
+ *   low-light gyms / bedrooms.
+ * - Detector is decoupled from the native ARKit frame buffer (no Swift edits):
+ *   it consumes a precomputed `brightness` mean (0-255) plus an optional
+ *   histogram. Callers can be the existing `pose-logger` `lightingScore` field
+ *   or any future telemetry pipeline.
+ *
+ * Bucket thresholds (empirical, conservative):
+ *   - `dark` < 40
+ *   - `dim`  < 80
+ *   - `good` >= 80
+ * Overexposure (>= 240) is bucketed `good` (no separate "blown" bucket — UX
+ * value of warning users about *too much* light is low).
+ */
+
+export type LightingBucket = 'dark' | 'dim' | 'good';
+
+export const LIGHTING_THRESHOLDS = {
+  /** Below this mean brightness, bucket = `dark` */
+  dark: 40,
+  /** Below this mean brightness, bucket = `dim` */
+  dim: 80,
+  /** Default histogram bin count when caller does not supply one */
+  defaultHistogramBins: 8,
+} as const;
+
+export interface LightingSample {
+  /** Mean per-pixel brightness 0-255 from ARKit/pose-logger sample. */
+  brightness: number;
+  /** Optional precomputed histogram (length = bin count, sum = pixel count). */
+  histogram?: number[];
+  /** Optional total pixel count if `histogram` is sparse. Defaults to histogram sum. */
+  totalPixels?: number;
+}
+
+export interface LightingReading {
+  bucket: LightingBucket;
+  /**
+   * Confidence 0-1 — derived from how far the brightness sits from the nearest
+   * bucket boundary. 1.0 = clearly inside bucket; 0.0 = right on the boundary.
+   */
+  confidence: number;
+  /** Histogram bins normalized to a fixed length (defaults to 8). */
+  histogramBins: number[];
+  /** Mean brightness 0-255 (clamped). */
+  brightness: number;
+}
+
+/**
+ * Clamp a number to a numeric range. Defensive against NaN / Infinity.
+ */
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, value));
+}
+
+/**
+ * Convert a raw brightness 0-255 to a lighting bucket.
+ */
+export function bucketForBrightness(brightness: number): LightingBucket {
+  const b = clamp(brightness, 0, 255);
+  if (b < LIGHTING_THRESHOLDS.dark) return 'dark';
+  if (b < LIGHTING_THRESHOLDS.dim) return 'dim';
+  return 'good';
+}
+
+/**
+ * Compute a 0-1 confidence score for a bucket assignment based on distance
+ * from the nearest boundary. Wider gap = higher confidence.
+ */
+export function confidenceForBrightness(brightness: number): number {
+  const b = clamp(brightness, 0, 255);
+  // Distance to nearest boundary among {dark, dim, 255-cap}.
+  const boundaries = [LIGHTING_THRESHOLDS.dark, LIGHTING_THRESHOLDS.dim];
+  let nearest = Number.POSITIVE_INFINITY;
+  for (const boundary of boundaries) {
+    const d = Math.abs(b - boundary);
+    if (d < nearest) nearest = d;
+  }
+  // Map distance (0..40) to confidence (0..1), saturating at distance 40.
+  // 40 = half of the dark bucket width, generous but stable.
+  const normalized = clamp(nearest / 40, 0, 1);
+  return Number(normalized.toFixed(3));
+}
+
+/**
+ * Normalize an arbitrary histogram into a fixed bin count. Buckets the input
+ * proportionally when the source bin count differs from the target.
+ *
+ * Edge cases:
+ * - Empty / undefined histogram → returns a zero-filled array.
+ * - All-zero histogram → returns it as-is.
+ * - Source bin count < target → linear duplication-style stretch.
+ */
+export function normalizeHistogram(
+  histogram: number[] | undefined,
+  bins: number = LIGHTING_THRESHOLDS.defaultHistogramBins
+): number[] {
+  const target = Math.max(1, Math.floor(bins));
+  if (!histogram || histogram.length === 0) {
+    return new Array(target).fill(0);
+  }
+  if (histogram.length === target) {
+    return histogram.map((v) => (Number.isFinite(v) && v >= 0 ? v : 0));
+  }
+  const out = new Array(target).fill(0);
+  const ratio = histogram.length / target;
+  for (let i = 0; i < target; i += 1) {
+    const start = Math.floor(i * ratio);
+    const end = Math.max(start + 1, Math.floor((i + 1) * ratio));
+    let sum = 0;
+    for (let j = start; j < end && j < histogram.length; j += 1) {
+      const v = histogram[j];
+      if (Number.isFinite(v) && v >= 0) sum += v;
+    }
+    out[i] = sum;
+  }
+  return out;
+}
+
+/**
+ * Analyze a single lighting sample and produce a `LightingReading`.
+ *
+ * All callers should debounce upstream (see `hooks/use-frame-lighting.ts`) to
+ * avoid jittery UI on micro-fluctuations.
+ */
+export function analyzeLighting(sample: LightingSample): LightingReading {
+  const brightness = clamp(sample.brightness, 0, 255);
+  const bucket = bucketForBrightness(brightness);
+  const confidence = confidenceForBrightness(brightness);
+  const histogramBins = normalizeHistogram(sample.histogram);
+  return { bucket, confidence, histogramBins, brightness };
+}
+
+/**
+ * Stateful 3-frame median filter for lighting samples — recommended for
+ * subscribers that want a smoother readout without implementing their own
+ * debounce logic. (Hooks may use this directly.)
+ */
+export class LightingSmoother {
+  private readonly window: number[] = [];
+  private readonly windowSize: number;
+
+  constructor(windowSize = 3) {
+    this.windowSize = Math.max(1, Math.floor(windowSize));
+  }
+
+  push(brightness: number): number {
+    const safe = clamp(brightness, 0, 255);
+    this.window.push(safe);
+    if (this.window.length > this.windowSize) {
+      this.window.shift();
+    }
+    const sorted = [...this.window].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    if (sorted.length % 2 === 0) {
+      return (sorted[mid - 1] + sorted[mid]) / 2;
+    }
+    return sorted[mid];
+  }
+
+  reset(): void {
+    this.window.length = 0;
+  }
+}

--- a/lib/services/pose-logger.ts
+++ b/lib/services/pose-logger.ts
@@ -68,6 +68,14 @@ let flushTimer: NodeJS.Timeout | null = null;
 let lastSampleTime = 0;
 let isFlushing = false;
 let frameCounter = 0;
+/**
+ * Latest known frame brightness (0-255 mean) — populated by callers that have
+ * cheap access to the frame buffer (lighting detector, ARKit overlay, etc.).
+ * Used to backfill the schema-level `lighting_score` column when a sample
+ * does not provide one inline. Persisted across sessions to avoid emitting
+ * `null` whenever a single frame skips reading the brightness.
+ */
+let latestFrameBrightness: number | null = null;
 
 /**
  * Check if confidence is below threshold
@@ -224,6 +232,10 @@ export async function logPoseSample(sample: PoseSample): Promise<void> {
       ...sample,
       userId,
       frameIdx: sample.frameIdx ?? frameCounter,
+      // Backfill `lightingScore` from the latest known brightness when the
+      // caller did not supply one — populated by `setLatestFrameBrightness`
+      // (typically from `hooks/use-frame-lighting.ts`).
+      lightingScore: sample.lightingScore ?? latestFrameBrightness ?? undefined,
       modelVersion: context.modelVersion,
       cueConfigVersion: context.cueConfigVersion,
     };
@@ -290,4 +302,25 @@ export function getFrameCounter(): number {
  */
 export function resetFrameCounter(): void {
   frameCounter = 0;
+}
+
+/**
+ * Update the cached frame brightness (0-255 mean). The next pose sample that
+ * does not specify `lightingScore` inline will use this value. Pass `null` to
+ * clear (e.g., when tracking stops).
+ */
+export function setLatestFrameBrightness(brightness: number | null): void {
+  if (brightness === null) {
+    latestFrameBrightness = null;
+    return;
+  }
+  if (!Number.isFinite(brightness)) return;
+  latestFrameBrightness = Math.max(0, Math.min(255, brightness));
+}
+
+/**
+ * Read the latest cached frame brightness (mostly for tests / debug).
+ */
+export function getLatestFrameBrightness(): number | null {
+  return latestFrameBrightness;
 }

--- a/lib/services/rep-analytics.ts
+++ b/lib/services/rep-analytics.ts
@@ -1,0 +1,57 @@
+/**
+ * Rep Analytics Service — minimal stub
+ *
+ * TODO(#444): merge with PR #444 canonical implementation on land.
+ *
+ * The canonical service in PR #444 will own bilateral angle aggregation,
+ * rep-over-rep diff series, and the keyframe extractor that feeds the ghost
+ * replay trail. This stub is shipped alongside #464 so the symmetry
+ * comparator card has a stable import path that does not break the build
+ * when #444 is not yet on `main`.
+ *
+ * Contract (kept intentionally narrow):
+ *   - `getBilateralRepHistory(sessionId, limit)` → array of bilateral angle
+ *     deltas keyed by rep number. Returns `[]` when no data is available so
+ *     consumers can render an empty-state card without throwing.
+ *
+ * When #444 lands, replace this file with the canonical implementation. The
+ * symmetry consumer hook (`use-symmetry-comparison`) intentionally does not
+ * import any types beyond `BilateralRepRow` to keep the merge low-conflict.
+ */
+
+export interface BilateralRepRow {
+  /** Rep number within the current set (1-indexed). */
+  repNumber: number;
+  /** Left-side angle (deg) at the rep boundary. */
+  leftAngleDeg: number;
+  /** Right-side angle (deg) at the rep boundary. */
+  rightAngleDeg: number;
+  /**
+   * Optional joint label (e.g., "elbow", "knee") so the comparator can group
+   * deltas by joint when the source set tracked multiple bilateral pairs.
+   */
+  joint?: string;
+}
+
+/**
+ * Stub fallback — returns an empty history so the comparator card renders an
+ * empty state. PR #444's canonical implementation will read from the
+ * `rep_features` Supabase table and project bilateral angle pairs.
+ */
+export async function getBilateralRepHistory(
+  _sessionId: string,
+  _limit = 50
+): Promise<BilateralRepRow[]> {
+  return [];
+}
+
+/**
+ * Synchronous stub for the same contract — used by tests + storybook
+ * fixtures. PR #444 should preserve this signature.
+ */
+export function getBilateralRepHistorySync(
+  _sessionId: string,
+  _limit = 50
+): BilateralRepRow[] {
+  return [];
+}

--- a/lib/services/rep-counter-overlay.ts
+++ b/lib/services/rep-counter-overlay.ts
@@ -1,0 +1,141 @@
+/**
+ * Rep Counter Overlay — 3D→2D projection helpers.
+ *
+ * The body-anchored rep counter mounts inside the existing scan-arkit SVG
+ * layer. It renders a large rep number near the user's hip joint so the
+ * user gets immediate visual feedback mid-rep without scanning the HUD.
+ *
+ * Service responsibilities:
+ *   - Project the 3D hip joint into the 2D overlay coordinate space.
+ *   - Cull the overlay when joint confidence is below 0.6 (occlusion guard).
+ *   - Compute the active opacity given the workout phase
+ *     ("rest" → fade out so the counter does not nag during recovery).
+ *
+ * The component (`RepCounterOverlay`) is presentational and consumes the
+ * `RepCounterPosition` returned here.
+ */
+
+import type { Joint2D, Joint3D } from '@/lib/arkit/ARKitBodyTracker';
+
+/** Confidence threshold below which we hide the counter (occlusion). */
+export const OCCLUSION_CONFIDENCE_THRESHOLD = 0.6;
+/** Fully visible opacity for the counter. */
+export const COUNTER_OPACITY_ACTIVE = 1;
+/** Faded opacity for the counter while resting between sets. */
+export const COUNTER_OPACITY_REST = 0.25;
+
+/** Joint names tried (in order) when locating the hip anchor. */
+export const HIP_JOINT_ALIASES = ['hips_joint', 'root', 'spine_4_joint'] as const;
+
+export interface RepCounterPosition {
+  /** Normalized 2D coordinate (0-1) of the counter anchor. */
+  x: number;
+  y: number;
+  /** Whether the counter should be rendered at all. */
+  visible: boolean;
+  /** Opacity 0-1 (lower during rest phase or low-confidence). */
+  opacity: number;
+}
+
+interface FindHipInput {
+  joints2D?: Joint2D[] | null;
+  joints3D?: Joint3D[] | null;
+}
+
+/**
+ * Locate the hip anchor in normalized 2D space. Tries `joints2D` first
+ * (already projected by the camera) and falls back to projecting the 3D hip
+ * joint with a simple orthographic projection (y inverted to match RN UI).
+ */
+export function findHipAnchor(input: FindHipInput): { x: number; y: number; isTracked: boolean; confidence: number } | null {
+  const { joints2D, joints3D } = input;
+  if (joints2D && joints2D.length > 0) {
+    for (const alias of HIP_JOINT_ALIASES) {
+      const found = joints2D.find((j) => j.name.toLowerCase() === alias);
+      if (found) {
+        return {
+          x: found.x,
+          y: found.y,
+          isTracked: found.isTracked,
+          // Joint2D does not carry a confidence; use isTracked as a proxy.
+          confidence: found.isTracked ? 1 : 0,
+        };
+      }
+    }
+  }
+  if (joints3D && joints3D.length > 0) {
+    for (const alias of HIP_JOINT_ALIASES) {
+      const found = joints3D.find((j) => j.name.toLowerCase() === alias);
+      if (found) {
+        // Naive orthographic projection: clamp into 0-1 by translating from
+        // ARKit-world coords (origin near user). This is intentionally
+        // simple — ARKit's `Joint2D` array is the canonical source. The 3D
+        // path exists for tests + headless fixture playback.
+        const x = clamp01(0.5 + found.x);
+        const y = clamp01(0.5 - found.y);
+        return {
+          x,
+          y,
+          isTracked: found.isTracked,
+          confidence: found.isTracked ? 1 : 0,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+export interface PositionInputs {
+  joints2D?: Joint2D[] | null;
+  joints3D?: Joint3D[] | null;
+  /** Phase from the workout controller; used to fade during `rest`. */
+  phase?: string | null;
+  /** Override confidence (e.g., when caller has a smoothed value). */
+  confidence?: number;
+}
+
+/**
+ * Compute the rep-counter position + visibility + opacity from the latest
+ * frame inputs. Returns a fully-derived `RepCounterPosition` ready for the
+ * SVG overlay.
+ */
+export function computeRepCounterPosition(input: PositionInputs): RepCounterPosition {
+  const anchor = findHipAnchor(input);
+  if (!anchor) {
+    return { x: 0.5, y: 0.5, visible: false, opacity: 0 };
+  }
+
+  const conf = typeof input.confidence === 'number' && Number.isFinite(input.confidence)
+    ? clamp01(input.confidence)
+    : anchor.confidence;
+
+  // Occlusion guard: hide when confidence is below threshold OR joint is not
+  // marked tracked.
+  if (!anchor.isTracked || conf < OCCLUSION_CONFIDENCE_THRESHOLD) {
+    return {
+      x: anchor.x,
+      y: anchor.y,
+      visible: false,
+      opacity: 0,
+    };
+  }
+
+  const phase = input.phase?.toLowerCase() ?? null;
+  const opacity = phase === 'rest' || phase === 'idle'
+    ? COUNTER_OPACITY_REST
+    : COUNTER_OPACITY_ACTIVE;
+
+  return {
+    x: anchor.x,
+    y: anchor.y,
+    visible: true,
+    opacity,
+  };
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0.5;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}

--- a/lib/services/thermal-monitor.ts
+++ b/lib/services/thermal-monitor.ts
@@ -1,0 +1,47 @@
+/**
+ * Thermal Monitor — minimal stub
+ *
+ * TODO(#449): merge with PR #449 canonical implementation on land.
+ *
+ * The canonical service in PR #449 will subscribe to the iOS
+ * `NSProcessInfo.thermalState` notification (via the resilience plumbing)
+ * and an Android `BatteryManager` thermal hint. This stub is shipped
+ * alongside #464 so the battery+thermal hook has a stable import path that
+ * does not break the build when #449 is not yet on `main`.
+ *
+ * Contract (kept narrow):
+ *   - `getThermalState()` → returns the current thermal bucket. Stub
+ *     defaults to `'normal'` (safe — no auto-pause is triggered).
+ *   - `subscribeThermalState(cb)` → noop in the stub; consumers should
+ *     handle the promise of a future canonical implementation.
+ */
+
+export type ThermalState = 'normal' | 'fair' | 'serious' | 'critical';
+
+let cachedState: ThermalState = 'normal';
+
+/**
+ * Synchronous thermal-state read. Always returns `'normal'` in the stub.
+ * PR #449's implementation should keep this signature for hook safety.
+ */
+export function getThermalState(): ThermalState {
+  return cachedState;
+}
+
+/**
+ * Test-only helper to simulate a thermal-state change before #449 lands.
+ * Real implementation will replace this with a NotificationCenter listener.
+ */
+export function __setThermalStateForTest(state: ThermalState): void {
+  cachedState = state;
+}
+
+/**
+ * Subscribe to thermal state changes. The stub returns a no-op unsubscribe
+ * function so consumers can register/cleanup safely.
+ */
+export function subscribeThermalState(_cb: (state: ThermalState) => void): () => void {
+  return () => {
+    /* noop in stub */
+  };
+}

--- a/lib/types/workout-session.ts
+++ b/lib/types/workout-session.ts
@@ -17,6 +17,13 @@ export type TutSource = 'measured' | 'estimated' | 'unknown';
 
 export type ExerciseCategory = 'push' | 'pull' | 'legs' | 'core' | 'cardio' | 'full_body';
 
+/**
+ * Pre-workout calibration status (used by the form-tracking pre-calibration
+ * overlay). `pending` = collecting frames; `success` = calibration confidence
+ * sufficient; `failed` = user-cancelled or timed out without converging.
+ */
+export type CalibrationStatus = 'pending' | 'success' | 'failed';
+
 export type SessionEventType =
   | 'session_started'
   | 'exercise_started'
@@ -104,6 +111,12 @@ export interface WorkoutSession {
   notes: string | null;
   created_at: string;
   updated_at: string;
+  /**
+   * Optional pre-workout calibration status — populated by the
+   * form-tracking pre-calibration overlay (see #464). Sessions started
+   * before that flow runs leave this `undefined`.
+   */
+  calibrationStatus?: CalibrationStatus;
 }
 
 export interface WorkoutSessionExercise {

--- a/tests/unit/app/form-tracking-pre-calibration.test.tsx
+++ b/tests/unit/app/form-tracking-pre-calibration.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const mockBack = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: mockBack }),
+}));
+
+import FormTrackingPreCalibrationModal from '@/app/(modals)/form-tracking-pre-calibration';
+import { PRE_CALIBRATION_CONSTANTS } from '@/hooks/use-pre-calibration-status';
+
+describe('<FormTrackingPreCalibrationModal />', () => {
+  beforeEach(async () => {
+    mockBack.mockClear();
+    await AsyncStorage.clear();
+  });
+
+  it('renders the check step on mount with continue + cancel actions', async () => {
+    const { getByTestId, getByText } = render(<FormTrackingPreCalibrationModal />);
+    await waitFor(() => {
+      expect(getByText('Pre-tracking check')).toBeTruthy();
+    });
+    expect(getByTestId('pre-calibration-continue')).toBeTruthy();
+    expect(getByTestId('pre-calibration-cancel')).toBeTruthy();
+  });
+
+  it('Cancel calls router.back', async () => {
+    const { getByTestId } = render(<FormTrackingPreCalibrationModal />);
+    fireEvent.press(getByTestId('pre-calibration-cancel'));
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  it('Continue advances to the preview step', async () => {
+    const { getByTestId, getByText } = render(<FormTrackingPreCalibrationModal />);
+    fireEvent.press(getByTestId('pre-calibration-continue'));
+    await waitFor(() => {
+      expect(getByText('Calibrating tracker')).toBeTruthy();
+    });
+  });
+
+  it('writes a success counter to AsyncStorage when markSuccess fires via Confirm', async () => {
+    const { getByTestId } = render(<FormTrackingPreCalibrationModal />);
+    fireEvent.press(getByTestId('pre-calibration-continue'));
+    // Wait until preview step is in flight.
+    await waitFor(() => {
+      expect(getByTestId('pre-calibration-confirm')).toBeTruthy();
+    });
+
+    // The confirm button is disabled until isReady — we trigger markSuccess
+    // by simulating enough recordFrame calls. To keep the test deterministic,
+    // we let the internal interval fire by progressing real timers a tick.
+    await waitFor(
+      () => {
+        const confirm = getByTestId('pre-calibration-confirm');
+        // Once enabled, accessibilityState.disabled should be false.
+        expect(confirm.props.accessibilityState?.disabled).toBeFalsy();
+      },
+      { timeout: 3000 }
+    );
+
+    fireEvent.press(getByTestId('pre-calibration-confirm'));
+
+    await waitFor(async () => {
+      const stored = await AsyncStorage.getItem(PRE_CALIBRATION_CONSTANTS.STORAGE_KEY);
+      expect(stored).toBe('1');
+    });
+  });
+});

--- a/tests/unit/components/form-tracking/BatteryThermalBadge.test.tsx
+++ b/tests/unit/components/form-tracking/BatteryThermalBadge.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { BatteryThermalBadge } from '@/components/form-tracking/BatteryThermalBadge';
+
+describe('<BatteryThermalBadge />', () => {
+  it('renders nothing on normal badgeLevel', () => {
+    const { toJSON } = render(
+      <BatteryThermalBadge badgeLevel="normal" batteryLevel={0.8} thermalState="normal" />
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders the warn chip with battery percent when thermal=normal', () => {
+    const { getByTestId, getByText } = render(
+      <BatteryThermalBadge badgeLevel="warn" batteryLevel={0.15} thermalState="normal" />
+    );
+    expect(getByTestId('battery-thermal-warn')).toBeTruthy();
+    expect(getByText(/Battery 15%/)).toBeTruthy();
+  });
+
+  it('prefers thermal copy over battery copy when both are concerning', () => {
+    const { getByText } = render(
+      <BatteryThermalBadge badgeLevel="warn" batteryLevel={0.5} thermalState="fair" />
+    );
+    expect(getByText(/Device warm/)).toBeTruthy();
+  });
+
+  it('renders the critical chip as a11y alert with assertive live region', () => {
+    const { getByTestId, getByText } = render(
+      <BatteryThermalBadge badgeLevel="critical" batteryLevel={0.05} thermalState="normal" />
+    );
+    const node = getByTestId('battery-thermal-critical');
+    expect(node.props.accessibilityRole).toBe('alert');
+    expect(node.props.accessibilityLiveRegion).toBe('assertive');
+    expect(getByText(/Battery 5%/)).toBeTruthy();
+  });
+
+  it('uses the thermal label on critical when device is too hot', () => {
+    const { getByText } = render(
+      <BatteryThermalBadge badgeLevel="critical" batteryLevel={0.8} thermalState="critical" />
+    );
+    expect(getByText(/Device too hot/)).toBeTruthy();
+  });
+
+  it('formats null battery as --%', () => {
+    const { getByText } = render(
+      <BatteryThermalBadge badgeLevel="warn" batteryLevel={null} thermalState="normal" />
+    );
+    expect(getByText(/Battery --%/)).toBeTruthy();
+  });
+});

--- a/tests/unit/components/form-tracking/LightingWarningBadge.test.tsx
+++ b/tests/unit/components/form-tracking/LightingWarningBadge.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { LightingWarningBadge } from '@/components/form-tracking/LightingWarningBadge';
+
+describe('<LightingWarningBadge />', () => {
+  it('renders nothing when bucket is "good"', () => {
+    const { toJSON } = render(<LightingWarningBadge bucket="good" />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders nothing when bucket is null', () => {
+    const { toJSON } = render(<LightingWarningBadge bucket={null} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders the "Low light" chip on dim bucket with a polite live region', () => {
+    const { getByTestId, getByText } = render(<LightingWarningBadge bucket="dim" />);
+    expect(getByText('Low light')).toBeTruthy();
+    const node = getByTestId('lighting-warning-dim');
+    expect(node.props.accessibilityRole).toBe('text');
+    expect(node.props.accessibilityLiveRegion).toBe('polite');
+  });
+
+  it('renders the "Lighting too dark" chip on dark bucket as an a11y alert', () => {
+    const { getByTestId, getByText } = render(<LightingWarningBadge bucket="dark" />);
+    expect(getByText('Lighting too dark')).toBeTruthy();
+    const node = getByTestId('lighting-warning-dark');
+    expect(node.props.accessibilityRole).toBe('alert');
+    expect(node.props.accessibilityLiveRegion).toBe('assertive');
+    expect(node.props.accessibilityLabel).toBe('Lighting too dark');
+  });
+
+  it('respects an explicit testID override', () => {
+    const { getByTestId } = render(
+      <LightingWarningBadge bucket="dark" testID="custom-test-id" />
+    );
+    expect(getByTestId('custom-test-id')).toBeTruthy();
+  });
+});

--- a/tests/unit/components/form-tracking/RepCounterOverlay.test.tsx
+++ b/tests/unit/components/form-tracking/RepCounterOverlay.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import Svg from 'react-native-svg';
+import { RepCounterOverlay } from '@/components/form-tracking/RepCounterOverlay';
+
+const renderInSvg = (ui: React.ReactElement) =>
+  render(<Svg viewBox="0 0 1 1">{ui}</Svg>);
+
+describe('<RepCounterOverlay />', () => {
+  it('renders a visible node when visible=true', () => {
+    const { getByTestId } = renderInSvg(
+      <RepCounterOverlay currentRep={7} visible x={0.5} y={0.5} opacity={1} />
+    );
+    expect(getByTestId('rep-counter-overlay')).toBeTruthy();
+  });
+
+  it('renders the rep digits as text content', () => {
+    const { getByTestId } = renderInSvg(
+      <RepCounterOverlay currentRep={7} visible x={0.5} y={0.5} opacity={1} />
+    );
+    // The SVG renderer wraps the number in an RNSVGTSpan; the resolved
+    // child is a React element with `props.children` containing the digits.
+    const node = getByTestId('rep-counter-overlay');
+    const tspan = node.props.children;
+    const inner = Array.isArray(tspan) ? tspan[0]?.props?.children : tspan?.props?.children;
+    expect(String(inner)).toBe('7');
+  });
+
+  it('returns null when visible=false on first render', () => {
+    const { queryByTestId } = renderInSvg(
+      <RepCounterOverlay currentRep={3} visible={false} x={0.5} y={0.5} opacity={0} />
+    );
+    expect(queryByTestId('rep-counter-overlay')).toBeNull();
+  });
+
+  it('respects an explicit testID override', () => {
+    const { getByTestId } = renderInSvg(
+      <RepCounterOverlay
+        currentRep={1}
+        visible
+        x={0.5}
+        y={0.5}
+        opacity={1}
+        testID="custom-rep-counter"
+      />
+    );
+    expect(getByTestId('custom-rep-counter')).toBeTruthy();
+  });
+
+  it('clamps opacity into 0-1 even with out-of-range input', () => {
+    const { getByTestId } = renderInSvg(
+      <RepCounterOverlay currentRep={5} visible x={0.5} y={0.5} opacity={2.5} />
+    );
+    expect(getByTestId('rep-counter-overlay')).toBeTruthy();
+    // No throw = pass; the Animated value will saturate to 1.
+  });
+
+  it('updates the rendered rep when currentRep changes', () => {
+    const readDigits = (node: { props: { children: unknown } }): string => {
+      const tspan = node.props.children as { props?: { children?: unknown } } | { props?: { children?: unknown } }[];
+      const inner = Array.isArray(tspan) ? tspan[0]?.props?.children : tspan?.props?.children;
+      return String(inner);
+    };
+    const { rerender, getByTestId } = renderInSvg(
+      <RepCounterOverlay currentRep={1} visible x={0.5} y={0.5} opacity={1} />
+    );
+    expect(readDigits(getByTestId('rep-counter-overlay'))).toBe('1');
+
+    rerender(
+      <Svg viewBox="0 0 1 1">
+        <RepCounterOverlay currentRep={2} visible x={0.5} y={0.5} opacity={1} />
+      </Svg>
+    );
+    expect(readDigits(getByTestId('rep-counter-overlay'))).toBe('2');
+  });
+});

--- a/tests/unit/components/form-tracking/SymmetryComparatorCard.test.tsx
+++ b/tests/unit/components/form-tracking/SymmetryComparatorCard.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import {
+  SymmetryComparatorCard,
+} from '@/components/form-tracking/SymmetryComparatorCard';
+import type { SymmetryDatum } from '@/hooks/use-symmetry-comparison';
+
+const SAMPLE_SERIES: SymmetryDatum[] = [
+  { repNumber: 1, leftAngleDeg: 100, rightAngleDeg: 90, asymmetryPct: 10 },
+  { repNumber: 2, leftAngleDeg: 110, rightAngleDeg: 80, asymmetryPct: 27.27 },
+  { repNumber: 3, leftAngleDeg: 95, rightAngleDeg: 95, asymmetryPct: 0 },
+];
+
+describe('<SymmetryComparatorCard />', () => {
+  it('renders the empty-state message when fallback is true', () => {
+    const { getByTestId } = render(<SymmetryComparatorCard series={[]} isFallback />);
+    expect(getByTestId('symmetry-comparator-empty')).toBeTruthy();
+  });
+
+  it('renders a not-enough-data message when no fallback flag is set', () => {
+    const { getByTestId } = render(<SymmetryComparatorCard series={[]} />);
+    expect(getByTestId('symmetry-comparator-empty').props.children).toMatch(
+      /Not enough valid bilateral data/i
+    );
+  });
+
+  it('renders the loading state', () => {
+    const { getByText } = render(<SymmetryComparatorCard series={[]} isLoading />);
+    expect(getByText(/Loading rep history/i)).toBeTruthy();
+  });
+
+  it('renders the chart + summary when series has valid data', () => {
+    const { getByTestId, getByText } = render(
+      <SymmetryComparatorCard series={SAMPLE_SERIES} />
+    );
+    expect(getByTestId('symmetry-comparator-card')).toBeTruthy();
+    expect(getByText(/Peak asymmetry/i)).toBeTruthy();
+    expect(getByText(/27\.3%/)).toBeTruthy();
+  });
+
+  it('filters out NaN/null asymmetryPct datapoints before charting', () => {
+    const series: SymmetryDatum[] = [
+      ...SAMPLE_SERIES,
+      { repNumber: 4, leftAngleDeg: 0, rightAngleDeg: 90, asymmetryPct: null },
+    ];
+    // Should still render chart from the 3 valid datapoints.
+    const { queryByTestId } = render(<SymmetryComparatorCard series={series} />);
+    expect(queryByTestId('symmetry-comparator-empty')).toBeNull();
+  });
+
+  it('always shows the threshold legend', () => {
+    const { getByText } = render(<SymmetryComparatorCard series={SAMPLE_SERIES} />);
+    expect(getByText(/15% threshold/)).toBeTruthy();
+  });
+});

--- a/tests/unit/hooks/use-device-thermal-battery.test.tsx
+++ b/tests/unit/hooks/use-device-thermal-battery.test.tsx
@@ -1,0 +1,96 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import {
+  deriveBadgeLevel,
+  deriveShouldPause,
+  useDeviceThermalBattery,
+} from '@/hooks/use-device-thermal-battery';
+import {
+  __setThermalStateForTest,
+} from '@/lib/services/thermal-monitor';
+
+afterEach(() => {
+  __setThermalStateForTest('normal');
+});
+
+describe('deriveBadgeLevel (pure)', () => {
+  it('returns "normal" with healthy battery + normal thermal', () => {
+    expect(deriveBadgeLevel(0.8, 'normal')).toBe('normal');
+  });
+
+  it('returns "warn" when battery < 20% (no thermal pressure)', () => {
+    expect(deriveBadgeLevel(0.15, 'normal')).toBe('warn');
+  });
+
+  it('returns "warn" when thermal=fair (battery healthy)', () => {
+    expect(deriveBadgeLevel(0.8, 'fair')).toBe('warn');
+  });
+
+  it('returns "critical" when battery < 10%', () => {
+    expect(deriveBadgeLevel(0.05, 'normal')).toBe('critical');
+  });
+
+  it('returns "critical" when thermal=serious or critical', () => {
+    expect(deriveBadgeLevel(0.8, 'serious')).toBe('critical');
+    expect(deriveBadgeLevel(0.8, 'critical')).toBe('critical');
+  });
+
+  it('handles a null battery level by relying on thermal alone', () => {
+    expect(deriveBadgeLevel(null, 'normal')).toBe('normal');
+    expect(deriveBadgeLevel(null, 'fair')).toBe('warn');
+    expect(deriveBadgeLevel(null, 'critical')).toBe('critical');
+  });
+
+  it('treats edge thresholds correctly (10% and 20%)', () => {
+    expect(deriveBadgeLevel(0.1, 'normal')).toBe('warn');
+    expect(deriveBadgeLevel(0.2, 'normal')).toBe('normal');
+    expect(deriveBadgeLevel(0, 'normal')).toBe('critical');
+  });
+});
+
+describe('deriveShouldPause (pure)', () => {
+  it('returns false on healthy battery + normal thermal', () => {
+    expect(deriveShouldPause(0.8, 'normal')).toBe(false);
+  });
+
+  it('returns true on critical thermal', () => {
+    expect(deriveShouldPause(0.8, 'critical')).toBe(true);
+  });
+
+  it('returns true on serious thermal', () => {
+    expect(deriveShouldPause(0.8, 'serious')).toBe(true);
+  });
+
+  it('returns true when battery < 10%', () => {
+    expect(deriveShouldPause(0.05, 'normal')).toBe(true);
+    expect(deriveShouldPause(0, 'normal')).toBe(true);
+  });
+
+  it('returns false at the 10% boundary', () => {
+    expect(deriveShouldPause(0.1, 'normal')).toBe(false);
+  });
+
+  it('handles null battery without spuriously pausing', () => {
+    expect(deriveShouldPause(null, 'normal')).toBe(false);
+    expect(deriveShouldPause(null, 'serious')).toBe(true);
+  });
+});
+
+describe('useDeviceThermalBattery', () => {
+  it('initializes with the current thermal state', async () => {
+    __setThermalStateForTest('normal');
+    const { result } = renderHook(() => useDeviceThermalBattery());
+    await waitFor(() => {
+      expect(result.current.thermalState).toBe('normal');
+    });
+    expect(result.current.badgeLevel).toBe('normal');
+    expect(result.current.shouldPauseLowPower).toBe(false);
+  });
+
+  it('returns null batteryLevel when expo-battery is not installed', async () => {
+    const { result } = renderHook(() => useDeviceThermalBattery());
+    // First polling tick should set batteryLevel; the stub will leave it null.
+    await waitFor(() => {
+      expect(result.current.batteryLevel).toBeNull();
+    });
+  });
+});

--- a/tests/unit/hooks/use-frame-lighting.test.tsx
+++ b/tests/unit/hooks/use-frame-lighting.test.tsx
@@ -1,0 +1,59 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { useFrameLighting } from '@/hooks/use-frame-lighting';
+
+describe('useFrameLighting', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('emits the first reading immediately on report()', () => {
+    const { result } = renderHook(() => useFrameLighting());
+    expect(result.current.reading).toBeNull();
+    act(() => {
+      result.current.report(20);
+    });
+    expect(result.current.reading?.bucket).toBe('dark');
+  });
+
+  it('debounces subsequent reports within the window', () => {
+    const { result } = renderHook(() => useFrameLighting({ debounceMs: 100 }));
+    act(() => {
+      result.current.report(20);
+    });
+    const first = result.current.reading;
+    expect(first?.bucket).toBe('dark');
+
+    // Burst of reports within 100 ms — only one trailing flush should occur.
+    act(() => {
+      jest.advanceTimersByTime(10);
+      result.current.report(150);
+      jest.advanceTimersByTime(10);
+      result.current.report(150);
+      jest.advanceTimersByTime(10);
+      result.current.report(150);
+    });
+    // Still last-emitted reading because debounce window not yet elapsed.
+    expect(result.current.reading?.bucket).toBe('dark');
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(result.current.reading?.bucket).toBe('good');
+  });
+
+  it('reset() clears the latest reading', () => {
+    const { result } = renderHook(() => useFrameLighting());
+    act(() => {
+      result.current.report(20);
+    });
+    expect(result.current.reading).not.toBeNull();
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.reading).toBeNull();
+  });
+});

--- a/tests/unit/hooks/use-pre-calibration-status.test.tsx
+++ b/tests/unit/hooks/use-pre-calibration-status.test.tsx
@@ -1,0 +1,102 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  PRE_CALIBRATION_CONSTANTS,
+  usePreCalibrationStatus,
+} from '@/hooks/use-pre-calibration-status';
+
+describe('usePreCalibrationStatus', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('starts in pending with shouldShow=true when storage is empty', async () => {
+    const { result } = renderHook(() => usePreCalibrationStatus());
+    await waitFor(() => {
+      expect(result.current.status.shouldShow).toBe(true);
+    });
+    expect(result.current.status.status).toBe('pending');
+    expect(result.current.status.framesObserved).toBe(0);
+  });
+
+  it('aggregates per-frame confidence into a running mean', async () => {
+    const { result } = renderHook(() => usePreCalibrationStatus());
+    await waitFor(() => {
+      expect(result.current.status.shouldShow).toBe(true);
+    });
+    act(() => {
+      result.current.recordFrame(0.8);
+      result.current.recordFrame(0.6);
+    });
+    expect(result.current.status.framesObserved).toBe(2);
+    expect(result.current.status.confidence).toBeCloseTo(0.7, 2);
+  });
+
+  it('auto-marks success once confidence + frame thresholds are met', async () => {
+    const { result } = renderHook(() => usePreCalibrationStatus());
+    await waitFor(() => {
+      expect(result.current.status.shouldShow).toBe(true);
+    });
+    await act(async () => {
+      for (let i = 0; i < PRE_CALIBRATION_CONSTANTS.REQUIRED_FRAMES; i += 1) {
+        result.current.recordFrame(0.9);
+      }
+    });
+    await waitFor(() => {
+      expect(result.current.status.status).toBe('success');
+    });
+    const stored = await AsyncStorage.getItem(PRE_CALIBRATION_CONSTANTS.STORAGE_KEY);
+    expect(stored).toBe('1');
+  });
+
+  it('suppresses shouldShow after the configured success count', async () => {
+    await AsyncStorage.setItem(
+      PRE_CALIBRATION_CONSTANTS.STORAGE_KEY,
+      String(PRE_CALIBRATION_CONSTANTS.SUPPRESS_AFTER_SUCCESS_COUNT)
+    );
+    const { result } = renderHook(() => usePreCalibrationStatus());
+    await waitFor(() => {
+      expect(result.current.status.shouldShow).toBe(false);
+    });
+  });
+
+  it('markFailed transitions status to failed', async () => {
+    const { result } = renderHook(() => usePreCalibrationStatus());
+    await waitFor(() => {
+      expect(result.current.status.shouldShow).toBe(true);
+    });
+    act(() => {
+      result.current.markFailed();
+    });
+    expect(result.current.status.status).toBe('failed');
+  });
+
+  it('reset() clears frame counters but preserves shouldShow', async () => {
+    const { result } = renderHook(() => usePreCalibrationStatus());
+    await waitFor(() => {
+      expect(result.current.status.shouldShow).toBe(true);
+    });
+    act(() => {
+      result.current.recordFrame(0.5);
+      result.current.recordFrame(0.5);
+    });
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.status.framesObserved).toBe(0);
+    expect(result.current.status.confidence).toBe(0);
+    expect(result.current.status.shouldShow).toBe(true);
+  });
+
+  it('clamps out-of-range confidence inputs', async () => {
+    const { result } = renderHook(() => usePreCalibrationStatus());
+    await waitFor(() => {
+      expect(result.current.status.shouldShow).toBe(true);
+    });
+    act(() => {
+      result.current.recordFrame(2);
+      result.current.recordFrame(-1);
+    });
+    expect(result.current.status.confidence).toBeCloseTo(0.5, 2);
+  });
+});

--- a/tests/unit/hooks/use-rep-counter-position.test.tsx
+++ b/tests/unit/hooks/use-rep-counter-position.test.tsx
@@ -1,0 +1,38 @@
+import { renderHook } from '@testing-library/react-native';
+import { useRepCounterPosition } from '@/hooks/use-rep-counter-position';
+
+describe('useRepCounterPosition', () => {
+  it('returns visible=false when no joints supplied', () => {
+    const { result } = renderHook(() =>
+      useRepCounterPosition({ repCount: 0 })
+    );
+    expect(result.current.visible).toBe(false);
+    expect(result.current.repCount).toBe(0);
+  });
+
+  it('passes through repCount and projects joints2D', () => {
+    const { result } = renderHook(() =>
+      useRepCounterPosition({
+        repCount: 5,
+        phase: 'pull',
+        joints2D: [{ name: 'hips_joint', x: 0.4, y: 0.6, isTracked: true }],
+      })
+    );
+    expect(result.current.repCount).toBe(5);
+    expect(result.current.visible).toBe(true);
+    expect(result.current.x).toBe(0.4);
+    expect(result.current.y).toBe(0.6);
+    expect(result.current.opacity).toBe(1);
+  });
+
+  it('fades when phase=rest', () => {
+    const { result } = renderHook(() =>
+      useRepCounterPosition({
+        repCount: 5,
+        phase: 'rest',
+        joints2D: [{ name: 'hips_joint', x: 0.5, y: 0.5, isTracked: true }],
+      })
+    );
+    expect(result.current.opacity).toBeLessThan(1);
+  });
+});

--- a/tests/unit/hooks/use-symmetry-comparison.test.tsx
+++ b/tests/unit/hooks/use-symmetry-comparison.test.tsx
@@ -1,0 +1,84 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import {
+  computeAsymmetryPct,
+  SYMMETRY_THRESHOLD_PCT,
+  useSymmetryComparison,
+} from '@/hooks/use-symmetry-comparison';
+
+const mockGet = jest.fn();
+jest.mock('@/lib/services/rep-analytics', () => ({
+  getBilateralRepHistory: (...args: unknown[]) => mockGet(...args),
+}));
+
+describe('computeAsymmetryPct (pure)', () => {
+  it('returns 0 for symmetric inputs', () => {
+    expect(computeAsymmetryPct(90, 90)).toBe(0);
+  });
+
+  it('computes a percentage relative to the larger side', () => {
+    // |100-80| / 100 * 100 = 20
+    expect(computeAsymmetryPct(100, 80)).toBe(20);
+  });
+
+  it('treats both-zero as a non-pathological 0%', () => {
+    expect(computeAsymmetryPct(0, 0)).toBe(0);
+  });
+
+  it('returns null for one-sided tracking loss', () => {
+    expect(computeAsymmetryPct(0, 90)).toBeNull();
+    expect(computeAsymmetryPct(90, 0)).toBeNull();
+  });
+
+  it('returns null for non-finite inputs', () => {
+    expect(computeAsymmetryPct(NaN, 90)).toBeNull();
+    expect(computeAsymmetryPct(90, Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});
+
+describe('useSymmetryComparison', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('marks isFallback=true when the analytics stub returns []', async () => {
+    mockGet.mockResolvedValueOnce([]);
+    const { result } = renderHook(() => useSymmetryComparison('session-1'));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.series).toEqual([]);
+    expect(result.current.isFallback).toBe(true);
+  });
+
+  it('projects rep rows into asymmetry datum series', async () => {
+    mockGet.mockResolvedValueOnce([
+      { repNumber: 1, leftAngleDeg: 100, rightAngleDeg: 90, joint: 'elbow' },
+      { repNumber: 2, leftAngleDeg: 80, rightAngleDeg: 80, joint: 'elbow' },
+      // One-sided tracking loss → asymmetryPct = null.
+      { repNumber: 3, leftAngleDeg: 0, rightAngleDeg: 75, joint: 'elbow' },
+    ]);
+    const { result } = renderHook(() => useSymmetryComparison('session-2'));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.series).toHaveLength(3);
+    expect(result.current.series[0].asymmetryPct).toBe(10);
+    expect(result.current.series[1].asymmetryPct).toBe(0);
+    expect(result.current.series[2].asymmetryPct).toBeNull();
+    expect(result.current.isFallback).toBe(false);
+  });
+
+  it('captures errors thrown by the analytics service', async () => {
+    mockGet.mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHook(() => useSymmetryComparison('session-3'));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.error?.message).toBe('boom');
+    expect(result.current.series).toEqual([]);
+  });
+
+  it('exposes the configured threshold constant', () => {
+    expect(SYMMETRY_THRESHOLD_PCT).toBe(15);
+  });
+});

--- a/tests/unit/services/lighting-detector.test.ts
+++ b/tests/unit/services/lighting-detector.test.ts
@@ -1,0 +1,124 @@
+import {
+  analyzeLighting,
+  bucketForBrightness,
+  confidenceForBrightness,
+  LightingSmoother,
+  LIGHTING_THRESHOLDS,
+  normalizeHistogram,
+} from '@/lib/services/lighting-detector';
+
+describe('lighting-detector / bucketForBrightness', () => {
+  it('returns "dark" below dark threshold', () => {
+    expect(bucketForBrightness(0)).toBe('dark');
+    expect(bucketForBrightness(LIGHTING_THRESHOLDS.dark - 1)).toBe('dark');
+  });
+
+  it('returns "dim" between dark and dim thresholds', () => {
+    expect(bucketForBrightness(LIGHTING_THRESHOLDS.dark)).toBe('dim');
+    expect(bucketForBrightness(LIGHTING_THRESHOLDS.dim - 1)).toBe('dim');
+  });
+
+  it('returns "good" at and above the dim threshold', () => {
+    expect(bucketForBrightness(LIGHTING_THRESHOLDS.dim)).toBe('good');
+    expect(bucketForBrightness(200)).toBe('good');
+    expect(bucketForBrightness(255)).toBe('good');
+  });
+
+  it('clamps out-of-range and non-finite inputs to "dark" floor', () => {
+    expect(bucketForBrightness(-100)).toBe('dark');
+    expect(bucketForBrightness(NaN)).toBe('dark');
+    // Infinity is non-finite → defensively bucketed as `dark` (safer than `good`).
+    expect(bucketForBrightness(Number.POSITIVE_INFINITY)).toBe('dark');
+  });
+});
+
+describe('lighting-detector / confidenceForBrightness', () => {
+  it('returns 0 confidence at the boundary', () => {
+    expect(confidenceForBrightness(LIGHTING_THRESHOLDS.dark)).toBe(0);
+    expect(confidenceForBrightness(LIGHTING_THRESHOLDS.dim)).toBe(0);
+  });
+
+  it('returns higher confidence farther from any boundary', () => {
+    const onBoundary = confidenceForBrightness(LIGHTING_THRESHOLDS.dim);
+    const farFromBoundary = confidenceForBrightness(200);
+    expect(farFromBoundary).toBeGreaterThan(onBoundary);
+    expect(farFromBoundary).toBeLessThanOrEqual(1);
+  });
+
+  it('saturates at 1 for very dark / very bright extremes', () => {
+    expect(confidenceForBrightness(0)).toBe(1);
+    expect(confidenceForBrightness(255)).toBe(1);
+  });
+});
+
+describe('lighting-detector / normalizeHistogram', () => {
+  it('returns a zero-filled bin array when histogram is missing', () => {
+    expect(normalizeHistogram(undefined)).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(normalizeHistogram([])).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
+  });
+
+  it('passes through histograms already at the target bin count', () => {
+    const input = [1, 2, 3, 4, 5, 6, 7, 8];
+    expect(normalizeHistogram(input)).toEqual(input);
+  });
+
+  it('downsamples larger histograms by summing into target bins', () => {
+    const input = new Array(16).fill(1);
+    const out = normalizeHistogram(input, 4);
+    expect(out).toHaveLength(4);
+    expect(out.reduce((a, b) => a + b, 0)).toBe(16);
+    expect(out.every((v) => v === 4)).toBe(true);
+  });
+
+  it('drops negative / non-finite source bins instead of throwing', () => {
+    expect(normalizeHistogram([-1, NaN, 5, 0, 0, 0, 0, 0])).toEqual([0, 0, 5, 0, 0, 0, 0, 0]);
+  });
+});
+
+describe('lighting-detector / analyzeLighting', () => {
+  it('handles an all-black sample (brightness 0)', () => {
+    const reading = analyzeLighting({ brightness: 0 });
+    expect(reading.bucket).toBe('dark');
+    expect(reading.confidence).toBe(1);
+    expect(reading.histogramBins).toHaveLength(8);
+    expect(reading.brightness).toBe(0);
+  });
+
+  it('handles an overexposed sample (brightness 255)', () => {
+    const reading = analyzeLighting({ brightness: 255 });
+    expect(reading.bucket).toBe('good');
+    expect(reading.brightness).toBe(255);
+  });
+
+  it('exposes the normalized histogram', () => {
+    const reading = analyzeLighting({
+      brightness: 100,
+      histogram: [1, 0, 0, 0, 0, 0, 0, 1],
+    });
+    expect(reading.histogramBins).toEqual([1, 0, 0, 0, 0, 0, 0, 1]);
+  });
+});
+
+describe('lighting-detector / LightingSmoother', () => {
+  it('returns the median of the rolling window', () => {
+    const smoother = new LightingSmoother(3);
+    expect(smoother.push(50)).toBe(50);
+    expect(smoother.push(100)).toBe(75);
+    expect(smoother.push(75)).toBe(75);
+    expect(smoother.push(200)).toBe(100);
+  });
+
+  it('clamps invalid samples instead of polluting the median', () => {
+    const smoother = new LightingSmoother(3);
+    smoother.push(50);
+    smoother.push(50);
+    expect(smoother.push(NaN)).toBe(50);
+  });
+
+  it('reset() empties the rolling window', () => {
+    const smoother = new LightingSmoother();
+    smoother.push(100);
+    smoother.reset();
+    expect(smoother.push(20)).toBe(20);
+  });
+});

--- a/tests/unit/services/rep-counter-overlay.test.ts
+++ b/tests/unit/services/rep-counter-overlay.test.ts
@@ -1,0 +1,111 @@
+import {
+  COUNTER_OPACITY_ACTIVE,
+  COUNTER_OPACITY_REST,
+  computeRepCounterPosition,
+  findHipAnchor,
+  HIP_JOINT_ALIASES,
+  OCCLUSION_CONFIDENCE_THRESHOLD,
+} from '@/lib/services/rep-counter-overlay';
+
+const trackedJoint2D = (name: string, x = 0.5, y = 0.5) => ({
+  name,
+  x,
+  y,
+  isTracked: true,
+});
+
+describe('rep-counter-overlay / findHipAnchor', () => {
+  it('returns null when no joints are supplied', () => {
+    expect(findHipAnchor({})).toBeNull();
+  });
+
+  it('prefers `joints2D` over `joints3D` when both supplied', () => {
+    const result = findHipAnchor({
+      joints2D: [trackedJoint2D('hips_joint', 0.4, 0.6)],
+      joints3D: [{ name: 'hips_joint', x: 0.1, y: 0.1, z: 0, isTracked: true }],
+    });
+    expect(result).toEqual({ x: 0.4, y: 0.6, isTracked: true, confidence: 1 });
+  });
+
+  it('falls back through the alias chain', () => {
+    const [, secondAlias] = HIP_JOINT_ALIASES;
+    const result = findHipAnchor({ joints2D: [trackedJoint2D(secondAlias, 0.55, 0.45)] });
+    expect(result?.x).toBe(0.55);
+    expect(result?.y).toBe(0.45);
+  });
+
+  it('projects 3D coordinates into 0-1 space when only joints3D supplied', () => {
+    const result = findHipAnchor({
+      joints3D: [{ name: 'hips_joint', x: 0, y: 0, z: 0, isTracked: true }],
+    });
+    expect(result?.x).toBeCloseTo(0.5, 3);
+    expect(result?.y).toBeCloseTo(0.5, 3);
+  });
+
+  it('clamps 3D projections that fall outside 0-1', () => {
+    const result = findHipAnchor({
+      joints3D: [{ name: 'hips_joint', x: 5, y: -5, z: 0, isTracked: true }],
+    });
+    expect(result?.x).toBe(1);
+    expect(result?.y).toBe(1);
+  });
+});
+
+describe('rep-counter-overlay / computeRepCounterPosition', () => {
+  it('hides when no hip anchor is found', () => {
+    const out = computeRepCounterPosition({});
+    expect(out.visible).toBe(false);
+    expect(out.opacity).toBe(0);
+  });
+
+  it('hides when caller-supplied confidence is below threshold', () => {
+    const out = computeRepCounterPosition({
+      joints2D: [trackedJoint2D('hips_joint')],
+      confidence: OCCLUSION_CONFIDENCE_THRESHOLD - 0.1,
+    });
+    expect(out.visible).toBe(false);
+  });
+
+  it('hides when joint isTracked = false', () => {
+    const out = computeRepCounterPosition({
+      joints2D: [{ name: 'hips_joint', x: 0.5, y: 0.5, isTracked: false }],
+    });
+    expect(out.visible).toBe(false);
+  });
+
+  it('returns active opacity outside rest/idle phases', () => {
+    const out = computeRepCounterPosition({
+      joints2D: [trackedJoint2D('hips_joint')],
+      phase: 'pull',
+    });
+    expect(out.visible).toBe(true);
+    expect(out.opacity).toBe(COUNTER_OPACITY_ACTIVE);
+  });
+
+  it('fades during rest phase', () => {
+    const out = computeRepCounterPosition({
+      joints2D: [trackedJoint2D('hips_joint')],
+      phase: 'rest',
+    });
+    expect(out.visible).toBe(true);
+    expect(out.opacity).toBe(COUNTER_OPACITY_REST);
+  });
+
+  it('fades during idle phase', () => {
+    const out = computeRepCounterPosition({
+      joints2D: [trackedJoint2D('hips_joint')],
+      phase: 'idle',
+    });
+    expect(out.opacity).toBe(COUNTER_OPACITY_REST);
+  });
+
+  it('respects supplied confidence over the joint-derived proxy', () => {
+    const out = computeRepCounterPosition({
+      joints2D: [trackedJoint2D('hips_joint')],
+      confidence: 0.95,
+      phase: 'pull',
+    });
+    expect(out.visible).toBe(true);
+    expect(out.opacity).toBe(COUNTER_OPACITY_ACTIVE);
+  });
+});


### PR DESCRIPTION
Closes #464.

## Summary
Bundles 5 deferred form-tracking visual polish items into one cohesive PR (per overnight directive: large-scope PRs with atomic commits). All TS/TSX, no native edits, no new dependencies, no migrations.

- Lighting detector + LightingWarningBadge (3-state UI: hidden/dim/dark, animated pulse on dark)
- Pre-calibration overlay modal (gated first-workout entry point, AsyncStorage suppression after 2 successful runs)
- SymmetryComparatorCard (per-rep bilateral asymmetry chart with 15% threshold line)
- Body-anchored RepCounterOverlay (3D-projected rep counter at hip joint, fades in rest phase, occlusion guard at <0.6 confidence)
- BatteryThermalBadge with low-power auto-pause (additive `pauseTracking` option on `useWorkoutController`)

## Commits (13)
```
aa293e2 feat(scan-arkit): mount lighting + battery/thermal badges + rep-counter overlay + pre-calibration gate
94d30d0 test(battery-thermal): bucketing + pause trigger
f3b7297 feat(hooks+components): add use-device-thermal-battery + BatteryThermalBadge + auto-pause
dafd0ad test(rep-counter): projection edge cases + animation
c61232c feat(services+components): add rep-counter-overlay 3D projection + RepCounterOverlay
8177dc8 test(symmetry): bilateral delta + render
3447704 feat(components): add SymmetryComparatorCard + use-symmetry-comparison
f717c29 test(pre-calibration): hook + modal navigation + confidence gating
b51a82d feat(modals): add form-tracking-pre-calibration overlay + use-pre-calibration-status
c8318c0 test(components): LightingWarningBadge render states + a11y
7b8067f feat(components): add LightingWarningBadge with 3-state UI
fcd06c2 test(lighting): unit coverage for histogram buckets + edge cases
4190c85 feat(services): add lighting-detector with histogram + frame-brightness analysis
```

## Verification
- `bun run lint` — 0 errors (2 pre-existing warnings in `template-builder.tsx`)
- `bun run check:types` — clean
- `bun run test --testPathPattern="(lighting|pre-calibration|symmetry|rep-counter|battery-thermal)"` — 9 suites / 66 tests passing
- Existing `use-workout-controller.test.ts` — 30/30 still passing after additive `pauseTracking` option

## Notes (judgment calls)
- **Cross-PR stubs** (wave 4-6 pattern):
  - `lib/services/rep-analytics.ts` — fallback stub returning `[]` with `TODO(#444)`. Used by `useSymmetryComparison`. The card renders an empty-state message until #444 lands.
  - `lib/services/thermal-monitor.ts` — fallback stub returning `'normal'` with `TODO(#449)`. Used by `useDeviceThermalBattery`. The badge stays hidden until thermal stub is replaced and `expo-battery` is wired in.
- **`expo-battery` deferred**: package isn't installed and overnight rules forbid new deps. Hook lazy-loads via `require('expo-battery')` so the bundler stays green; badge defaults to hidden, auto-pause uses thermal alone. Documented inline + in commit message.
- **`useWorkoutController.pauseTracking`**: added as a non-breaking optional flag with `TODO(#464)` so PRs #427 / #434 can swap it for a richer pause API on land without conflict. All 30 existing controller tests pass unchanged.
- **`scan-arkit.tsx` edit regions**: badges mount in a new column anchored beneath the existing status badge (no overlap with #424's status row). Pre-calibration gate sits in a new `useEffect` adjacent to the auto-start effect (no overlap with #463's bootstrap). RepCounterOverlay mounts inside the existing SVG render tree at the hip joint (orthogonal to #449's overlay surfaces).
- **Pose-logger `setLatestFrameBrightness`**: API is in place + tested but is intentionally NOT wired in `scan-arkit` since there's no real per-frame brightness source on the JS side yet. Future PR can call it from the lighting subscription once a Swift bridge lands.

## Out of scope (deferred to docs/OVERNIGHT_CHANGELOG.md)
- Ghost replay trail (W7-A #5) — depends on #444 keyframe extractor
- Social sharing rep highlights (W7-A #6) — adjacent dedicated daytime PR
- Pre-set continuous stance polling (W7-A #8) — duplicates the just-landed #463 `PreSetPreviewCard`