### PR TITLE
feat(overload): progressive overload intelligence — weight suggester + 1RM + PR detector + history + Gemma progression planner

### DIFF
--- a/app/(modals)/_layout.tsx
+++ b/app/(modals)/_layout.tsx
@@ -65,6 +65,14 @@ export default function ModalsLayout() {
           contentStyle: { backgroundColor: '#050E1F' },
         }}
       />
+      <Stack.Screen
+        name="progression-plan"
+        options={{
+          presentation: 'modal',
+          gestureEnabled: true,
+          contentStyle: { backgroundColor: '#050E1F' },
+        }}
+      />
     </Stack>
   );
 }

--- a/app/(modals)/progression-plan.tsx
+++ b/app/(modals)/progression-plan.tsx
@@ -1,0 +1,411 @@
+/**
+ * ProgressionPlanModal
+ *
+ * Post-session modal that shows the lifter:
+ *   - Estimated 1RM for the selected exercise
+ *   - PR chips for the most recent set (1RM / 3RM / 5RM / volume)
+ *   - A Gemma-generated progressive overload plan (via coach-service)
+ *   - A suggested working weight for the next session with an Accept CTA
+ *
+ * Launched via `router.push({ pathname: '/(modals)/progression-plan', params })`
+ * with at minimum `exercise` as a param; `userId` is read from AuthContext.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/contexts/ToastContext';
+import {
+  getExerciseHistorySummary,
+  type ExerciseHistorySummary,
+} from '@/lib/services/exercise-history-service';
+import {
+  generateProgressionPlan,
+  type ProgressionPlan,
+} from '@/lib/services/progression-planner';
+import { suggestWeight, type WeightSuggestion } from '@/lib/services/weight-suggester';
+import type { PrResult } from '@/lib/services/pr-detector';
+
+const BG = '#050E1F';
+const PANEL = '#0E1A2E';
+const ACCENT = '#4C8CFF';
+const TEXT_PRIMARY = '#F8F9FF';
+const TEXT_SECONDARY = '#8E9BAD';
+const SUCCESS = '#3CC8A9';
+
+function prCategoryLabel(category: PrResult['category']): string {
+  switch (category) {
+    case 'one_rep_max':
+      return '1RM';
+    case 'three_rep_max':
+      return '3RM';
+    case 'five_rep_max':
+      return '5RM';
+    case 'volume':
+    default:
+      return 'Volume';
+  }
+}
+
+export default function ProgressionPlanModal() {
+  const router = useRouter();
+  const { user } = useAuth();
+  const { show: showToast } = useToast();
+  const params = useLocalSearchParams<{ exercise?: string; horizonWeeks?: string }>();
+  const exercise = typeof params.exercise === 'string' && params.exercise.length > 0
+    ? params.exercise
+    : 'Bench Press';
+  const horizonWeeks = useMemo(() => {
+    const raw = Number.parseInt(params.horizonWeeks ?? '', 10);
+    if (!Number.isFinite(raw) || raw <= 0) return 3;
+    return Math.min(12, Math.max(1, raw));
+  }, [params.horizonWeeks]);
+
+  const [summary, setSummary] = useState<ExerciseHistorySummary | null>(null);
+  const [suggestion, setSuggestion] = useState<WeightSuggestion | null>(null);
+  const [plan, setPlan] = useState<ProgressionPlan | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [planLoading, setPlanLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [acceptedWeight, setAcceptedWeight] = useState<number | null>(null);
+
+  const loadSummary = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const userId = user?.id ?? 'local-user';
+      const result = await getExerciseHistorySummary({ userId, exerciseNameOrId: exercise });
+      setSummary(result);
+      const suggestion = suggestWeight({
+        history: result.sets.map((s) => ({
+          weight: s.weight,
+          reps: s.reps,
+          date: s.date,
+        })),
+      });
+      setSuggestion(suggestion);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load history.');
+    } finally {
+      setLoading(false);
+    }
+  }, [exercise, user?.id]);
+
+  const loadPlan = useCallback(
+    async (history: ExerciseHistorySummary) => {
+      setPlanLoading(true);
+      try {
+        const userId = user?.id ?? 'local-user';
+        const result = await generateProgressionPlan({
+          userId,
+          exercise,
+          summary: history,
+          horizonWeeks,
+        });
+        setPlan(result);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Coach is temporarily unavailable.';
+        showToast(message, { type: 'error' });
+      } finally {
+        setPlanLoading(false);
+      }
+    },
+    [exercise, horizonWeeks, showToast, user?.id],
+  );
+
+  useEffect(() => {
+    loadSummary();
+  }, [loadSummary]);
+
+  useEffect(() => {
+    if (summary && summary.sets.length > 0) {
+      loadPlan(summary);
+    }
+  }, [summary, loadPlan]);
+
+  const triggeredPrs = useMemo(
+    () => (summary?.prData ?? []).filter((p) => p.isPr),
+    [summary],
+  );
+
+  const handleAcceptWeight = useCallback(() => {
+    if (!suggestion || suggestion.suggestedWeight <= 0) return;
+    setAcceptedWeight(suggestion.suggestedWeight);
+    showToast(
+      `Logged target of ${suggestion.suggestedWeight} for your next ${exercise} session.`,
+      { type: 'success' },
+    );
+  }, [exercise, showToast, suggestion]);
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+      <View style={styles.header}>
+        <TouchableOpacity
+          accessibilityLabel="Close progression plan"
+          accessibilityRole="button"
+          onPress={() => router.back()}
+          style={styles.closeButton}
+        >
+          <Ionicons name="close" size={24} color={TEXT_PRIMARY} />
+        </TouchableOpacity>
+        <Text style={styles.title} numberOfLines={1}>
+          {exercise}
+        </Text>
+        <View style={{ width: 32 }} />
+      </View>
+
+      {loading ? (
+        <View style={styles.loadingPanel}>
+          <ActivityIndicator size="large" color={ACCENT} />
+          <Text style={styles.loadingText}>Building your overload plan…</Text>
+        </View>
+      ) : error ? (
+        <View style={styles.errorPanel}>
+          <Ionicons name="alert-circle" size={40} color="#EF4444" />
+          <Text style={styles.errorText}>{error}</Text>
+          <TouchableOpacity style={styles.primaryButton} onPress={loadSummary}>
+            <Text style={styles.primaryButtonText}>Try again</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <ScrollView contentContainerStyle={styles.content}>
+          <View style={styles.statsCard}>
+            <Text style={styles.sectionLabel}>Estimated 1RM</Text>
+            <Text style={styles.statsValue}>
+              {summary?.estimatedOneRepMax ? `${summary.estimatedOneRepMax}` : '—'}
+            </Text>
+            <Text style={styles.sectionSub}>
+              {summary?.lastSession
+                ? `Last set ${summary.lastSession.weight} × ${summary.lastSession.reps} on ${summary.lastSession.date}`
+                : 'No sets logged yet for this exercise.'}
+            </Text>
+          </View>
+
+          <Text style={styles.sectionLabel}>PR summary</Text>
+          {triggeredPrs.length === 0 ? (
+            <View style={styles.card}>
+              <Text style={styles.cardBody}>No new PRs in this window — good time to drive overload.</Text>
+            </View>
+          ) : (
+            <View style={styles.chipRow}>
+              {triggeredPrs.map((pr) => (
+                <View key={pr.category} style={styles.chip}>
+                  <Ionicons name="trophy" size={14} color={SUCCESS} />
+                  <Text style={styles.chipText}>{prCategoryLabel(pr.category)}</Text>
+                  <Text style={styles.chipValue}>{Math.round(pr.current)}</Text>
+                </View>
+              ))}
+            </View>
+          )}
+
+          <Text style={styles.sectionLabel}>Suggested next weight</Text>
+          <View style={styles.suggestionCard}>
+            <Text style={styles.suggestionValue}>
+              {suggestion?.suggestedWeight ? suggestion.suggestedWeight : '—'}
+            </Text>
+            <Text style={styles.suggestionReason}>
+              {suggestion?.reasoning ?? 'No suggestion yet.'}
+            </Text>
+            <TouchableOpacity
+              style={[
+                styles.primaryButton,
+                (!suggestion || suggestion.suggestedWeight <= 0) && styles.primaryButtonDisabled,
+              ]}
+              disabled={!suggestion || suggestion.suggestedWeight <= 0}
+              onPress={handleAcceptWeight}
+              accessibilityLabel="Accept suggested weight for the next session"
+            >
+              <Text style={styles.primaryButtonText}>
+                {acceptedWeight !== null
+                  ? `Accepted ${acceptedWeight}`
+                  : 'Accept weight for next session'}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          <Text style={styles.sectionLabel}>Progression plan ({horizonWeeks} weeks)</Text>
+          <View style={styles.card}>
+            {planLoading ? (
+              <View style={styles.planLoading}>
+                <ActivityIndicator size="small" color={ACCENT} />
+                <Text style={styles.loadingText}>Asking the coach…</Text>
+              </View>
+            ) : plan ? (
+              <Text style={styles.planText}>{plan.text}</Text>
+            ) : (
+              <Text style={styles.cardBody}>
+                The coach service is unavailable — your suggested weight above still applies.
+              </Text>
+            )}
+          </View>
+        </ScrollView>
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: BG,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  closeButton: {
+    width: 32,
+    height: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    flex: 1,
+    textAlign: 'center',
+    fontSize: 18,
+    fontWeight: '600',
+    color: TEXT_PRIMARY,
+  },
+  content: {
+    paddingHorizontal: 16,
+    paddingBottom: 40,
+  },
+  statsCard: {
+    backgroundColor: PANEL,
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 20,
+  },
+  statsValue: {
+    fontSize: 40,
+    fontWeight: '700',
+    color: TEXT_PRIMARY,
+    marginTop: 4,
+  },
+  sectionLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: TEXT_SECONDARY,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    marginTop: 8,
+    marginBottom: 8,
+  },
+  sectionSub: {
+    fontSize: 13,
+    color: TEXT_SECONDARY,
+    marginTop: 8,
+  },
+  card: {
+    backgroundColor: PANEL,
+    borderRadius: 14,
+    padding: 14,
+    marginBottom: 20,
+  },
+  cardBody: {
+    fontSize: 14,
+    color: TEXT_PRIMARY,
+    lineHeight: 20,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginBottom: 20,
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+    backgroundColor: 'rgba(60,200,169,0.12)',
+  },
+  chipText: {
+    fontSize: 12,
+    color: SUCCESS,
+    fontWeight: '600',
+  },
+  chipValue: {
+    fontSize: 12,
+    color: TEXT_PRIMARY,
+    fontWeight: '600',
+  },
+  suggestionCard: {
+    backgroundColor: PANEL,
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 20,
+  },
+  suggestionValue: {
+    fontSize: 34,
+    fontWeight: '700',
+    color: TEXT_PRIMARY,
+  },
+  suggestionReason: {
+    fontSize: 13,
+    color: TEXT_SECONDARY,
+    marginBottom: 16,
+    marginTop: 6,
+  },
+  primaryButton: {
+    backgroundColor: ACCENT,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  primaryButtonDisabled: {
+    opacity: 0.4,
+  },
+  primaryButtonText: {
+    color: TEXT_PRIMARY,
+    fontWeight: '600',
+    fontSize: 15,
+  },
+  loadingPanel: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  loadingText: {
+    color: TEXT_SECONDARY,
+    fontSize: 14,
+  },
+  errorPanel: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    paddingHorizontal: 24,
+  },
+  errorText: {
+    color: TEXT_SECONDARY,
+    textAlign: 'center',
+  },
+  planText: {
+    fontSize: 14,
+    color: TEXT_PRIMARY,
+    lineHeight: 22,
+  },
+  planLoading: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+});

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -3,9 +3,11 @@ import * as Haptics from 'expo-haptics';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
 import { DeleteAction } from '@/components';
+import { OverloadAnalyticsCard } from '@/components/workouts/OverloadAnalyticsCard';
+import { useAuth } from '@/contexts/AuthContext';
 import { useUnits } from '@/contexts/UnitsContext';
 import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
     ActivityIndicator,
     Alert,
@@ -40,12 +42,34 @@ const buildWorkoutShareMessage = (workout: Workout, weightLabel: string): string
 
 export default function WorkoutsScreen() {
   const router = useRouter();
+  const { user } = useAuth();
   const { getWeightLabel } = useUnits();
   const { workouts, loading, refreshWorkouts, deleteWorkout } = useWorkouts();
   const { show: showToast } = useToast();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [lastSynced, setLastSynced] = useState<Date | null>(null);
   const swipeableRefs = useRef<Map<string, Swipeable>>(new Map());
+
+  // Pick the most recently logged exercise for the overload card. We fall
+  // back to the first row when dates are missing; if the list is empty, the
+  // card is hidden entirely to keep the empty-state screen clean.
+  const featuredExercise = useMemo(() => {
+    if (!workouts || workouts.length === 0) return null;
+    const sorted = [...workouts].sort((a, b) => {
+      const ad = a.date ? new Date(a.date).getTime() : 0;
+      const bd = b.date ? new Date(b.date).getTime() : 0;
+      return bd - ad;
+    });
+    return sorted[0].exercise;
+  }, [workouts]);
+
+  const openProgressionPlan = useCallback(() => {
+    if (!featuredExercise) return;
+    Haptics.selectionAsync().catch(() => {});
+    router.push(
+      `/(modals)/progression-plan?exercise=${encodeURIComponent(featuredExercise)}`,
+    );
+  }, [featuredExercise, router]);
 
   const onRefresh = useCallback(async () => {
     setIsRefreshing(true);
@@ -316,9 +340,18 @@ export default function WorkoutsScreen() {
           contentContainerStyle={styles.list}
           showsVerticalScrollIndicator={false}
           ListHeaderComponent={
-            lastUpdatedLabel ? (
-              <Text style={{ color: '#8E8E93', fontSize: 12, marginBottom: 12, textAlign: 'center' }}>{lastUpdatedLabel}</Text>
-            ) : null
+            <View>
+              {lastUpdatedLabel ? (
+                <Text style={{ color: '#8E8E93', fontSize: 12, marginBottom: 12, textAlign: 'center' }}>{lastUpdatedLabel}</Text>
+              ) : null}
+              {featuredExercise ? (
+                <OverloadAnalyticsCard
+                  userId={user?.id ?? 'local-user'}
+                  exercise={featuredExercise}
+                  onPressPlan={openProgressionPlan}
+                />
+              ) : null}
+            </View>
           }
           refreshControl={
             <RefreshControl

--- a/components/workouts/OverloadAnalyticsCard.tsx
+++ b/components/workouts/OverloadAnalyticsCard.tsx
@@ -1,0 +1,339 @@
+/**
+ * OverloadAnalyticsCard
+ *
+ * Compact chart card visualising progressive-overload history for a single
+ * exercise. Renders:
+ *   - Weight-over-time line (newest-rightmost)
+ *   - Rep-count legend badge
+ *   - PR markers (1RM / 5RM / Volume) pulled from the exercise history
+ *     service, plus a "next PR" threshold banner.
+ *
+ * Uses `react-native-chart-kit` (already a dependency) for the line plot.
+ * The card is additive and safe to mount on any scrollable container.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Dimensions,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { LineChart } from 'react-native-chart-kit';
+import { Ionicons } from '@expo/vector-icons';
+import { getExerciseHistorySummary } from '@/lib/services/exercise-history-service';
+import type {
+  ExerciseHistorySummary,
+  ExerciseHistorySet,
+} from '@/lib/services/exercise-history-service';
+import type { PrResult } from '@/lib/services/pr-detector';
+
+export interface OverloadAnalyticsCardProps {
+  userId: string;
+  exercise: string;
+  limit?: number;
+  /** Optional handler fired when user taps the card CTA. */
+  onPressPlan?: () => void;
+  /** Optional override for testing / storybook. */
+  summaryOverride?: ExerciseHistorySummary;
+}
+
+const PANEL = '#0E1A2E';
+const ACCENT = '#4C8CFF';
+const TEXT_PRIMARY = '#F8F9FF';
+const TEXT_SECONDARY = '#8E9BAD';
+const SUCCESS = '#3CC8A9';
+
+function buildChartLabels(sets: ExerciseHistorySet[]): string[] {
+  if (sets.length === 0) return [];
+  // sets are newest-first; render oldest-first left-to-right.
+  const ordered = [...sets].reverse();
+  const stride = Math.max(1, Math.ceil(ordered.length / 4));
+  return ordered.map((set, index) => {
+    if (index % stride !== 0 && index !== ordered.length - 1) return '';
+    const date = new Date(set.date);
+    if (Number.isNaN(date.getTime())) return '';
+    return `${date.getMonth() + 1}/${date.getDate()}`;
+  });
+}
+
+function buildChartDataset(sets: ExerciseHistorySet[]): number[] {
+  if (sets.length === 0) return [0];
+  return [...sets].reverse().map((s) => s.weight);
+}
+
+function nextPrThreshold(summary: ExerciseHistorySummary): number | null {
+  if (!summary.lastSession) return null;
+  const est = summary.estimatedOneRepMax;
+  if (est <= 0) return Math.round(summary.lastSession.weight * 1.025);
+  // Target a 2.5% bump on the working weight; the estimated 1RM flags when
+  // we are creeping close to a new 1RM PR.
+  return Math.round(summary.lastSession.weight * 1.025);
+}
+
+function prChipLabel(pr: PrResult): string {
+  switch (pr.category) {
+    case 'one_rep_max':
+      return `1RM ${Math.round(pr.current)}`;
+    case 'three_rep_max':
+      return `3RM ${Math.round(pr.current)}`;
+    case 'five_rep_max':
+      return `5RM ${Math.round(pr.current)}`;
+    case 'volume':
+    default:
+      return `Vol ${Math.round(pr.current)}`;
+  }
+}
+
+export function OverloadAnalyticsCard({
+  userId,
+  exercise,
+  limit = 30,
+  onPressPlan,
+  summaryOverride,
+}: OverloadAnalyticsCardProps): React.ReactElement {
+  const [summary, setSummary] = useState<ExerciseHistorySummary | null>(
+    summaryOverride ?? null,
+  );
+  const [loading, setLoading] = useState<boolean>(!summaryOverride);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (summaryOverride) {
+      setSummary(summaryOverride);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await getExerciseHistorySummary({
+          userId,
+          exerciseNameOrId: exercise,
+          limit,
+        });
+        if (!cancelled) setSummary(result);
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : 'Could not load history.',
+          );
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, exercise, limit, summaryOverride]);
+
+  const chartWidth = Math.max(260, Dimensions.get('window').width - 48);
+
+  const labels = useMemo(() => buildChartLabels(summary?.sets ?? []), [summary]);
+  const data = useMemo(() => buildChartDataset(summary?.sets ?? []), [summary]);
+  const triggeredPrs = useMemo(
+    () => (summary?.prData ?? []).filter((p) => p.isPr),
+    [summary],
+  );
+  const threshold = useMemo(() => (summary ? nextPrThreshold(summary) : null), [summary]);
+
+  if (loading) {
+    return (
+      <View style={styles.card} testID="overload-card-loading">
+        <ActivityIndicator color={ACCENT} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.card} testID="overload-card-error">
+        <Text style={styles.errorText}>{error}</Text>
+      </View>
+    );
+  }
+
+  if (!summary || summary.sets.length === 0) {
+    return (
+      <View style={styles.card} testID="overload-card-empty">
+        <View style={styles.headerRow}>
+          <Text style={styles.exerciseName}>{exercise}</Text>
+          <Text style={styles.subLabel}>Progressive overload</Text>
+        </View>
+        <Text style={styles.emptyText}>
+          No history yet for this exercise. Log a set to start tracking overload.
+        </Text>
+      </View>
+    );
+  }
+
+  const lastWeight = summary.lastSession?.weight ?? 0;
+  const est = summary.estimatedOneRepMax;
+
+  return (
+    <View style={styles.card} testID="overload-card">
+      <View style={styles.headerRow}>
+        <View>
+          <Text style={styles.exerciseName}>{exercise}</Text>
+          <Text style={styles.subLabel}>
+            Last {lastWeight} lb · est. 1RM {est || '—'}
+          </Text>
+        </View>
+        {onPressPlan ? (
+          <TouchableOpacity
+            onPress={onPressPlan}
+            accessibilityRole="button"
+            accessibilityLabel="Open progression plan"
+            style={styles.planButton}
+          >
+            <Ionicons name="sparkles" size={14} color={ACCENT} />
+            <Text style={styles.planButtonText}>Plan</Text>
+          </TouchableOpacity>
+        ) : null}
+      </View>
+
+      <LineChart
+        data={{
+          labels,
+          datasets: [
+            {
+              data,
+              color: (opacity = 1) => `rgba(76, 140, 255, ${opacity})`,
+              strokeWidth: 2,
+            },
+          ],
+        }}
+        width={chartWidth}
+        height={160}
+        bezier
+        withInnerLines={false}
+        withOuterLines={false}
+        withHorizontalLabels
+        withVerticalLabels
+        fromZero={false}
+        chartConfig={{
+          backgroundGradientFrom: PANEL,
+          backgroundGradientTo: PANEL,
+          color: (opacity = 1) => `rgba(76, 140, 255, ${opacity})`,
+          labelColor: (opacity = 1) => `rgba(142, 155, 173, ${opacity})`,
+          propsForDots: { r: '3' },
+          propsForBackgroundLines: { stroke: 'rgba(142,155,173,0.12)' },
+          decimalPlaces: 0,
+        }}
+        style={styles.chart}
+      />
+
+      {triggeredPrs.length > 0 ? (
+        <View style={styles.chipRow}>
+          {triggeredPrs.map((pr) => (
+            <View key={pr.category} style={styles.chip} testID={`overload-pr-${pr.category}`}>
+              <Ionicons name="trophy" size={12} color={SUCCESS} />
+              <Text style={styles.chipText}>{prChipLabel(pr)}</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      {threshold ? (
+        <View style={styles.thresholdBanner} testID="overload-card-threshold">
+          <Ionicons name="trending-up" size={14} color={ACCENT} />
+          <Text style={styles.thresholdText}>
+            Next PR threshold ≈ {threshold} lb
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export default OverloadAnalyticsCard;
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: PANEL,
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 16,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 8,
+  },
+  exerciseName: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: TEXT_PRIMARY,
+  },
+  subLabel: {
+    fontSize: 12,
+    color: TEXT_SECONDARY,
+    marginTop: 2,
+  },
+  chart: {
+    borderRadius: 12,
+    marginVertical: 4,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginTop: 8,
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 999,
+    backgroundColor: 'rgba(60,200,169,0.12)',
+  },
+  chipText: {
+    color: SUCCESS,
+    fontSize: 11,
+    fontWeight: '600',
+  },
+  thresholdBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    backgroundColor: 'rgba(76,140,255,0.08)',
+    borderRadius: 8,
+  },
+  thresholdText: {
+    color: TEXT_PRIMARY,
+    fontSize: 12,
+  },
+  planButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+    backgroundColor: 'rgba(76,140,255,0.12)',
+  },
+  planButtonText: {
+    color: ACCENT,
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  emptyText: {
+    color: TEXT_SECONDARY,
+    fontSize: 13,
+  },
+  errorText: {
+    color: '#EF4444',
+    fontSize: 13,
+  },
+});

--- a/lib/services/database/local-db.ts
+++ b/lib/services/database/local-db.ts
@@ -830,6 +830,42 @@ class LocalDatabase {
     });
   }
 
+  /**
+   * Fetch workouts for a specific exercise, sorted by date descending.
+   *
+   * The legacy `workouts` table is single-user-per-device (no `user_id` column);
+   * `userId` is accepted for API symmetry with the forthcoming Supabase equivalent
+   * so callers can pass a stable identifier without branching. The parameter name
+   * `exerciseNameOrId` reflects that the local table stores the exercise as a
+   * free-text `exercise` column — callers may pass either the canonical exercise
+   * name (legacy path) or an exercise id if the session-based tables grow a
+   * local aggregate view later.
+   *
+   * @param userId - Accepted for API parity; currently unused locally.
+   * @param exerciseNameOrId - Exact match on the stored `exercise` column.
+   * @param limit - Optional cap on the number of rows returned (newest first).
+   */
+  async getWorkoutsByExercise(
+    userId: string,
+    exerciseNameOrId: string,
+    limit?: number,
+  ): Promise<LocalWorkout[]> {
+    void userId; // reserved for multi-user support; see Supabase stub in sync-service.ts
+    const dbResult = await this.ensureInitialized();
+    if (!dbResult.ok) {
+      throw new Error(dbResult.error.message);
+    }
+
+    const params: (string | number)[] = [exerciseNameOrId];
+    let query =
+      'SELECT * FROM workouts WHERE deleted = 0 AND exercise = ? ORDER BY date DESC';
+    if (typeof limit === 'number' && limit > 0) {
+      query += ' LIMIT ?';
+      params.push(Math.floor(limit));
+    }
+    return dbResult.data.getAllAsync<LocalWorkout>(query, params);
+  }
+
   // Health Metric operations
   async insertHealthMetric(metric: Omit<LocalHealthMetric, 'synced' | 'updated_at'>): Promise<void> {
     if (!this.db) throw new Error('Database not initialized');

--- a/lib/services/database/local-db.web.ts
+++ b/lib/services/database/local-db.web.ts
@@ -233,6 +233,21 @@ class LocalDatabase {
     return this.getData<LocalWorkout>(this.getStorageKey('workouts'));
   }
 
+  async getWorkoutsByExercise(
+    userId: string,
+    exerciseNameOrId: string,
+    limit?: number,
+  ): Promise<LocalWorkout[]> {
+    void userId;
+    const rows = this.getData<LocalWorkout>(this.getStorageKey('workouts'))
+      .filter(w => w.deleted === 0 && w.exercise === exerciseNameOrId)
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+    if (typeof limit === 'number' && limit > 0) {
+      return rows.slice(0, Math.floor(limit));
+    }
+    return rows;
+  }
+
   async updateWorkoutSyncStatus(id: string, synced: boolean): Promise<void> {
     await this.updateWorkout(id, { synced: synced ? 1 : 0 });
   }

--- a/lib/services/database/sync-service.ts
+++ b/lib/services/database/sync-service.ts
@@ -1632,6 +1632,26 @@ class SyncService {
     this.setSyncStatus({ state: 'idle', lastError: null, lastErrorAt: null });
     logWithTs('[SyncService] Sync queue cleared');
   }
+
+  /**
+   * Fetch remote workouts for a given exercise. Mirrors
+   * `localDB.getWorkoutsByExercise()` so callers can prefer local-first and
+   * fall through to Supabase when the local store is cold.
+   *
+   * TODO(day): wire the remote Supabase query once progressive overload
+   * becomes multi-device. For now we defer entirely to the local store to
+   * avoid an extra network round-trip on the hot path.
+   */
+  async getWorkoutsByExerciseRemote(
+    userId: string,
+    exerciseNameOrId: string,
+    limit?: number,
+  ): Promise<LocalWorkout[]> {
+    void userId;
+    void exerciseNameOrId;
+    void limit;
+    return [];
+  }
 }
 
 // Export singleton instance

--- a/lib/services/exercise-history-service.ts
+++ b/lib/services/exercise-history-service.ts
@@ -1,0 +1,141 @@
+/**
+ * Exercise history aggregator.
+ *
+ * Composes local-db lookups, the rep-max calculator, and the PR detector
+ * into a single read-only view that powers the overload analytics card
+ * and the progression plan modal.
+ *
+ * Pure in terms of logic (no UI), async in terms of I/O. Consumers pass a
+ * userId/exerciseNameOrId pair and an optional history window.
+ */
+
+import { localDB, type LocalWorkout } from './database/local-db';
+import { estimateOneRepMaxAveraged } from './rep-max-calculator';
+import {
+  detectAllPrs,
+  type PrResult,
+  type SetRecord,
+} from './pr-detector';
+
+export interface ExerciseHistorySet {
+  id: string;
+  weight: number;
+  reps: number;
+  sets: number;
+  duration?: number;
+  date: string;
+}
+
+export interface TrendSeries {
+  label: string;
+  values: number[];
+  /** ISO date for each value. */
+  dates: string[];
+}
+
+export interface ExerciseHistorySummary {
+  exercise: string;
+  sets: ExerciseHistorySet[];
+  volumeTrend: TrendSeries;
+  repTrend: TrendSeries;
+  lastSession: ExerciseHistorySet | null;
+  prData: PrResult[];
+  /** Current best estimated 1RM across the entire window. */
+  estimatedOneRepMax: number;
+}
+
+export interface ExerciseHistoryInput {
+  userId: string;
+  exerciseNameOrId: string;
+  /** Maximum rows to pull from local history. Defaults to 50. */
+  limit?: number;
+}
+
+const DEFAULT_LIMIT = 50;
+
+function toHistorySet(row: LocalWorkout): ExerciseHistorySet | null {
+  if (!row) return null;
+  return {
+    id: row.id,
+    weight: typeof row.weight === 'number' ? row.weight : 0,
+    reps: typeof row.reps === 'number' ? row.reps : 0,
+    sets: typeof row.sets === 'number' ? row.sets : 0,
+    duration: typeof row.duration === 'number' ? row.duration : undefined,
+    date: row.date,
+  };
+}
+
+function buildVolumeTrend(sets: ExerciseHistorySet[]): TrendSeries {
+  // sets are newest-first; invert so charts render left-to-right chronologically.
+  const ordered = [...sets].reverse();
+  return {
+    label: 'Volume',
+    values: ordered.map((s) => Math.round(s.weight * s.reps * Math.max(1, s.sets))),
+    dates: ordered.map((s) => s.date),
+  };
+}
+
+function buildRepTrend(sets: ExerciseHistorySet[]): TrendSeries {
+  const ordered = [...sets].reverse();
+  return {
+    label: 'Reps per set',
+    values: ordered.map((s) => s.reps),
+    dates: ordered.map((s) => s.date),
+  };
+}
+
+function bestOneRepMaxOver(sets: ExerciseHistorySet[]): number {
+  let best = 0;
+  for (const s of sets) {
+    if (!s.weight || !s.reps) continue;
+    const est = estimateOneRepMaxAveraged({ weight: s.weight, reps: s.reps }).oneRepMax;
+    if (est > best) best = est;
+  }
+  return Math.round(best);
+}
+
+export async function getExerciseHistorySummary(
+  input: ExerciseHistoryInput,
+): Promise<ExerciseHistorySummary> {
+  const limit = input.limit ?? DEFAULT_LIMIT;
+  const rows = await localDB.getWorkoutsByExercise(
+    input.userId,
+    input.exerciseNameOrId,
+    limit,
+  );
+
+  const normalized = rows
+    .map(toHistorySet)
+    .filter((r): r is ExerciseHistorySet => r !== null && r.weight > 0 && r.reps > 0);
+
+  const lastSession = normalized[0] ?? null;
+
+  let prData: PrResult[] = [];
+  if (lastSession && normalized.length > 1) {
+    const previous: SetRecord[] = normalized.slice(1).map((s) => ({
+      weight: s.weight,
+      reps: s.reps,
+      date: s.date,
+    }));
+    prData = detectAllPrs(
+      { weight: lastSession.weight, reps: lastSession.reps, date: lastSession.date },
+      previous,
+    );
+  } else if (lastSession) {
+    // First-ever set: every category is a PR by default.
+    prData = detectAllPrs(
+      { weight: lastSession.weight, reps: lastSession.reps, date: lastSession.date },
+      [],
+    );
+  }
+
+  return {
+    exercise: input.exerciseNameOrId,
+    sets: normalized,
+    volumeTrend: buildVolumeTrend(normalized),
+    repTrend: buildRepTrend(normalized),
+    lastSession,
+    prData,
+    estimatedOneRepMax: bestOneRepMaxOver(normalized),
+  };
+}

--- a/lib/services/pr-detector.ts
+++ b/lib/services/pr-detector.ts
@@ -1,0 +1,168 @@
+/**
+ * Personal-record detector — category-aware.
+ *
+ * Detects four flavours of overload PRs from a completed set compared to
+ * prior history:
+ *   - 1RM   : highest estimated one-rep max (best formula blend)
+ *   - 3RM   : heaviest load * 3 reps (actual, not estimated)
+ *   - 5RM   : heaviest load * 5 reps (actual, not estimated)
+ *   - volume: highest (weight × reps) on any single set
+ *
+ * TODO(#447): PR #450 (template-form-target-pr-detection) also lands a
+ * `pr-detector.ts` scoped to template-celebration flows. On merge, the
+ * two files must reconcile into a single module — this file ships the
+ * overload categories additively so the reconcile is a type-level
+ * superset rather than a semantic rewrite. See issue #475 cross-PR
+ * stubs.
+ */
+
+import {
+  estimateOneRepMaxAveraged,
+  type RepMaxInput,
+} from './rep-max-calculator';
+
+export type PrCategory = 'one_rep_max' | 'three_rep_max' | 'five_rep_max' | 'volume';
+
+export interface SetRecord extends RepMaxInput {
+  /** Optional ISO date stamp. Used only to break ties when two sets match. */
+  date?: string;
+}
+
+export interface PrResult {
+  category: PrCategory;
+  /**
+   * Previous record value (1RM for one_rep_max / 3RM / 5RM, volume for
+   * volume). Null when no prior history existed.
+   */
+  previous: number | null;
+  /** The new value from the current set. */
+  current: number;
+  /** Absolute delta from previous. Equals `current` when previous is null. */
+  delta: number;
+  /** True when `current` strictly beats the previous record. */
+  isPr: boolean;
+  /** Human-readable reasoning. */
+  label: string;
+}
+
+function bestRepMaxValue(history: SetRecord[], targetReps: number): number {
+  let best = 0;
+  for (const entry of history) {
+    if (entry.reps === targetReps && entry.weight > best) {
+      best = entry.weight;
+    }
+  }
+  return best;
+}
+
+function bestOneRepMaxEstimate(history: SetRecord[]): number {
+  let best = 0;
+  for (const entry of history) {
+    const est = estimateOneRepMaxAveraged(entry).oneRepMax;
+    if (est > best) best = est;
+  }
+  return best;
+}
+
+function bestVolume(history: SetRecord[]): number {
+  let best = 0;
+  for (const entry of history) {
+    const volume = entry.weight * entry.reps;
+    if (volume > best) best = volume;
+  }
+  return best;
+}
+
+function isNumberPositive(n: number): boolean {
+  return Number.isFinite(n) && n > 0;
+}
+
+export function detectOneRepMaxPr(current: SetRecord, history: SetRecord[]): PrResult {
+  const candidateEst = estimateOneRepMaxAveraged(current).oneRepMax;
+  const previous = history.length ? bestOneRepMaxEstimate(history) : 0;
+  const prev = previous > 0 ? previous : null;
+  return {
+    category: 'one_rep_max',
+    previous: prev,
+    current: candidateEst,
+    delta: prev === null ? candidateEst : candidateEst - prev,
+    isPr: isNumberPositive(candidateEst) && candidateEst > (prev ?? 0),
+    label: `Estimated 1RM ${Math.round(candidateEst)}${
+      prev !== null ? ` vs prior ${Math.round(prev)}` : ''
+    }`,
+  };
+}
+
+function detectRepMaxPr(
+  targetReps: number,
+  category: Exclude<PrCategory, 'one_rep_max' | 'volume'>,
+  current: SetRecord,
+  history: SetRecord[],
+): PrResult {
+  if (current.reps !== targetReps) {
+    return {
+      category,
+      previous: bestRepMaxValue(history, targetReps) || null,
+      current: 0,
+      delta: 0,
+      isPr: false,
+      label: `${targetReps}RM requires a set at exactly ${targetReps} reps.`,
+    };
+  }
+  const previous = bestRepMaxValue(history, targetReps);
+  const prev = previous > 0 ? previous : null;
+  return {
+    category,
+    previous: prev,
+    current: current.weight,
+    delta: prev === null ? current.weight : current.weight - prev,
+    isPr: isNumberPositive(current.weight) && current.weight > (prev ?? 0),
+    label: `${targetReps}RM ${current.weight}${
+      prev !== null ? ` vs prior ${prev}` : ''
+    }`,
+  };
+}
+
+export function detectThreeRepMaxPr(current: SetRecord, history: SetRecord[]): PrResult {
+  return detectRepMaxPr(3, 'three_rep_max', current, history);
+}
+
+export function detectFiveRepMaxPr(current: SetRecord, history: SetRecord[]): PrResult {
+  return detectRepMaxPr(5, 'five_rep_max', current, history);
+}
+
+export function detectVolumePr(current: SetRecord, history: SetRecord[]): PrResult {
+  const currentVolume = current.weight * current.reps;
+  const previous = history.length ? bestVolume(history) : 0;
+  const prev = previous > 0 ? previous : null;
+  return {
+    category: 'volume',
+    previous: prev,
+    current: currentVolume,
+    delta: prev === null ? currentVolume : currentVolume - prev,
+    isPr: isNumberPositive(currentVolume) && currentVolume > (prev ?? 0),
+    label: `Volume ${Math.round(currentVolume)}${
+      prev !== null ? ` vs prior ${Math.round(prev)}` : ''
+    }`,
+  };
+}
+
+/**
+ * Run all four category detectors in one pass. Returns results in a stable
+ * order regardless of which actually triggered.
+ */
+export function detectAllPrs(current: SetRecord, history: SetRecord[]): PrResult[] {
+  return [
+    detectOneRepMaxPr(current, history),
+    detectThreeRepMaxPr(current, history),
+    detectFiveRepMaxPr(current, history),
+    detectVolumePr(current, history),
+  ];
+}
+
+/**
+ * Filter to just the triggered PRs. Useful for UI confetti / toasts.
+ */
+export function triggeredPrs(current: SetRecord, history: SetRecord[]): PrResult[] {
+  return detectAllPrs(current, history).filter((result) => result.isPr);
+}

--- a/lib/services/progression-planner.ts
+++ b/lib/services/progression-planner.ts
@@ -1,0 +1,129 @@
+/**
+ * Progression plan generator.
+ *
+ * Builds a compact prompt from a summary of recent exercise performance and
+ * dispatches it through the existing coach-service so the backend can route
+ * the request (OpenAI today, Gemma once the #457/#471 provider dispatch
+ * merges). Caches plans in-memory keyed by (user, exercise, weekHash) so
+ * the modal can re-render without re-invoking the Edge Function.
+ *
+ * TODO(#466): wire provider/dispatch streaming opts once they land; today
+ * the coach Edge Function returns a single blob and we surface it as-is.
+ */
+
+import { sendCoachPrompt, type CoachContext, type CoachMessage } from './coach-service';
+import type { ExerciseHistorySummary } from './exercise-history-service';
+
+export interface ProgressionPlanInput {
+  userId: string;
+  exercise: string;
+  summary: ExerciseHistorySummary;
+  /** Optional override — otherwise defaults to a 3-week horizon. */
+  horizonWeeks?: number;
+  /** Coach context (profile/session) to forward for persistence. */
+  context?: CoachContext;
+}
+
+export interface ProgressionPlan {
+  /** Raw text returned by the coach. */
+  text: string;
+  /** Same prompt body that was sent (surfaced for debug + replay). */
+  promptPreview: string;
+  /** ISO timestamp when the plan was generated. */
+  generatedAt: string;
+  /** Horizon used for the prompt. */
+  horizonWeeks: number;
+  /** Unique cache key used. */
+  cacheKey: string;
+}
+
+const DEFAULT_HORIZON_WEEKS = 3;
+
+type PlanCacheEntry = { key: string; value: ProgressionPlan };
+
+const PLAN_CACHE: Map<string, PlanCacheEntry> = new Map();
+const PLAN_CACHE_MAX = 32;
+
+function summarizeLatestSets(summary: ExerciseHistorySummary): string {
+  if (!summary.sets.length) return 'no prior sets logged';
+  const recent = summary.sets.slice(0, 3);
+  return recent
+    .map(
+      (s) =>
+        `${s.weight}lb × ${s.reps} reps (${s.sets} set${s.sets === 1 ? '' : 's'}) on ${s.date}`,
+    )
+    .join('; ');
+}
+
+function summarizePrs(summary: ExerciseHistorySummary): string {
+  const triggered = summary.prData.filter((p) => p.isPr);
+  if (!triggered.length) return 'no new PRs in the current window';
+  return triggered.map((p) => p.label).join(' | ');
+}
+
+export function buildProgressionPrompt(
+  input: ProgressionPlanInput,
+): string {
+  const { summary, exercise } = input;
+  const horizon = input.horizonWeeks ?? DEFAULT_HORIZON_WEEKS;
+  const latest = summarizeLatestSets(summary);
+  const prs = summarizePrs(summary);
+  const est = summary.estimatedOneRepMax;
+  return [
+    `Exercise: ${exercise}.`,
+    `Recent sets: ${latest}.`,
+    `Estimated 1RM: ${est || 'unknown'}.`,
+    `Recent PRs: ${prs}.`,
+    `Please propose a ${horizon}-week progressive overload plan with target weight, reps, and RPE per session. Be concise; use bullet points per week.`,
+  ].join('\n');
+}
+
+function cacheKeyFor(input: ProgressionPlanInput): string {
+  const latest = input.summary.lastSession;
+  const bucket = latest
+    ? `${latest.date}-${latest.weight}-${latest.reps}`
+    : 'empty';
+  const horizon = input.horizonWeeks ?? DEFAULT_HORIZON_WEEKS;
+  return `${input.userId}::${input.exercise}::${horizon}w::${bucket}`;
+}
+
+function insertCacheEntry(entry: PlanCacheEntry): void {
+  PLAN_CACHE.set(entry.key, entry);
+  if (PLAN_CACHE.size > PLAN_CACHE_MAX) {
+    const firstKey = PLAN_CACHE.keys().next().value;
+    if (firstKey !== undefined) PLAN_CACHE.delete(firstKey);
+  }
+}
+
+export function clearProgressionPlanCache(): void {
+  PLAN_CACHE.clear();
+}
+
+export async function generateProgressionPlan(
+  input: ProgressionPlanInput,
+): Promise<ProgressionPlan> {
+  const prompt = buildProgressionPrompt(input);
+  const cacheKey = cacheKeyFor(input);
+  const cached = PLAN_CACHE.get(cacheKey);
+  if (cached) return cached.value;
+
+  const messages: CoachMessage[] = [
+    {
+      role: 'system',
+      content:
+        'You are a strength coach. Produce concise progressive overload plans with specific target weights, reps, and RPE values. Use markdown bullet lists grouped per week.',
+    },
+    { role: 'user', content: prompt },
+  ];
+
+  const response = await sendCoachPrompt(messages, input.context);
+  const plan: ProgressionPlan = {
+    text: response.content,
+    promptPreview: prompt,
+    generatedAt: new Date().toISOString(),
+    horizonWeeks: input.horizonWeeks ?? DEFAULT_HORIZON_WEEKS,
+    cacheKey,
+  };
+  insertCacheEntry({ key: cacheKey, value: plan });
+  return plan;
+}

--- a/lib/services/rep-max-calculator.ts
+++ b/lib/services/rep-max-calculator.ts
@@ -1,0 +1,161 @@
+/**
+ * Rep-max / 1-RM estimation helpers.
+ *
+ * Implements three industry-standard estimators so downstream suggestion
+ * logic can average or compare them:
+ *   - Epley    : 1RM = weight * (1 + reps / 30)
+ *   - Brzycki  : 1RM = weight * 36 / (37 - reps)   [reps < 37]
+ *   - Lombardi : 1RM = weight * reps ^ 0.10
+ *
+ * All formulas degenerate cleanly at reps = 1 (1RM = weight). Brzycki's
+ * denominator blows up near reps = 37, so we clamp before computing.
+ *
+ * Confidence scoring favours lower rep counts (3-6 is sweet spot); very
+ * high-rep sets drift further from the true 1RM and the estimators diverge.
+ */
+
+export type RepMaxFormula = 'epley' | 'brzycki' | 'lombardi';
+
+export interface RepMaxInput {
+  /** Weight lifted in the set (any consistent unit). */
+  weight: number;
+  /** Reps completed at that weight. Must be a positive integer. */
+  reps: number;
+}
+
+export interface RepMaxEstimate {
+  /** Estimated one-rep max in the same unit as the input weight. */
+  oneRepMax: number;
+  /** Which formula produced the estimate. */
+  formula: RepMaxFormula;
+  /** 0..1 confidence that the estimate reflects a true maximal effort. */
+  confidence: number;
+}
+
+export interface MultiFormulaEstimate {
+  /** Average 1RM across the three formulas. */
+  oneRepMax: number;
+  /** Estimate per formula (useful for charts + debugging). */
+  perFormula: Record<RepMaxFormula, number>;
+  /** 0..1 confidence. */
+  confidence: number;
+}
+
+const MAX_BRZYCKI_REPS = 36;
+
+function isValidInput({ weight, reps }: RepMaxInput): boolean {
+  return (
+    Number.isFinite(weight) &&
+    weight > 0 &&
+    Number.isInteger(reps) &&
+    reps > 0
+  );
+}
+
+function round(value: number, digits = 2): number {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+export function epleyOneRepMax(weight: number, reps: number): number {
+  if (reps === 1) return weight;
+  return round(weight * (1 + reps / 30));
+}
+
+export function brzyckiOneRepMax(weight: number, reps: number): number {
+  if (reps === 1) return weight;
+  const clamped = Math.min(reps, MAX_BRZYCKI_REPS);
+  return round(weight * (36 / (37 - clamped)));
+}
+
+export function lombardiOneRepMax(weight: number, reps: number): number {
+  if (reps === 1) return weight;
+  return round(weight * Math.pow(reps, 0.1));
+}
+
+/**
+ * Confidence band based on rep count. Single-rep lifts are treated as
+ * ground truth (1.0); bands taper as reps grow because the relationship
+ * between sub-maximal reps and 1RM becomes noisier.
+ */
+export function repsToConfidence(reps: number): number {
+  if (!Number.isInteger(reps) || reps <= 0) return 0;
+  if (reps === 1) return 1;
+  if (reps <= 3) return 0.95;
+  if (reps <= 6) return 0.88;
+  if (reps <= 10) return 0.78;
+  if (reps <= 15) return 0.6;
+  if (reps <= 20) return 0.45;
+  return 0.3;
+}
+
+export function estimateOneRepMax(
+  input: RepMaxInput,
+  formula: RepMaxFormula = 'epley',
+): RepMaxEstimate {
+  if (!isValidInput(input)) {
+    return { oneRepMax: 0, formula, confidence: 0 };
+  }
+
+  const { weight, reps } = input;
+  let oneRepMax: number;
+  switch (formula) {
+    case 'brzycki':
+      oneRepMax = brzyckiOneRepMax(weight, reps);
+      break;
+    case 'lombardi':
+      oneRepMax = lombardiOneRepMax(weight, reps);
+      break;
+    case 'epley':
+    default:
+      oneRepMax = epleyOneRepMax(weight, reps);
+      break;
+  }
+
+  return {
+    oneRepMax,
+    formula,
+    confidence: repsToConfidence(reps),
+  };
+}
+
+/**
+ * Blend all three formulas to smooth per-formula quirks.
+ */
+export function estimateOneRepMaxAveraged(input: RepMaxInput): MultiFormulaEstimate {
+  if (!isValidInput(input)) {
+    return {
+      oneRepMax: 0,
+      perFormula: { epley: 0, brzycki: 0, lombardi: 0 },
+      confidence: 0,
+    };
+  }
+  const epley = epleyOneRepMax(input.weight, input.reps);
+  const brzycki = brzyckiOneRepMax(input.weight, input.reps);
+  const lombardi = lombardiOneRepMax(input.weight, input.reps);
+  const oneRepMax = round((epley + brzycki + lombardi) / 3);
+  return {
+    oneRepMax,
+    perFormula: { epley, brzycki, lombardi },
+    confidence: repsToConfidence(input.reps),
+  };
+}
+
+/**
+ * Pick the highest 1RM across a history of sets (best-set method).
+ * Returns null when the history has no valid sets.
+ */
+export function bestOneRepMaxFromHistory(
+  history: RepMaxInput[],
+  formula: RepMaxFormula = 'epley',
+): RepMaxEstimate | null {
+  let best: RepMaxEstimate | null = null;
+  for (const entry of history) {
+    const est = estimateOneRepMax(entry, formula);
+    if (est.oneRepMax <= 0) continue;
+    if (!best || est.oneRepMax > best.oneRepMax) {
+      best = est;
+    }
+  }
+  return best;
+}

--- a/lib/services/weight-suggester.ts
+++ b/lib/services/weight-suggester.ts
@@ -1,0 +1,207 @@
+/**
+ * Weight suggestion engine.
+ *
+ * Given a rolling history of completed sets for a given exercise, suggest a
+ * target weight for the upcoming set that nudges the lifter along a
+ * progressive-overload curve. Supports:
+ *   - Data-rich path (>= LINEAR_FALLBACK_THRESHOLD sets) : blend of
+ *     (a) best estimated 1RM at a target-RPE fraction, and
+ *     (b) linear-trend extrapolation.
+ *   - Linear fallback (< threshold)                      : bump the last
+ *     known top-set weight by a small compound-exercise friendly delta.
+ *
+ * Output is deterministic (same history ⇒ same suggestion), snapped to the
+ * nearest 2.5 unit plate, and reasoning is a human-readable string to
+ * surface in the UI.
+ */
+
+import {
+  bestOneRepMaxFromHistory,
+  estimateOneRepMaxAveraged,
+  type RepMaxInput,
+} from './rep-max-calculator';
+
+export interface WeightSuggestionInput {
+  /** Past sets (any time order — newest-first preferred but not required). */
+  history: HistorySet[];
+  /** Target reps for the next set (defaults to median of last 3 sets). */
+  targetReps?: number;
+  /** Target RPE on a 6-10 scale. Defaults to 8 (hypertrophy). */
+  targetRpe?: number;
+  /** Plate rounding increment. Defaults to 2.5. */
+  plateIncrement?: number;
+}
+
+export interface HistorySet extends RepMaxInput {
+  /** ISO date when the set was recorded. */
+  date?: string;
+  /** RPE the lifter reported, 6-10. Optional. */
+  rpe?: number;
+}
+
+export interface WeightSuggestion {
+  suggestedWeight: number;
+  /** 0..1 confidence in the suggestion. */
+  confidence: number;
+  reasoning: string;
+  /** Number of history sets considered. */
+  historyCount: number;
+  /** Whether the linear-progression fallback was used. */
+  fallback: boolean;
+}
+
+const LINEAR_FALLBACK_THRESHOLD = 5;
+const DEFAULT_TARGET_RPE = 8;
+const DEFAULT_PLATE_INCREMENT = 2.5;
+const MAX_BUMP_RATIO = 0.05; // cap weekly overload at 5% per session
+const LINEAR_BUMP_DEFAULT = 2.5; // one micro-plate bump when we lack data
+
+/**
+ * RPE → percent of 1RM lookup based on Mike Tuchscherer's chart for 1-rep
+ * execution; we interpolate for higher rep ranges via the reps-in-reserve
+ * adjustment below (0.033 per rep below max).
+ */
+const RPE_TO_PERCENT_1RM: Record<number, number> = {
+  6: 0.86,
+  7: 0.9,
+  8: 0.93,
+  9: 0.96,
+  10: 1.0,
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function snapToPlate(value: number, increment: number): number {
+  if (increment <= 0) return Math.round(value);
+  return Math.round(value / increment) * increment;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+function rpeToPercent(rpe: number, reps: number): number {
+  const base = RPE_TO_PERCENT_1RM[clamp(Math.round(rpe), 6, 10)] ?? 0.93;
+  // RIR adjustment: subtract (reps - 1) * 0.033 to approximate the drop in
+  // intensity needed to hit the same RPE at higher rep counts.
+  const rirDelta = Math.max(0, reps - 1) * 0.033;
+  return clamp(base - rirDelta, 0.4, 1);
+}
+
+function byDateDesc(a: HistorySet, b: HistorySet): number {
+  const ad = a.date ? Date.parse(a.date) : 0;
+  const bd = b.date ? Date.parse(b.date) : 0;
+  return bd - ad;
+}
+
+function linearTrendSlope(history: HistorySet[]): number {
+  // Simple least-squares slope over ordinal index vs weight.
+  const n = history.length;
+  if (n < 2) return 0;
+  const ordered = [...history].sort(byDateDesc).reverse();
+  let sumX = 0;
+  let sumY = 0;
+  let sumXY = 0;
+  let sumXX = 0;
+  for (let i = 0; i < n; i++) {
+    const x = i;
+    const y = ordered[i].weight;
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumXX += x * x;
+  }
+  const denom = n * sumXX - sumX * sumX;
+  if (denom === 0) return 0;
+  return (n * sumXY - sumX * sumY) / denom;
+}
+
+export function suggestWeight(input: WeightSuggestionInput): WeightSuggestion {
+  const plateIncrement = input.plateIncrement ?? DEFAULT_PLATE_INCREMENT;
+  const history = (input.history ?? []).filter(
+    (h) => Number.isFinite(h.weight) && h.weight > 0 && Number.isInteger(h.reps) && h.reps > 0,
+  );
+
+  if (history.length === 0) {
+    return {
+      suggestedWeight: 0,
+      confidence: 0,
+      reasoning:
+        'No recorded sets yet for this exercise. Start with a conservative warm-up weight and log your first working set.',
+      historyCount: 0,
+      fallback: true,
+    };
+  }
+
+  const sortedNewestFirst = [...history].sort(byDateDesc);
+  const mostRecent = sortedNewestFirst[0];
+  const targetRpe = clamp(input.targetRpe ?? DEFAULT_TARGET_RPE, 6, 10);
+  const targetReps = clamp(
+    Math.round(
+      input.targetReps ??
+        median(sortedNewestFirst.slice(0, 3).map((s) => s.reps)) ??
+        mostRecent.reps,
+    ),
+    1,
+    30,
+  );
+
+  if (history.length < LINEAR_FALLBACK_THRESHOLD) {
+    const bumped = snapToPlate(
+      mostRecent.weight +
+        Math.min(LINEAR_BUMP_DEFAULT, mostRecent.weight * MAX_BUMP_RATIO),
+      plateIncrement,
+    );
+    return {
+      suggestedWeight: bumped,
+      confidence: clamp(0.35 + history.length * 0.08, 0.3, 0.6),
+      reasoning: `Only ${history.length} set(s) logged — applying a conservative linear bump from your last top set of ${mostRecent.weight}.`,
+      historyCount: history.length,
+      fallback: true,
+    };
+  }
+
+  // Data-rich path: blend 1RM-driven target with linear trend.
+  const best = bestOneRepMaxFromHistory(history);
+  const averaged = estimateOneRepMaxAveraged({
+    weight: mostRecent.weight,
+    reps: mostRecent.reps,
+  });
+  const oneRepMax = best?.oneRepMax ?? averaged.oneRepMax ?? mostRecent.weight;
+  const percentOfMax = rpeToPercent(targetRpe, targetReps);
+  const rpeDriven = oneRepMax * percentOfMax;
+
+  const slope = linearTrendSlope(sortedNewestFirst.slice(0, 10));
+  const trendDriven = mostRecent.weight + slope;
+  const weightedTrend = 0.6 * rpeDriven + 0.4 * trendDriven;
+
+  const capped = clamp(
+    weightedTrend,
+    mostRecent.weight * (1 - MAX_BUMP_RATIO),
+    mostRecent.weight * (1 + MAX_BUMP_RATIO),
+  );
+  const suggestedWeight = snapToPlate(capped, plateIncrement);
+  const confidence = clamp(
+    0.6 + Math.min(history.length, 20) * 0.015 + (best?.confidence ?? 0.5) * 0.1,
+    0.5,
+    0.95,
+  );
+
+  const trendLabel = slope > 0 ? 'upward' : slope < 0 ? 'downward' : 'flat';
+  return {
+    suggestedWeight,
+    confidence,
+    reasoning: `Based on ${history.length} recent sets (est. 1RM ${Math.round(
+      oneRepMax,
+    )}, ${trendLabel} trend, target RPE ${targetRpe} × ${targetReps} reps).`,
+    historyCount: history.length,
+    fallback: false,
+  };
+}

--- a/tests/unit/components/overload-analytics-card.test.tsx
+++ b/tests/unit/components/overload-analytics-card.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+
+const mockGetExerciseHistorySummary = jest.fn();
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('react-native-chart-kit', () => {
+  const R = require('react');
+  const { View } = require('react-native');
+  return {
+    LineChart: (props: Record<string, unknown>) =>
+      R.createElement(View, { testID: 'mock-line-chart', ...props }),
+  };
+});
+
+jest.mock('@/lib/services/exercise-history-service', () => ({
+  getExerciseHistorySummary: (...args: unknown[]) =>
+    mockGetExerciseHistorySummary(...args),
+}));
+
+import { OverloadAnalyticsCard } from '../../../components/workouts/OverloadAnalyticsCard';
+
+function sampleSummary(
+  overrides: Partial<
+    import('../../../lib/services/exercise-history-service').ExerciseHistorySummary
+  > = {},
+) {
+  const set = {
+    id: 'set-1',
+    weight: 225,
+    reps: 5,
+    sets: 3,
+    date: '2025-04-10',
+  };
+  return {
+    exercise: 'Bench Press',
+    sets: [set],
+    volumeTrend: { label: 'Volume', values: [3375], dates: ['2025-04-10'] },
+    repTrend: { label: 'Reps', values: [5], dates: ['2025-04-10'] },
+    lastSession: set,
+    prData: [
+      {
+        category: 'five_rep_max' as const,
+        previous: 220,
+        current: 225,
+        delta: 5,
+        isPr: true,
+        label: '5RM 225',
+      },
+    ],
+    estimatedOneRepMax: 265,
+    ...overrides,
+  };
+}
+
+describe('OverloadAnalyticsCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetExerciseHistorySummary.mockResolvedValue(sampleSummary());
+  });
+
+  it('renders a loading indicator before data resolves', () => {
+    const { getByTestId } = render(
+      <OverloadAnalyticsCard userId="u1" exercise="Bench Press" />,
+    );
+    expect(getByTestId('overload-card-loading')).toBeTruthy();
+  });
+
+  it('renders header summary + PR chip once data resolves', async () => {
+    const { getByText, getByTestId } = render(
+      <OverloadAnalyticsCard userId="u1" exercise="Bench Press" />,
+    );
+    await waitFor(() => expect(getByText('Bench Press')).toBeTruthy());
+    expect(getByText(/Last 225 lb · est\. 1RM 265/)).toBeTruthy();
+    expect(getByTestId('overload-pr-five_rep_max')).toBeTruthy();
+    expect(getByTestId('overload-card-threshold')).toBeTruthy();
+  });
+
+  it('uses summaryOverride when provided and skips the network fetch', () => {
+    const override = sampleSummary();
+    const { getByText } = render(
+      <OverloadAnalyticsCard
+        userId="u1"
+        exercise="Bench Press"
+        summaryOverride={override}
+      />,
+    );
+    expect(getByText('Bench Press')).toBeTruthy();
+    expect(mockGetExerciseHistorySummary).not.toHaveBeenCalled();
+  });
+
+  it('shows an empty state when no sets are present', async () => {
+    mockGetExerciseHistorySummary.mockResolvedValueOnce(
+      sampleSummary({
+        sets: [],
+        lastSession: null,
+        prData: [],
+        estimatedOneRepMax: 0,
+        volumeTrend: { label: 'Volume', values: [], dates: [] },
+        repTrend: { label: 'Reps', values: [], dates: [] },
+      }),
+    );
+    const { getByTestId, getByText } = render(
+      <OverloadAnalyticsCard userId="u1" exercise="Squat" />,
+    );
+    await waitFor(() => expect(getByTestId('overload-card-empty')).toBeTruthy());
+    expect(getByText(/No history yet for this exercise/)).toBeTruthy();
+  });
+
+  it('shows an error state when the service rejects', async () => {
+    mockGetExerciseHistorySummary.mockRejectedValueOnce(new Error('db cold'));
+    const { getByTestId, getByText } = render(
+      <OverloadAnalyticsCard userId="u1" exercise="Deadlift" />,
+    );
+    await waitFor(() => expect(getByTestId('overload-card-error')).toBeTruthy());
+    expect(getByText(/db cold/)).toBeTruthy();
+  });
+
+  it('forwards the limit prop to the history service', async () => {
+    render(
+      <OverloadAnalyticsCard userId="u1" exercise="Row" limit={12} />,
+    );
+    await waitFor(() =>
+      expect(mockGetExerciseHistorySummary).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'u1',
+          exerciseNameOrId: 'Row',
+          limit: 12,
+        }),
+      ),
+    );
+  });
+});

