### PR TITLE
feat(form-intel): fault explainability + rep pain journal + session export + unified timeline

### DIFF
--- a/app/(modals)/_layout.tsx
+++ b/app/(modals)/_layout.tsx
@@ -44,6 +44,22 @@ export default function ModalsLayout() {
         }}
       />
       <Stack.Screen
+        name="rep-pain-journal"
+        options={{
+          presentation: 'modal',
+          gestureEnabled: true,
+          contentStyle: { backgroundColor: '#050E1F' },
+        }}
+      />
+      <Stack.Screen
+        name="session-timeline"
+        options={{
+          presentation: 'modal',
+          gestureEnabled: true,
+          contentStyle: { backgroundColor: '#050E1F' },
+        }}
+      />
+      <Stack.Screen
         name="coach-history"
         options={{
           presentation: 'modal',

--- a/app/(modals)/rep-pain-journal.tsx
+++ b/app/(modals)/rep-pain-journal.tsx
@@ -1,0 +1,374 @@
+/**
+ * RepPainJournalScreen (modal)
+ *
+ * Scrollable timeline of pain/injury flags logged across the user's
+ * sessions. Flags are pulled from on-device AsyncStorage via
+ * `rep-pain-journal` — server sync is stubbed pending a migration (see
+ * `syncToSupabase` in that file).
+ *
+ * Reached via the workouts tab header menu.
+ */
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+
+import {
+  deletePainFlag,
+  getPainFlags,
+  PAIN_LOCATION_LABELS,
+  type PainFlag,
+} from '@/lib/services/rep-pain-journal';
+import { useAuth } from '@/contexts/AuthContext';
+import { tabColors } from '@/styles/tabs/_tab-theme';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function formatWhen(iso: string): string {
+  const d = new Date(iso);
+  const ms = Date.now() - d.getTime();
+  const hr = ms / (60 * 60 * 1000);
+  if (hr < 1) return 'Just now';
+  if (hr < 24) return `${Math.round(hr)}h ago`;
+  const days = Math.round(hr / 24);
+  if (days === 1) return 'Yesterday';
+  if (days < 7) return `${days}d ago`;
+  return d.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function severityColor(sev: number): string {
+  if (sev >= 4) return '#FF3B30';
+  if (sev === 3) return '#FF9500';
+  return '#4C8CFF';
+}
+
+// =============================================================================
+// Screen
+// =============================================================================
+
+export default function RepPainJournalScreen() {
+  const router = useRouter();
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
+
+  const [flags, setFlags] = useState<PainFlag[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!userId) {
+      setFlags([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await getPainFlags(userId, 90);
+      setFlags(result);
+    } catch (err) {
+      setError('Failed to load pain journal.');
+      console.error('[RepPainJournalScreen] load failed', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleDelete = useCallback(
+    async (flagId: string) => {
+      if (!userId) return;
+      await deletePainFlag(userId, flagId);
+      setFlags((prev) => prev.filter((f) => f.id !== flagId));
+    },
+    [userId],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: PainFlag }) => (
+      <View style={styles.card} testID={`pain-flag-${item.id}`}>
+        <View style={styles.cardHeader}>
+          <View style={styles.locationBadge}>
+            <Ionicons
+              name="medkit-outline"
+              size={14}
+              color={severityColor(item.severity)}
+            />
+            <Text style={styles.locationText}>
+              {PAIN_LOCATION_LABELS[item.location] ?? item.location}
+            </Text>
+          </View>
+          <Text style={styles.when}>{formatWhen(item.createdAt)}</Text>
+        </View>
+
+        <View style={styles.severityRow}>
+          <Text
+            style={[styles.severity, { color: severityColor(item.severity) }]}
+          >
+            Severity {item.severity}/5
+          </Text>
+          {!item.synced ? (
+            <View style={styles.syncBadge}>
+              <Text style={styles.syncBadgeText}>On-device</Text>
+            </View>
+          ) : null}
+        </View>
+
+        {item.notes ? <Text style={styles.notes}>{item.notes}</Text> : null}
+
+        <View style={styles.meta}>
+          <Text style={styles.metaText}>Rep {item.repId}</Text>
+          <Pressable
+            onPress={() => handleDelete(item.id)}
+            accessibilityRole="button"
+            accessibilityLabel="Delete this flag"
+            testID={`pain-flag-${item.id}-delete`}
+            hitSlop={8}
+            style={styles.deleteBtn}
+          >
+            <Ionicons name="trash-outline" size={14} color="#FF3B30" />
+            <Text style={styles.deleteText}>Delete</Text>
+          </Pressable>
+        </View>
+      </View>
+    ),
+    [handleDelete],
+  );
+
+  const content = useMemo(() => {
+    if (loading) {
+      return (
+        <View style={styles.center}>
+          <ActivityIndicator color={tabColors.accent} />
+        </View>
+      );
+    }
+    if (error) {
+      return (
+        <View style={styles.center}>
+          <Ionicons name="alert-circle-outline" size={40} color="#FF3B30" />
+          <Text style={styles.errorText}>{error}</Text>
+          <Pressable onPress={load} style={styles.retry}>
+            <Text style={styles.retryText}>Retry</Text>
+          </Pressable>
+        </View>
+      );
+    }
+    if (flags.length === 0) {
+      return (
+        <View style={styles.center}>
+          <Ionicons name="medkit-outline" size={48} color={tabColors.textSecondary} />
+          <Text style={styles.emptyTitle}>No pain flags yet</Text>
+          <Text style={styles.emptySub}>
+            When something hurts mid-set, tap the Flag pain button so we
+            can adjust upcoming weights.
+          </Text>
+        </View>
+      );
+    }
+    return (
+      <FlatList
+        data={flags}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={styles.list}
+        showsVerticalScrollIndicator={false}
+      />
+    );
+  }, [loading, error, flags, renderItem, load]);
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.navBar}>
+        <Pressable
+          onPress={() => router.back()}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+        >
+          <Ionicons name="arrow-back" size={24} color={tabColors.textPrimary} />
+        </Pressable>
+        <Text style={styles.title}>Pain journal</Text>
+        <View style={{ width: 24 }} />
+      </View>
+      <Text style={styles.disclaimer}>
+        Stored on this device. Cloud sync lands with the next data migration.
+      </Text>
+      {content}
+    </SafeAreaView>
+  );
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: tabColors.background,
+  },
+  navBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: tabColors.border,
+  },
+  title: {
+    fontSize: 18,
+    fontFamily: 'Lexend_700Bold',
+    color: tabColors.textPrimary,
+  },
+  disclaimer: {
+    fontSize: 12,
+    fontFamily: 'Lexend_400Regular',
+    color: tabColors.textSecondary,
+    textAlign: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+  },
+  list: {
+    paddingHorizontal: 16,
+    paddingBottom: 32,
+  },
+  card: {
+    backgroundColor: 'rgba(15, 35, 57, 0.85)',
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: 'rgba(27, 46, 74, 0.6)',
+    padding: 16,
+    marginBottom: 12,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 6,
+  },
+  locationBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  locationText: {
+    fontSize: 14,
+    fontFamily: 'Lexend_500Medium',
+    color: tabColors.textPrimary,
+  },
+  when: {
+    fontSize: 12,
+    fontFamily: 'Lexend_400Regular',
+    color: tabColors.textSecondary,
+  },
+  severityRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 6,
+  },
+  severity: {
+    fontSize: 13,
+    fontFamily: 'Lexend_500Medium',
+  },
+  syncBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 6,
+    backgroundColor: '#1B2E4A',
+  },
+  syncBadgeText: {
+    fontSize: 10,
+    fontFamily: 'Lexend_500Medium',
+    color: '#8E8E93',
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+  notes: {
+    fontSize: 13,
+    fontFamily: 'Lexend_400Regular',
+    color: '#D1D5DB',
+    lineHeight: 18,
+    marginBottom: 8,
+  },
+  meta: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  metaText: {
+    fontSize: 11,
+    fontFamily: 'Lexend_400Regular',
+    color: '#8E8E93',
+  },
+  deleteBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+  },
+  deleteText: {
+    fontSize: 12,
+    fontFamily: 'Lexend_500Medium',
+    color: '#FF3B30',
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  },
+  errorText: {
+    color: '#FF3B30',
+    fontSize: 14,
+    fontFamily: 'Lexend_500Medium',
+    marginTop: 12,
+    textAlign: 'center',
+  },
+  retry: {
+    marginTop: 12,
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 10,
+    backgroundColor: '#4C8CFF',
+  },
+  retryText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    fontFamily: 'Lexend_700Bold',
+  },
+  emptyTitle: {
+    fontSize: 16,
+    fontFamily: 'Lexend_700Bold',
+    color: tabColors.textPrimary,
+    marginTop: 10,
+  },
+  emptySub: {
+    fontSize: 13,
+    fontFamily: 'Lexend_400Regular',
+    color: tabColors.textSecondary,
+    textAlign: 'center',
+    marginTop: 8,
+    lineHeight: 18,
+  },
+});

--- a/app/(modals)/session-timeline.tsx
+++ b/app/(modals)/session-timeline.tsx
@@ -1,0 +1,324 @@
+/**
+ * SessionTimelineScreen (modal)
+ *
+ * Unified view of recent workout + scan-arkit sessions. Data comes from
+ * `session-timeline-service`; the service currently reads workouts from
+ * local SQLite and expects scan sessions to be passed in from a caller
+ * once scan-persistence lands (see the service's TODO).
+ *
+ * Entries are grouped into date buckets (Today / Yesterday / This week /
+ * Last week / This month / Older) and tapping an entry drills into
+ * /(modals)/workout-insights (workout) or surfaces a toast for scans
+ * (detail screen is TODO).
+ */
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  SectionList,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+
+import { useAuth } from '@/contexts/AuthContext';
+import { tabColors } from '@/styles/tabs/_tab-theme';
+import {
+  getUnifiedTimeline,
+  groupByDateBucket,
+  type TimelineEntry,
+  type TimelineSection,
+} from '@/lib/services/session-timeline-service';
+
+// =============================================================================
+// Screen
+// =============================================================================
+
+export default function SessionTimelineScreen() {
+  const router = useRouter();
+  const { user } = useAuth();
+  const userId = user?.id ?? '';
+
+  const [entries, setEntries] = useState<TimelineEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // TODO(scan-persistence): pass options.scanSessions once scan
+      // sessions land in a durable store.
+      const timeline = await getUnifiedTimeline(userId, 30);
+      setEntries(timeline);
+    } catch (err) {
+      console.error('[SessionTimelineScreen] load failed', err);
+      setError('Failed to load timeline.');
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const sections = useMemo<TimelineSection[]>(
+    () => groupByDateBucket(entries),
+    [entries],
+  );
+
+  const sectionListData = useMemo(
+    () =>
+      sections.map((s) => ({
+        title: s.label,
+        data: s.entries,
+      })),
+    [sections],
+  );
+
+  const handlePress = useCallback(
+    (entry: TimelineEntry) => {
+      if (entry.href) {
+        router.push(entry.href as never);
+      }
+    },
+    [router],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: TimelineEntry }) => (
+      <Pressable
+        onPress={() => handlePress(item)}
+        accessibilityRole="button"
+        accessibilityLabel={`${item.title} ${item.type} session`}
+        style={styles.row}
+        testID={`timeline-row-${item.id}`}
+        disabled={!item.href}
+      >
+        <View
+          style={[
+            styles.typeBadge,
+            item.type === 'scan' ? styles.typeBadgeScan : styles.typeBadgeWorkout,
+          ]}
+        >
+          <Ionicons
+            name={item.type === 'scan' ? 'scan-outline' : 'barbell-outline'}
+            size={14}
+            color={item.type === 'scan' ? '#00C28C' : '#4C8CFF'}
+          />
+          <Text
+            style={[
+              styles.typeBadgeText,
+              { color: item.type === 'scan' ? '#00C28C' : '#4C8CFF' },
+            ]}
+          >
+            {item.type === 'scan' ? 'Scan' : 'Workout'}
+          </Text>
+        </View>
+
+        <View style={styles.rowBody}>
+          <Text style={styles.rowTitle} numberOfLines={1}>
+            {item.title}
+          </Text>
+          {item.subtitle ? (
+            <Text style={styles.rowSubtitle} numberOfLines={1}>
+              {item.subtitle}
+            </Text>
+          ) : null}
+        </View>
+
+        {item.href ? (
+          <Ionicons name="chevron-forward" size={18} color="#8E8E93" />
+        ) : null}
+      </Pressable>
+    ),
+    [handlePress],
+  );
+
+  const renderSectionHeader = useCallback(
+    ({ section }: { section: { title: string } }) => (
+      <Text style={styles.sectionHeader}>{section.title}</Text>
+    ),
+    [],
+  );
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.navBar}>
+        <Pressable
+          onPress={() => router.back()}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+        >
+          <Ionicons name="arrow-back" size={24} color={tabColors.textPrimary} />
+        </Pressable>
+        <Text style={styles.title}>Session timeline</Text>
+        <View style={{ width: 24 }} />
+      </View>
+
+      {loading ? (
+        <View style={styles.center}>
+          <ActivityIndicator color={tabColors.accent} />
+        </View>
+      ) : error ? (
+        <View style={styles.center}>
+          <Ionicons name="alert-circle-outline" size={40} color="#FF3B30" />
+          <Text style={styles.errorText}>{error}</Text>
+          <Pressable onPress={load} style={styles.retry}>
+            <Text style={styles.retryText}>Retry</Text>
+          </Pressable>
+        </View>
+      ) : entries.length === 0 ? (
+        <View style={styles.center}>
+          <Ionicons
+            name="calendar-outline"
+            size={48}
+            color={tabColors.textSecondary}
+          />
+          <Text style={styles.emptyTitle}>No sessions yet</Text>
+          <Text style={styles.emptySub}>
+            Your workouts and form scans will appear here once you log one.
+          </Text>
+        </View>
+      ) : (
+        <SectionList
+          sections={sectionListData}
+          keyExtractor={(item) => item.id}
+          renderItem={renderItem}
+          renderSectionHeader={renderSectionHeader}
+          contentContainerStyle={styles.list}
+          showsVerticalScrollIndicator={false}
+          stickySectionHeadersEnabled={false}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: tabColors.background,
+  },
+  navBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: tabColors.border,
+  },
+  title: {
+    fontSize: 18,
+    fontFamily: 'Lexend_700Bold',
+    color: tabColors.textPrimary,
+  },
+  list: {
+    paddingHorizontal: 16,
+    paddingBottom: 32,
+  },
+  sectionHeader: {
+    fontSize: 12,
+    fontFamily: 'Lexend_700Bold',
+    color: tabColors.textSecondary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginTop: 18,
+    marginBottom: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    backgroundColor: 'rgba(15, 35, 57, 0.85)',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(27, 46, 74, 0.6)',
+    marginBottom: 10,
+  },
+  typeBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 8,
+  },
+  typeBadgeWorkout: {
+    backgroundColor: '#4C8CFF20',
+  },
+  typeBadgeScan: {
+    backgroundColor: '#00C28C20',
+  },
+  typeBadgeText: {
+    fontSize: 11,
+    fontFamily: 'Lexend_700Bold',
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+  rowBody: {
+    flex: 1,
+  },
+  rowTitle: {
+    fontSize: 14,
+    fontFamily: 'Lexend_500Medium',
+    color: tabColors.textPrimary,
+  },
+  rowSubtitle: {
+    fontSize: 12,
+    fontFamily: 'Lexend_400Regular',
+    color: tabColors.textSecondary,
+    marginTop: 2,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  },
+  errorText: {
+    color: '#FF3B30',
+    fontSize: 14,
+    fontFamily: 'Lexend_500Medium',
+    marginTop: 12,
+    textAlign: 'center',
+  },
+  retry: {
+    marginTop: 12,
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 10,
+    backgroundColor: '#4C8CFF',
+  },
+  retryText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    fontFamily: 'Lexend_700Bold',
+  },
+  emptyTitle: {
+    fontSize: 16,
+    fontFamily: 'Lexend_700Bold',
+    color: tabColors.textPrimary,
+    marginTop: 10,
+  },
+  emptySub: {
+    fontSize: 13,
+    fontFamily: 'Lexend_400Regular',
+    color: tabColors.textSecondary,
+    textAlign: 'center',
+    marginTop: 8,
+    lineHeight: 18,
+  },
+});

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'expo-router';
 import { DeleteAction } from '@/components';
 import { useUnits } from '@/contexts/UnitsContext';
 import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
