### PR TITLE
fix(sync): restore errorWithTs breadcrumb in realtime handler (unblocks CI)

### DIFF
--- a/lib/services/database/generic-sync.ts
+++ b/lib/services/database/generic-sync.ts
@@ -424,6 +424,10 @@ export async function handleGenericRealtimeChange(
       notifyCallback();
     }
   } catch (error) {
+    errorWithTs(
+      `[GenericSync] Error handling realtime ${label} change:`,
+      error instanceof Error ? error : new Error(String(error)),
+    );
     const appError = createError(
       'sync',
       'REALTIME_CHANGE_FAILED',


### PR DESCRIPTION
## Summary
- Main's `Code Quality & Testing` job has been failing since April 10, blocking every downstream CI stage (Voice, E2E, AI Coach, Security, Deploy, Build).
- One test is red: `tests/unit/services/database/generic-sync.test.ts` → `handleGenericRealtimeChange › logs error and does not throw on internal failure`.
- The refactor in 5385ad5 added structured `logError`/`createError` but removed the `errorWithTs('[GenericSync] Error handling realtime …', error)` breadcrumb the test still asserts on.
- Restores the breadcrumb alongside the structured path, matching `sync-service.ts` which uses both. Non-Error rejections are wrapped so the `expect.any(Error)` matcher holds for Supabase payloads that throw strings/plain objects.

## Test plan
- [x] `bun run test tests/unit/services/database/generic-sync.test.ts` → 73/73 pass locally
- [x] `bunx tsc --noEmit` clean
- [ ] CI `Code Quality & Testing` job turns green
- [ ] Downstream `Voice Integration Tests`, `E2E Tests`, `AI Coach Evaluation`, `Security Scan`, `Build Verification` all run (no longer skipped)