--- a/tests/unit/screens/progression-plan-modal.test.tsx
+++ b/tests/unit/screens/progression-plan-modal.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+
+const mockRouterBack = jest.fn();
+const mockShowToast = jest.fn();
+const mockGetExerciseHistorySummary = jest.fn();
+const mockGenerateProgressionPlan = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn(), back: mockRouterBack }),
+  useLocalSearchParams: () => ({ exercise: 'Bench Press', horizonWeeks: '3' }),
+}));
+
+jest.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user-1' } }),
+}));
+
+jest.mock('../../../contexts/ToastContext', () => ({
+  useToast: () => ({ show: mockShowToast }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactRef = require('react');
+  const { View } = require('react-native');
+  return {
+    SafeAreaView: (props: { children: unknown }) =>
+      ReactRef.createElement(View, props),
+  };
+});
+
+jest.mock('@/lib/services/exercise-history-service', () => ({
+  getExerciseHistorySummary: (...args: unknown[]) =>
+    mockGetExerciseHistorySummary(...args),
+}));
+
+jest.mock('@/lib/services/progression-planner', () => ({
+  generateProgressionPlan: (...args: unknown[]) =>
+    mockGenerateProgressionPlan(...args),
+}));
+
+import ProgressionPlanModal from '../../../app/(modals)/progression-plan';
+
+function sampleSummary() {
+  const set = {
+    id: 'abc',
+    weight: 225,
+    reps: 5,
+    sets: 3,
+    date: '2025-04-10',
+  };
+  return {
+    exercise: 'Bench Press',
+    sets: [set],
+    volumeTrend: { label: 'Volume', values: [3375], dates: ['2025-04-10'] },
+    repTrend: { label: 'Reps per set', values: [5], dates: ['2025-04-10'] },
+    lastSession: set,
+    prData: [
+      {
+        category: 'five_rep_max' as const,
+        previous: 220,
+        current: 225,
+        delta: 5,
+        isPr: true,
+        label: '5RM 225',
+      },
+    ],
+    estimatedOneRepMax: 265,
+  };
+}
+
+describe('ProgressionPlanModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetExerciseHistorySummary.mockResolvedValue(sampleSummary());
+    mockGenerateProgressionPlan.mockResolvedValue({
+      text: 'Week 1: 5x5 @ 230.',
+      promptPreview: 'prompt',
+      generatedAt: new Date().toISOString(),
+      horizonWeeks: 3,
+      cacheKey: 'cache-key',
+    });
+  });
+
+  it('renders a loading state before data resolves', () => {
+    const { getByText } = render(<ProgressionPlanModal />);
+    expect(getByText(/Building your overload plan/)).toBeTruthy();
+  });
+
+  it('renders summary and PR chips after data loads', async () => {
+    const { getByText } = render(<ProgressionPlanModal />);
+    await waitFor(() => {
+      expect(getByText('265')).toBeTruthy(); // estimated 1RM
+    });
+    expect(getByText(/Last set 225 × 5/)).toBeTruthy();
+    expect(getByText('5RM')).toBeTruthy();
+  });
+
+  it('renders the coach-generated plan text once resolved', async () => {
+    const { getByText } = render(<ProgressionPlanModal />);
+    await waitFor(() => expect(getByText(/Week 1: 5x5 @ 230/)).toBeTruthy());
+    expect(mockGenerateProgressionPlan).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces an error state when the summary lookup fails', async () => {
+    mockGetExerciseHistorySummary.mockRejectedValueOnce(new Error('offline'));
+    const { getByText } = render(<ProgressionPlanModal />);
+    await waitFor(() => expect(getByText(/offline/)).toBeTruthy());
+    expect(getByText(/Try again/)).toBeTruthy();
+  });
+
+  it('shows a graceful empty-state when no sets exist', async () => {
+    mockGetExerciseHistorySummary.mockResolvedValueOnce({
+      ...sampleSummary(),
+      sets: [],
+      lastSession: null,
+      prData: [],
+      estimatedOneRepMax: 0,
+      volumeTrend: { label: 'Volume', values: [], dates: [] },
+      repTrend: { label: 'Reps per set', values: [], dates: [] },
+    });
+    const { getByText } = render(<ProgressionPlanModal />);
+    await waitFor(() =>
+      expect(getByText(/No sets logged yet for this exercise/)).toBeTruthy(),
+    );
+    // Planner should not be invoked when there is no history.
+    expect(mockGenerateProgressionPlan).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/exercise-history-service.test.ts
+++ b/tests/unit/services/exercise-history-service.test.ts
@@ -1,0 +1,162 @@
+import { getExerciseHistorySummary } from '../../../lib/services/exercise-history-service';
+
+const mockGetWorkoutsByExercise = jest.fn();
+
+jest.mock('../../../lib/services/database/local-db', () => ({
+  localDB: {
+    getWorkoutsByExercise: (...args: unknown[]) => mockGetWorkoutsByExercise(...args),
+  },
+}));
+
+function row(
+  id: string,
+  weight: number,
+  reps: number,
+  date: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id,
+    exercise: 'Bench Press',
+    weight,
+    reps,
+    sets: 1,
+    date,
+    synced: 1,
+    deleted: 0,
+    updated_at: date,
+    ...overrides,
+  };
+}
+
+describe('exercise-history-service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an empty summary when local-db has no rows', async () => {
+    mockGetWorkoutsByExercise.mockResolvedValue([]);
+
+    const summary = await getExerciseHistorySummary({
+      userId: 'u1',
+      exerciseNameOrId: 'Bench Press',
+    });
+
+    expect(summary.sets).toEqual([]);
+    expect(summary.lastSession).toBeNull();
+    expect(summary.prData).toEqual([]);
+    expect(summary.estimatedOneRepMax).toBe(0);
+    expect(summary.volumeTrend.values).toEqual([]);
+    expect(summary.repTrend.values).toEqual([]);
+  });
+
+  it('forwards limit param to local-db with default of 50', async () => {
+    mockGetWorkoutsByExercise.mockResolvedValue([]);
+
+    await getExerciseHistorySummary({ userId: 'u1', exerciseNameOrId: 'Squat' });
+    expect(mockGetWorkoutsByExercise).toHaveBeenCalledWith('u1', 'Squat', 50);
+
+    await getExerciseHistorySummary({ userId: 'u1', exerciseNameOrId: 'Squat', limit: 10 });
+    expect(mockGetWorkoutsByExercise).toHaveBeenLastCalledWith('u1', 'Squat', 10);
+  });
+
+  it('filters out invalid rows (missing weight / reps)', async () => {
+    mockGetWorkoutsByExercise.mockResolvedValue([
+      row('a', 225, 5, '2025-04-10'),
+      row('b', 0, 5, '2025-04-05'),
+      row('c', 225, 0, '2025-04-01'),
+    ]);
+
+    const summary = await getExerciseHistorySummary({
+      userId: 'u1',
+      exerciseNameOrId: 'Bench Press',
+    });
+
+    expect(summary.sets).toHaveLength(1);
+    expect(summary.sets[0].id).toBe('a');
+  });
+
+  it('sets lastSession to the first row in (newest-first) response', async () => {
+    mockGetWorkoutsByExercise.mockResolvedValue([
+      row('newest', 230, 5, '2025-04-15'),
+      row('middle', 225, 5, '2025-04-10'),
+    ]);
+
+    const summary = await getExerciseHistorySummary({
+      userId: 'u1',
+      exerciseNameOrId: 'Bench Press',
+    });
+
+    expect(summary.lastSession?.id).toBe('newest');
+    expect(summary.lastSession?.weight).toBe(230);
+  });
+
+  it('builds a chronologically-ordered volume trend', async () => {
+    mockGetWorkoutsByExercise.mockResolvedValue([
+      row('c', 230, 5, '2025-04-15', { sets: 3 }),
+      row('b', 225, 5, '2025-04-10', { sets: 3 }),
+      row('a', 220, 5, '2025-04-05', { sets: 3 }),
+    ]);
+
+    const summary = await getExerciseHistorySummary({
+      userId: 'u1',
+      exerciseNameOrId: 'Bench Press',
+    });
+
+    // Expected volumes ascending = oldest first.
+    expect(summary.volumeTrend.values).toEqual([
+      Math.round(220 * 5 * 3),
+      Math.round(225 * 5 * 3),
+      Math.round(230 * 5 * 3),
+    ]);
+    expect(summary.volumeTrend.dates[0]).toBe('2025-04-05');
+    expect(summary.volumeTrend.dates[2]).toBe('2025-04-15');
+  });
+
+  it('computes the best estimated 1RM across the window', async () => {
+    mockGetWorkoutsByExercise.mockResolvedValue([
+      row('a', 225, 3, '2025-04-15'), // big 1RM estimate
+      row('b', 185, 10, '2025-04-10'),
+    ]);
+
+    const summary = await getExerciseHistorySummary({
+      userId: 'u1',
+      exerciseNameOrId: 'Bench Press',
+    });
+
+    expect(summary.estimatedOneRepMax).toBeGreaterThan(225);
+  });
+
+  it('treats a first-ever set as a PR across all categories', async () => {
+    mockGetWorkoutsByExercise.mockResolvedValue([row('first', 135, 5, '2025-04-15')]);
+
+    const summary = await getExerciseHistorySummary({
+      userId: 'u1',
+      exerciseNameOrId: 'Bench Press',
+    });
+
+    const prCategories = summary.prData.filter((p) => p.isPr).map((p) => p.category);
+    expect(prCategories).toContain('one_rep_max');
+    expect(prCategories).toContain('five_rep_max');
+    expect(prCategories).toContain('volume');
+    // 3RM requires a 3-rep set; this was 5 reps, so not triggered.
+    expect(prCategories).not.toContain('three_rep_max');
+  });
+
+  it('compares latest set against prior history for PR data', async () => {
+    mockGetWorkoutsByExercise.mockResolvedValue([
+      row('latest', 230, 5, '2025-04-15'),
+      row('prev', 225, 5, '2025-04-10'),
+    ]);
+
+    const summary = await getExerciseHistorySummary({
+      userId: 'u1',
+      exerciseNameOrId: 'Bench Press',
+    });
+
+    const fiveRm = summary.prData.find((p) => p.category === 'five_rep_max');
+    expect(fiveRm?.isPr).toBe(true);
+    expect(fiveRm?.previous).toBe(225);
+    expect(fiveRm?.current).toBe(230);
+  });
+});