+import { exportSession } from '@/lib/services/session-export-service';
 import React, { useCallback, useRef, useState } from 'react';
 import {
     ActivityIndicator,
@@ -13,6 +14,7 @@ import {
     RefreshControl,
     ScrollView,
     Share,
+    StyleSheet,
     Text,
     TouchableOpacity,
     View
@@ -135,6 +137,77 @@ export default function WorkoutsScreen() {
       }
     },
     [getWeightLabel, showToast]
+  );
+
+  // --- Session timeline + export (#476) -----------------------------------
+  const handleOpenTimeline = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    router.push('/(modals)/session-timeline');
+  }, [router]);
+
+  const exportLatestSession = useCallback(
+    async (format: 'json' | 'csv') => {
+      try {
+        const db = (await import('@/lib/services/database/local-db')).localDB.db;
+        if (!db) {
+          showToast('Storage unavailable — try again shortly.', { type: 'error' });
+          return;
+        }
+        const rows = await db.getAllAsync<{ id: string }>(
+          `SELECT id FROM workout_sessions
+            WHERE deleted = 0 AND ended_at IS NOT NULL
+            ORDER BY started_at DESC LIMIT 1`,
+        );
+        const sessionId = rows[0]?.id;
+        if (!sessionId) {
+          showToast('No completed sessions to export yet.', { type: 'info' });
+          return;
+        }
+        const res = await exportSession(sessionId, format);
+        await Share.share({ url: res.path, title: `Session export (${format.toUpperCase()})` });
+        showToast(`Exported ${format.toUpperCase()}`, { type: 'success' });
+      } catch (err) {
+        errorWithTs('[Workouts] export failed', err);
+        showToast('Export failed — please try again.', { type: 'error' });
+      }
+    },
+    [showToast]
+  );
+
+  const handleOpenExportMenu = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+    Alert.alert(
+      'Export latest session',
+      'Choose a format to share with your coach.',
+      [
+        { text: 'JSON', onPress: () => exportLatestSession('json') },
+        { text: 'CSV', onPress: () => exportLatestSession('csv') },
+        { text: 'Cancel', style: 'cancel' },
+      ],
+    );
+  }, [exportLatestSession]);
+
+  const renderIntelHeader = () => (
+    <View style={intelHeaderStyles.row}>
+      <TouchableOpacity
+        style={intelHeaderStyles.pill}
+        onPress={handleOpenTimeline}
+        accessibilityLabel="Open session timeline"
+        accessibilityRole="button"
+      >
+        <Ionicons name="calendar-outline" size={14} color="#4C8CFF" />
+        <Text style={intelHeaderStyles.pillText}>Timeline</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={intelHeaderStyles.pill}
+        onPress={handleOpenExportMenu}
+        accessibilityLabel="Export latest session"
+        accessibilityRole="button"
+      >
+        <Ionicons name="download-outline" size={14} color="#4C8CFF" />
+        <Text style={intelHeaderStyles.pillText}>Export</Text>
+      </TouchableOpacity>
+    </View>
   );
 
   const renderItem = (info: { item: Workout }) => {
@@ -279,6 +352,7 @@ export default function WorkoutsScreen() {
             />
           }
         >
+          {renderIntelHeader()}
           {lastUpdatedLabel ? (
             <Text style={{ color: '#8E8E93', fontSize: 12, marginBottom: 16, textAlign: 'center' }}>{lastUpdatedLabel}</Text>
           ) : null}
@@ -316,9 +390,12 @@ export default function WorkoutsScreen() {
           contentContainerStyle={styles.list}
           showsVerticalScrollIndicator={false}
           ListHeaderComponent={
-            lastUpdatedLabel ? (
-              <Text style={{ color: '#8E8E93', fontSize: 12, marginBottom: 12, textAlign: 'center' }}>{lastUpdatedLabel}</Text>
-            ) : null
+            <>
+              {renderIntelHeader()}
+              {lastUpdatedLabel ? (
+                <Text style={{ color: '#8E8E93', fontSize: 12, marginBottom: 12, textAlign: 'center' }}>{lastUpdatedLabel}</Text>
+              ) : null}
+            </>
           }
           refreshControl={
             <RefreshControl
@@ -342,3 +419,29 @@ export default function WorkoutsScreen() {
     </View>
   );
 }
+
+// --- Local styles for the form-intel header pills (#476) ---------------------
+const intelHeaderStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 8,
+    marginBottom: 10,
+  },
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 16,
+    backgroundColor: '#4C8CFF15',
+    borderWidth: 1,
+    borderColor: '#4C8CFF30',
+  },
+  pillText: {
+    fontSize: 12,
+    fontFamily: 'Lexend_500Medium',
+    color: '#4C8CFF',
+  },
+});

--- a/components/form-tracking/FaultExplanationChip.tsx
+++ b/components/form-tracking/FaultExplanationChip.tsx
@@ -1,0 +1,312 @@
+/**
+ * FaultExplanationChip
+ *
+ * Compact chip that displays a detected fault name and, on tap, opens a
+ * modal rationale card built from the `fault-explainability` service.
+ *
+ * Usage:
+ *   <FaultExplanationChip
+ *     faultId="hips_rise_first"
+ *     faultDisplayName="Hips Rise First"
+ *     severity={2}
+ *     repId={`${setId}:${rep.repNumber}`}
+ *     repContext={rep}
+ *     workoutId="deadlift"
+ *   />
+ */
+import React, { useCallback, useState } from 'react';
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import { useFaultExplanations } from '@/hooks/use-fault-explanations';
+import type { RepContext, FaultSeverity } from '@/lib/types/workout-definitions';
+import type { FaultExplanation } from '@/lib/services/fault-explainability';
+
+// =============================================================================
+// Props
+// =============================================================================
+
+export interface FaultExplanationChipProps {
+  faultId: string;
+  faultDisplayName: string;
+  severity: FaultSeverity;
+  repId: string;
+  repContext: RepContext;
+  workoutId: string;
+  /** Optional override so hosts can share a single hook instance. */
+  getExplanation?: (
+    repId: string,
+    faultId: string,
+    rep: RepContext,
+    workoutId: string,
+  ) => FaultExplanation;
+  testID?: string;
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+function severityTone(severity: FaultSeverity): { bg: string; fg: string } {
+  switch (severity) {
+    case 3:
+      return { bg: '#FF3B3020', fg: '#FF3B30' };
+    case 2:
+      return { bg: '#FF950020', fg: '#FF9500' };
+    default:
+      return { bg: '#4C8CFF20', fg: '#4C8CFF' };
+  }
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export function FaultExplanationChip({
+  faultId,
+  faultDisplayName,
+  severity,
+  repId,
+  repContext,
+  workoutId,
+  getExplanation,
+  testID = 'fault-explanation-chip',
+}: FaultExplanationChipProps) {
+  const [isOpen, setOpen] = useState(false);
+  const fallbackHook = useFaultExplanations();
+  const resolve = getExplanation ?? fallbackHook.getExplanation;
+  const tone = severityTone(severity);
+
+  const open = useCallback(() => setOpen(true), []);
+  const close = useCallback(() => setOpen(false), []);
+
+  // Compute lazily when the modal is opened so closed chips stay cheap.
+  const explanation: FaultExplanation | null = isOpen
+    ? resolve(repId, faultId, repContext, workoutId)
+    : null;
+
+  return (
+    <>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`${faultDisplayName}, tap to see why`}
+        accessibilityHint="Opens a card explaining this form fault"
+        onPress={open}
+        testID={testID}
+        style={[styles.chip, { backgroundColor: tone.bg }]}
+      >
+        <Ionicons name="alert-circle" size={14} color={tone.fg} />
+        <Text style={[styles.chipText, { color: tone.fg }]} numberOfLines={1}>
+          {faultDisplayName}
+        </Text>
+        <Ionicons name="chevron-forward" size={12} color={tone.fg} />
+      </Pressable>
+
+      <Modal
+        visible={isOpen}
+        transparent
+        animationType="fade"
+        onRequestClose={close}
+      >
+        <Pressable
+          style={styles.backdrop}
+          onPress={close}
+          testID={`${testID}-backdrop`}
+        >
+          <Pressable style={styles.card} onPress={(e) => e.stopPropagation()}>
+            <View style={styles.header}>
+              <View style={[styles.badge, { backgroundColor: tone.bg }]}>
+                <Text style={[styles.badgeText, { color: tone.fg }]}>
+                  Rep {explanation?.repNumber ?? repContext.repNumber} •{' '}
+                  {severityLabel(severity)}
+                </Text>
+              </View>
+              <Pressable
+                onPress={close}
+                hitSlop={12}
+                accessibilityRole="button"
+                accessibilityLabel="Close"
+                testID={`${testID}-close`}
+              >
+                <Ionicons name="close" size={22} color="#8E8E93" />
+              </Pressable>
+            </View>
+
+            {explanation ? (
+              <ScrollView style={styles.body}>
+                <Text style={styles.title}>{explanation.title}</Text>
+                <Text style={styles.rationale}>{explanation.rationale}</Text>
+
+                <View style={styles.cueBox}>
+                  <Ionicons name="fitness" size={16} color="#4C8CFF" />
+                  <Text style={styles.cueText}>{explanation.cue}</Text>
+                </View>
+
+                {Object.keys(explanation.metrics).length > 0 ? (
+                  <View style={styles.metrics} testID={`${testID}-metrics`}>
+                    <Text style={styles.metricsHeader}>Details</Text>
+                    {Object.entries(explanation.metrics).map(([k, v]) => (
+                      <View key={k} style={styles.metricRow}>
+                        <Text style={styles.metricLabel}>
+                          {humanizeMetricKey(k)}
+                        </Text>
+                        <Text style={styles.metricValue}>
+                          {formatMetric(k, v)}
+                        </Text>
+                      </View>
+                    ))}
+                  </View>
+                ) : null}
+              </ScrollView>
+            ) : null}
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </>
+  );
+}
+
+function severityLabel(sev: FaultSeverity): string {
+  if (sev === 3) return 'major';
+  if (sev === 2) return 'moderate';
+  return 'minor';
+}
+
+function humanizeMetricKey(k: string): string {
+  // `peakHipDeg` -> `Peak hip`
+  const withoutDeg = k.replace(/Deg$|Ms$/g, '');
+  const spaced = withoutDeg.replace(/([A-Z])/g, ' $1').trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
+}
+
+function formatMetric(key: string, value: number): string {
+  if (key.endsWith('Ms')) {
+    return `${(value / 1000).toFixed(1)}s`;
+  }
+  if (!Number.isFinite(value)) return '-';
+  return `${Math.round(value * 10) / 10}°`;
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = StyleSheet.create({
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 12,
+    alignSelf: 'flex-start',
+    maxWidth: 220,
+  },
+  chipText: {
+    fontSize: 12,
+    fontFamily: 'Lexend_500Medium',
+  },
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+  },
+  card: {
+    width: '100%',
+    maxWidth: 420,
+    maxHeight: '80%',
+    backgroundColor: '#0F2339',
+    borderRadius: 16,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: '#1B2E4A',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  badge: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 8,
+  },
+  badgeText: {
+    fontSize: 11,
+    fontFamily: 'Lexend_500Medium',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  body: {
+    maxHeight: 400,
+  },
+  title: {
+    fontSize: 18,
+    fontFamily: 'Lexend_700Bold',
+    color: '#FFFFFF',
+    marginBottom: 8,
+  },
+  rationale: {
+    fontSize: 14,
+    fontFamily: 'Lexend_400Regular',
+    color: '#D1D5DB',
+    lineHeight: 20,
+    marginBottom: 12,
+  },
+  cueBox: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+    backgroundColor: '#4C8CFF15',
+    borderRadius: 10,
+    padding: 12,
+    marginBottom: 12,
+  },
+  cueText: {
+    flex: 1,
+    fontSize: 13,
+    fontFamily: 'Lexend_500Medium',
+    color: '#4C8CFF',
+    lineHeight: 18,
+  },
+  metrics: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: '#1B2E4A',
+    paddingTop: 12,
+  },
+  metricsHeader: {
+    fontSize: 11,
+    fontFamily: 'Lexend_700Bold',
+    color: '#8E8E93',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 8,
+  },
+  metricRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 4,
+  },
+  metricLabel: {
+    fontSize: 12,
+    fontFamily: 'Lexend_400Regular',
+    color: '#8E8E93',
+  },
+  metricValue: {
+    fontSize: 12,
+    fontFamily: 'Lexend_500Medium',
+    color: '#FFFFFF',
+  },
+});
+
+export default FaultExplanationChip;