--- a/tests/unit/services/local-db-get-workouts-by-exercise.test.ts
+++ b/tests/unit/services/local-db-get-workouts-by-exercise.test.ts
@@ -1,0 +1,140 @@
+import { localDB } from '../../../lib/services/database/local-db';
+
+const mockOpenDatabaseAsync = jest.fn();
+const mockExecAsync = jest.fn();
+const mockRunAsync = jest.fn();
+const mockGetAllAsync = jest.fn();
+const mockCloseAsync = jest.fn();
+const mockWithTransactionAsync = jest.fn();
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: (...args: unknown[]) => mockOpenDatabaseAsync(...args),
+}));
+
+function buildMockDb() {
+  return {
+    execAsync: mockExecAsync.mockResolvedValue(undefined),
+    runAsync: mockRunAsync.mockResolvedValue(undefined),
+    getAllAsync: mockGetAllAsync,
+    closeAsync: mockCloseAsync.mockResolvedValue(undefined),
+    withTransactionAsync: mockWithTransactionAsync.mockImplementation(
+      async (fn: () => Promise<void>) => fn(),
+    ),
+  };
+}
+
+async function initLocalDbWith(rows: unknown[]) {
+  const db = buildMockDb();
+  mockOpenDatabaseAsync.mockResolvedValue(db);
+  // Seed call inside initialize asks for exercises count; return zero rows.
+  mockGetAllAsync.mockResolvedValue([]);
+  await localDB.initialize();
+  // After init, configure the query that the test is actually observing.
+  mockGetAllAsync.mockReset();
+  mockGetAllAsync.mockResolvedValue(rows);
+  return db;
+}
+
+describe('LocalDatabase.getWorkoutsByExercise', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (localDB as unknown as { db: unknown; initPromise: unknown }).db = null;
+    (localDB as unknown as { db: unknown; initPromise: unknown }).initPromise = null;
+  });
+
+  it('returns rows ordered by date desc for matching exercise', async () => {
+    const rows = [
+      {
+        id: 'w1',
+        exercise: 'Bench Press',
+        sets: 3,
+        reps: 5,
+        weight: 185,
+        date: '2025-04-12',
+        synced: 1,
+        deleted: 0,
+        updated_at: '2025-04-12T00:00:00.000Z',
+      },
+      {
+        id: 'w2',
+        exercise: 'Bench Press',
+        sets: 3,
+        reps: 5,
+        weight: 180,
+        date: '2025-04-05',
+        synced: 1,
+        deleted: 0,
+        updated_at: '2025-04-05T00:00:00.000Z',
+      },
+    ];
+    await initLocalDbWith(rows);
+
+    const result = await localDB.getWorkoutsByExercise('user-1', 'Bench Press');
+
+    expect(result).toEqual(rows);
+    expect(mockGetAllAsync).toHaveBeenCalledTimes(1);
+    const [query, params] = mockGetAllAsync.mock.calls[0];
+    expect(query).toContain('FROM workouts');
+    expect(query).toContain('ORDER BY date DESC');
+    expect(query).toContain('exercise = ?');
+    expect(params).toEqual(['Bench Press']);
+  });
+
+  it('applies LIMIT clause when limit is positive', async () => {
+    await initLocalDbWith([]);
+
+    await localDB.getWorkoutsByExercise('user-1', 'Squat', 5);
+
+    const [query, params] = mockGetAllAsync.mock.calls[0];
+    expect(query).toContain('LIMIT ?');
+    expect(params).toEqual(['Squat', 5]);
+  });
+
+  it('omits LIMIT clause when limit is undefined', async () => {
+    await initLocalDbWith([]);
+
+    await localDB.getWorkoutsByExercise('user-1', 'Deadlift');
+
+    const [query, params] = mockGetAllAsync.mock.calls[0];
+    expect(query).not.toContain('LIMIT');
+    expect(params).toEqual(['Deadlift']);
+  });
+
+  it('ignores non-positive limit values', async () => {
+    await initLocalDbWith([]);
+
+    await localDB.getWorkoutsByExercise('user-1', 'Pullup', 0);
+
+    const [query, params] = mockGetAllAsync.mock.calls[0];
+    expect(query).not.toContain('LIMIT');
+    expect(params).toEqual(['Pullup']);
+  });
+
+  it('floors fractional limit values', async () => {
+    await initLocalDbWith([]);
+
+    await localDB.getWorkoutsByExercise('user-1', 'OHP', 3.7);
+
+    const [, params] = mockGetAllAsync.mock.calls[0];
+    expect(params).toEqual(['OHP', 3]);
+  });
+
+  it('filters deleted rows via SQL predicate', async () => {
+    await initLocalDbWith([]);
+
+    await localDB.getWorkoutsByExercise('user-1', 'Row');
+
+    const [query] = mockGetAllAsync.mock.calls[0];
+    expect(query).toContain('deleted = 0');
+  });
+
+  it('accepts userId without using it in the query (local single-user)', async () => {
+    await initLocalDbWith([]);
+
+    await localDB.getWorkoutsByExercise('any-user', 'Row');
+
+    const [query, params] = mockGetAllAsync.mock.calls[0];
+    expect(query).not.toContain('user_id');
+    expect(params).not.toContain('any-user');
+  });
+});

--- a/tests/unit/services/pr-detector-categories.test.ts
+++ b/tests/unit/services/pr-detector-categories.test.ts
@@ -1,0 +1,163 @@
+import {
+  detectAllPrs,
+  detectFiveRepMaxPr,
+  detectOneRepMaxPr,
+  detectThreeRepMaxPr,
+  detectVolumePr,
+  triggeredPrs,
+} from '../../../lib/services/pr-detector';
+
+describe('pr-detector categories', () => {
+  describe('1RM category', () => {
+    it('flags a new 1RM when estimated max beats prior history', () => {
+      const result = detectOneRepMaxPr(
+        { weight: 250, reps: 3 },
+        [{ weight: 225, reps: 5 }],
+      );
+      expect(result.category).toBe('one_rep_max');
+      expect(result.isPr).toBe(true);
+      expect(result.current).toBeGreaterThan(result.previous ?? 0);
+    });
+
+    it('does not flag when estimated max is lower', () => {
+      const result = detectOneRepMaxPr(
+        { weight: 135, reps: 5 },
+        [{ weight: 225, reps: 5 }],
+      );
+      expect(result.isPr).toBe(false);
+    });
+
+    it('flags first-ever set as a PR (null previous)', () => {
+      const result = detectOneRepMaxPr({ weight: 135, reps: 5 }, []);
+      expect(result.previous).toBeNull();
+      expect(result.isPr).toBe(true);
+      expect(result.delta).toBeGreaterThan(0);
+    });
+
+    it('rejects invalid current sets', () => {
+      const result = detectOneRepMaxPr({ weight: 0, reps: 0 }, []);
+      expect(result.isPr).toBe(false);
+    });
+  });
+
+  describe('3RM category', () => {
+    it('flags new 3RM when weight at 3 reps exceeds history', () => {
+      const result = detectThreeRepMaxPr(
+        { weight: 255, reps: 3 },
+        [
+          { weight: 245, reps: 3 },
+          { weight: 225, reps: 5 },
+        ],
+      );
+      expect(result.category).toBe('three_rep_max');
+      expect(result.isPr).toBe(true);
+      expect(result.current).toBe(255);
+      expect(result.previous).toBe(245);
+    });
+
+    it('skips when current set is not at exactly 3 reps', () => {
+      const result = detectThreeRepMaxPr(
+        { weight: 255, reps: 5 },
+        [{ weight: 245, reps: 3 }],
+      );
+      expect(result.isPr).toBe(false);
+      expect(result.label).toMatch(/requires a set at exactly 3 reps/);
+    });
+
+    it('ignores history sets at other rep counts', () => {
+      const result = detectThreeRepMaxPr(
+        { weight: 220, reps: 3 },
+        [{ weight: 250, reps: 5 }],
+      );
+      expect(result.isPr).toBe(true);
+      expect(result.previous).toBeNull();
+    });
+  });
+
+  describe('5RM category', () => {
+    it('flags new 5RM against prior 5s', () => {
+      const result = detectFiveRepMaxPr(
+        { weight: 210, reps: 5 },
+        [
+          { weight: 205, reps: 5 },
+          { weight: 185, reps: 5 },
+        ],
+      );
+      expect(result.category).toBe('five_rep_max');
+      expect(result.isPr).toBe(true);
+      expect(result.previous).toBe(205);
+    });
+
+    it('does not flag on ties', () => {
+      const result = detectFiveRepMaxPr(
+        { weight: 205, reps: 5 },
+        [{ weight: 205, reps: 5 }],
+      );
+      expect(result.isPr).toBe(false);
+    });
+
+    it('first-ever 5-rep set is a PR', () => {
+      const result = detectFiveRepMaxPr({ weight: 135, reps: 5 }, []);
+      expect(result.previous).toBeNull();
+      expect(result.isPr).toBe(true);
+    });
+  });
+
+  describe('volume category', () => {
+    it('flags new volume PR when (weight * reps) beats history', () => {
+      const result = detectVolumePr(
+        { weight: 200, reps: 8 }, // 1600
+        [
+          { weight: 185, reps: 8 }, // 1480
+          { weight: 225, reps: 5 }, // 1125
+        ],
+      );
+      expect(result.category).toBe('volume');
+      expect(result.isPr).toBe(true);
+      expect(result.current).toBe(1600);
+      expect(result.previous).toBe(1480);
+    });
+
+    it('does not flag when volume is lower', () => {
+      const result = detectVolumePr(
+        { weight: 135, reps: 8 },
+        [{ weight: 200, reps: 8 }],
+      );
+      expect(result.isPr).toBe(false);
+    });
+
+    it('includes volume in the label', () => {
+      const result = detectVolumePr(
+        { weight: 200, reps: 8 },
+        [{ weight: 185, reps: 8 }],
+      );
+      expect(result.label).toMatch(/Volume 1600/);
+    });
+  });
+
+  describe('detectAllPrs / triggeredPrs', () => {
+    it('returns four category results regardless of triggers', () => {
+      const all = detectAllPrs({ weight: 225, reps: 5 }, []);
+      expect(all.map((r) => r.category)).toEqual([
+        'one_rep_max',
+        'three_rep_max',
+        'five_rep_max',
+        'volume',
+      ]);
+    });
+
+    it('triggeredPrs filters out non-PR categories', () => {
+      const history = [
+        { weight: 225, reps: 5 }, // 5RM baseline
+        { weight: 205, reps: 3 }, // 3RM baseline
+      ];
+      // New set: heavier 5 that beats 5RM, volume, and 1RM but isn't a 3-rep set.
+      const results = triggeredPrs({ weight: 230, reps: 5 }, history);
+      const categories = results.map((r) => r.category);
+      expect(categories).toContain('five_rep_max');
+      expect(categories).toContain('volume');
+      expect(categories).toContain('one_rep_max');
+      expect(categories).not.toContain('three_rep_max');
+    });
+  });
+});