--- a/components/form-tracking/RepPainFlagButton.tsx
+++ b/components/form-tracking/RepPainFlagButton.tsx
@@ -1,0 +1,466 @@
+/**
+ * RepPainFlagButton
+ *
+ * Button + modal workflow for flagging pain/injury on a specific rep.
+ * Opens a modal with:
+ *   - Location picker (lower_back / upper_back / knee / shoulder / elbow /
+ *     wrist / hip / other)
+ *   - Severity slider (1-5)
+ *   - Free-form notes (optional, capped at 500 chars)
+ *   - "Log & adjust next set" CTA that writes the flag and emits an
+ *     adjustNextSetWeight recommendation. Host UI wires the recommendation
+ *     into the session runner when it's ready (see TODO inside the service).
+ */
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import {
+  adjustNextSetWeight,
+  flagRepPain,
+  PAIN_LOCATION_LABELS,
+  type PainFlag,
+  type PainLocation,
+  type PainSeverity,
+} from '@/lib/services/rep-pain-journal';
+import { errorWithTs } from '@/lib/logger';
+
+// =============================================================================
+// Props
+// =============================================================================
+
+export interface RepPainFlagButtonProps {
+  userId: string;
+  sessionId: string;
+  repId: string;
+  /**
+   * Invoked after the flag is written and a weight recommendation is
+   * emitted. Host can use this to push a toast, trigger haptics, or
+   * call into the session runner to apply the recommended delta.
+   */
+  onFlagged?: (
+    flag: PainFlag,
+    recommendation: ReturnType<typeof adjustNextSetWeight>,
+  ) => void;
+  testID?: string;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+const LOCATIONS: PainLocation[] = [
+  'lower_back',
+  'upper_back',
+  'knee',
+  'shoulder',
+  'elbow',
+  'wrist',
+  'hip',
+  'other',
+];
+
+const SEVERITIES: PainSeverity[] = [1, 2, 3, 4, 5];
+
+export function RepPainFlagButton({
+  userId,
+  sessionId,
+  repId,
+  onFlagged,
+  testID = 'rep-pain-flag-button',
+}: RepPainFlagButtonProps) {
+  const [isOpen, setOpen] = useState(false);
+  const [location, setLocation] = useState<PainLocation | null>(null);
+  const [severity, setSeverity] = useState<PainSeverity>(2);
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const reset = useCallback(() => {
+    setLocation(null);
+    setSeverity(2);
+    setNotes('');
+    setSubmitting(false);
+  }, []);
+
+  const open = useCallback(() => {
+    reset();
+    setOpen(true);
+  }, [reset]);
+
+  const close = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  const canSubmit = location != null && !submitting;
+
+  const submit = useCallback(async () => {
+    if (!location || submitting) return;
+    setSubmitting(true);
+    try {
+      const flag = await flagRepPain(userId, {
+        repId,
+        sessionId,
+        location,
+        severity,
+        notes: notes.trim() || undefined,
+      });
+      const recommendation = adjustNextSetWeight(sessionId, severity);
+      onFlagged?.(flag, recommendation);
+      setOpen(false);
+      reset();
+    } catch (err) {
+      errorWithTs('[RepPainFlagButton] failed to log pain flag', err);
+      setSubmitting(false);
+    }
+  }, [
+    location,
+    severity,
+    notes,
+    userId,
+    sessionId,
+    repId,
+    submitting,
+    onFlagged,
+    reset,
+  ]);
+
+  const severityLabel = useMemo(
+    () => SEVERITY_LABELS[severity - 1] ?? '',
+    [severity],
+  );
+
+  return (
+    <>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Flag pain on this rep"
+        accessibilityHint="Opens a form to log pain or injury"
+        onPress={open}
+        testID={testID}
+        style={styles.trigger}
+      >
+        <Ionicons name="medkit-outline" size={16} color="#FF3B30" />
+        <Text style={styles.triggerText}>Flag pain</Text>
+      </Pressable>
+
+      <Modal
+        visible={isOpen}
+        transparent
+        animationType="slide"
+        onRequestClose={close}
+      >
+        <View style={styles.backdrop} testID={`${testID}-backdrop`}>
+          <View style={styles.sheet}>
+            <View style={styles.handle} />
+            <View style={styles.header}>
+              <Text style={styles.title}>Log pain</Text>
+              <Pressable
+                onPress={close}
+                hitSlop={12}
+                accessibilityRole="button"
+                accessibilityLabel="Close"
+                testID={`${testID}-close`}
+              >
+                <Ionicons name="close" size={22} color="#8E8E93" />
+              </Pressable>
+            </View>
+
+            <ScrollView contentContainerStyle={styles.body}>
+              <Text style={styles.sectionLabel}>Where?</Text>
+              <View style={styles.grid} testID={`${testID}-locations`}>
+                {LOCATIONS.map((loc) => {
+                  const active = location === loc;
+                  return (
+                    <Pressable
+                      key={loc}
+                      onPress={() => setLocation(loc)}
+                      accessibilityRole="button"
+                      accessibilityLabel={`${PAIN_LOCATION_LABELS[loc]} location`}
+                      accessibilityState={{ selected: active }}
+                      testID={`${testID}-location-${loc}`}
+                      style={[
+                        styles.gridItem,
+                        active && styles.gridItemActive,
+                      ]}
+                    >
+                      <Text
+                        style={[
+                          styles.gridItemText,
+                          active && styles.gridItemTextActive,
+                        ]}
+                      >
+                        {PAIN_LOCATION_LABELS[loc]}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+
+              <Text style={styles.sectionLabel}>
+                Severity: {severity}/5 · {severityLabel}
+              </Text>
+              <View style={styles.severityRow} testID={`${testID}-severities`}>
+                {SEVERITIES.map((s) => {
+                  const active = severity === s;
+                  return (
+                    <Pressable
+                      key={s}
+                      onPress={() => setSeverity(s)}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Severity ${s}`}
+                      accessibilityState={{ selected: active }}
+                      testID={`${testID}-severity-${s}`}
+                      style={[
+                        styles.severityDot,
+                        active && styles.severityDotActive,
+                      ]}
+                    >
+                      <Text
+                        style={[
+                          styles.severityText,
+                          active && styles.severityTextActive,
+                        ]}
+                      >
+                        {s}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+
+              <Text style={styles.sectionLabel}>Notes (optional)</Text>
+              <TextInput
+                value={notes}
+                onChangeText={(v) => setNotes(v.slice(0, 500))}
+                placeholder="What triggered it? Rep 3 of set 2…"
+                placeholderTextColor="#8E8E93"
+                multiline
+                accessibilityLabel="Notes"
+                testID={`${testID}-notes`}
+                style={styles.notesInput}
+              />
+              <Text style={styles.charCount}>{notes.length}/500</Text>
+            </ScrollView>
+
+            <View style={styles.footer}>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Cancel"
+                onPress={close}
+                style={[styles.cta, styles.ctaSecondary]}
+                testID={`${testID}-cancel`}
+              >
+                <Text style={styles.ctaSecondaryText}>Cancel</Text>
+              </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Log pain and adjust next set"
+                accessibilityState={{ disabled: !canSubmit }}
+                disabled={!canSubmit}
+                onPress={submit}
+                style={[
+                  styles.cta,
+                  styles.ctaPrimary,
+                  !canSubmit && styles.ctaDisabled,
+                ]}
+                testID={`${testID}-submit`}
+              >
+                <Text style={styles.ctaPrimaryText}>
+                  {submitting ? 'Logging…' : 'Log & adjust next set'}
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </>
+  );
+}
+
+const SEVERITY_LABELS = [
+  'twinge',
+  'noticeable',
+  'uncomfortable',
+  'sharp',
+  'stop the set',
+];
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = StyleSheet.create({
+  trigger: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 10,
+    backgroundColor: '#FF3B3015',
+    alignSelf: 'flex-start',
+  },
+  triggerText: {
+    fontSize: 13,
+    fontFamily: 'Lexend_500Medium',
+    color: '#FF3B30',
+  },
+  backdrop: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    backgroundColor: 'rgba(0, 0, 0, 0.55)',
+  },
+  sheet: {
+    backgroundColor: '#0F2339',
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    paddingBottom: 28,
+    maxHeight: '85%',
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: '#1B2E4A',
+    marginTop: 8,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontFamily: 'Lexend_700Bold',
+    color: '#FFFFFF',
+  },
+  body: {
+    paddingHorizontal: 20,
+    paddingBottom: 12,
+  },
+  sectionLabel: {
+    fontSize: 13,
+    fontFamily: 'Lexend_500Medium',
+    color: '#8E8E93',
+    marginTop: 16,
+    marginBottom: 8,
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  gridItem: {
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 12,
+    backgroundColor: '#152C47',
+    borderWidth: 1,
+    borderColor: '#1B2E4A',
+  },
+  gridItemActive: {
+    backgroundColor: '#4C8CFF25',
+    borderColor: '#4C8CFF',
+  },
+  gridItemText: {
+    fontSize: 13,
+    fontFamily: 'Lexend_400Regular',
+    color: '#D1D5DB',
+  },
+  gridItemTextActive: {
+    color: '#FFFFFF',
+    fontFamily: 'Lexend_500Medium',
+  },
+  severityRow: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+  severityDot: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#152C47',
+    borderWidth: 1,
+    borderColor: '#1B2E4A',
+  },
+  severityDotActive: {
+    backgroundColor: '#FF3B30',
+    borderColor: '#FF3B30',
+  },
+  severityText: {
+    fontSize: 16,
+    fontFamily: 'Lexend_500Medium',
+    color: '#D1D5DB',
+  },
+  severityTextActive: {
+    color: '#FFFFFF',
+    fontFamily: 'Lexend_700Bold',
+  },
+  notesInput: {
+    minHeight: 80,
+    backgroundColor: '#152C47',
+    borderWidth: 1,
+    borderColor: '#1B2E4A',
+    borderRadius: 12,
+    padding: 12,
+    color: '#FFFFFF',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 14,
+    textAlignVertical: 'top',
+  },
+  charCount: {
+    marginTop: 4,
+    textAlign: 'right',
+    fontSize: 11,
+    fontFamily: 'Lexend_400Regular',
+    color: '#8E8E93',
+  },
+  footer: {
+    flexDirection: 'row',
+    gap: 10,
+    paddingHorizontal: 20,
+    paddingTop: 12,
+  },
+  cta: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 14,
+    alignItems: 'center',
+  },
+  ctaPrimary: {
+    backgroundColor: '#4C8CFF',
+  },
+  ctaPrimaryText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontFamily: 'Lexend_700Bold',
+  },
+  ctaSecondary: {
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+    borderColor: '#1B2E4A',
+  },
+  ctaSecondaryText: {
+    color: '#D1D5DB',
+    fontSize: 15,
+    fontFamily: 'Lexend_500Medium',
+  },
+  ctaDisabled: {
+    opacity: 0.5,
+  },
+});
+
+export default RepPainFlagButton;

--- a/hooks/use-fault-explanations.ts
+++ b/hooks/use-fault-explanations.ts
@@ -1,0 +1,116 @@
+/**
+ * useFaultExplanations
+ *
+ * React hook that wraps the `fault-explainability` service with a
+ * component-scoped memoisation cache. Keys are `(repId, faultId)` so the
+ * same rep's rationale is only computed once per mount even if the
+ * consuming chip list re-renders.
+ *
+ * The cache is a simple `Map` stored in a `useRef` — it survives the
+ * component's lifetime but is dropped on unmount. For persistence across
+ * screens, callers can promote the cache to a context.
+ */
+import { useCallback, useMemo, useRef } from 'react';
+
+import type { RepContext } from '@/lib/types/workout-definitions';
+import {
+  generateFaultExplanationDetail,
+  renderExplanation,
+  type FaultExplanation,
+} from '@/lib/services/fault-explainability';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface UseFaultExplanationsResult {
+  /**
+   * Resolve (or compute + cache) the structured explanation for a fault on
+   * a specific rep. `repId` is any stable identifier — we recommend the
+   * `session_set_id` suffixed with `:<repNumber>`.
+   */
+  getExplanation: (
+    repId: string,
+    faultId: string,
+    rep: RepContext,
+    workoutId: string,
+  ) => FaultExplanation;
+
+  /**
+   * Convenience wrapper returning the flattened display string.
+   */
+  getExplanationText: (
+    repId: string,
+    faultId: string,
+    rep: RepContext,
+    workoutId: string,
+  ) => string;
+
+  /** Clear the in-memory cache (useful when switching sessions). */
+  clearCache: () => void;
+
+  /** Current cache size (primarily for testing / debugging). */
+  readonly cacheSize: number;
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+function cacheKey(repId: string, faultId: string): string {
+  return `${repId}::${faultId}`;
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+export function useFaultExplanations(): UseFaultExplanationsResult {
+  // `useRef` keeps a stable reference across renders. We intentionally
+  // mutate the underlying Map rather than replacing it so consumers don't
+  // have to deal with "did the Map change" memo invalidation.
+  const cacheRef = useRef<Map<string, FaultExplanation>>(new Map());
+
+  const getExplanation = useCallback(
+    (
+      repId: string,
+      faultId: string,
+      rep: RepContext,
+      workoutId: string,
+    ): FaultExplanation => {
+      const key = cacheKey(repId, faultId);
+      const cached = cacheRef.current.get(key);
+      if (cached) return cached;
+      const detail = generateFaultExplanationDetail(faultId, rep, workoutId);
+      cacheRef.current.set(key, detail);
+      return detail;
+    },
+    [],
+  );
+
+  const getExplanationText = useCallback(
+    (
+      repId: string,
+      faultId: string,
+      rep: RepContext,
+      workoutId: string,
+    ): string => renderExplanation(getExplanation(repId, faultId, rep, workoutId)),
+    [getExplanation],
+  );
+
+  const clearCache = useCallback(() => {
+    cacheRef.current.clear();
+  }, []);
+
+  return useMemo<UseFaultExplanationsResult>(
+    () => ({
+      getExplanation,
+      getExplanationText,
+      clearCache,
+      get cacheSize() {
+        return cacheRef.current.size;
+      },
+    }),
+    [getExplanation, getExplanationText, clearCache],
+  );
+}

--- a/lib/services/fault-explainability.ts
+++ b/lib/services/fault-explainability.ts
@@ -1,0 +1,547 @@
+/**
+ * Fault Explainability Service
+ *
+ * Converts opaque fault IDs (e.g. `hips_rise_first`, `forward_lean`) into
+ * natural-language rationales enriched with the per-rep angle deltas that
+ * triggered the fault. This lives alongside the existing fault detectors in
+ * `lib/workouts/*.ts` — those detectors emit the IDs while this service is
+ * the single source of truth for human-readable explanations.
+ *
+ * The service is pure (no side effects, no I/O) and deterministic for a
+ * given `(faultId, repContext, workoutId)` triple, which makes it safe to
+ * memoise inside UI-layer hooks.
+ */
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { RepContext } from '@/lib/types/workout-definitions';
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/**
+ * Structured explanation payload. Consumers that just need a single string
+ * can call `renderExplanation(explanation)`.
+ */
+export interface FaultExplanation {
+  /** Fault id that triggered this explanation (e.g. `hips_rise_first`). */
+  faultId: string;
+  /** Human-readable workout id (e.g. `deadlift`). Empty string if unknown. */
+  workoutId: string;
+  /** Rep number within the set (1-indexed). */
+  repNumber: number;
+  /** Short title suitable for a chip/card header. */
+  title: string;
+  /** Full rationale (1-3 sentences) with angle deltas inlined. */
+  rationale: string;
+  /** Coaching cue (short, imperative). */
+  cue: string;
+  /** Raw numeric deltas the rationale was built from (for UI readouts). */
+  metrics: Record<string, number>;
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+function avg(a: number, b: number): number {
+  return (a + b) / 2;
+}
+
+/**
+ * Round a degrees value to 1 decimal place. Guards against `NaN`/`Infinity`
+ * so template strings never render "NaN" to the user.
+ */
+function fmtDeg(n: number): string {
+  if (!Number.isFinite(n)) return '0';
+  return Math.abs(n) >= 10 ? Math.round(n).toString() : n.toFixed(1);
+}
+
+function fmtSec(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '0s';
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function maxJoint(
+  angles: JointAngles,
+  left: keyof JointAngles,
+  right: keyof JointAngles,
+): number {
+  return Math.max(angles[left], angles[right]);
+}
+
+function minJoint(
+  angles: JointAngles,
+  left: keyof JointAngles,
+  right: keyof JointAngles,
+): number {
+  return Math.min(angles[left], angles[right]);
+}
+
+// =============================================================================
+// Fault template registry
+// =============================================================================
+
+type ExplanationBuilder = (ctx: RepContext, workoutId: string) => FaultExplanation;
+
+/**
+ * Registry of per-fault explanation builders. Keyed by fault id; values
+ * produce a fully populated `FaultExplanation` for the given rep context.
+ *
+ * Shared ids (e.g. `incomplete_lockout`) may dispatch on `workoutId` inside
+ * the builder since the same fault often applies to different joints
+ * depending on the exercise.
+ */
+const BUILDERS: Record<string, ExplanationBuilder> = {
+  hips_rise_first: (ctx, workoutId) => {
+    const hipChange = ctx.maxAngles.leftHip - ctx.startAngles.leftHip;
+    const kneeChange = ctx.maxAngles.leftKnee - ctx.startAngles.leftKnee;
+    const delta = hipChange - kneeChange;
+    return {
+      faultId: 'hips_rise_first',
+      workoutId,
+      repNumber: ctx.repNumber,
+      title: 'Hips rose before the bar',
+      rationale:
+        `Your hips extended ${fmtDeg(hipChange)} deg while your knees ` +
+        `only extended ${fmtDeg(kneeChange)} deg — a ${fmtDeg(delta)} deg ` +
+        `hip-lead. This shifts the load onto the lower back instead of ` +
+        `the legs.`,
+      cue: 'Drive with your legs — push the floor away, keep chest and hips rising together.',
+      metrics: {
+        hipChangeDeg: hipChange,
+        kneeChangeDeg: kneeChange,
+        hipLeadDeg: delta,
+      },
+    };
+  },
+
+  forward_lean: (ctx, workoutId): FaultExplanation => {
+    // Squat / farmers-walk both fire `forward_lean`. We dispatch by workout
+    // so the rationale references the right joint delta.
+    if (workoutId === 'farmers_walk') {
+      const maxHip = avg(ctx.maxAngles.leftHip, ctx.maxAngles.rightHip);
+      const shortfall = 180 - maxHip;
+      return {
+        faultId: 'forward_lean',
+        workoutId,
+        repNumber: ctx.repNumber,
+        title: 'Trunk collapsed forward',
+        rationale:
+          `Hip angle never reached full extension — peaked at ` +
+          `${fmtDeg(maxHip)} deg (${fmtDeg(shortfall)} deg short of upright). ` +
+          `Under load this loads the low back instead of the legs.`,
+        cue: 'Stand tall — brace the core, pull the ribs down, and lock out the hips.',
+        metrics: {
+          peakHipDeg: maxHip,
+          shortfallFromUprightDeg: shortfall,
+        },
+      };
+    }
+    // Default: squat forward lean — hip much lower than knee at depth.
+    const minHip = avg(ctx.minAngles.leftHip, ctx.minAngles.rightHip);
+    const minKnee = avg(ctx.minAngles.leftKnee, ctx.minAngles.rightKnee);
+    const gap = minKnee - minHip;
+    return {
+      faultId: 'forward_lean',
+      workoutId,
+      repNumber: ctx.repNumber,
+      title: 'Chest folded over at depth',
+      rationale:
+        `At the bottom of the rep, hip angle (${fmtDeg(minHip)} deg) ` +
+        `closed ${fmtDeg(gap)} deg further than knee angle ` +
+        `(${fmtDeg(minKnee)} deg). That forward torso tilt shifts the ` +
+        `bar path over the toes and offloads the quads.`,
+      cue: 'Keep your chest up — sit between your knees, don\'t bow over the bar.',
+      metrics: {
+        minHipDeg: minHip,
+        minKneeDeg: minKnee,
+        leanGapDeg: gap,
+      },
+    };
+  },
+
+  lateral_lean: (ctx, workoutId) => {
+    const hipDiff = Math.abs(ctx.minAngles.leftHip - ctx.minAngles.rightHip);
+    return {
+      faultId: 'lateral_lean',
+      workoutId,
+      repNumber: ctx.repNumber,
+      title: 'Leaning to one side',
+      rationale:
+        `Left and right hip angles diverged by ${fmtDeg(hipDiff)} deg ` +
+        `(L=${fmtDeg(ctx.minAngles.leftHip)} deg, ` +
+        `R=${fmtDeg(ctx.minAngles.rightHip)} deg). The heavier side is ` +
+        `compensating for the lighter one, which is an injury risk under load.`,
+      cue: 'Stay centered over your hips — even weight on both feet, don\'t let one side drop.',
+      metrics: {
+        hipAsymmetryDeg: hipDiff,
+        leftHipDeg: ctx.minAngles.leftHip,
+        rightHipDeg: ctx.minAngles.rightHip,
+      },
+    };
+  },
+
+  incomplete_lockout: (ctx, workoutId): FaultExplanation => {
+    // Dispatch by workout — different joints define lockout.
+    if (workoutId === 'pushup' || workoutId === 'benchpress') {
+      const endElbow = avg(ctx.endAngles.leftElbow, ctx.endAngles.rightElbow);
+      const shortfall = 180 - endElbow;
+      return {
+        faultId: 'incomplete_lockout',
+        workoutId,
+        repNumber: ctx.repNumber,
+        title: 'Arms didn\'t fully lock out',
+        rationale:
+          `Elbows finished at ${fmtDeg(endElbow)} deg ` +
+          `(${fmtDeg(shortfall)} deg short of full extension). Each ` +
+          `incomplete rep costs triceps work and may skew rep-count ` +
+          `accuracy.`,
+        cue: 'Press all the way through — finish every rep with the elbows straight.',
+        metrics: {
+          endElbowDeg: endElbow,
+          shortfallFromLockoutDeg: shortfall,
+        },
+      };
+    }
+    if (workoutId === 'squat') {
+      const endKnee = avg(ctx.endAngles.leftKnee, ctx.endAngles.rightKnee);
+      const shortfall = 180 - endKnee;
+      return {
+        faultId: 'incomplete_lockout',
+        workoutId,
+        repNumber: ctx.repNumber,
+        title: 'Didn\'t stand all the way up',
+        rationale:
+          `Knees finished at ${fmtDeg(endKnee)} deg ` +
+          `(${fmtDeg(shortfall)} deg short of standing). Stand tall ` +
+          `between reps so each rep is a clean one.`,
+        cue: 'Drive all the way up — hips through, knees straight, then descend.',
+        metrics: {
+          endKneeDeg: endKnee,
+          shortfallFromLockoutDeg: shortfall,
+        },
+      };
+    }
+    // deadlift / rdl default — lockout is measured at the hip.
+    const maxHip = avg(ctx.maxAngles.leftHip, ctx.maxAngles.rightHip);
+    const shortfall = 180 - maxHip;
+    return {
+      faultId: 'incomplete_lockout',
+      workoutId,
+      repNumber: ctx.repNumber,
+      title: 'Hips never fully locked out',
+      rationale:
+        `Hip angle peaked at ${fmtDeg(maxHip)} deg — ${fmtDeg(shortfall)} ` +
+        `deg short of full extension. Finish the pull by squeezing the ` +
+        `glutes and standing tall.`,
+      cue: 'Finish the rep — glutes squeezed, hips through, chest tall.',
+      metrics: {
+        peakHipDeg: maxHip,
+        shortfallFromLockoutDeg: shortfall,
+      },
+    };
+  },
+
+  knee_valgus: (ctx, workoutId) => {
+    const kneeDiff = Math.abs(
+      ctx.minAngles.leftKnee - ctx.minAngles.rightKnee,
+    );
+    const dominant = ctx.minAngles.leftKnee < ctx.minAngles.rightKnee
+      ? 'left'
+      : 'right';
+    return {
+      faultId: 'knee_valgus',
+      workoutId,
+      repNumber: ctx.repNumber,
+      title: 'Knee caving in',
+      rationale:
+        `Knees diverged by ${fmtDeg(kneeDiff)} deg at depth ` +
+        `(L=${fmtDeg(ctx.minAngles.leftKnee)} deg, ` +
+        `R=${fmtDeg(ctx.minAngles.rightKnee)} deg). The ${dominant} knee ` +
+        `bent further than the other, suggesting valgus collapse — a ` +
+        `common cause of knee pain.`,
+      cue: 'Push your knees out over your toes — drive the floor apart.',
+      metrics: {
+        kneeAsymmetryDeg: kneeDiff,
+        leftKneeDeg: ctx.minAngles.leftKnee,
+        rightKneeDeg: ctx.minAngles.rightKnee,
+      },
+    };
+  },
+
+  elbow_flare: (ctx, workoutId) => {
+    const maxShoulder = maxJoint(
+      ctx.maxAngles,
+      'leftShoulder',
+      'rightShoulder',
+    );
+    const over = Math.max(0, maxShoulder - 120);
+    return {
+      faultId: 'elbow_flare',
+      workoutId,
+      repNumber: ctx.repNumber,
+      title: 'Elbows flared out',
+      rationale:
+        `Shoulder abduction peaked at ${fmtDeg(maxShoulder)} deg ` +
+        `(${fmtDeg(over)} deg past the 120 deg safety threshold). ` +
+        `Flared elbows stress the anterior shoulder and limit how much ` +
+        `the ${workoutId === 'benchpress' ? 'chest' : 'triceps'} can contribute.`,
+      cue: 'Tuck your elbows to ~45 deg — think "break the bar" to engage lats.',
+      metrics: {
+        peakShoulderDeg: maxShoulder,
+        degreesPastThreshold: over,
+      },
+    };
+  },
+
+  // -----------------------------------------------------------------
+  // Bonus faults (not required by the acceptance criteria, but present
+  // in workouts so shipping rationales avoids "unknown fault" cards).
+  // -----------------------------------------------------------------
+
+  shallow_depth: (ctx, workoutId): FaultExplanation => {
+    if (workoutId === 'pushup' || workoutId === 'benchpress') {
+      const minElbow = avg(ctx.minAngles.leftElbow, ctx.minAngles.rightElbow);
+      const gap = Math.max(0, minElbow - 90);
+      return {
+        faultId: 'shallow_depth',
+        workoutId,
+        repNumber: ctx.repNumber,
+        title: 'Not deep enough',
+        rationale:
+          `Minimum elbow angle was ${fmtDeg(minElbow)} deg — ${fmtDeg(gap)} ` +
+          `deg shallower than the 90 deg target.`,
+        cue: 'Lower all the way down until your elbows reach ~90 deg.',
+        metrics: {
+          minElbowDeg: minElbow,
+          gapFromTargetDeg: gap,
+        },
+      };
+    }
+    const minKnee = avg(ctx.minAngles.leftKnee, ctx.minAngles.rightKnee);
+    const gap = Math.max(0, minKnee - 90);
+    return {
+      faultId: 'shallow_depth',
+      workoutId,
+      repNumber: ctx.repNumber,
+      title: 'Not deep enough',
+      rationale:
+        `Knees bent to ${fmtDeg(minKnee)} deg — ${fmtDeg(gap)} deg ` +
+        `shallow of parallel. Target hip crease below the top of the knee.`,
+      cue: 'Sit deeper — hip crease under the knee for a full rep.',
+      metrics: {
+        minKneeDeg: minKnee,
+        gapFromParallelDeg: gap,
+      },
+    };
+  },
+
+  rounded_back: (ctx, workoutId) => {
+    const maxShoulder = maxJoint(
+      ctx.maxAngles,
+      'leftShoulder',
+      'rightShoulder',
+    );
+    return {
+      faultId: 'rounded_back',
+      workoutId,
+      repNumber: ctx.repNumber,
+      title: 'Back rounded under load',
+      rationale:
+        `Shoulder angle reached ${fmtDeg(maxShoulder)} deg, indicating ` +
+        `the upper back lost its brace. Spinal flexion with weight is the ` +
+        `highest-risk deadlift fault.`,
+      cue: 'Chest proud, lats tight — pull the slack out before driving.',
+      metrics: {
+        maxShoulderDeg: maxShoulder,
+      },
+    };
+  },
+
+  asymmetric_pull: (ctx, workoutId) => {
+    const hipDiff = Math.abs(ctx.maxAngles.leftHip - ctx.maxAngles.rightHip);
+    return {
+      faultId: 'asymmetric_pull',
+      workoutId,
+      repNumber: ctx.repNumber,
+      title: 'Pulling unevenly',
+      rationale:
+        `Hip extension asymmetry peaked at ${fmtDeg(hipDiff)} deg. One ` +
+        `side of the bar rose faster than the other.`,
+      cue: 'Keep the bar level — grip even, breathe in, brace, then drive.',
+      metrics: {
+        hipAsymmetryDeg: hipDiff,
+      },
+    };
+  },
+
+  asymmetric_press: (ctx, workoutId) => {
+    const elbowDiff = Math.abs(
+      ctx.minAngles.leftElbow - ctx.minAngles.rightElbow,
+    );
+    return {
+      faultId: 'asymmetric_press',
+      workoutId,
+      repNumber: ctx.repNumber,
+      title: 'Pressing unevenly',
+      rationale:
+        `Elbow depth diverged by ${fmtDeg(elbowDiff)} deg between sides ` +
+        `(L=${fmtDeg(ctx.minAngles.leftElbow)} deg, ` +
+        `R=${fmtDeg(ctx.minAngles.rightElbow)} deg).`,
+      cue: 'Press both arms together — match depth on the way down, match lockout on the way up.',
+      metrics: {
+        elbowAsymmetryDeg: elbowDiff,
+      },
+    };
+  },
+
+  hip_sag: (ctx, workoutId) => {
+    const minHip = minJoint(ctx.minAngles, 'leftHip', 'rightHip');
+    const sagBelowNeutral = Math.max(0, 160 - minHip);
+    return {
+      faultId: 'hip_sag',
+      workoutId,
+      repNumber: ctx.repNumber,
+      title: 'Hips dropped mid-rep',
+      rationale:
+        `Minimum hip angle was ${fmtDeg(minHip)} deg — ${fmtDeg(sagBelowNeutral)} ` +
+        `deg below a neutral plank. That breaks your rigid-body line.`,
+      cue: 'Squeeze your glutes — keep your body in a straight line head to heel.',
+      metrics: {
+        minHipDeg: minHip,
+        sagBelowNeutralDeg: sagBelowNeutral,
+      },
+    };
+  },
+
+  hip_shift: (ctx, workoutId) => {
+    const hipDiff = Math.abs(ctx.minAngles.leftHip - ctx.minAngles.rightHip);
+    const dominant = ctx.minAngles.leftHip < ctx.minAngles.rightHip
+      ? 'left'
+      : 'right';
+    return {
+      faultId: 'hip_shift',
+      workoutId,
+      repNumber: ctx.repNumber,
+      title: 'Hips shifted sideways',
+      rationale:
+        `At depth your hips shifted ${fmtDeg(hipDiff)} deg toward the ` +
+        `${dominant} side. Unilateral hip drop loads one knee harder ` +
+        `than the other.`,
+      cue: 'Stay centered — push the floor evenly with both feet.',
+      metrics: {
+        hipShiftDeg: hipDiff,
+      },
+    };
+  },
+
+  fast_rep: (ctx, workoutId) => ({
+    faultId: 'fast_rep',
+    workoutId,
+    repNumber: ctx.repNumber,
+    title: 'Too fast',
+    rationale:
+      `Rep lasted only ${fmtSec(ctx.durationMs)}. Under-controlled tempo ` +
+      `skips time-under-tension and makes form breakdown easy to miss.`,
+    cue: 'Slow the eccentric — 2-3 seconds down, then drive.',
+    metrics: { durationMs: ctx.durationMs },
+  }),
+
+  fast_descent: (ctx, workoutId) => ({
+    faultId: 'fast_descent',
+    workoutId,
+    repNumber: ctx.repNumber,
+    title: 'Uncontrolled descent',
+    rationale:
+      `Rep completed in ${fmtSec(ctx.durationMs)} — too quick to track the ` +
+      `bar path back down.`,
+    cue: 'Control the eccentric — lower with intent, don\'t drop the weight.',
+    metrics: { durationMs: ctx.durationMs },
+  }),
+
+  incomplete_rom: (ctx, workoutId) => {
+    const minElbow = avg(ctx.minAngles.leftElbow, ctx.minAngles.rightElbow);
+    return {
+      faultId: 'incomplete_rom',
+      workoutId,
+      repNumber: ctx.repNumber,
+      title: 'Short range of motion',
+      rationale:
+        `Elbows only reached ${fmtDeg(minElbow)} deg at the top — aim for a ` +
+        `full pull so the chin clears the bar.`,
+      cue: 'Pull all the way — chin over the bar, then lower with control.',
+      metrics: { minElbowDeg: minElbow },
+    };
+  },
+};
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Generate a natural-language explanation for a detected fault.
+ *
+ * Returns a formatted string ready to display in a card. For richer UI
+ * (metrics readouts, custom layouts), use `generateFaultExplanationDetail`
+ * which returns the structured `FaultExplanation`.
+ */
+export function generateFaultExplanation(
+  faultId: string,
+  rep: RepContext,
+  workoutId: string,
+): string {
+  const detail = generateFaultExplanationDetail(faultId, rep, workoutId);
+  return renderExplanation(detail);
+}
+
+/**
+ * Structured variant of `generateFaultExplanation` — returns the full
+ * `FaultExplanation` object so the UI can layout title/rationale/cue
+ * separately and surface raw metrics if desired.
+ */
+export function generateFaultExplanationDetail(
+  faultId: string,
+  rep: RepContext,
+  workoutId: string,
+): FaultExplanation {
+  const builder = BUILDERS[faultId];
+  if (builder) {
+    return builder(rep, workoutId);
+  }
+  // Unknown fault — return a safe generic explanation so UI never crashes.
+  return {
+    faultId,
+    workoutId,
+    repNumber: rep.repNumber,
+    title: 'Form issue detected',
+    rationale:
+      `A form issue ("${faultId}") was flagged on this rep, but no ` +
+      `detailed rationale is available yet.`,
+    cue: 'Keep an eye on your form and rewatch the set if possible.',
+    metrics: {},
+  };
+}
+
+/**
+ * Flatten a `FaultExplanation` into a single paragraph suitable for a
+ * toast or chip subtitle.
+ */
+export function renderExplanation(exp: FaultExplanation): string {
+  return `${exp.title}. ${exp.rationale} ${exp.cue}`;
+}
+
+/**
+ * List fault ids that have a dedicated explanation template. Useful for
+ * admin UI / coverage reports.
+ */
+export function listExplainedFaultIds(): string[] {
+  return Object.keys(BUILDERS).sort();
+}
+
+/**
+ * True when a bespoke rationale template exists for the given fault id.
+ */
+export function hasExplanationFor(faultId: string): boolean {
+  return Object.prototype.hasOwnProperty.call(BUILDERS, faultId);
+}

--- a/lib/services/rep-pain-journal.ts
+++ b/lib/services/rep-pain-journal.ts
@@ -1,0 +1,279 @@
+/**
+ * Rep Pain Journal
+ *
+ * AsyncStorage-backed on-device journal for rep-level injury/pain flags.
+ * This is intentionally NOT persisted to Supabase tonight — adding a
+ * `pain_flags` table requires a migration, which is banned under the
+ * overnight rules (see CLAUDE.md). A `syncToSupabase()` stub is provided
+ * so callers can wire the UI today; the stub is a typed no-op and will
+ * be replaced with a real sync call once a migration lands (see
+ * TODO(day) below).
+ *
+ * Storage shape: one key per user (`pain-journal:v1:<userId>`) containing
+ * a JSON array of `PainFlag` records. Keeping everything in a single key
+ * keeps read/write cheap (one round-trip) and is fine for the expected
+ * volume (< 1k flags per user).
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { errorWithTs, logWithTs } from '@/lib/logger';
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+export type PainLocation =
+  | 'lower_back'
+  | 'upper_back'
+  | 'knee'
+  | 'shoulder'
+  | 'elbow'
+  | 'wrist'
+  | 'hip'
+  | 'other';
+
+/** Severity on a 1-5 scale. 1 = twinge, 5 = stop-the-set. */
+export type PainSeverity = 1 | 2 | 3 | 4 | 5;
+
+export interface PainFlag {
+  /** Client-side UUID (pass in or we'll mint one). */
+  id: string;
+  /** Stable rep identifier — recommend `${sessionSetId}:${repNumber}`. */
+  repId: string;
+  /** Session the rep belongs to. */
+  sessionId: string;
+  /** Pain location. `other` allows free-form via `notes`. */
+  location: PainLocation;
+  /** 1-5 severity. */
+  severity: PainSeverity;
+  /** Optional free-form notes (<= 500 chars). */
+  notes?: string;
+  /** ISO timestamp when the flag was created (user's clock). */
+  createdAt: string;
+  /**
+   * Whether this flag has been pushed to Supabase. Always `false` at the
+   * moment since `syncToSupabase()` is a no-op; field exists so the UI
+   * can show sync state once the migration lands.
+   */
+  synced: boolean;
+}
+
+export interface FlagRepPainInput {
+  repId: string;
+  sessionId: string;
+  location: PainLocation;
+  severity: PainSeverity;
+  notes?: string;
+  /** Optional pre-minted id (tests pass this in). */
+  id?: string;
+}
+
+// =============================================================================
+// Key construction
+// =============================================================================
+
+const KEY_PREFIX = 'pain-journal:v1:';
+
+/** Build the storage key for a given user. Exposed for testing. */
+export function painJournalKey(userId: string): string {
+  if (!userId || typeof userId !== 'string') {
+    throw new Error('[pain-journal] userId is required');
+  }
+  return `${KEY_PREFIX}${userId}`;
+}
+
+// =============================================================================
+// Internal I/O helpers
+// =============================================================================
+
+async function readAll(userId: string): Promise<PainFlag[]> {
+  const raw = await AsyncStorage.getItem(painJournalKey(userId));
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    // Defensive: drop any malformed entries so a corrupt item can't break
+    // the whole timeline render.
+    return parsed.filter(isPainFlag);
+  } catch (err) {
+    errorWithTs('[pain-journal] Failed to parse stored flags', err);
+    return [];
+  }
+}
+
+async function writeAll(userId: string, flags: PainFlag[]): Promise<void> {
+  await AsyncStorage.setItem(painJournalKey(userId), JSON.stringify(flags));
+}
+
+function isPainFlag(value: unknown): value is PainFlag {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === 'string' &&
+    typeof v.repId === 'string' &&
+    typeof v.sessionId === 'string' &&
+    typeof v.location === 'string' &&
+    typeof v.severity === 'number' &&
+    typeof v.createdAt === 'string'
+  );
+}
+
+function mintId(): string {
+  const rand = Math.random().toString(36).slice(2, 10);
+  return `pf_${Date.now().toString(36)}_${rand}`;
+}
+
+function clampSeverity(n: number): PainSeverity {
+  const rounded = Math.round(n);
+  if (rounded < 1) return 1;
+  if (rounded > 5) return 5;
+  return rounded as PainSeverity;
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Log a pain flag against a specific rep. Returns the persisted flag so
+ * callers can immediately render it or feed it into weight-adjustment
+ * heuristics (see `adjustNextSetWeight`).
+ */
+export async function flagRepPain(
+  userId: string,
+  input: FlagRepPainInput,
+): Promise<PainFlag> {
+  const flags = await readAll(userId);
+  const flag: PainFlag = {
+    id: input.id ?? mintId(),
+    repId: input.repId,
+    sessionId: input.sessionId,
+    location: input.location,
+    severity: clampSeverity(input.severity),
+    notes: input.notes?.slice(0, 500),
+    createdAt: new Date().toISOString(),
+    synced: false,
+  };
+  flags.push(flag);
+  await writeAll(userId, flags);
+  logWithTs('[pain-journal] flag recorded', {
+    repId: flag.repId,
+    severity: flag.severity,
+  });
+  return flag;
+}
+
+/**
+ * Read pain flags for a user, optionally constrained to the last `days`
+ * days. Results are sorted newest-first.
+ *
+ * `days` defaults to 30; pass `Infinity` to read everything.
+ */
+export async function getPainFlags(
+  userId: string,
+  days: number = 30,
+): Promise<PainFlag[]> {
+  const flags = await readAll(userId);
+  const cutoff = Number.isFinite(days)
+    ? Date.now() - days * 24 * 60 * 60 * 1000
+    : -Infinity;
+  return flags
+    .filter((f) => {
+      const t = Date.parse(f.createdAt);
+      return Number.isFinite(t) ? t >= cutoff : true;
+    })
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+/** Remove a single flag by id. No-op if not present. */
+export async function deletePainFlag(
+  userId: string,
+  flagId: string,
+): Promise<void> {
+  const flags = await readAll(userId);
+  const next = flags.filter((f) => f.id !== flagId);
+  if (next.length === flags.length) return;
+  await writeAll(userId, next);
+}
+
+/** Wipe the entire journal for a user (used by sign-out / tests). */
+export async function clearPainJournal(userId: string): Promise<void> {
+  await AsyncStorage.removeItem(painJournalKey(userId));
+}
+
+/**
+ * Compute a fractional weight reduction for the next set based on the
+ * severity of a pain flag. `severity * 2%` per the issue spec, capped
+ * at 15% so a severity 5 flag doesn't zero out the next set.
+ */
+export function computeWeightReductionFraction(severity: PainSeverity): number {
+  const raw = severity * 0.02;
+  return Math.min(raw, 0.15);
+}
+
+/**
+ * Apply a weight-adjustment recommendation for the next set. The real
+ * session runner does not currently expose a typed "pending weight"
+ * API, so we emit a debug log and return the recommended delta for the
+ * caller. When #461 or a session-runner refactor lands, this function
+ * can be updated to call into the store directly.
+ *
+ * TODO(session-runner): wire into `useSessionRunner.updateSet` once the
+ * store exposes a "next pending set" accessor.
+ */
+export function adjustNextSetWeight(
+  sessionId: string,
+  severity: PainSeverity,
+): { sessionId: string; severity: PainSeverity; recommendedDeltaFraction: number } {
+  const fraction = computeWeightReductionFraction(severity);
+  logWithTs('[pain-journal] recommending next-set reduction', {
+    sessionId,
+    severity,
+    reductionFraction: fraction,
+  });
+  return {
+    sessionId,
+    severity,
+    recommendedDeltaFraction: -fraction,
+  };
+}
+
+/**
+ * Push pending pain flags to Supabase.
+ *
+ * NO-OP STUB — a real `pain_flags` table requires a Supabase migration,
+ * which is banned under the overnight rules (CLAUDE.md). Once the
+ * migration ships, this function should:
+ *   1. Read any flags where `synced=false`.
+ *   2. Upsert to `public.pain_flags` keyed on `id`.
+ *   3. Update local copies with `synced=true`.
+ *
+ * TODO(day): replace with real Supabase upsert once `pain_flags` migration
+ * is merged (see related issue filed with this PR).
+ */
+export async function syncToSupabase(_userId: string): Promise<{
+  attempted: number;
+  synced: number;
+  skipped: 'migration_pending';
+}> {
+  return Promise.resolve({
+    attempted: 0,
+    synced: 0,
+    skipped: 'migration_pending' as const,
+  });
+}
+
+/**
+ * Human-readable labels for pain locations, keyed by PainLocation.
+ * Exposed so modals/pickers don't have to hardcode copy.
+ */
+export const PAIN_LOCATION_LABELS: Record<PainLocation, string> = {
+  lower_back: 'Lower back',
+  upper_back: 'Upper back',
+  knee: 'Knee',
+  shoulder: 'Shoulder',
+  elbow: 'Elbow',
+  wrist: 'Wrist',
+  hip: 'Hip',
+  other: 'Other',
+};

--- a/lib/services/session-export-service.ts
+++ b/lib/services/session-export-service.ts
@@ -1,0 +1,424 @@
+/**
+ * Session Export Service
+ *
+ * Reads a workout session from local SQLite and writes a JSON or CSV
+ * artefact to `expo-file-system` so the user can share it with a
+ * trainer via the built-in `Share` sheet. No new deps: uses
+ * `expo-file-system` (already a project dep) and `react-native`'s
+ * `Share`.
+ *
+ * CSV schema (one row per rep):
+ *   session_id, session_name, exercise_id, exercise_name,
+ *   set_sort_order, set_type, rep_number, actual_weight,
+ *   actual_reps, actual_seconds, planned_weight, planned_reps,
+ *   perceived_rpe, tut_ms, tut_source, fqi_score, faults,
+ *   completed_at
+ *
+ * JSON schema: the structured `SessionExportPayload` below.
+ *
+ * TODO(#461): once `lib/services/coach-service.ts` lands coach memory
+ * enrichment, add a `coach_notes` column pulled from the daily debrief.
+ */
+import * as FileSystem from 'expo-file-system/legacy';
+
+import { localDB } from '@/lib/services/database/local-db';
+import { logWithTs } from '@/lib/logger';
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+export type SessionExportFormat = 'json' | 'csv';
+
+export interface SessionExportSetRow {
+  sessionId: string;
+  sessionName: string | null;
+  exerciseId: string;
+  exerciseName: string | null;
+  setSortOrder: number;
+  setType: string;
+  /** Per-set number of reps (1 row per set). */
+  actualReps: number | null;
+  plannedReps: number | null;
+  actualWeight: number | null;
+  plannedWeight: number | null;
+  actualSeconds: number | null;
+  perceivedRpe: number | null;
+  tutMs: number | null;
+  tutSource: string | null;
+  /** Optional FQI score pulled from set notes if present. */
+  fqiScore: number | null;
+  /** Comma-separated fault IDs if present in set notes. */
+  faults: string | null;
+  completedAt: string | null;
+}
+
+export interface SessionExportPayload {
+  schemaVersion: 1;
+  generatedAt: string;
+  session: {
+    id: string;
+    name: string | null;
+    goalProfile: string;
+    startedAt: string;
+    endedAt: string | null;
+    durationSeconds: number | null;
+    bodyweightLb: number | null;
+    notes: string | null;
+  };
+  exercises: {
+    id: string;
+    exerciseId: string;
+    exerciseName: string | null;
+    sortOrder: number;
+    notes: string | null;
+    sets: SessionExportSetRow[];
+  }[];
+  totalSetCount: number;
+  totalVolumeLb: number;
+}
+
+export interface SessionExportResult {
+  path: string;
+  bytes: number;
+  format: SessionExportFormat;
+}
+
+// =============================================================================
+// Internal helpers — SQLite shape passthroughs
+// =============================================================================
+
+interface SessionRow {
+  id: string;
+  name: string | null;
+  goal_profile: string;
+  started_at: string;
+  ended_at: string | null;
+  bodyweight_lb: number | null;
+  notes: string | null;
+}
+
+interface SessionExerciseRow {
+  id: string;
+  exercise_id: string;
+  exercise_name: string | null;
+  sort_order: number;
+  notes: string | null;
+}
+
+interface SessionSetRow {
+  id: string;
+  session_exercise_id: string;
+  sort_order: number;
+  set_type: string;
+  planned_reps: number | null;
+  planned_seconds: number | null;
+  planned_weight: number | null;
+  actual_reps: number | null;
+  actual_seconds: number | null;
+  actual_weight: number | null;
+  completed_at: string | null;
+  perceived_rpe: number | null;
+  tut_ms: number | null;
+  tut_source: string | null;
+  notes: string | null;
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+/**
+ * Some rows store notes as JSON blobs with FQI / fault context. Parse
+ * defensively so non-JSON notes (free-form) simply skip extraction.
+ */
+function parseSetNotes(notes: string | null): {
+  fqiScore: number | null;
+  faults: string | null;
+} {
+  if (!notes) return { fqiScore: null, faults: null };
+  try {
+    const parsed = JSON.parse(notes) as unknown;
+    if (!parsed || typeof parsed !== 'object') {
+      return { fqiScore: null, faults: null };
+    }
+    const rec = parsed as Record<string, unknown>;
+    const fqi =
+      typeof rec.fqiScore === 'number'
+        ? rec.fqiScore
+        : typeof rec.fqi_score === 'number'
+          ? rec.fqi_score
+          : null;
+    let faults: string | null = null;
+    if (Array.isArray(rec.faults)) {
+      faults = rec.faults
+        .map((x) => (typeof x === 'string' ? x : (x as { id?: string })?.id))
+        .filter((x): x is string => typeof x === 'string' && x.length > 0)
+        .join(',');
+    } else if (typeof rec.faults === 'string') {
+      faults = rec.faults;
+    }
+    return { fqiScore: fqi, faults };
+  } catch {
+    return { fqiScore: null, faults: null };
+  }
+}
+
+function escapeCsvField(value: string | number | null | undefined): string {
+  if (value == null) return '';
+  const s = String(value);
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+function rowsToCsv(rows: SessionExportSetRow[]): string {
+  const header = [
+    'session_id',
+    'session_name',
+    'exercise_id',
+    'exercise_name',
+    'set_sort_order',
+    'set_type',
+    'actual_reps',
+    'planned_reps',
+    'actual_weight',
+    'planned_weight',
+    'actual_seconds',
+    'perceived_rpe',
+    'tut_ms',
+    'tut_source',
+    'fqi_score',
+    'faults',
+    'completed_at',
+  ];
+  const lines = [header.join(',')];
+  for (const r of rows) {
+    lines.push(
+      [
+        r.sessionId,
+        r.sessionName,
+        r.exerciseId,
+        r.exerciseName,
+        r.setSortOrder,
+        r.setType,
+        r.actualReps,
+        r.plannedReps,
+        r.actualWeight,
+        r.plannedWeight,
+        r.actualSeconds,
+        r.perceivedRpe,
+        r.tutMs,
+        r.tutSource,
+        r.fqiScore,
+        r.faults,
+        r.completedAt,
+      ]
+        .map(escapeCsvField)
+        .join(','),
+    );
+  }
+  return lines.join('\n');
+}
+
+// =============================================================================
+// Database layer
+// =============================================================================
+
+/**
+ * Build an in-memory `SessionExportPayload` for the given session id.
+ * Exported for tests / previews — does NOT touch the filesystem.
+ */
+export async function buildSessionExportPayload(
+  sessionId: string,
+): Promise<SessionExportPayload> {
+  const db = localDB.db;
+  if (!db) {
+    throw new Error('[session-export] local database not initialised');
+  }
+
+  const sessions = await db.getAllAsync<SessionRow>(
+    `SELECT id, name, goal_profile, started_at, ended_at, bodyweight_lb, notes
+       FROM workout_sessions
+      WHERE id = ? AND deleted = 0`,
+    [sessionId],
+  );
+  const session = sessions[0];
+  if (!session) {
+    throw new Error(`[session-export] session ${sessionId} not found`);
+  }
+
+  const exerciseRows = await db.getAllAsync<SessionExerciseRow>(
+    `SELECT wse.id, wse.exercise_id, e.name AS exercise_name, wse.sort_order, wse.notes
+       FROM workout_session_exercises wse
+       LEFT JOIN exercises e ON e.id = wse.exercise_id
+      WHERE wse.session_id = ? AND wse.deleted = 0
+      ORDER BY wse.sort_order ASC`,
+    [sessionId],
+  );
+
+  const exerciseIds = exerciseRows.map((r) => r.id);
+  let setRows: SessionSetRow[] = [];
+  if (exerciseIds.length > 0) {
+    const placeholders = exerciseIds.map(() => '?').join(',');
+    setRows = await db.getAllAsync<SessionSetRow>(
+      `SELECT id, session_exercise_id, sort_order, set_type,
+              planned_reps, planned_seconds, planned_weight,
+              actual_reps, actual_seconds, actual_weight,
+              completed_at, perceived_rpe, tut_ms, tut_source, notes
+         FROM workout_session_sets
+        WHERE session_exercise_id IN (${placeholders}) AND deleted = 0
+        ORDER BY session_exercise_id, sort_order ASC`,
+      exerciseIds,
+    );
+  }
+
+  const sessionName = session.name;
+
+  const exercises = exerciseRows.map((ex) => {
+    const sets = setRows
+      .filter((s) => s.session_exercise_id === ex.id)
+      .map((s): SessionExportSetRow => {
+        const extra = parseSetNotes(s.notes);
+        return {
+          sessionId: session.id,
+          sessionName,
+          exerciseId: ex.exercise_id,
+          exerciseName: ex.exercise_name,
+          setSortOrder: s.sort_order,
+          setType: s.set_type,
+          actualReps: s.actual_reps,
+          plannedReps: s.planned_reps,
+          actualWeight: s.actual_weight,
+          plannedWeight: s.planned_weight,
+          actualSeconds: s.actual_seconds,
+          perceivedRpe: s.perceived_rpe,
+          tutMs: s.tut_ms,
+          tutSource: s.tut_source,
+          fqiScore: extra.fqiScore,
+          faults: extra.faults,
+          completedAt: s.completed_at,
+        };
+      });
+    return {
+      id: ex.id,
+      exerciseId: ex.exercise_id,
+      exerciseName: ex.exercise_name,
+      sortOrder: ex.sort_order,
+      notes: ex.notes,
+      sets,
+    };
+  });
+
+  const totalSetCount = exercises.reduce((acc, ex) => acc + ex.sets.length, 0);
+  const totalVolumeLb = exercises.reduce((acc, ex) => {
+    return (
+      acc +
+      ex.sets.reduce((s, row) => {
+        const reps = row.actualReps ?? 0;
+        const weight = row.actualWeight ?? 0;
+        return s + reps * weight;
+      }, 0)
+    );
+  }, 0);
+
+  const durationSeconds = session.ended_at
+    ? Math.max(
+        0,
+        Math.round(
+          (Date.parse(session.ended_at) - Date.parse(session.started_at)) / 1000,
+        ),
+      )
+    : null;
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    session: {
+      id: session.id,
+      name: session.name,
+      goalProfile: session.goal_profile,
+      startedAt: session.started_at,
+      endedAt: session.ended_at,
+      durationSeconds,
+      bodyweightLb: session.bodyweight_lb,
+      notes: session.notes,
+    },
+    exercises,
+    totalSetCount,
+    totalVolumeLb,
+  };
+}
+
+/** Flatten a payload into the CSV row list (1 row per set). */
+export function payloadToSetRows(
+  payload: SessionExportPayload,
+): SessionExportSetRow[] {
+  return payload.exercises.flatMap((ex) => ex.sets);
+}
+
+/** Serialize a payload to its final string content for the chosen format. */
+export function serializeExport(
+  payload: SessionExportPayload,
+  format: SessionExportFormat,
+): string {
+  if (format === 'json') {
+    return JSON.stringify(payload, null, 2);
+  }
+  return rowsToCsv(payloadToSetRows(payload));
+}
+
+// =============================================================================
+// Filesystem layer
+// =============================================================================
+
+const EXPORT_SUBDIR = 'exports/';
+
+/**
+ * Build the absolute export file path inside the app's document directory.
+ * Exported so tests can assert against a deterministic path prefix.
+ */
+export function buildExportPath(
+  sessionId: string,
+  format: SessionExportFormat,
+  now: Date = new Date(),
+): string {
+  const base = FileSystem.documentDirectory ?? '';
+  const stamp = now.toISOString().replace(/[:.]/g, '-');
+  const safeSession = sessionId.replace(/[^a-zA-Z0-9_-]/g, '_');
+  return `${base}${EXPORT_SUBDIR}session-${safeSession}-${stamp}.${format}`;
+}
+
+async function ensureExportDir(): Promise<void> {
+  const base = FileSystem.documentDirectory;
+  if (!base) return;
+  const dir = `${base}${EXPORT_SUBDIR}`;
+  const info = await FileSystem.getInfoAsync(dir);
+  if (!info.exists) {
+    await FileSystem.makeDirectoryAsync(dir, { intermediates: true });
+  }
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Export a session to disk and return the resulting path + byte size.
+ * Host UI is responsible for calling `Share.share({ url: path })` (built
+ * into React Native — no new dep).
+ */
+export async function exportSession(
+  sessionId: string,
+  format: SessionExportFormat,
+): Promise<SessionExportResult> {
+  const payload = await buildSessionExportPayload(sessionId);
+  const content = serializeExport(payload, format);
+  const path = buildExportPath(sessionId, format);
+  await ensureExportDir();
+  await FileSystem.writeAsStringAsync(path, content);
+  const bytes = new TextEncoder().encode(content).byteLength;
+  logWithTs('[session-export] wrote export', { path, bytes, format });
+  return { path, bytes, format };
+}

--- a/lib/services/session-timeline-service.ts
+++ b/lib/services/session-timeline-service.ts
@@ -1,0 +1,249 @@
+/**
+ * Session Timeline Service
+ *
+ * Builds a unified chronological timeline of workout sessions and
+ * scan-arkit sessions for display in the session-timeline modal.
+ *
+ * Scan-arkit sessions are NOT currently persisted to any durable store
+ * in this codebase (verified against `lib/` and `app/(tabs)/scan-arkit.tsx`
+ * on 2026-04-16 — scan sessions live only in runtime state). Rather
+ * than fabricate data, this service treats scan sessions as an optional
+ * input: when a future scan-persistence layer lands (see TODO below),
+ * it can feed rows into `options.scanSessions` and the merge will
+ * continue to work unchanged.
+ *
+ * TODO(scan-persistence): add a dedicated `scan_sessions` table or
+ * AsyncStorage journal, then populate `options.scanSessions` from it
+ * inside the hook that calls this service.
+ */
+import { localDB } from '@/lib/services/database/local-db';
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+export type TimelineEntryType = 'workout' | 'scan';
+
+export interface TimelineEntry {
+  /** Stable id for FlatList keyExtractor — prefixed with type for uniqueness. */
+  id: string;
+  /** Discriminant for rendering. */
+  type: TimelineEntryType;
+  /** ISO timestamp for sorting + grouping. */
+  occurredAt: string;
+  /** Short title (session name or exercise label). */
+  title: string;
+  /** One-line subtitle (duration, set count, FQI score, etc.). */
+  subtitle: string | null;
+  /**
+   * Route for drill-in navigation (e.g.
+   * `/(modals)/workout-insights?sessionId=…`). Empty string when the
+   * underlying detail screen does not exist yet (see scan TODO).
+   */
+  href: string;
+  /** Underlying id of the backing record (pre-fix). */
+  sourceId: string;
+}
+
+export interface ScanTimelineInput {
+  id: string;
+  startedAt: string;
+  /** Optional human label (exercise name or "Form scan"). */
+  label?: string | null;
+  /** Optional subtitle (e.g. "4 reps · FQI 82"). */
+  subtitle?: string | null;
+}
+
+export type DateBucket =
+  | 'today'
+  | 'yesterday'
+  | 'this_week'
+  | 'last_week'
+  | 'this_month'
+  | 'older';
+
+export interface TimelineSection {
+  bucket: DateBucket;
+  label: string;
+  entries: TimelineEntry[];
+}
+
+export interface GetUnifiedTimelineOptions {
+  /** External scan sessions to merge (until persistence lands). */
+  scanSessions?: ScanTimelineInput[];
+  /** Override "now" for deterministic date-bucket tests. */
+  now?: Date;
+}
+
+// =============================================================================
+// Date bucketing
+// =============================================================================
+
+const BUCKET_LABELS: Record<DateBucket, string> = {
+  today: 'Today',
+  yesterday: 'Yesterday',
+  this_week: 'This week',
+  last_week: 'Last week',
+  this_month: 'This month',
+  older: 'Older',
+};
+
+/** Public for tests — deterministic day-delta bucketing. */
+export function classifyBucket(
+  occurredAt: string,
+  now: Date = new Date(),
+): DateBucket {
+  const occurred = Date.parse(occurredAt);
+  if (!Number.isFinite(occurred)) return 'older';
+  const diffMs = now.getTime() - occurred;
+  const dayMs = 24 * 60 * 60 * 1000;
+  const diffDays = Math.floor(diffMs / dayMs);
+  if (diffDays <= 0) return 'today';
+  if (diffDays === 1) return 'yesterday';
+  if (diffDays < 7) return 'this_week';
+  if (diffDays < 14) return 'last_week';
+  if (diffDays < 30) return 'this_month';
+  return 'older';
+}
+
+// =============================================================================
+// Internal queries
+// =============================================================================
+
+interface WorkoutSessionTimelineRow {
+  id: string;
+  name: string | null;
+  started_at: string;
+  ended_at: string | null;
+  set_count: number;
+}
+
+async function readWorkoutSessions(
+  sinceIso: string,
+): Promise<WorkoutSessionTimelineRow[]> {
+  const db = localDB.db;
+  if (!db) return [];
+  try {
+    return await db.getAllAsync<WorkoutSessionTimelineRow>(
+      `SELECT ws.id, ws.name, ws.started_at, ws.ended_at,
+              (SELECT COUNT(*) FROM workout_session_sets wss
+                 JOIN workout_session_exercises wse
+                   ON wse.id = wss.session_exercise_id
+                WHERE wse.session_id = ws.id AND wss.deleted = 0 AND wse.deleted = 0) AS set_count
+         FROM workout_sessions ws
+        WHERE ws.deleted = 0 AND ws.started_at >= ?
+        ORDER BY ws.started_at DESC`,
+      [sinceIso],
+    );
+  } catch {
+    return [];
+  }
+}
+
+function formatWorkoutSubtitle(row: WorkoutSessionTimelineRow): string {
+  const parts: string[] = [];
+  if (row.ended_at) {
+    const durationMs =
+      Date.parse(row.ended_at) - Date.parse(row.started_at);
+    if (Number.isFinite(durationMs) && durationMs > 0) {
+      const mins = Math.round(durationMs / 60000);
+      parts.push(mins < 60 ? `${mins}m` : `${Math.floor(mins / 60)}h ${mins % 60}m`);
+    }
+  } else {
+    parts.push('In progress');
+  }
+  if (row.set_count > 0) {
+    parts.push(`${row.set_count} set${row.set_count === 1 ? '' : 's'}`);
+  }
+  return parts.join(' · ');
+}
+
+function mapWorkoutRow(row: WorkoutSessionTimelineRow): TimelineEntry {
+  return {
+    id: `workout:${row.id}`,
+    type: 'workout',
+    occurredAt: row.started_at,
+    title: row.name ?? 'Workout session',
+    subtitle: formatWorkoutSubtitle(row) || null,
+    href: `/(modals)/workout-insights?sessionId=${row.id}`,
+    sourceId: row.id,
+  };
+}
+
+function mapScanRow(row: ScanTimelineInput): TimelineEntry {
+  return {
+    id: `scan:${row.id}`,
+    type: 'scan',
+    occurredAt: row.startedAt,
+    title: row.label ?? 'Form scan',
+    subtitle: row.subtitle ?? null,
+    // TODO(scan-persistence): once a detail screen exists, set this to
+    // /(modals)/scan-session-detail?sessionId={row.id}
+    href: '',
+    sourceId: row.id,
+  };
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Merge workout + scan sessions for the last `days` days into a single
+ * timeline. Result is sorted newest-first and tagged by type.
+ */
+export async function getUnifiedTimeline(
+  _userId: string,
+  days: number = 30,
+  options: GetUnifiedTimelineOptions = {},
+): Promise<TimelineEntry[]> {
+  const now = options.now ?? new Date();
+  const since = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+  const sinceIso = since.toISOString();
+
+  const [workoutRows, scanEntries] = await Promise.all([
+    readWorkoutSessions(sinceIso),
+    Promise.resolve(options.scanSessions ?? []),
+  ]);
+
+  const workoutEntries = workoutRows.map(mapWorkoutRow);
+  const mappedScan = scanEntries
+    .filter((s) => Date.parse(s.startedAt) >= since.getTime())
+    .map(mapScanRow);
+
+  const merged = [...workoutEntries, ...mappedScan];
+  return merged.sort((a, b) => b.occurredAt.localeCompare(a.occurredAt));
+}
+
+/**
+ * Group timeline entries into date buckets (Today / Yesterday / This
+ * week / Last week / This month / Older). Preserves the newest-first
+ * ordering within each bucket and drops empty buckets.
+ */
+export function groupByDateBucket(
+  entries: TimelineEntry[],
+  now: Date = new Date(),
+): TimelineSection[] {
+  const bucketOrder: DateBucket[] = [
+    'today',
+    'yesterday',
+    'this_week',
+    'last_week',
+    'this_month',
+    'older',
+  ];
+  const map = new Map<DateBucket, TimelineEntry[]>();
+  for (const b of bucketOrder) map.set(b, []);
+  for (const entry of entries) {
+    const bucket = classifyBucket(entry.occurredAt, now);
+    const bucketEntries = map.get(bucket);
+    if (bucketEntries) bucketEntries.push(entry);
+  }
+  return bucketOrder
+    .map((bucket) => ({
+      bucket,
+      label: BUCKET_LABELS[bucket],
+      entries: map.get(bucket) ?? [],
+    }))
+    .filter((section) => section.entries.length > 0);
+}

--- a/tests/unit/services/fault-explainability.test.ts
+++ b/tests/unit/services/fault-explainability.test.ts
@@ -1,0 +1,548 @@
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { RepContext } from '@/lib/types/workout-definitions';
+import {
+  generateFaultExplanation,
+  generateFaultExplanationDetail,
+  renderExplanation,
+  listExplainedFaultIds,
+  hasExplanationFor,
+} from '@/lib/services/fault-explainability';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function mkAngles(overrides: Partial<JointAngles> = {}): JointAngles {
+  return {
+    leftKnee: 120,
+    rightKnee: 120,
+    leftElbow: 180,
+    rightElbow: 180,
+    leftHip: 90,
+    rightHip: 90,
+    leftShoulder: 90,
+    rightShoulder: 90,
+    ...overrides,
+  };
+}
+
+function mkRep(overrides: Partial<RepContext> = {}): RepContext {
+  const base: RepContext = {
+    startAngles: mkAngles(),
+    endAngles: mkAngles(),
+    minAngles: mkAngles(),
+    maxAngles: mkAngles(),
+    durationMs: 2000,
+    repNumber: 1,
+    workoutId: 'deadlift',
+  };
+  return { ...base, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// Registry sanity
+// ---------------------------------------------------------------------------
+
+describe('fault-explainability registry', () => {
+  it('lists at least the six required faults', () => {
+    const ids = listExplainedFaultIds();
+    expect(ids).toContain('hips_rise_first');
+    expect(ids).toContain('forward_lean');
+    expect(ids).toContain('lateral_lean');
+    expect(ids).toContain('incomplete_lockout');
+    expect(ids).toContain('knee_valgus');
+    expect(ids).toContain('elbow_flare');
+  });
+
+  it('reports hasExplanationFor for known and unknown ids', () => {
+    expect(hasExplanationFor('hips_rise_first')).toBe(true);
+    expect(hasExplanationFor('__not_a_real_fault__')).toBe(false);
+  });
+
+  it('lists ids alphabetically', () => {
+    const ids = listExplainedFaultIds();
+    const sorted = [...ids].sort();
+    expect(ids).toEqual(sorted);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown fault fallback
+// ---------------------------------------------------------------------------
+
+describe('unknown fault fallback', () => {
+  it('returns a safe generic explanation for unknown faultId', () => {
+    const exp = generateFaultExplanationDetail(
+      'unknown_fault_xyz',
+      mkRep(),
+      'deadlift',
+    );
+    expect(exp.faultId).toBe('unknown_fault_xyz');
+    expect(exp.workoutId).toBe('deadlift');
+    expect(exp.title.length).toBeGreaterThan(0);
+    expect(exp.rationale.length).toBeGreaterThan(0);
+    expect(exp.cue.length).toBeGreaterThan(0);
+    // No angle deltas surfaced for unknown faults.
+    expect(Object.keys(exp.metrics)).toHaveLength(0);
+  });
+
+  it('flattens an unknown-fault explanation to a single sentence string', () => {
+    const text = generateFaultExplanation('mystery', mkRep(), 'squat');
+    expect(text).toContain('Form issue');
+    expect(text).toContain('mystery');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hips_rise_first
+// ---------------------------------------------------------------------------
+
+describe('hips_rise_first', () => {
+  it('reports hip-lead delta in degrees and returns the matching faultId', () => {
+    const rep = mkRep({
+      startAngles: mkAngles({ leftHip: 80, leftKnee: 110 }),
+      maxAngles: mkAngles({ leftHip: 170, leftKnee: 150 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'hips_rise_first',
+      rep,
+      'deadlift',
+    );
+    expect(detail.faultId).toBe('hips_rise_first');
+    // hip: 80 -> 170 = 90; knee: 110 -> 150 = 40; lead = 50
+    expect(detail.metrics.hipChangeDeg).toBe(90);
+    expect(detail.metrics.kneeChangeDeg).toBe(40);
+    expect(detail.metrics.hipLeadDeg).toBe(50);
+    expect(detail.rationale).toContain('hip-lead');
+    expect(detail.cue.length).toBeGreaterThan(0);
+    expect(detail.repNumber).toBe(1);
+  });
+
+  it('carries the rep number through from the context', () => {
+    const detail = generateFaultExplanationDetail(
+      'hips_rise_first',
+      mkRep({ repNumber: 5 }),
+      'deadlift',
+    );
+    expect(detail.repNumber).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forward_lean
+// ---------------------------------------------------------------------------
+
+describe('forward_lean', () => {
+  it('squat variant surfaces min-hip vs min-knee gap', () => {
+    const rep = mkRep({
+      minAngles: mkAngles({
+        leftHip: 60,
+        rightHip: 60,
+        leftKnee: 100,
+        rightKnee: 100,
+      }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'forward_lean',
+      rep,
+      'squat',
+    );
+    expect(detail.metrics.minHipDeg).toBe(60);
+    expect(detail.metrics.minKneeDeg).toBe(100);
+    expect(detail.metrics.leanGapDeg).toBe(40);
+    expect(detail.title.toLowerCase()).toContain('chest');
+  });
+
+  it('farmers_walk variant surfaces hip-shortfall from upright', () => {
+    const rep = mkRep({
+      maxAngles: mkAngles({ leftHip: 150, rightHip: 150 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'forward_lean',
+      rep,
+      'farmers_walk',
+    );
+    expect(detail.metrics.peakHipDeg).toBe(150);
+    expect(detail.metrics.shortfallFromUprightDeg).toBe(30);
+    expect(detail.title.toLowerCase()).toContain('trunk');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lateral_lean
+// ---------------------------------------------------------------------------
+
+describe('lateral_lean', () => {
+  it('reports absolute hip asymmetry', () => {
+    const rep = mkRep({
+      minAngles: mkAngles({ leftHip: 70, rightHip: 95 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'lateral_lean',
+      rep,
+      'farmers_walk',
+    );
+    expect(detail.metrics.hipAsymmetryDeg).toBe(25);
+    expect(detail.metrics.leftHipDeg).toBe(70);
+    expect(detail.metrics.rightHipDeg).toBe(95);
+    expect(detail.title.toLowerCase()).toContain('lean');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// incomplete_lockout (dispatched by workoutId)
+// ---------------------------------------------------------------------------
+
+describe('incomplete_lockout', () => {
+  it('pushup variant references elbow shortfall', () => {
+    const rep = mkRep({
+      endAngles: mkAngles({ leftElbow: 140, rightElbow: 140 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'incomplete_lockout',
+      rep,
+      'pushup',
+    );
+    expect(detail.metrics.endElbowDeg).toBe(140);
+    expect(detail.metrics.shortfallFromLockoutDeg).toBe(40);
+    expect(detail.title.toLowerCase()).toContain('lock out');
+  });
+
+  it('benchpress variant shares the elbow dispatch', () => {
+    const rep = mkRep({
+      endAngles: mkAngles({ leftElbow: 160, rightElbow: 160 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'incomplete_lockout',
+      rep,
+      'benchpress',
+    );
+    expect(detail.metrics.endElbowDeg).toBe(160);
+    expect(detail.metrics.shortfallFromLockoutDeg).toBe(20);
+  });
+
+  it('squat variant references knee shortfall', () => {
+    const rep = mkRep({
+      endAngles: mkAngles({ leftKnee: 150, rightKnee: 150 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'incomplete_lockout',
+      rep,
+      'squat',
+    );
+    expect(detail.metrics.endKneeDeg).toBe(150);
+    expect(detail.metrics.shortfallFromLockoutDeg).toBe(30);
+    expect(detail.rationale.toLowerCase()).toContain('stand');
+  });
+
+  it('deadlift variant references hip shortfall', () => {
+    const rep = mkRep({
+      maxAngles: mkAngles({ leftHip: 150, rightHip: 150 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'incomplete_lockout',
+      rep,
+      'deadlift',
+    );
+    expect(detail.metrics.peakHipDeg).toBe(150);
+    expect(detail.metrics.shortfallFromLockoutDeg).toBe(30);
+    expect(detail.rationale.toLowerCase()).toContain('hip');
+  });
+
+  it('rdl variant defaults to hip as well', () => {
+    const rep = mkRep({
+      maxAngles: mkAngles({ leftHip: 160, rightHip: 160 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'incomplete_lockout',
+      rep,
+      'rdl',
+    );
+    expect(detail.metrics.peakHipDeg).toBe(160);
+    expect(detail.metrics.shortfallFromLockoutDeg).toBe(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// knee_valgus
+// ---------------------------------------------------------------------------
+
+describe('knee_valgus', () => {
+  it('reports knee asymmetry and dominant side', () => {
+    const rep = mkRep({
+      minAngles: mkAngles({ leftKnee: 75, rightKnee: 105 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'knee_valgus',
+      rep,
+      'squat',
+    );
+    expect(detail.metrics.kneeAsymmetryDeg).toBe(30);
+    expect(detail.metrics.leftKneeDeg).toBe(75);
+    expect(detail.metrics.rightKneeDeg).toBe(105);
+    // left bent further => dominant side is 'left'
+    expect(detail.rationale.toLowerCase()).toContain('left knee');
+  });
+
+  it('identifies right side when right knee bends further', () => {
+    const rep = mkRep({
+      minAngles: mkAngles({ leftKnee: 110, rightKnee: 80 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'knee_valgus',
+      rep,
+      'squat',
+    );
+    expect(detail.rationale.toLowerCase()).toContain('right knee');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// elbow_flare
+// ---------------------------------------------------------------------------
+
+describe('elbow_flare', () => {
+  it('reports shoulder abduction past 120° threshold', () => {
+    const rep = mkRep({
+      maxAngles: mkAngles({ leftShoulder: 130, rightShoulder: 145 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'elbow_flare',
+      rep,
+      'benchpress',
+    );
+    expect(detail.metrics.peakShoulderDeg).toBe(145);
+    expect(detail.metrics.degreesPastThreshold).toBe(25);
+    expect(detail.rationale.toLowerCase()).toContain('chest');
+  });
+
+  it('references triceps for pushup variant', () => {
+    const rep = mkRep({
+      maxAngles: mkAngles({ leftShoulder: 135, rightShoulder: 135 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'elbow_flare',
+      rep,
+      'pushup',
+    );
+    expect(detail.rationale.toLowerCase()).toContain('triceps');
+  });
+
+  it('reports zero degreesPastThreshold when under 120°', () => {
+    const rep = mkRep({
+      maxAngles: mkAngles({ leftShoulder: 100, rightShoulder: 110 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'elbow_flare',
+      rep,
+      'benchpress',
+    );
+    // max shoulder = 110, so 110 - 120 clamped to 0
+    expect(detail.metrics.degreesPastThreshold).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bonus faults — smoke coverage
+// ---------------------------------------------------------------------------
+
+describe('bonus fault templates', () => {
+  it('shallow_depth (pushup) surfaces elbow gap from 90°', () => {
+    const rep = mkRep({
+      minAngles: mkAngles({ leftElbow: 130, rightElbow: 130 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'shallow_depth',
+      rep,
+      'pushup',
+    );
+    expect(detail.metrics.minElbowDeg).toBe(130);
+    expect(detail.metrics.gapFromTargetDeg).toBe(40);
+  });
+
+  it('shallow_depth (squat) surfaces knee gap from parallel', () => {
+    const rep = mkRep({
+      minAngles: mkAngles({ leftKnee: 115, rightKnee: 115 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'shallow_depth',
+      rep,
+      'squat',
+    );
+    expect(detail.metrics.minKneeDeg).toBe(115);
+    expect(detail.metrics.gapFromParallelDeg).toBe(25);
+  });
+
+  it('rounded_back reports max shoulder angle', () => {
+    const rep = mkRep({
+      maxAngles: mkAngles({ leftShoulder: 140, rightShoulder: 135 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'rounded_back',
+      rep,
+      'deadlift',
+    );
+    expect(detail.metrics.maxShoulderDeg).toBe(140);
+  });
+
+  it('asymmetric_pull reports hip diff', () => {
+    const rep = mkRep({
+      maxAngles: mkAngles({ leftHip: 160, rightHip: 140 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'asymmetric_pull',
+      rep,
+      'deadlift',
+    );
+    expect(detail.metrics.hipAsymmetryDeg).toBe(20);
+  });
+
+  it('asymmetric_press reports elbow diff', () => {
+    const rep = mkRep({
+      minAngles: mkAngles({ leftElbow: 80, rightElbow: 105 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'asymmetric_press',
+      rep,
+      'benchpress',
+    );
+    expect(detail.metrics.elbowAsymmetryDeg).toBe(25);
+  });
+
+  it('hip_sag reports sag depth below 160°', () => {
+    const rep = mkRep({
+      minAngles: mkAngles({ leftHip: 140, rightHip: 150 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'hip_sag',
+      rep,
+      'pushup',
+    );
+    expect(detail.metrics.minHipDeg).toBe(140);
+    expect(detail.metrics.sagBelowNeutralDeg).toBe(20);
+  });
+
+  it('hip_shift flags the side that dropped', () => {
+    const rep = mkRep({
+      minAngles: mkAngles({ leftHip: 60, rightHip: 85 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'hip_shift',
+      rep,
+      'squat',
+    );
+    expect(detail.metrics.hipShiftDeg).toBe(25);
+    expect(detail.rationale.toLowerCase()).toContain('left');
+  });
+
+  it('fast_rep reports duration in seconds', () => {
+    const detail = generateFaultExplanationDetail(
+      'fast_rep',
+      mkRep({ durationMs: 800 }),
+      'squat',
+    );
+    expect(detail.metrics.durationMs).toBe(800);
+    expect(detail.rationale).toContain('0.8s');
+  });
+
+  it('fast_descent reports duration', () => {
+    const detail = generateFaultExplanationDetail(
+      'fast_descent',
+      mkRep({ durationMs: 1100 }),
+      'deadlift',
+    );
+    expect(detail.metrics.durationMs).toBe(1100);
+  });
+
+  it('incomplete_rom reports min elbow angle', () => {
+    const rep = mkRep({
+      minAngles: mkAngles({ leftElbow: 110, rightElbow: 110 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'incomplete_rom',
+      rep,
+      'pullup',
+    );
+    expect(detail.metrics.minElbowDeg).toBe(110);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Render helpers
+// ---------------------------------------------------------------------------
+
+describe('renderExplanation + generateFaultExplanation (string)', () => {
+  it('flattens a structured detail to "title. rationale cue"', () => {
+    const detail = generateFaultExplanationDetail(
+      'hips_rise_first',
+      mkRep({
+        startAngles: mkAngles({ leftHip: 80, leftKnee: 110 }),
+        maxAngles: mkAngles({ leftHip: 170, leftKnee: 150 }),
+      }),
+      'deadlift',
+    );
+    const flat = renderExplanation(detail);
+    expect(flat.startsWith(detail.title)).toBe(true);
+    expect(flat).toContain(detail.rationale);
+    expect(flat).toContain(detail.cue);
+  });
+
+  it('generateFaultExplanation matches renderExplanation(detail)', () => {
+    const rep = mkRep({
+      minAngles: mkAngles({ leftKnee: 75, rightKnee: 105 }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'knee_valgus',
+      rep,
+      'squat',
+    );
+    expect(generateFaultExplanation('knee_valgus', rep, 'squat')).toBe(
+      renderExplanation(detail),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe('edge-case robustness', () => {
+  it('never produces "NaN" in rationale strings', () => {
+    const rep = mkRep({
+      startAngles: mkAngles({ leftHip: NaN, leftKnee: NaN }),
+      maxAngles: mkAngles({ leftHip: NaN, leftKnee: NaN }),
+    });
+    const detail = generateFaultExplanationDetail(
+      'hips_rise_first',
+      rep,
+      'deadlift',
+    );
+    expect(detail.rationale).not.toContain('NaN');
+  });
+
+  it('never produces "Infinity" in rationale strings', () => {
+    const rep = mkRep({
+      durationMs: Infinity,
+    });
+    const detail = generateFaultExplanationDetail('fast_rep', rep, 'squat');
+    expect(detail.rationale).not.toContain('Infinity');
+  });
+
+  it('returns workoutId untouched on the detail payload', () => {
+    const detail = generateFaultExplanationDetail(
+      'lateral_lean',
+      mkRep(),
+      'farmers_walk',
+    );
+    expect(detail.workoutId).toBe('farmers_walk');
+  });
+
+  it('rationale never ends with a dangling placeholder (no "${" substrings)', () => {
+    const ids = listExplainedFaultIds();
+    for (const id of ids) {
+      const detail = generateFaultExplanationDetail(id, mkRep(), 'deadlift');
+      expect(detail.rationale).not.toContain('${');
+      expect(detail.cue).not.toContain('${');
+    }
+  });
+});

--- a/tests/unit/services/rep-pain-journal.test.ts
+++ b/tests/unit/services/rep-pain-journal.test.ts
@@ -1,0 +1,318 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  flagRepPain,
+  getPainFlags,
+  deletePainFlag,
+  clearPainJournal,
+  painJournalKey,
+  computeWeightReductionFraction,
+  adjustNextSetWeight,
+  syncToSupabase,
+  PAIN_LOCATION_LABELS,
+} from '@/lib/services/rep-pain-journal';
+
+const USER = 'user-test-1';
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Key construction
+// ---------------------------------------------------------------------------
+
+describe('painJournalKey', () => {
+  it('namespaces under pain-journal:v1:<userId>', () => {
+    expect(painJournalKey('abc')).toBe('pain-journal:v1:abc');
+  });
+
+  it('throws on empty / non-string userId', () => {
+    expect(() => painJournalKey('')).toThrow();
+    // @ts-expect-error — deliberate bad input
+    expect(() => painJournalKey(null)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// flagRepPain + getPainFlags
+// ---------------------------------------------------------------------------
+
+describe('flagRepPain', () => {
+  it('writes a flag to AsyncStorage keyed by userId', async () => {
+    const flag = await flagRepPain(USER, {
+      repId: 'set1:2',
+      sessionId: 'sess1',
+      location: 'lower_back',
+      severity: 3,
+      notes: 'Twinge on rep 2',
+    });
+    expect(flag.id).toMatch(/^pf_/);
+    expect(flag.location).toBe('lower_back');
+    expect(flag.severity).toBe(3);
+    expect(flag.notes).toBe('Twinge on rep 2');
+    expect(flag.synced).toBe(false);
+    expect(flag.createdAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+
+    const raw = await AsyncStorage.getItem(painJournalKey(USER));
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!) as unknown[];
+    expect(parsed).toHaveLength(1);
+  });
+
+  it('clamps severity to [1..5]', async () => {
+    const tooLow = await flagRepPain(USER, {
+      repId: 'r',
+      sessionId: 's',
+      location: 'knee',
+      // @ts-expect-error — invalid but we want to exercise clamp
+      severity: 0,
+    });
+    const tooHigh = await flagRepPain(USER, {
+      repId: 'r',
+      sessionId: 's',
+      location: 'knee',
+      // @ts-expect-error — invalid but we want to exercise clamp
+      severity: 99,
+    });
+    expect(tooLow.severity).toBe(1);
+    expect(tooHigh.severity).toBe(5);
+  });
+
+  it('truncates notes to 500 chars', async () => {
+    const flag = await flagRepPain(USER, {
+      repId: 'r',
+      sessionId: 's',
+      location: 'other',
+      severity: 2,
+      notes: 'x'.repeat(1000),
+    });
+    expect(flag.notes?.length).toBe(500);
+  });
+
+  it('preserves caller-supplied id', async () => {
+    const flag = await flagRepPain(USER, {
+      id: 'pf_custom_1',
+      repId: 'r',
+      sessionId: 's',
+      location: 'wrist',
+      severity: 1,
+    });
+    expect(flag.id).toBe('pf_custom_1');
+  });
+
+  it('accumulates multiple flags for the same user', async () => {
+    await flagRepPain(USER, { repId: 'r1', sessionId: 's', location: 'hip', severity: 1 });
+    await flagRepPain(USER, { repId: 'r2', sessionId: 's', location: 'hip', severity: 2 });
+    await flagRepPain(USER, { repId: 'r3', sessionId: 's', location: 'hip', severity: 3 });
+    const flags = await getPainFlags(USER);
+    expect(flags).toHaveLength(3);
+  });
+
+  it('isolates storage between users', async () => {
+    await flagRepPain('u1', { repId: 'r', sessionId: 's', location: 'hip', severity: 1 });
+    await flagRepPain('u2', { repId: 'r', sessionId: 's', location: 'hip', severity: 2 });
+    expect(await getPainFlags('u1')).toHaveLength(1);
+    expect(await getPainFlags('u2')).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPainFlags — date range filtering and sorting
+// ---------------------------------------------------------------------------
+
+describe('getPainFlags', () => {
+  it('returns empty array for an unknown user', async () => {
+    expect(await getPainFlags('no-such-user')).toEqual([]);
+  });
+
+  it('sorts results newest-first', async () => {
+    // Manually seed with varying timestamps so ordering is deterministic.
+    const now = Date.now();
+    const flags = [
+      {
+        id: 'old',
+        repId: 'r1',
+        sessionId: 's',
+        location: 'hip',
+        severity: 1,
+        createdAt: new Date(now - 60_000).toISOString(),
+        synced: false,
+      },
+      {
+        id: 'new',
+        repId: 'r2',
+        sessionId: 's',
+        location: 'hip',
+        severity: 2,
+        createdAt: new Date(now).toISOString(),
+        synced: false,
+      },
+    ];
+    await AsyncStorage.setItem(painJournalKey(USER), JSON.stringify(flags));
+    const sorted = await getPainFlags(USER);
+    expect(sorted.map((f) => f.id)).toEqual(['new', 'old']);
+  });
+
+  it('filters out flags older than the window', async () => {
+    const now = Date.now();
+    const flags = [
+      {
+        id: 'ancient',
+        repId: 'r1',
+        sessionId: 's',
+        location: 'hip',
+        severity: 1,
+        // 60 days ago
+        createdAt: new Date(now - 60 * 24 * 60 * 60 * 1000).toISOString(),
+        synced: false,
+      },
+      {
+        id: 'recent',
+        repId: 'r2',
+        sessionId: 's',
+        location: 'hip',
+        severity: 2,
+        // 5 days ago
+        createdAt: new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString(),
+        synced: false,
+      },
+    ];
+    await AsyncStorage.setItem(painJournalKey(USER), JSON.stringify(flags));
+    const last30 = await getPainFlags(USER, 30);
+    expect(last30.map((f) => f.id)).toEqual(['recent']);
+  });
+
+  it('returns all flags when days=Infinity', async () => {
+    const now = Date.now();
+    const flags = [
+      {
+        id: 'ancient',
+        repId: 'r1',
+        sessionId: 's',
+        location: 'hip',
+        severity: 1,
+        createdAt: new Date(now - 365 * 24 * 60 * 60 * 1000).toISOString(),
+        synced: false,
+      },
+    ];
+    await AsyncStorage.setItem(painJournalKey(USER), JSON.stringify(flags));
+    expect(await getPainFlags(USER, Infinity)).toHaveLength(1);
+  });
+
+  it('ignores malformed entries in storage', async () => {
+    await AsyncStorage.setItem(
+      painJournalKey(USER),
+      JSON.stringify([
+        { id: 'good', repId: 'r', sessionId: 's', location: 'hip', severity: 1, createdAt: new Date().toISOString(), synced: false },
+        { id: 'bad' }, // missing required fields
+        'not an object',
+        null,
+      ]),
+    );
+    const flags = await getPainFlags(USER);
+    expect(flags).toHaveLength(1);
+    expect(flags[0].id).toBe('good');
+  });
+
+  it('returns empty array if storage holds invalid JSON', async () => {
+    await AsyncStorage.setItem(painJournalKey(USER), 'not-json');
+    expect(await getPainFlags(USER)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// delete + clear
+// ---------------------------------------------------------------------------
+
+describe('deletePainFlag + clearPainJournal', () => {
+  it('deletes a single flag by id', async () => {
+    const a = await flagRepPain(USER, { repId: 'r1', sessionId: 's', location: 'hip', severity: 1 });
+    const b = await flagRepPain(USER, { repId: 'r2', sessionId: 's', location: 'hip', severity: 2 });
+    await deletePainFlag(USER, a.id);
+    const flags = await getPainFlags(USER);
+    expect(flags.map((f) => f.id)).toEqual([b.id]);
+  });
+
+  it('is a no-op if the flag id does not exist', async () => {
+    await flagRepPain(USER, { repId: 'r1', sessionId: 's', location: 'hip', severity: 1 });
+    await deletePainFlag(USER, 'pf_not_present');
+    expect(await getPainFlags(USER)).toHaveLength(1);
+  });
+
+  it('clearPainJournal wipes the key entirely', async () => {
+    await flagRepPain(USER, { repId: 'r1', sessionId: 's', location: 'hip', severity: 1 });
+    await clearPainJournal(USER);
+    expect(await AsyncStorage.getItem(painJournalKey(USER))).toBeNull();
+    expect(await getPainFlags(USER)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Weight-adjust helpers
+// ---------------------------------------------------------------------------
+
+describe('computeWeightReductionFraction', () => {
+  it('returns severity * 2%', () => {
+    expect(computeWeightReductionFraction(1)).toBeCloseTo(0.02, 5);
+    expect(computeWeightReductionFraction(2)).toBeCloseTo(0.04, 5);
+    expect(computeWeightReductionFraction(3)).toBeCloseTo(0.06, 5);
+    expect(computeWeightReductionFraction(4)).toBeCloseTo(0.08, 5);
+    expect(computeWeightReductionFraction(5)).toBeCloseTo(0.10, 5);
+  });
+
+  it('caps at 15% even if severity extrapolates higher (defensive)', () => {
+    // Cast so we can test the cap branch without relying on clamp upstream.
+    // @ts-expect-error — defensive upper bound
+    expect(computeWeightReductionFraction(20)).toBeLessThanOrEqual(0.15);
+  });
+});
+
+describe('adjustNextSetWeight', () => {
+  it('returns a negative delta fraction tagged with sessionId + severity', () => {
+    const res = adjustNextSetWeight('sess-1', 3);
+    expect(res.sessionId).toBe('sess-1');
+    expect(res.severity).toBe(3);
+    expect(res.recommendedDeltaFraction).toBeCloseTo(-0.06, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syncToSupabase stub
+// ---------------------------------------------------------------------------
+
+describe('syncToSupabase (stub)', () => {
+  it('returns a no-op payload flagged as migration_pending', async () => {
+    const res = await syncToSupabase(USER);
+    expect(res.attempted).toBe(0);
+    expect(res.synced).toBe(0);
+    expect(res.skipped).toBe('migration_pending');
+  });
+
+  it('does not read or write AsyncStorage', async () => {
+    // Clear prior-call tallies first — beforeEach() invokes AsyncStorage.clear,
+    // which increments the jest-mock counters for this suite.
+    (AsyncStorage.getItem as jest.Mock).mockClear();
+    (AsyncStorage.setItem as jest.Mock).mockClear();
+    await syncToSupabase(USER);
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Location labels export
+// ---------------------------------------------------------------------------
+
+describe('PAIN_LOCATION_LABELS', () => {
+  it('maps every location type to a human-readable label', () => {
+    expect(PAIN_LOCATION_LABELS.lower_back).toBe('Lower back');
+    expect(PAIN_LOCATION_LABELS.upper_back).toBe('Upper back');
+    expect(PAIN_LOCATION_LABELS.knee).toBe('Knee');
+    expect(PAIN_LOCATION_LABELS.shoulder).toBe('Shoulder');
+    expect(PAIN_LOCATION_LABELS.elbow).toBe('Elbow');
+    expect(PAIN_LOCATION_LABELS.wrist).toBe('Wrist');
+    expect(PAIN_LOCATION_LABELS.hip).toBe('Hip');
+    expect(PAIN_LOCATION_LABELS.other).toBe('Other');
+  });
+});

--- a/tests/unit/services/session-export-service.test.ts
+++ b/tests/unit/services/session-export-service.test.ts
@@ -1,0 +1,344 @@
+/**
+ * session-export-service tests
+ *
+ * The service reads from local SQLite and writes to expo-file-system. We
+ * stub both so tests don't touch disk and can assert on shaping logic
+ * (JSON payload, CSV row count, path construction, edge cases).
+ */
+
+jest.mock('expo-file-system/legacy', () => ({
+  documentDirectory: 'file:///tmp/ff-test/',
+  getInfoAsync: jest.fn().mockResolvedValue({ exists: true }),
+  makeDirectoryAsync: jest.fn().mockResolvedValue(undefined),
+  writeAsStringAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/services/database/local-db', () => ({
+  localDB: {
+    db: {
+      getAllAsync: jest.fn(),
+    },
+  },
+}));
+
+import * as FileSystem from 'expo-file-system/legacy';
+
+import { localDB } from '@/lib/services/database/local-db';
+import {
+  buildExportPath,
+  buildSessionExportPayload,
+  exportSession,
+  payloadToSetRows,
+  serializeExport,
+  type SessionExportPayload,
+} from '@/lib/services/session-export-service';
+
+const writeMock = FileSystem.writeAsStringAsync as jest.Mock;
+const makeDirMock = FileSystem.makeDirectoryAsync as jest.Mock;
+const getInfoMock = FileSystem.getInfoAsync as jest.Mock;
+const dbGetAll = localDB.db!.getAllAsync as jest.Mock;
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function mkSessionRow(overrides: Record<string, unknown> = {}) {
+  return [
+    {
+      id: 'sess1',
+      name: 'Leg Day',
+      goal_profile: 'hypertrophy',
+      started_at: '2026-04-10T09:00:00.000Z',
+      ended_at: '2026-04-10T10:30:00.000Z',
+      bodyweight_lb: 180,
+      notes: null,
+      ...overrides,
+    },
+  ];
+}
+
+function mkExerciseRows() {
+  return [
+    {
+      id: 'wse1',
+      exercise_id: 'squat',
+      exercise_name: 'Back Squat',
+      sort_order: 0,
+      notes: null,
+    },
+    {
+      id: 'wse2',
+      exercise_id: 'rdl',
+      exercise_name: 'RDL',
+      sort_order: 1,
+      notes: null,
+    },
+  ];
+}
+
+function mkSetRows() {
+  return [
+    {
+      id: 'set1',
+      session_exercise_id: 'wse1',
+      sort_order: 0,
+      set_type: 'warmup',
+      planned_reps: 5,
+      planned_seconds: null,
+      planned_weight: 95,
+      actual_reps: 5,
+      actual_seconds: null,
+      actual_weight: 95,
+      completed_at: '2026-04-10T09:05:00.000Z',
+      perceived_rpe: 4,
+      tut_ms: 15000,
+      tut_source: 'measured',
+      notes: JSON.stringify({ fqiScore: 88, faults: ['forward_lean'] }),
+    },
+    {
+      id: 'set2',
+      session_exercise_id: 'wse1',
+      sort_order: 1,
+      set_type: 'normal',
+      planned_reps: 5,
+      planned_seconds: null,
+      planned_weight: 225,
+      actual_reps: 5,
+      actual_seconds: null,
+      actual_weight: 225,
+      completed_at: '2026-04-10T09:15:00.000Z',
+      perceived_rpe: 8,
+      tut_ms: 20000,
+      tut_source: 'measured',
+      notes: null,
+    },
+    {
+      id: 'set3',
+      session_exercise_id: 'wse2',
+      sort_order: 0,
+      set_type: 'normal',
+      planned_reps: 8,
+      planned_seconds: null,
+      planned_weight: 185,
+      actual_reps: 8,
+      actual_seconds: null,
+      actual_weight: 185,
+      completed_at: '2026-04-10T10:00:00.000Z',
+      perceived_rpe: 7,
+      tut_ms: 22000,
+      tut_source: 'estimated',
+      notes: JSON.stringify({ fqi_score: 92 }),
+    },
+  ];
+}
+
+function stubQueries() {
+  dbGetAll
+    .mockImplementationOnce(async () => mkSessionRow())
+    .mockImplementationOnce(async () => mkExerciseRows())
+    .mockImplementationOnce(async () => mkSetRows());
+}
+
+beforeEach(() => {
+  // resetAllMocks also drains mockImplementationOnce queues — important
+  // because tests below chain `.mockImplementationOnce(...)` and we don't
+  // want leftover queue entries leaking between tests.
+  jest.resetAllMocks();
+  getInfoMock.mockResolvedValue({ exists: true });
+  makeDirMock.mockResolvedValue(undefined);
+  writeMock.mockResolvedValue(undefined);
+});
+
+// ---------------------------------------------------------------------------
+// buildExportPath
+// ---------------------------------------------------------------------------
+
+describe('buildExportPath', () => {
+  it('prefixes with documentDirectory and exports/ subdir', () => {
+    const now = new Date('2026-04-16T10:30:45.123Z');
+    const path = buildExportPath('sess-abc', 'json', now);
+    expect(path.startsWith('file:///tmp/ff-test/exports/')).toBe(true);
+    expect(path.endsWith('.json')).toBe(true);
+  });
+
+  it('sanitises unsafe characters in sessionId', () => {
+    const now = new Date('2026-04-16T10:30:45.123Z');
+    const path = buildExportPath('../sneaky/path', 'csv', now);
+    expect(path).not.toContain('../');
+    expect(path).not.toContain('sneaky/path');
+    expect(path.endsWith('.csv')).toBe(true);
+  });
+
+  it('uses stable timestamp slug (colons/dots replaced)', () => {
+    const now = new Date('2026-04-16T10:30:45.123Z');
+    const path = buildExportPath('sess', 'json', now);
+    // `file:` prefix contains a colon — strip the scheme before asserting.
+    const withoutScheme = path.replace(/^file:/, '');
+    expect(withoutScheme).not.toMatch(/:/);
+    expect(path).toContain('2026-04-16T10-30-45-123Z');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSessionExportPayload
+// ---------------------------------------------------------------------------
+
+describe('buildSessionExportPayload', () => {
+  it('returns a structured payload with session + exercises + totals', async () => {
+    stubQueries();
+    const payload = await buildSessionExportPayload('sess1');
+    expect(payload.schemaVersion).toBe(1);
+    expect(payload.session.id).toBe('sess1');
+    expect(payload.session.goalProfile).toBe('hypertrophy');
+    expect(payload.session.durationSeconds).toBe(5400); // 90 minutes
+    expect(payload.exercises).toHaveLength(2);
+    expect(payload.totalSetCount).toBe(3);
+    // Volume = 5*95 + 5*225 + 8*185 = 475 + 1125 + 1480 = 3080
+    expect(payload.totalVolumeLb).toBe(3080);
+  });
+
+  it('surfaces per-set fqi and faults parsed from notes JSON', async () => {
+    stubQueries();
+    const payload = await buildSessionExportPayload('sess1');
+    const flat = payloadToSetRows(payload);
+    expect(flat[0].fqiScore).toBe(88);
+    expect(flat[0].faults).toBe('forward_lean');
+    // set 2 has notes=null -> no fqi/faults
+    expect(flat[1].fqiScore).toBeNull();
+    expect(flat[1].faults).toBeNull();
+    // set 3 uses snake_case fqi_score
+    expect(flat[2].fqiScore).toBe(92);
+  });
+
+  it('copes with empty session (no exercises)', async () => {
+    dbGetAll
+      .mockImplementationOnce(async () => mkSessionRow())
+      .mockImplementationOnce(async () => [])
+      .mockImplementationOnce(async () => []);
+    const payload = await buildSessionExportPayload('sess1');
+    expect(payload.exercises).toHaveLength(0);
+    expect(payload.totalSetCount).toBe(0);
+    expect(payload.totalVolumeLb).toBe(0);
+  });
+
+  it('throws when the session does not exist', async () => {
+    dbGetAll.mockImplementationOnce(async () => []);
+    await expect(buildSessionExportPayload('missing')).rejects.toThrow(
+      /not found/,
+    );
+  });
+
+  it('handles missing ended_at (in-progress session) by setting durationSeconds=null', async () => {
+    dbGetAll
+      .mockImplementationOnce(async () => mkSessionRow({ ended_at: null }))
+      .mockImplementationOnce(async () => mkExerciseRows())
+      .mockImplementationOnce(async () => mkSetRows());
+    const payload = await buildSessionExportPayload('sess1');
+    expect(payload.session.durationSeconds).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// serializeExport
+// ---------------------------------------------------------------------------
+
+describe('serializeExport (json)', () => {
+  it('returns pretty-printed JSON with a parseable payload', async () => {
+    stubQueries();
+    const payload = await buildSessionExportPayload('sess1');
+    const json = serializeExport(payload, 'json');
+    expect(json.startsWith('{')).toBe(true);
+    expect(() => JSON.parse(json)).not.toThrow();
+    const reparsed = JSON.parse(json) as SessionExportPayload;
+    expect(reparsed.schemaVersion).toBe(1);
+    expect(reparsed.exercises).toHaveLength(2);
+  });
+});
+
+describe('serializeExport (csv)', () => {
+  it('writes a header row + 1 row per set', async () => {
+    stubQueries();
+    const payload = await buildSessionExportPayload('sess1');
+    const csv = serializeExport(payload, 'csv');
+    const lines = csv.split('\n');
+    expect(lines).toHaveLength(4); // header + 3 rows
+    expect(lines[0]).toContain('session_id,session_name,exercise_id');
+    expect(lines[0]).toContain('fqi_score,faults,completed_at');
+  });
+
+  it('escapes commas/quotes inside fields', async () => {
+    dbGetAll
+      .mockImplementationOnce(async () =>
+        mkSessionRow({ name: 'Leg Day, Heavy "Push"' }),
+      )
+      .mockImplementationOnce(async () => mkExerciseRows())
+      .mockImplementationOnce(async () => mkSetRows());
+    const payload = await buildSessionExportPayload('sess1');
+    const csv = serializeExport(payload, 'csv');
+    // The session name should be wrapped in quotes with inner quotes doubled.
+    expect(csv).toContain('"Leg Day, Heavy ""Push"""');
+  });
+
+  it('empty sessions produce header-only CSV', async () => {
+    dbGetAll
+      .mockImplementationOnce(async () => mkSessionRow())
+      .mockImplementationOnce(async () => [])
+      .mockImplementationOnce(async () => []);
+    const payload = await buildSessionExportPayload('sess1');
+    const csv = serializeExport(payload, 'csv');
+    expect(csv.split('\n')).toHaveLength(1);
+    expect(csv).toContain('session_id');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exportSession end-to-end
+// ---------------------------------------------------------------------------
+
+describe('exportSession', () => {
+  it('writes a JSON file and returns path + byte count + format', async () => {
+    stubQueries();
+    const result = await exportSession('sess1', 'json');
+    expect(result.format).toBe('json');
+    expect(result.bytes).toBeGreaterThan(0);
+    expect(result.path).toContain('exports/');
+    expect(writeMock).toHaveBeenCalledTimes(1);
+    const [calledPath, calledBody] = writeMock.mock.calls[0];
+    expect(calledPath).toBe(result.path);
+    expect(typeof calledBody).toBe('string');
+    expect(calledBody.startsWith('{')).toBe(true);
+  });
+
+  it('writes a CSV file when format=csv', async () => {
+    stubQueries();
+    const result = await exportSession('sess1', 'csv');
+    expect(result.format).toBe('csv');
+    const [, body] = writeMock.mock.calls[0];
+    expect(body.startsWith('session_id,')).toBe(true);
+  });
+
+  it('creates the exports/ subdirectory if missing', async () => {
+    getInfoMock.mockResolvedValueOnce({ exists: false });
+    stubQueries();
+    await exportSession('sess1', 'json');
+    expect(makeDirMock).toHaveBeenCalledWith(
+      'file:///tmp/ff-test/exports/',
+      { intermediates: true },
+    );
+  });
+
+  it('skips makeDirectory when exports/ already exists', async () => {
+    getInfoMock.mockResolvedValueOnce({ exists: true });
+    stubQueries();
+    await exportSession('sess1', 'json');
+    expect(makeDirMock).not.toHaveBeenCalled();
+  });
+
+  it('propagates missing-session errors from the payload builder', async () => {
+    dbGetAll.mockImplementationOnce(async () => []);
+    await expect(exportSession('missing', 'json')).rejects.toThrow(
+      /not found/,
+    );
+    expect(writeMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/session-timeline-service.test.ts
+++ b/tests/unit/services/session-timeline-service.test.ts
@@ -1,0 +1,242 @@
+jest.mock('@/lib/services/database/local-db', () => ({
+  localDB: {
+    db: {
+      getAllAsync: jest.fn(),
+    },
+  },
+}));
+
+import { localDB } from '@/lib/services/database/local-db';
+import {
+  classifyBucket,
+  getUnifiedTimeline,
+  groupByDateBucket,
+  type TimelineEntry,
+} from '@/lib/services/session-timeline-service';
+
+const dbGetAll = localDB.db!.getAllAsync as jest.Mock;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// classifyBucket
+// ---------------------------------------------------------------------------
+
+describe('classifyBucket', () => {
+  const now = new Date('2026-04-16T12:00:00.000Z');
+
+  it('buckets same-day as "today"', () => {
+    expect(
+      classifyBucket('2026-04-16T08:00:00.000Z', now),
+    ).toBe('today');
+  });
+
+  it('buckets 1 day ago as "yesterday"', () => {
+    expect(
+      classifyBucket('2026-04-15T12:00:00.000Z', now),
+    ).toBe('yesterday');
+  });
+
+  it('buckets 3 days ago as "this_week"', () => {
+    expect(
+      classifyBucket('2026-04-13T12:00:00.000Z', now),
+    ).toBe('this_week');
+  });
+
+  it('buckets 10 days ago as "last_week"', () => {
+    expect(
+      classifyBucket('2026-04-06T12:00:00.000Z', now),
+    ).toBe('last_week');
+  });
+
+  it('buckets 20 days ago as "this_month"', () => {
+    expect(
+      classifyBucket('2026-03-27T12:00:00.000Z', now),
+    ).toBe('this_month');
+  });
+
+  it('buckets > 30 days ago as "older"', () => {
+    expect(
+      classifyBucket('2026-01-01T12:00:00.000Z', now),
+    ).toBe('older');
+  });
+
+  it('handles invalid timestamps by bucketing as "older"', () => {
+    expect(classifyBucket('not-a-date', now)).toBe('older');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getUnifiedTimeline
+// ---------------------------------------------------------------------------
+
+describe('getUnifiedTimeline', () => {
+  it('returns workout entries sorted newest-first', async () => {
+    dbGetAll.mockResolvedValueOnce([
+      {
+        id: 'w1',
+        name: 'Leg Day',
+        started_at: '2026-04-14T08:00:00.000Z',
+        ended_at: '2026-04-14T09:30:00.000Z',
+        set_count: 12,
+      },
+      {
+        id: 'w2',
+        name: 'Push Day',
+        started_at: '2026-04-10T08:00:00.000Z',
+        ended_at: '2026-04-10T09:00:00.000Z',
+        set_count: 8,
+      },
+    ]);
+    const timeline = await getUnifiedTimeline('user1', 30, {
+      now: new Date('2026-04-16T12:00:00.000Z'),
+    });
+    expect(timeline.map((e) => e.id)).toEqual(['workout:w1', 'workout:w2']);
+    expect(timeline[0].type).toBe('workout');
+    expect(timeline[0].title).toBe('Leg Day');
+    expect(timeline[0].href).toContain('workout-insights');
+    expect(timeline[0].subtitle).toContain('1h 30m');
+    expect(timeline[0].subtitle).toContain('12 sets');
+  });
+
+  it('merges scan sessions with workouts by date', async () => {
+    dbGetAll.mockResolvedValueOnce([
+      {
+        id: 'w1',
+        name: 'Legs',
+        started_at: '2026-04-15T08:00:00.000Z',
+        ended_at: null,
+        set_count: 0,
+      },
+    ]);
+    const timeline = await getUnifiedTimeline('user1', 30, {
+      now: new Date('2026-04-16T12:00:00.000Z'),
+      scanSessions: [
+        {
+          id: 'scan1',
+          startedAt: '2026-04-15T09:00:00.000Z',
+          label: 'Squat scan',
+        },
+        {
+          id: 'scan2',
+          startedAt: '2026-04-16T07:00:00.000Z',
+          label: 'Push-up scan',
+        },
+      ],
+    });
+    expect(timeline.map((e) => e.id)).toEqual([
+      'scan:scan2',
+      'scan:scan1',
+      'workout:w1',
+    ]);
+    const scan = timeline.find((e) => e.id === 'scan:scan1');
+    expect(scan?.type).toBe('scan');
+    expect(scan?.title).toBe('Squat scan');
+    expect(scan?.href).toBe('');
+  });
+
+  it('subtitle reads "In progress" when ended_at is null', async () => {
+    dbGetAll.mockResolvedValueOnce([
+      {
+        id: 'w1',
+        name: null,
+        started_at: '2026-04-16T08:00:00.000Z',
+        ended_at: null,
+        set_count: 0,
+      },
+    ]);
+    const timeline = await getUnifiedTimeline('user1', 30, {
+      now: new Date('2026-04-16T12:00:00.000Z'),
+    });
+    expect(timeline[0].subtitle).toContain('In progress');
+    expect(timeline[0].title).toBe('Workout session'); // default when name null
+  });
+
+  it('filters scan sessions older than the window', async () => {
+    dbGetAll.mockResolvedValueOnce([]);
+    const timeline = await getUnifiedTimeline('user1', 7, {
+      now: new Date('2026-04-16T12:00:00.000Z'),
+      scanSessions: [
+        {
+          id: 'recent',
+          startedAt: '2026-04-15T00:00:00.000Z',
+        },
+        {
+          id: 'stale',
+          startedAt: '2026-04-01T00:00:00.000Z',
+        },
+      ],
+    });
+    expect(timeline.map((e) => e.sourceId)).toEqual(['recent']);
+  });
+
+  it('returns an empty array when SQL throws', async () => {
+    dbGetAll.mockRejectedValueOnce(new Error('db offline'));
+    const timeline = await getUnifiedTimeline('user1', 30);
+    expect(timeline).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupByDateBucket
+// ---------------------------------------------------------------------------
+
+describe('groupByDateBucket', () => {
+  const now = new Date('2026-04-16T12:00:00.000Z');
+
+  function mkEntry(
+    id: string,
+    occurredAt: string,
+    type: 'workout' | 'scan' = 'workout',
+  ): TimelineEntry {
+    return {
+      id,
+      type,
+      occurredAt,
+      title: id,
+      subtitle: null,
+      href: '',
+      sourceId: id,
+    };
+  }
+
+  it('splits entries into non-empty sections labelled newest-first', () => {
+    const entries = [
+      mkEntry('today', '2026-04-16T09:00:00.000Z'),
+      mkEntry('yday', '2026-04-15T09:00:00.000Z'),
+      mkEntry('week', '2026-04-12T09:00:00.000Z'),
+      mkEntry('older', '2026-02-01T09:00:00.000Z'),
+    ];
+    const sections = groupByDateBucket(entries, now);
+    expect(sections.map((s) => s.bucket)).toEqual([
+      'today',
+      'yesterday',
+      'this_week',
+      'older',
+    ]);
+    expect(sections[0].label).toBe('Today');
+    expect(sections[0].entries[0].id).toBe('today');
+  });
+
+  it('drops empty buckets', () => {
+    const entries = [mkEntry('a', '2026-04-16T00:00:00.000Z')];
+    const sections = groupByDateBucket(entries, now);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].bucket).toBe('today');
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(groupByDateBucket([], now)).toEqual([]);
+  });
+
+  it('preserves entry order within a bucket', () => {
+    const entries = [
+      mkEntry('a', '2026-04-16T10:00:00.000Z'),
+      mkEntry('b', '2026-04-16T08:00:00.000Z'),
+    ];
+    const sections = groupByDateBucket(entries, now);
+    expect(sections[0].entries.map((e) => e.id)).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
## Summary
Bundles four unclaimed post-session depth gaps into one large-scope PR:
- **Rep-level fault explainability** — natural-language rationale per fault with angle deltas, surfaced via `FaultExplanationChip` + cached `useFaultExplanations` hook.
- **Rep pain journal** — AsyncStorage-backed on-device journal with location picker, 1-5 severity, notes, and an auto weight-reduction recommendation for the next set. Server sync is a typed no-op stub pending a migration (see below).
- **Session data export** — JSON + CSV via `expo-file-system` (already installed) + built-in `Share`. One row per set in CSV, full nested payload in JSON.
- **Unified timeline** — merged workout + scan-arkit sessions, 30-day window, date-bucketed (Today / Yesterday / This week / Last week / This month / Older).

## Closes
Closes #348, closes #476.

## Atomic commits
- `feat(fault-explainability): add service to convert fault IDs to NL rationales`
- `feat(fault-explainability): add useFaultExplanations hook with memo cache`
- `feat(fault-explainability): add FaultExplanationChip component`
- `test(fault-explainability): cover 6 required faults + 8 bonus templates`
- `feat(pain-journal): add AsyncStorage-backed rep pain journal service`
- `test(pain-journal): cover flag+read+delete, date filter, no-op sync`
- `feat(pain-journal): add RepPainFlagButton + timeline modal screen`
- `feat(session-export): add JSON/CSV exporter writing to documentDirectory`
- `test(session-export): cover JSON/CSV shaping, path construction, edge cases`
- `feat(session-timeline): merge workout + scan sessions for 30-day view`
- `feat(session-timeline): add unified timeline modal + tests`
- `feat(workouts-tab): wire up session timeline + export menu header`

(12 commits — inside the 10-13 target.)

## Tests
- `tests/unit/services/fault-explainability.test.ts` — 36 tests / 111 assertions
- `tests/unit/services/rep-pain-journal.test.ts` — 23 tests / ~50 assertions
- `tests/unit/services/session-export-service.test.ts` — 17 tests / ~40 assertions
- `tests/unit/services/session-timeline-service.test.ts` — 16 tests / ~30 assertions

Total: **4 suites, 92 tests, ~230 assertions** (exceeds 80+ target).

## Cross-PR stubs
- **`TODO(day)`** in `lib/services/rep-pain-journal.ts` → `syncToSupabase()` is a typed no-op. A real `pain_flags` table needs a Supabase migration, which is banned overnight per `CLAUDE.md`. Once a daytime migration lands, replace the stub with an upsert against `public.pain_flags`.
- **`TODO(#461)`** in `lib/services/session-export-service.ts` → add a `coach_notes` column sourced from the daily debrief once coach memory enrichment lands.
- **`TODO(scan-persistence)`** in `lib/services/session-timeline-service.ts` and `app/(modals)/session-timeline.tsx` → scan-arkit sessions aren't persisted to any durable store today. The timeline service already accepts `options.scanSessions` so it will light up automatically once a journal/table exists.
- **`TODO(session-runner)`** in `lib/services/rep-pain-journal.ts` → `adjustNextSetWeight` currently returns a typed recommendation object (no store mutation). Once `useSessionRunner` exposes a "pending next set" accessor, wire the recommendation into `updateSet`.

## Judgment calls
- **Pain journal is AsyncStorage-only.** The original Wave-9 audit proposed a Supabase migration; `CLAUDE.md` bans migrations overnight, so I built the on-device journal with a well-typed `syncToSupabase()` no-op. Tests assert the stub returns `{ attempted: 0, synced: 0, skipped: 'migration_pending' }` and performs zero AsyncStorage calls.
- **Scan-arkit history is opt-in.** I searched `lib/` and `app/(tabs)/scan-arkit.tsx` — there is no durable store for scan sessions. Rather than invent one, the timeline service accepts caller-provided scan rows through `options.scanSessions` and returns workouts-only by default. Once a scan-persistence layer exists this becomes wired-in with a one-line change in the modal screen.
- **Export target is "latest completed session".** The workouts-tab header-row delta stayed inside the ~40-LOC budget. A future PR can add per-row export actions; today the Export button looks up the most recent ended session and hands off to `Share.share({ url })`.
- **Dynamic import for `localDB`** inside the export handler keeps Metro from hoisting the SQLite mock into the workouts bundle on first render.

## Verification
- [x] `bun run lint` clean (0 errors, only 2 pre-existing warnings in `template-builder.tsx`)
- [x] `bun run check:types` clean
- [x] All 4 new test suites pass (92 tests)
- [x] No edits to banned paths — `git diff origin/main..HEAD --name-only` only touches `lib/services/`, `hooks/`, `components/form-tracking/`, `app/(modals)/`, `app/(tabs)/`, `tests/unit/services/`
- [x] No new deps — uses `expo-file-system/legacy` (already imported by `video-service.ts`), built-in `Share`, `@react-native-async-storage/async-storage` (already a dep)