--- a/tests/unit/services/progression-planner.test.ts
+++ b/tests/unit/services/progression-planner.test.ts
@@ -1,0 +1,208 @@
+import type { ExerciseHistorySummary } from '../../../lib/services/exercise-history-service';
+
+const mockSendCoachPrompt = jest.fn();
+
+jest.mock('../../../lib/services/coach-service', () => ({
+  sendCoachPrompt: (...args: unknown[]) => mockSendCoachPrompt(...args),
+}));
+
+let buildProgressionPrompt: typeof import('../../../lib/services/progression-planner')['buildProgressionPrompt'];
+let generateProgressionPlan: typeof import('../../../lib/services/progression-planner')['generateProgressionPlan'];
+let clearProgressionPlanCache: typeof import('../../../lib/services/progression-planner')['clearProgressionPlanCache'];
+
+beforeAll(() => {
+  ({
+    buildProgressionPrompt,
+    generateProgressionPlan,
+    clearProgressionPlanCache,
+  } = require('../../../lib/services/progression-planner'));
+});
+
+function summaryFixture(overrides: Partial<ExerciseHistorySummary> = {}): ExerciseHistorySummary {
+  const baseSet = {
+    id: 's1',
+    weight: 225,
+    reps: 5,
+    sets: 3,
+    date: '2025-04-10',
+  };
+  return {
+    exercise: 'Bench Press',
+    sets: [baseSet],
+    volumeTrend: { label: 'Volume', values: [3375], dates: ['2025-04-10'] },
+    repTrend: { label: 'Reps per set', values: [5], dates: ['2025-04-10'] },
+    lastSession: baseSet,
+    prData: [
+      {
+        category: 'five_rep_max',
+        previous: 220,
+        current: 225,
+        delta: 5,
+        isPr: true,
+        label: '5RM 225 vs prior 220',
+      },
+    ],
+    estimatedOneRepMax: 265,
+    ...overrides,
+  };
+}
+
+describe('progression-planner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearProgressionPlanCache();
+    mockSendCoachPrompt.mockResolvedValue({
+      role: 'assistant',
+      content: 'Week 1: 5x5 @ 230. Week 2: 5x5 @ 232.5. Week 3: 5x3 @ 240.',
+    });
+  });
+
+  describe('buildProgressionPrompt', () => {
+    it('includes exercise name and 1RM estimate', () => {
+      const prompt = buildProgressionPrompt({
+        userId: 'u1',
+        exercise: 'Bench Press',
+        summary: summaryFixture(),
+      });
+      expect(prompt).toMatch(/Exercise: Bench Press/);
+      expect(prompt).toMatch(/Estimated 1RM: 265/);
+    });
+
+    it('includes the most recent sets in the prompt body', () => {
+      const prompt = buildProgressionPrompt({
+        userId: 'u1',
+        exercise: 'Bench Press',
+        summary: summaryFixture(),
+      });
+      expect(prompt).toMatch(/225lb × 5 reps \(3 sets\) on 2025-04-10/);
+    });
+
+    it('surfaces triggered PRs', () => {
+      const prompt = buildProgressionPrompt({
+        userId: 'u1',
+        exercise: 'Bench Press',
+        summary: summaryFixture(),
+      });
+      expect(prompt).toMatch(/5RM 225 vs prior 220/);
+    });
+
+    it('handles empty history gracefully', () => {
+      const prompt = buildProgressionPrompt({
+        userId: 'u1',
+        exercise: 'Row',
+        summary: summaryFixture({
+          sets: [],
+          lastSession: null,
+          estimatedOneRepMax: 0,
+          prData: [],
+        }),
+      });
+      expect(prompt).toMatch(/Recent sets: no prior sets logged/);
+      expect(prompt).toMatch(/Estimated 1RM: unknown/);
+      expect(prompt).toMatch(/Recent PRs: no new PRs/);
+    });
+
+    it('honours a custom horizon', () => {
+      const prompt = buildProgressionPrompt({
+        userId: 'u1',
+        exercise: 'Bench Press',
+        summary: summaryFixture(),
+        horizonWeeks: 6,
+      });
+      expect(prompt).toMatch(/6-week progressive overload plan/);
+    });
+  });
+
+  describe('generateProgressionPlan', () => {
+    it('calls sendCoachPrompt with a system + user message pair', async () => {
+      await generateProgressionPlan({
+        userId: 'u1',
+        exercise: 'Bench Press',
+        summary: summaryFixture(),
+      });
+
+      expect(mockSendCoachPrompt).toHaveBeenCalledTimes(1);
+      const [messages] = mockSendCoachPrompt.mock.calls[0];
+      expect(messages).toHaveLength(2);
+      expect(messages[0].role).toBe('system');
+      expect(messages[1].role).toBe('user');
+      expect(messages[1].content).toMatch(/Bench Press/);
+    });
+
+    it('forwards coach context for persistence', async () => {
+      const context = {
+        profile: { id: 'u1', name: 'Test', email: null },
+        sessionId: 'sess-1',
+        focus: 'overload',
+      };
+      await generateProgressionPlan({
+        userId: 'u1',
+        exercise: 'Bench Press',
+        summary: summaryFixture(),
+        context,
+      });
+
+      expect(mockSendCoachPrompt.mock.calls[0][1]).toEqual(context);
+    });
+
+    it('caches plans by (user, exercise, horizon, lastSession)', async () => {
+      const input = {
+        userId: 'u1',
+        exercise: 'Bench Press',
+        summary: summaryFixture(),
+      };
+      const first = await generateProgressionPlan(input);
+      const second = await generateProgressionPlan(input);
+
+      expect(mockSendCoachPrompt).toHaveBeenCalledTimes(1);
+      expect(second).toBe(first);
+    });
+
+    it('re-runs the coach when the last session changes', async () => {
+      await generateProgressionPlan({
+        userId: 'u1',
+        exercise: 'Bench Press',
+        summary: summaryFixture(),
+      });
+      await generateProgressionPlan({
+        userId: 'u1',
+        exercise: 'Bench Press',
+        summary: summaryFixture({
+          lastSession: {
+            id: 's2',
+            weight: 230,
+            reps: 5,
+            sets: 3,
+            date: '2025-04-17',
+          },
+        }),
+      });
+
+      expect(mockSendCoachPrompt).toHaveBeenCalledTimes(2);
+    });
+
+    it('propagates coach failures to the caller', async () => {
+      mockSendCoachPrompt.mockRejectedValueOnce(new Error('boom'));
+      await expect(
+        generateProgressionPlan({
+          userId: 'u1',
+          exercise: 'Bench Press',
+          summary: summaryFixture(),
+        }),
+      ).rejects.toThrow('boom');
+    });
+
+    it('returns the coach content plus metadata', async () => {
+      const plan = await generateProgressionPlan({
+        userId: 'u1',
+        exercise: 'Bench Press',
+        summary: summaryFixture(),
+      });
+      expect(plan.text).toMatch(/Week 1/);
+      expect(plan.promptPreview).toMatch(/Bench Press/);
+      expect(plan.horizonWeeks).toBe(3);
+      expect(plan.cacheKey).toMatch(/u1::Bench Press::3w::2025-04-10-225-5/);
+      expect(plan.generatedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+    });
+  });
+});

--- a/tests/unit/services/rep-max-calculator.test.ts
+++ b/tests/unit/services/rep-max-calculator.test.ts
@@ -1,0 +1,157 @@
+import {
+  bestOneRepMaxFromHistory,
+  brzyckiOneRepMax,
+  epleyOneRepMax,
+  estimateOneRepMax,
+  estimateOneRepMaxAveraged,
+  lombardiOneRepMax,
+  repsToConfidence,
+} from '../../../lib/services/rep-max-calculator';
+
+describe('rep-max-calculator', () => {
+  describe('epleyOneRepMax', () => {
+    it('returns the weight itself at 1 rep', () => {
+      expect(epleyOneRepMax(200, 1)).toBe(200);
+    });
+
+    it('matches the published Epley formula at 5 reps @ 225lb', () => {
+      // 225 * (1 + 5/30) = 262.5
+      expect(epleyOneRepMax(225, 5)).toBeCloseTo(262.5, 1);
+    });
+
+    it('scales linearly with weight', () => {
+      const low = epleyOneRepMax(100, 10);
+      const high = epleyOneRepMax(200, 10);
+      expect(high).toBeCloseTo(low * 2, 1);
+    });
+  });
+
+  describe('brzyckiOneRepMax', () => {
+    it('returns the weight itself at 1 rep', () => {
+      expect(brzyckiOneRepMax(200, 1)).toBe(200);
+    });
+
+    it('matches published Brzycki formula at 5 reps @ 225lb', () => {
+      // 225 * 36 / (37 - 5) = 225 * 36 / 32 = 253.125
+      expect(brzyckiOneRepMax(225, 5)).toBeCloseTo(253.13, 1);
+    });
+
+    it('clamps reps >= 37 to prevent divide-by-zero', () => {
+      expect(Number.isFinite(brzyckiOneRepMax(100, 40))).toBe(true);
+    });
+  });
+
+  describe('lombardiOneRepMax', () => {
+    it('returns the weight itself at 1 rep', () => {
+      expect(lombardiOneRepMax(200, 1)).toBe(200);
+    });
+
+    it('matches published Lombardi formula at 5 reps @ 225lb', () => {
+      // 225 * 5^0.1 ≈ 225 * 1.1746 ≈ 264.3
+      expect(lombardiOneRepMax(225, 5)).toBeCloseTo(264.29, 1);
+    });
+
+    it('grows monotonically in reps', () => {
+      expect(lombardiOneRepMax(100, 10)).toBeGreaterThan(lombardiOneRepMax(100, 5));
+    });
+  });
+
+  describe('repsToConfidence', () => {
+    it('returns 1.0 for a 1-rep set (ground truth)', () => {
+      expect(repsToConfidence(1)).toBe(1);
+    });
+
+    it('decreases monotonically as reps grow', () => {
+      const bands = [1, 3, 6, 10, 15, 20, 25].map(repsToConfidence);
+      for (let i = 1; i < bands.length; i++) {
+        expect(bands[i]).toBeLessThanOrEqual(bands[i - 1]);
+      }
+    });
+
+    it('returns 0 for invalid reps', () => {
+      expect(repsToConfidence(0)).toBe(0);
+      expect(repsToConfidence(-3)).toBe(0);
+      expect(repsToConfidence(3.5)).toBe(0);
+    });
+  });
+
+  describe('estimateOneRepMax', () => {
+    it('uses Epley by default', () => {
+      const epley = estimateOneRepMax({ weight: 225, reps: 5 });
+      expect(epley.formula).toBe('epley');
+      expect(epley.oneRepMax).toBeCloseTo(262.5, 1);
+    });
+
+    it('switches to Brzycki when requested', () => {
+      const brzycki = estimateOneRepMax({ weight: 225, reps: 5 }, 'brzycki');
+      expect(brzycki.formula).toBe('brzycki');
+      expect(brzycki.oneRepMax).toBeCloseTo(253.13, 1);
+    });
+
+    it('switches to Lombardi when requested', () => {
+      const lombardi = estimateOneRepMax({ weight: 225, reps: 5 }, 'lombardi');
+      expect(lombardi.formula).toBe('lombardi');
+      expect(lombardi.oneRepMax).toBeCloseTo(264.29, 1);
+    });
+
+    it('returns 0 for invalid input', () => {
+      expect(estimateOneRepMax({ weight: 0, reps: 5 }).oneRepMax).toBe(0);
+      expect(estimateOneRepMax({ weight: 100, reps: 0 }).oneRepMax).toBe(0);
+      expect(estimateOneRepMax({ weight: 100, reps: 1.5 }).oneRepMax).toBe(0);
+      expect(estimateOneRepMax({ weight: Number.NaN, reps: 5 }).oneRepMax).toBe(0);
+    });
+
+    it('includes a confidence band', () => {
+      const low = estimateOneRepMax({ weight: 100, reps: 20 });
+      const mid = estimateOneRepMax({ weight: 100, reps: 5 });
+      expect(mid.confidence).toBeGreaterThan(low.confidence);
+    });
+  });
+
+  describe('estimateOneRepMaxAveraged', () => {
+    it('returns the arithmetic mean of the three estimators', () => {
+      const averaged = estimateOneRepMaxAveraged({ weight: 225, reps: 5 });
+      const expected =
+        (epleyOneRepMax(225, 5) +
+          brzyckiOneRepMax(225, 5) +
+          lombardiOneRepMax(225, 5)) /
+        3;
+      expect(averaged.oneRepMax).toBeCloseTo(expected, 1);
+      expect(averaged.perFormula.epley).toBeCloseTo(262.5, 1);
+      expect(averaged.perFormula.brzycki).toBeCloseTo(253.13, 1);
+      expect(averaged.perFormula.lombardi).toBeCloseTo(264.29, 1);
+    });
+
+    it('returns zeros for invalid input', () => {
+      const empty = estimateOneRepMaxAveraged({ weight: 0, reps: 0 });
+      expect(empty.oneRepMax).toBe(0);
+      expect(empty.confidence).toBe(0);
+      expect(empty.perFormula.epley).toBe(0);
+    });
+  });
+
+  describe('bestOneRepMaxFromHistory', () => {
+    it('returns null on an empty history', () => {
+      expect(bestOneRepMaxFromHistory([])).toBeNull();
+    });
+
+    it('picks the highest 1RM across multiple sets', () => {
+      const history = [
+        { weight: 185, reps: 5 }, // epley ~215.83
+        { weight: 225, reps: 3 }, // epley ~247.5
+        { weight: 205, reps: 8 }, // epley ~259.67
+      ];
+      const best = bestOneRepMaxFromHistory(history);
+      expect(best).not.toBeNull();
+      expect(best?.oneRepMax).toBeCloseTo(259.67, 1);
+    });
+
+    it('ignores invalid entries', () => {
+      const best = bestOneRepMaxFromHistory([
+        { weight: 0, reps: 0 },
+        { weight: 100, reps: 10 },
+      ]);
+      expect(best?.oneRepMax).toBeCloseTo(133.33, 1);
+    });
+  });
+});

--- a/tests/unit/services/weight-suggester.test.ts
+++ b/tests/unit/services/weight-suggester.test.ts
@@ -1,0 +1,125 @@
+import { suggestWeight } from '../../../lib/services/weight-suggester';
+
+function buildHistory(weights: number[], reps = 5) {
+  const startDate = new Date('2025-03-01T00:00:00.000Z').getTime();
+  return weights.map((weight, index) => ({
+    weight,
+    reps,
+    date: new Date(startDate + index * 7 * 86400000).toISOString(),
+  }));
+}
+
+describe('weight-suggester', () => {
+  describe('empty history', () => {
+    it('returns 0 and flags zero confidence', () => {
+      const result = suggestWeight({ history: [] });
+      expect(result.suggestedWeight).toBe(0);
+      expect(result.confidence).toBe(0);
+      expect(result.fallback).toBe(true);
+      expect(result.reasoning).toMatch(/no recorded sets/i);
+    });
+
+    it('ignores invalid rows even if present', () => {
+      const result = suggestWeight({
+        history: [
+          { weight: 0, reps: 5 },
+          { weight: 100, reps: 0 },
+          { weight: Number.NaN, reps: 5 },
+        ],
+      });
+      expect(result.suggestedWeight).toBe(0);
+      expect(result.historyCount).toBe(0);
+    });
+  });
+
+  describe('linear fallback path (< 5 sets)', () => {
+    it('bumps the most recent weight by one plate', () => {
+      const result = suggestWeight({ history: buildHistory([185]) });
+      expect(result.fallback).toBe(true);
+      expect(result.suggestedWeight).toBeGreaterThanOrEqual(185);
+      expect(result.suggestedWeight).toBeLessThanOrEqual(187.5);
+      expect(result.reasoning).toMatch(/conservative linear bump/i);
+    });
+
+    it('caps bumps at 5% of the last weight for heavy lifters', () => {
+      const result = suggestWeight({ history: buildHistory([600]) });
+      expect(result.suggestedWeight - 600).toBeLessThanOrEqual(30);
+    });
+
+    it('confidence grows modestly with each additional set', () => {
+      const one = suggestWeight({ history: buildHistory([185]) }).confidence;
+      const three = suggestWeight({ history: buildHistory([185, 190, 195]) }).confidence;
+      expect(three).toBeGreaterThan(one);
+      expect(three).toBeLessThanOrEqual(0.6);
+    });
+
+    it('picks the newest-dated row as the anchor regardless of input order', () => {
+      const history = [
+        { weight: 150, reps: 5, date: '2025-03-01T00:00:00.000Z' },
+        { weight: 180, reps: 5, date: '2025-03-15T00:00:00.000Z' },
+      ];
+      const result = suggestWeight({ history });
+      expect(result.suggestedWeight).toBeGreaterThanOrEqual(180);
+    });
+  });
+
+  describe('data-rich path (>= 5 sets)', () => {
+    it('does not trigger the fallback flag', () => {
+      const result = suggestWeight({ history: buildHistory([180, 185, 190, 192.5, 195]) });
+      expect(result.fallback).toBe(false);
+      expect(result.historyCount).toBe(5);
+    });
+
+    it('produces a suggestion clamped around the most recent weight', () => {
+      const history = buildHistory([180, 185, 190, 192.5, 195]);
+      const result = suggestWeight({ history });
+      expect(result.suggestedWeight).toBeGreaterThanOrEqual(195 * 0.95);
+      expect(result.suggestedWeight).toBeLessThanOrEqual(195 * 1.05);
+    });
+
+    it('higher target RPE biases the suggestion upward', () => {
+      const history = buildHistory([180, 185, 190, 192.5, 195]);
+      const lowRpe = suggestWeight({ history, targetRpe: 6 });
+      const highRpe = suggestWeight({ history, targetRpe: 10 });
+      expect(highRpe.suggestedWeight).toBeGreaterThanOrEqual(lowRpe.suggestedWeight);
+    });
+
+    it('snaps output to the plate increment', () => {
+      const history = buildHistory([181, 183, 186, 189, 192]);
+      const result = suggestWeight({ history, plateIncrement: 5 });
+      expect(result.suggestedWeight % 5).toBe(0);
+    });
+
+    it('confidence rises with history depth and stays <= 0.95', () => {
+      const shallow = suggestWeight({ history: buildHistory([180, 185, 190, 195, 200]) });
+      const deep = suggestWeight({
+        history: buildHistory(
+          Array.from({ length: 20 }, (_, i) => 180 + i * 2),
+        ),
+      });
+      expect(deep.confidence).toBeGreaterThanOrEqual(shallow.confidence);
+      expect(deep.confidence).toBeLessThanOrEqual(0.95);
+    });
+
+    it('reasoning surfaces the trend direction', () => {
+      const rising = suggestWeight({ history: buildHistory([180, 185, 190, 192.5, 195]) });
+      expect(rising.reasoning).toMatch(/upward|flat/);
+    });
+  });
+
+  describe('RPE scaling edge cases', () => {
+    it('clamps out-of-range RPE values', () => {
+      const history = buildHistory([180, 185, 190, 195, 200]);
+      const crazyHigh = suggestWeight({ history, targetRpe: 20 });
+      const crazyLow = suggestWeight({ history, targetRpe: -5 });
+      expect(Number.isFinite(crazyHigh.suggestedWeight)).toBe(true);
+      expect(Number.isFinite(crazyLow.suggestedWeight)).toBe(true);
+    });
+
+    it('defaults target reps to recent median when omitted', () => {
+      const history = buildHistory([180, 185, 190, 195, 200], 8);
+      const result = suggestWeight({ history });
+      expect(result.reasoning).toMatch(/target RPE 8 × 8 reps/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Ships the four unclaimed P0/P1/P2 overload issues (#306/#307/#308/#309) as a coherent engine: exercise-history query + 1RM estimator (Epley/Brzycki/Lombardi) + weight suggester (linear fallback + RPE scaling) + category-aware PR detector (1RM/3RM/5RM/volume) + aggregator service.
- Adds a Gemma-ready progression-plan generator that dispatches through the existing `coach-service.sendCoachPrompt()` and caches responses per (user, exercise, horizon, last-session bucket).
- New `app/(modals)/progression-plan.tsx` surfaces estimated 1RM, triggered PR chips, a coach-generated multi-week plan, and an "Accept weight" CTA.
- New `components/workouts/OverloadAnalyticsCard.tsx` (react-native-chart-kit) mounted additively on the workouts tab's FlatList header; opens the modal via a "Plan" button.

## Closes
Closes #306, closes #307, closes #308, closes #309, closes #475.

## Atomic commits
- `feat(overload): add getWorkoutsByExercise query + Supabase stub`
- `feat(overload): add 1RM estimator with Epley/Brzycki/Lombardi formulas`
- `feat(overload): add weight-suggester with linear fallback + RPE scaling`
- `feat(overload): add pr-detector with 1RM / 3RM / 5RM / volume categories`
- `feat(overload): add exercise-history-service aggregator`
- `feat(overload): add progression-planner that dispatches through coach-service`
- `feat(overload): add progression-plan modal with Accept-weight CTA`
- `feat(overload): add OverloadAnalyticsCard and mount on workouts tab`

## Tests
8 new suites, 88 assertions:
- `tests/unit/services/local-db-get-workouts-by-exercise.test.ts` — 7 cases
- `tests/unit/services/rep-max-calculator.test.ts` — 22 cases (all 3 formulas + confidence bands + best-set picker)
- `tests/unit/services/weight-suggester.test.ts` — 14 cases (empty / fallback / data-rich / RPE scaling)
- `tests/unit/services/pr-detector-categories.test.ts` — 15 cases (per category + combined runner)
- `tests/unit/services/exercise-history-service.test.ts` — 8 cases (aggregation + PR composition)
- `tests/unit/services/progression-planner.test.ts` — 11 cases (prompt shape + cache + mocked coach)
- `tests/unit/screens/progression-plan-modal.test.tsx` — 5 cases (loading / loaded / error / empty / plan)
- `tests/unit/components/overload-analytics-card.test.tsx` — 6 cases (loading / loaded / empty / error / override / limit)

## Cross-PR stubs
- `TODO(#447)` — `lib/services/pr-detector.ts` reconciliation with PR #450's template-celebration version. Landed additively so the reconcile is a type-level superset rather than a semantic rewrite.
- `TODO(#466)` — `progression-planner.ts` streaming dispatch opts once the provider-routing work lands. Today the Edge Function returns a single blob and we surface it as-is.
- `TODO(day)` — `sync-service.getWorkoutsByExerciseRemote()` is a no-op stub. When progressive overload becomes multi-device, wire the Supabase query; for now the local-first store is authoritative.

## Judgment calls
- **PR detector file ownership.** The spec notes #450 owns the current `pr-detector.ts`; on `origin/main f1ad896` the file does not yet exist, so this PR creates it additively with the four overload categories. The commit message calls out the reconcile requirement with an explicit `TODO(#447)`.
- **Legacy workouts table has no `user_id`.** `LocalWorkout` is per-device (by design); the new `getWorkoutsByExercise(userId, exerciseNameOrId, limit)` accepts `userId` for API symmetry with the forthcoming Supabase equivalent but does not filter on it. This keeps the signature compatible with the spec without a migration.
- **Chart library.** Used the already-present `react-native-chart-kit` (no new deps) per the "NEVER add new npm/Bun deps" rule.
- **Modal empty-state.** When the lifter has no sets for the exercise, the modal skips the coach call entirely (prevents wasted Edge Function invocations) and surfaces a clear empty-state message.
- **Cache key granularity.** Progression plans are cached by `(user, exercise, horizon, last-session signature)` so any new set invalidates the cached plan automatically.

## Verification
- [x] `bun run lint` clean (0 errors, only pre-existing `template-builder.tsx` warnings)
- [x] `bun run check:types` clean
- [x] All 8 new test suites pass (88/88)
- [x] No edits to `supabase/migrations/`, `ios/`, `android/`, or `.env` files
- [x] No new npm/Bun dependencies added