### PR TITLE
feat(rest-coach): between-sets coaching experience — breathing + mobility + reflection during rest timer

### DIFF
--- a/components/workout/BreathingCueCard.tsx
+++ b/components/workout/BreathingCueCard.tsx
@@ -1,0 +1,159 @@
+/**
+ * BreathingCueCard Component
+ *
+ * Renders a breathing pattern as a timed phase-cycler. Tracks progress
+ * through the pattern's phases in local state and loops through cycles
+ * until explicitly paused. Visualization is a simple phase badge + cue
+ * line — no animation engine required, just a seconds countdown that
+ * advances through the phase list.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { colors } from '@/styles/workout-session.styles';
+import type { BreathingPattern, BreathingPhase } from '@/lib/services/breathing-patterns';
+
+interface BreathingCueCardProps {
+  pattern: BreathingPattern;
+  /** Auto-start the breathing cycle on mount. */
+  autoStart?: boolean;
+  /** Emit each phase transition. */
+  onPhaseChange?: (phase: BreathingPhase, phaseIndex: number) => void;
+}
+
+const PHASE_LABEL: Record<BreathingPhase['type'], string> = {
+  inhale: 'Inhale',
+  'hold-in': 'Hold',
+  exhale: 'Exhale',
+  'hold-out': 'Hold',
+};
+
+function BreathingCueCard({ pattern, autoStart = true, onPhaseChange }: BreathingCueCardProps) {
+  const [running, setRunning] = useState<boolean>(autoStart);
+  const [phaseIndex, setPhaseIndex] = useState<number>(0);
+  const [secondsLeft, setSecondsLeft] = useState<number>(pattern.phases[0]?.seconds ?? 0);
+
+  useEffect(() => {
+    setPhaseIndex(0);
+    setSecondsLeft(pattern.phases[0]?.seconds ?? 0);
+  }, [pattern]);
+
+  useEffect(() => {
+    if (!running) return;
+    const interval = setInterval(() => {
+      setSecondsLeft((prev) => {
+        if (prev > 1) return prev - 1;
+        setPhaseIndex((idx) => {
+          const next = (idx + 1) % pattern.phases.length;
+          const phase = pattern.phases[next];
+          setSecondsLeft(phase.seconds);
+          onPhaseChange?.(phase, next);
+          return next;
+        });
+        return pattern.phases[(phaseIndex + 1) % pattern.phases.length]?.seconds ?? 0;
+      });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [running, pattern, phaseIndex, onPhaseChange]);
+
+  const toggle = useCallback(() => {
+    setRunning((r) => !r);
+  }, []);
+
+  const currentPhase = pattern.phases[phaseIndex];
+  const phaseColor = currentPhase.type.startsWith('inhale')
+    ? colors.success
+    : currentPhase.type.startsWith('exhale')
+      ? colors.accent
+      : colors.restActive;
+
+  return (
+    <View style={styles.card} testID="breathing-cue-card">
+      <View style={styles.header}>
+        <Text style={styles.title} testID="breathing-pattern-name">
+          {pattern.name}
+        </Text>
+        <TouchableOpacity
+          onPress={toggle}
+          style={styles.toggleButton}
+          testID="breathing-toggle"
+          accessibilityRole="button"
+          accessibilityLabel={running ? 'Pause breathing guide' : 'Start breathing guide'}
+        >
+          <Text style={styles.toggleText}>{running ? 'Pause' : 'Start'}</Text>
+        </TouchableOpacity>
+      </View>
+      <Text style={styles.description}>{pattern.description}</Text>
+      <View style={[styles.phaseBadge, { borderColor: phaseColor }]} testID="breathing-phase">
+        <Text style={[styles.phaseLabel, { color: phaseColor }]}>
+          {PHASE_LABEL[currentPhase.type]}
+        </Text>
+        <Text style={styles.phaseCue}>{currentPhase.cue}</Text>
+        <Text style={[styles.phaseSeconds, { color: phaseColor }]} testID="breathing-seconds">
+          {secondsLeft}s
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.cardSurface,
+    borderColor: colors.cardBorder,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 14,
+    padding: 16,
+    gap: 10,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  title: {
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 16,
+    color: colors.textPrimary,
+  },
+  toggleButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    backgroundColor: colors.restActive,
+  },
+  toggleText: {
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 12,
+    color: colors.background,
+  },
+  description: {
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 13,
+    color: colors.textSecondary,
+  },
+  phaseBadge: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 14,
+    alignItems: 'center',
+    gap: 4,
+  },
+  phaseLabel: {
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 18,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+  },
+  phaseCue: {
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 13,
+    color: colors.textSecondary,
+  },
+  phaseSeconds: {
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 28,
+  },
+});
+
+export default React.memo(BreathingCueCard);

--- a/components/workout/MobilityDrillCard.tsx
+++ b/components/workout/MobilityDrillCard.tsx
@@ -1,0 +1,150 @@
+/**
+ * MobilityDrillCard Component
+ *
+ * Renders a MobilityDrill with its target muscle tags, duration, and
+ * an expandable step list.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { colors } from '@/styles/workout-session.styles';
+import type { MobilityDrill } from '@/lib/services/mobility-drills';
+
+interface MobilityDrillCardProps {
+  drill: MobilityDrill;
+  defaultExpanded?: boolean;
+}
+
+function MobilityDrillCard({ drill, defaultExpanded = false }: MobilityDrillCardProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  const toggle = useCallback(() => {
+    setExpanded((e) => !e);
+  }, []);
+
+  const intensityColor = drill.intensity === 'moderate' ? colors.warmup : colors.restActive;
+
+  return (
+    <View style={styles.card} testID="mobility-drill-card">
+      <TouchableOpacity
+        onPress={toggle}
+        style={styles.header}
+        testID="mobility-drill-toggle"
+        accessibilityRole="button"
+        accessibilityLabel={expanded ? 'Collapse drill steps' : 'Expand drill steps'}
+      >
+        <View style={styles.headerLeft}>
+          <Text style={styles.title} testID="mobility-drill-name">
+            {drill.name}
+          </Text>
+          <View style={styles.tagRow}>
+            <View style={[styles.tag, { borderColor: intensityColor }]}>
+              <Text style={[styles.tagText, { color: intensityColor }]}>
+                {drill.intensity}
+              </Text>
+            </View>
+            <View style={styles.tag}>
+              <Text style={styles.tagText}>{drill.durationSeconds}s</Text>
+            </View>
+          </View>
+        </View>
+        <Ionicons
+          name={expanded ? 'chevron-up' : 'chevron-down'}
+          size={18}
+          color={colors.textSecondary}
+        />
+      </TouchableOpacity>
+      <Text style={styles.description}>{drill.description}</Text>
+      {expanded ? (
+        <View style={styles.steps} testID="mobility-drill-steps">
+          {drill.steps.map((step, idx) => (
+            <View key={`${drill.id}-step-${idx}`} style={styles.stepRow}>
+              <View style={styles.stepBullet}>
+                <Text style={styles.stepBulletText}>{idx + 1}</Text>
+              </View>
+              <Text style={styles.stepText}>{step}</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.cardSurface,
+    borderColor: colors.cardBorder,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 14,
+    padding: 14,
+    gap: 8,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  headerLeft: {
+    flex: 1,
+    gap: 6,
+  },
+  title: {
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 15,
+    color: colors.textPrimary,
+  },
+  tagRow: {
+    flexDirection: 'row',
+    gap: 6,
+  },
+  tag: {
+    borderWidth: 1,
+    borderColor: colors.cardBorder,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 10,
+  },
+  tagText: {
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 11,
+    color: colors.textSecondary,
+  },
+  description: {
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 13,
+    color: colors.textSecondary,
+  },
+  steps: {
+    gap: 8,
+    paddingTop: 4,
+  },
+  stepRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+  },
+  stepBullet: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    backgroundColor: colors.cardBorder,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  stepBulletText: {
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 11,
+    color: colors.textPrimary,
+  },
+  stepText: {
+    flex: 1,
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 13,
+    color: colors.textPrimary,
+    lineHeight: 19,
+  },
+});
+
+export default React.memo(MobilityDrillCard);

--- a/components/workout/ReflectionPromptCard.tsx
+++ b/components/workout/ReflectionPromptCard.tsx
@@ -1,0 +1,84 @@
+/**
+ * ReflectionPromptCard Component
+ *
+ * Renders a single reflection prompt with its category tag. Visual
+ * weight is intentionally light — the goal is a gentle nudge, not a
+ * dense card.
+ */
+
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { colors } from '@/styles/workout-session.styles';
+import type { ReflectionCategory, ReflectionPrompt } from '@/lib/services/between-sets-coach';
+
+interface ReflectionPromptCardProps {
+  prompt: ReflectionPrompt;
+}
+
+const CATEGORY_LABEL: Record<ReflectionCategory, string> = {
+  form: 'Form',
+  breathing: 'Breath',
+  mindset: 'Focus',
+  progress: 'Progress',
+};
+
+const CATEGORY_COLOR: Record<ReflectionCategory, string> = {
+  form: colors.accent,
+  breathing: colors.restActive,
+  mindset: colors.warmup,
+  progress: colors.success,
+};
+
+function ReflectionPromptCard({ prompt }: ReflectionPromptCardProps) {
+  const tint = CATEGORY_COLOR[prompt.category];
+
+  return (
+    <View style={[styles.card, { borderLeftColor: tint }]} testID="reflection-prompt-card">
+      <View style={styles.header}>
+        <View style={[styles.tag, { borderColor: tint }]}>
+          <Text style={[styles.tagText, { color: tint }]}>
+            {CATEGORY_LABEL[prompt.category]}
+          </Text>
+        </View>
+      </View>
+      <Text style={styles.text} testID="reflection-prompt-text">
+        {prompt.text}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.cardSurface,
+    borderColor: colors.cardBorder,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderLeftWidth: 3,
+    borderRadius: 14,
+    padding: 14,
+    gap: 8,
+  },
+  header: {
+    flexDirection: 'row',
+  },
+  tag: {
+    borderWidth: 1,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 10,
+  },
+  tagText: {
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  text: {
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 14,
+    color: colors.textPrimary,
+    lineHeight: 20,
+  },
+});
+
+export default React.memo(ReflectionPromptCard);

--- a/components/workout/RestActiveRecoveryPanel.tsx
+++ b/components/workout/RestActiveRecoveryPanel.tsx
@@ -1,0 +1,146 @@
+/**
+ * RestActiveRecoveryPanel Component
+ *
+ * The main content block for the rest-timer sheet: a compact context
+ * header (fatigue, muscle group) followed by BreathingCueCard,
+ * MobilityDrillCard, ReflectionPromptCard, and a refresh button that
+ * re-picks mobility + reflection content without restarting breathing.
+ */
+
+import React, { useCallback } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { colors } from '@/styles/workout-session.styles';
+import BreathingCueCard from './BreathingCueCard';
+import MobilityDrillCard from './MobilityDrillCard';
+import ReflectionPromptCard from './ReflectionPromptCard';
+import type { BetweenSetsRecommendation } from '@/lib/services/between-sets-coach';
+
+interface RestActiveRecoveryPanelProps {
+  recommendation: BetweenSetsRecommendation | null;
+  onRefresh?: () => void;
+}
+
+function formatFatigueLabel(score: number): string {
+  if (score < 0.25) return 'Fresh';
+  if (score < 0.5) return 'Moderate';
+  if (score < 0.75) return 'High';
+  return 'Max';
+}
+
+function fatigueTint(score: number): string {
+  if (score < 0.25) return colors.success;
+  if (score < 0.5) return colors.restActive;
+  if (score < 0.75) return colors.warmup;
+  return colors.dropset;
+}
+
+function RestActiveRecoveryPanel({
+  recommendation,
+  onRefresh,
+}: RestActiveRecoveryPanelProps) {
+  const handleRefresh = useCallback(() => {
+    onRefresh?.();
+  }, [onRefresh]);
+
+  if (!recommendation) {
+    return (
+      <View style={styles.emptyContainer} testID="rest-active-recovery-empty">
+        <Text style={styles.emptyText}>No active rest — complete a set to see recovery content.</Text>
+      </View>
+    );
+  }
+
+  const fatigueLabel = formatFatigueLabel(recommendation.fatigueScore);
+  const tint = fatigueTint(recommendation.fatigueScore);
+
+  return (
+    <View style={styles.container} testID="rest-active-recovery-panel">
+      <View style={styles.headerRow}>
+        <View style={[styles.fatigueBadge, { borderColor: tint }]}>
+          <Text style={[styles.fatigueBadgeText, { color: tint }]} testID="rest-fatigue-label">
+            {fatigueLabel}
+          </Text>
+        </View>
+        {recommendation.context.muscleGroup ? (
+          <View style={styles.muscleBadge}>
+            <Text style={styles.muscleText} testID="rest-muscle-group">
+              {recommendation.context.muscleGroup}
+            </Text>
+          </View>
+        ) : null}
+        {onRefresh ? (
+          <TouchableOpacity
+            onPress={handleRefresh}
+            style={styles.refreshButton}
+            testID="rest-recommendation-refresh"
+            accessibilityRole="button"
+            accessibilityLabel="Refresh recovery content"
+          >
+            <Ionicons name="refresh" size={16} color={colors.textSecondary} />
+          </TouchableOpacity>
+        ) : null}
+      </View>
+
+      <BreathingCueCard pattern={recommendation.breathing} autoStart={true} />
+      <MobilityDrillCard drill={recommendation.mobility} defaultExpanded={false} />
+      <ReflectionPromptCard prompt={recommendation.reflection} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 10,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  fatigueBadge: {
+    borderWidth: 1,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 10,
+  },
+  fatigueBadgeText: {
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  muscleBadge: {
+    borderWidth: 1,
+    borderColor: colors.cardBorder,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 10,
+  },
+  muscleText: {
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 11,
+    color: colors.textSecondary,
+    textTransform: 'capitalize',
+  },
+  refreshButton: {
+    marginLeft: 'auto',
+    padding: 6,
+    borderRadius: 999,
+    backgroundColor: colors.cardSurface,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.cardBorder,
+  },
+  emptyContainer: {
+    padding: 16,
+    alignItems: 'center',
+  },
+  emptyText: {
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 13,
+    color: colors.textSecondary,
+    textAlign: 'center',
+  },
+});
+
+export default React.memo(RestActiveRecoveryPanel);

--- a/components/workout/RestTimerSheet.tsx
+++ b/components/workout/RestTimerSheet.tsx
@@ -1,29 +1,35 @@
 /**
  * RestTimerSheet Component
  *
- * Bottom sheet showing the rest timer countdown with skip, +15s, +30s buttons
- * and a "next up" preview.
+ * Bottom sheet shown while resting between sets. Displays the countdown,
+ * extend buttons, a deliberate SetReady CTA (primary), a quiet Skip
+ * affordance (secondary), and a RestActiveRecoveryPanel with breathing
+ * + mobility + reflection content tailored to the just-completed set.
  */
 
 import React, { useEffect, useMemo, useState, forwardRef } from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
-import BottomSheet, { BottomSheetView } from '@gorhom/bottom-sheet';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { sessionStyles as styles, colors } from '@/styles/workout-session.styles';
 import { useSessionRunner } from '@/lib/stores/session-runner';
 import { computeRemainingSeconds, formatRestTime } from '@/lib/services/rest-timer';
+import { useBetweenSetsCoach } from '@/hooks/use-between-sets-coach';
+import RestActiveRecoveryPanel from './RestActiveRecoveryPanel';
+import SetReadyButton from './SetReadyButton';
 
 interface RestTimerSheetProps {
   onClose: () => void;
 }
 
 const RestTimerSheet = forwardRef<BottomSheet, RestTimerSheetProps>(({ onClose }, ref) => {
-  const snapPoints = useMemo(() => ['50%'], []);
+  const snapPoints = useMemo(() => ['85%'], []);
   const restTimer = useSessionRunner((s) => s.restTimer);
   const skipRest = useSessionRunner((s) => s.skipRest);
   const extendRest = useSessionRunner((s) => s.extendRest);
   const exercises = useSessionRunner((s) => s.exercises);
   const sets = useSessionRunner((s) => s.sets);
 
+  const { recommendation, refresh } = useBetweenSetsCoach();
   const [remaining, setRemaining] = useState(0);
 
   useEffect(() => {
@@ -42,7 +48,6 @@ const RestTimerSheet = forwardRef<BottomSheet, RestTimerSheetProps>(({ onClose }
     return () => clearInterval(interval);
   }, [restTimer]);
 
-  // Find next set info
   let nextUpText = '';
   if (restTimer) {
     for (const ex of exercises) {
@@ -52,7 +57,6 @@ const RestTimerSheet = forwardRef<BottomSheet, RestTimerSheetProps>(({ onClose }
         nextUpText = `${ex.exercise?.name ?? 'Exercise'} - Set ${completedSetIdx + 2}`;
         break;
       }
-      // If last set in this exercise, check next exercise
       if (completedSetIdx === exSets.length - 1) {
         const exIdx = exercises.indexOf(ex);
         if (exIdx < exercises.length - 1) {
@@ -64,10 +68,17 @@ const RestTimerSheet = forwardRef<BottomSheet, RestTimerSheetProps>(({ onClose }
     }
   }
 
+  const handleReady = async () => {
+    await skipRest();
+    onClose();
+  };
+
   const handleSkip = async () => {
     await skipRest();
     onClose();
   };
+
+  const restComplete = remaining <= 0;
 
   return (
     <BottomSheet
@@ -79,38 +90,44 @@ const RestTimerSheet = forwardRef<BottomSheet, RestTimerSheetProps>(({ onClose }
       backgroundStyle={{ backgroundColor: colors.background }}
       handleIndicatorStyle={{ backgroundColor: colors.textSecondary }}
     >
-      <BottomSheetView style={styles.sheetContainer}>
-        <View style={styles.restTimerContainer}>
-          {/* Countdown */}
-          <Text style={styles.restTimerDisplay}>
+      <BottomSheetScrollView contentContainerStyle={sheetStyles.scrollContent}>
+        <View style={styles.restTimerContainer} testID="rest-timer-sheet">
+          <Text style={styles.restTimerDisplay} testID="rest-timer-display">
             {remaining > 0 ? formatRestTime(remaining) : '0:00'}
           </Text>
           <Text style={styles.restTimerLabel}>
             {remaining > 0 ? 'Rest Time' : 'Rest Complete'}
           </Text>
 
-          {/* Extend buttons */}
           <View style={styles.restTimerButtons}>
             <TouchableOpacity
               style={styles.restTimerBtn}
               onPress={() => extendRest(15)}
+              testID="rest-timer-extend-15"
             >
               <Text style={styles.restTimerBtnText}>+15s</Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={styles.restTimerBtn}
               onPress={() => extendRest(30)}
+              testID="rest-timer-extend-30"
             >
               <Text style={styles.restTimerBtnText}>+30s</Text>
             </TouchableOpacity>
           </View>
 
-          {/* Skip button */}
-          <TouchableOpacity style={styles.restTimerSkipBtn} onPress={handleSkip}>
-            <Text style={styles.restTimerSkipText}>Skip</Text>
+          <View style={sheetStyles.primaryActionRow}>
+            <SetReadyButton onReady={handleReady} restComplete={restComplete} />
+          </View>
+
+          <TouchableOpacity
+            style={sheetStyles.skipLinkButton}
+            onPress={handleSkip}
+            testID="rest-timer-skip"
+          >
+            <Text style={sheetStyles.skipLinkText}>Skip rest</Text>
           </TouchableOpacity>
 
-          {/* Next up */}
           {nextUpText ? (
             <View style={styles.nextUpContainer}>
               <Text style={styles.nextUpLabel}>Next up</Text>
@@ -118,9 +135,40 @@ const RestTimerSheet = forwardRef<BottomSheet, RestTimerSheetProps>(({ onClose }
             </View>
           ) : null}
         </View>
-      </BottomSheetView>
+
+        <View style={sheetStyles.panelContainer}>
+          <RestActiveRecoveryPanel recommendation={recommendation} onRefresh={refresh} />
+        </View>
+      </BottomSheetScrollView>
     </BottomSheet>
   );
+});
+
+const sheetStyles = StyleSheet.create({
+  scrollContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 40,
+    gap: 16,
+  },
+  primaryActionRow: {
+    marginTop: 12,
+    width: '100%',
+  },
+  skipLinkButton: {
+    marginTop: 8,
+    alignSelf: 'center',
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+  },
+  skipLinkText: {
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 13,
+    color: colors.textSecondary,
+    textDecorationLine: 'underline',
+  },
+  panelContainer: {
+    marginTop: 4,
+  },
 });
 
 RestTimerSheet.displayName = 'RestTimerSheet';

--- a/components/workout/SetReadyButton.tsx
+++ b/components/workout/SetReadyButton.tsx
@@ -1,0 +1,103 @@
+/**
+ * SetReadyButton Component
+ *
+ * Deliberate "I'm ready for the next set" affordance for the rest sheet.
+ * Differs from Skip: Skip means "rush past rest", SetReady means "I've
+ * reset and I'm bracing for the next set intentionally." Plays a
+ * medium-impact haptic when tapped so the gesture feels committed.
+ */
+
+import React, { useCallback } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import * as Haptics from 'expo-haptics';
+import { Ionicons } from '@expo/vector-icons';
+import { colors } from '@/styles/workout-session.styles';
+
+interface SetReadyButtonProps {
+  onReady: () => void;
+  /**
+   * Whether the rest timer has reached zero. Enables visual emphasis
+   * (full success color + pulse) but does not gate activation — the
+   * user can commit to being ready before the full rest window ends.
+   */
+  restComplete?: boolean;
+  /**
+   * Disable the button while a commit is in flight.
+   */
+  disabled?: boolean;
+  /**
+   * Optional label override. Defaults to "I'm ready".
+   */
+  label?: string;
+}
+
+function SetReadyButton({
+  onReady,
+  restComplete = false,
+  disabled = false,
+  label = "I'm ready",
+}: SetReadyButtonProps) {
+  const handlePress = useCallback(async () => {
+    if (disabled) return;
+    try {
+      await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    } catch {
+      // Haptics are best-effort; unavailable on some platforms.
+    }
+    onReady();
+  }, [disabled, onReady]);
+
+  const accent = restComplete ? colors.success : colors.restActive;
+
+  return (
+    <TouchableOpacity
+      onPress={handlePress}
+      disabled={disabled}
+      style={[
+        styles.container,
+        { borderColor: accent, backgroundColor: restComplete ? accent : 'transparent' },
+        disabled && styles.disabled,
+      ]}
+      testID="set-ready-button"
+      accessibilityRole="button"
+      accessibilityState={{ disabled }}
+      accessibilityLabel={label}
+    >
+      <View style={styles.row}>
+        <Ionicons
+          name={restComplete ? 'checkmark-circle' : 'flash-outline'}
+          size={18}
+          color={restComplete ? colors.background : accent}
+        />
+        <Text style={[styles.label, { color: restComplete ? colors.background : accent }]}>
+          {label}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 2,
+    borderRadius: 14,
+    paddingVertical: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  label: {
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 15,
+    letterSpacing: 0.5,
+  },
+  disabled: {
+    opacity: 0.4,
+  },
+});
+
+export default React.memo(SetReadyButton);

--- a/hooks/use-between-sets-coach.ts
+++ b/hooks/use-between-sets-coach.ts
@@ -1,0 +1,81 @@
+/**
+ * useBetweenSetsCoach Hook
+ *
+ * Subscribes to the active rest timer in the session-runner store and
+ * returns a fresh BetweenSetsRecommendation for the just-completed set.
+ * Tracks an in-memory history of previously-shown mobility and
+ * reflection IDs so consecutive rest periods don't repeat content.
+ */
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useSessionRunner } from '@/lib/stores/session-runner';
+import {
+  BetweenSetsRecommendation,
+  buildBetweenSetsRecommendation,
+} from '@/lib/services/between-sets-coach';
+import type { MobilityDrillId } from '@/lib/services/mobility-drills';
+
+const MAX_HISTORY = 6;
+
+export interface UseBetweenSetsCoachResult {
+  recommendation: BetweenSetsRecommendation | null;
+  refresh: () => void;
+  setId: string | null;
+}
+
+export function useBetweenSetsCoach(): UseBetweenSetsCoachResult {
+  const restTimer = useSessionRunner((s) => s.restTimer);
+  const exercises = useSessionRunner((s) => s.exercises);
+  const sets = useSessionRunner((s) => s.sets);
+
+  const mobilityHistoryRef = useRef<MobilityDrillId[]>([]);
+  const reflectionHistoryRef = useRef<string[]>([]);
+  const [refreshNonce, setRefreshNonce] = useState(0);
+
+  const refresh = useCallback(() => {
+    setRefreshNonce((n) => n + 1);
+  }, []);
+
+  const recommendation = useMemo<BetweenSetsRecommendation | null>(() => {
+    if (!restTimer) return null;
+
+    for (const exercise of exercises) {
+      const exerciseSets = sets[exercise.id] ?? [];
+      const setIdx = exerciseSets.findIndex((s) => s.id === restTimer.setId);
+      if (setIdx < 0) continue;
+
+      const target = exerciseSets[setIdx];
+      const rec = buildBetweenSetsRecommendation({
+        setType: target.set_type,
+        setIndex: setIdx,
+        totalSets: exerciseSets.length,
+        restSeconds: restTimer.targetSeconds,
+        muscleGroup: exercise.exercise?.muscle_group ?? null,
+        plannedReps: target.planned_reps,
+        actualReps: target.actual_reps,
+        perceivedRpe: target.perceived_rpe,
+        previouslyShownMobilityIds: mobilityHistoryRef.current,
+        previouslyShownReflectionIds: reflectionHistoryRef.current,
+      });
+
+      mobilityHistoryRef.current = [
+        rec.mobility.id,
+        ...mobilityHistoryRef.current.filter((id) => id !== rec.mobility.id),
+      ].slice(0, MAX_HISTORY);
+      reflectionHistoryRef.current = [
+        rec.reflection.id,
+        ...reflectionHistoryRef.current.filter((id) => id !== rec.reflection.id),
+      ].slice(0, MAX_HISTORY);
+
+      return rec;
+    }
+
+    return null;
+  }, [restTimer, exercises, sets, refreshNonce]);
+
+  return {
+    recommendation,
+    refresh,
+    setId: restTimer?.setId ?? null,
+  };
+}

--- a/lib/services/between-sets-coach.ts
+++ b/lib/services/between-sets-coach.ts
@@ -1,0 +1,222 @@
+/**
+ * Between-Sets Coach Service
+ *
+ * Pure content-composition layer that combines a breathing pattern,
+ * a mobility drill, and a reflection prompt into a single
+ * `BetweenSetsRecommendation` tailored to the just-completed set.
+ * No network, no storage, no React — deterministic and fully testable.
+ */
+
+import type { SetType } from '@/lib/types/workout-session';
+import {
+  BreathingPattern,
+  pickBreathingPattern,
+} from './breathing-patterns';
+import {
+  MobilityDrill,
+  MobilityDrillId,
+  pickMobilityDrill,
+} from './mobility-drills';
+
+export type ReflectionCategory = 'form' | 'breathing' | 'mindset' | 'progress';
+
+export interface ReflectionPrompt {
+  id: string;
+  text: string;
+  category: ReflectionCategory;
+}
+
+export const REFLECTION_PROMPTS: readonly ReflectionPrompt[] = [
+  { id: 'form-bracing', text: 'How tight was your brace before the first rep?', category: 'form' },
+  { id: 'form-bar-path', text: 'Did the bar stay over mid-foot across every rep?', category: 'form' },
+  { id: 'form-tempo', text: 'Were your reps the same speed from first to last?', category: 'form' },
+  {
+    id: 'form-rom',
+    text: 'Did you hit the same depth or range on every rep?',
+    category: 'form',
+  },
+  { id: 'breath-reset', text: 'Let the next breath in be slower than the last.', category: 'breathing' },
+  {
+    id: 'breath-exhale',
+    text: 'Lengthen your exhale — heart rate comes down faster.',
+    category: 'breathing',
+  },
+  { id: 'mindset-focus', text: 'Pick one cue to execute on the next set.', category: 'mindset' },
+  {
+    id: 'mindset-reset',
+    text: 'Name one thing that felt strong — anchor to it next set.',
+    category: 'mindset',
+  },
+  {
+    id: 'mindset-composure',
+    text: 'Feel your feet. Ground through the floor before standing up.',
+    category: 'mindset',
+  },
+  { id: 'progress-prev', text: 'How did this set compare to last week?', category: 'progress' },
+  {
+    id: 'progress-final',
+    text: 'What made this session move forward from the last?',
+    category: 'progress',
+  },
+] as const;
+
+export interface BetweenSetsRecommendation {
+  breathing: BreathingPattern;
+  mobility: MobilityDrill;
+  reflection: ReflectionPrompt;
+  fatigueScore: number;
+  context: {
+    setType: SetType;
+    setIndex: number;
+    totalSets: number;
+    restSeconds: number;
+    muscleGroup: string | null;
+  };
+}
+
+export interface FatigueScoreInput {
+  setType: SetType;
+  setIndex: number;
+  totalSets: number;
+  plannedReps: number | null;
+  actualReps: number | null;
+  perceivedRpe?: number | null;
+}
+
+export function computeFatigueScore(input: FatigueScoreInput): number {
+  const { setType, setIndex, totalSets, plannedReps, actualReps, perceivedRpe } = input;
+
+  let score = 0;
+
+  if (totalSets > 0) {
+    score += Math.min(0.4, (setIndex / totalSets) * 0.4);
+  }
+
+  if (setType === 'failure') {
+    score += 0.4;
+  } else if (setType === 'dropset' || setType === 'amrap') {
+    score += 0.2;
+  }
+
+  if (plannedReps != null && actualReps != null && plannedReps > 0 && actualReps < plannedReps) {
+    const shortfall = (plannedReps - actualReps) / plannedReps;
+    score += Math.min(0.3, shortfall * 0.5);
+  }
+
+  if (perceivedRpe != null) {
+    const rpe = Math.max(1, Math.min(10, perceivedRpe));
+    const rpeComponent = ((rpe - 5) / 5) * 0.3;
+    score += Math.max(0, rpeComponent);
+  }
+
+  if (!Number.isFinite(score)) return 0;
+  return Math.max(0, Math.min(1, score));
+}
+
+export interface PickReflectionInput {
+  setType: SetType;
+  setIndex: number;
+  totalSets: number;
+  fatigueScore: number;
+  previouslyShownIds?: readonly string[];
+}
+
+function promptsByCategory(category: ReflectionCategory): readonly ReflectionPrompt[] {
+  return REFLECTION_PROMPTS.filter((p) => p.category === category);
+}
+
+function firstAvailable(
+  prompts: readonly ReflectionPrompt[],
+  exclude: Set<string>,
+): ReflectionPrompt | undefined {
+  return prompts.find((p) => !exclude.has(p.id));
+}
+
+export function pickReflectionPrompt(input: PickReflectionInput): ReflectionPrompt {
+  const exclude = new Set(input.previouslyShownIds ?? []);
+
+  const isWarmup = input.setType === 'warmup';
+  const isFailure = input.setType === 'failure' || input.fatigueScore >= 0.75;
+  const isLastSet = input.totalSets > 0 && input.setIndex >= input.totalSets - 1;
+  const isMidSession = !isWarmup && !isFailure && !isLastSet;
+
+  const order: ReflectionCategory[] = isFailure
+    ? ['mindset', 'breathing', 'form', 'progress']
+    : isWarmup
+      ? ['form', 'breathing', 'mindset', 'progress']
+      : isLastSet
+        ? ['progress', 'mindset', 'form', 'breathing']
+        : ['form', 'mindset', 'breathing', 'progress'];
+
+  for (const category of order) {
+    const prompt = firstAvailable(promptsByCategory(category), exclude);
+    if (prompt) return prompt;
+  }
+
+  if (isMidSession) {
+    return REFLECTION_PROMPTS[0];
+  }
+  return REFLECTION_PROMPTS[0];
+}
+
+export interface BuildRecommendationInput {
+  setType: SetType;
+  setIndex: number;
+  totalSets: number;
+  restSeconds: number;
+  muscleGroup: string | null;
+  plannedReps: number | null;
+  actualReps: number | null;
+  perceivedRpe?: number | null;
+  previouslyShownMobilityIds?: readonly MobilityDrillId[];
+  previouslyShownReflectionIds?: readonly string[];
+}
+
+export function buildBetweenSetsRecommendation(
+  input: BuildRecommendationInput,
+): BetweenSetsRecommendation {
+  const fatigueScore = computeFatigueScore({
+    setType: input.setType,
+    setIndex: input.setIndex,
+    totalSets: input.totalSets,
+    plannedReps: input.plannedReps,
+    actualReps: input.actualReps,
+    perceivedRpe: input.perceivedRpe,
+  });
+
+  const breathing = pickBreathingPattern({
+    setType: input.setType,
+    setIndex: input.setIndex,
+    totalSets: input.totalSets,
+    restSeconds: input.restSeconds,
+    fatigueScore,
+  });
+
+  const mobility = pickMobilityDrill({
+    muscleGroup: input.muscleGroup,
+    restSeconds: input.restSeconds,
+    previouslyShownIds: input.previouslyShownMobilityIds,
+  });
+
+  const reflection = pickReflectionPrompt({
+    setType: input.setType,
+    setIndex: input.setIndex,
+    totalSets: input.totalSets,
+    fatigueScore,
+    previouslyShownIds: input.previouslyShownReflectionIds,
+  });
+
+  return {
+    breathing,
+    mobility,
+    reflection,
+    fatigueScore,
+    context: {
+      setType: input.setType,
+      setIndex: input.setIndex,
+      totalSets: input.totalSets,
+      restSeconds: input.restSeconds,
+      muscleGroup: input.muscleGroup,
+    },
+  };
+}

--- a/lib/services/breathing-patterns.ts
+++ b/lib/services/breathing-patterns.ts
@@ -1,0 +1,151 @@
+/**
+ * Breathing Patterns Library
+ *
+ * Pure data + picker for structured breathing drills used during rest
+ * between sets. Each pattern defines phase durations (in seconds) plus a
+ * short cue string for each phase, so a timed visualization can drive a
+ * simple inhale/hold/exhale/hold animation.
+ */
+
+import type { SetType } from '@/lib/types/workout-session';
+
+export type BreathingPhaseType = 'inhale' | 'hold-in' | 'exhale' | 'hold-out';
+
+export interface BreathingPhase {
+  type: BreathingPhaseType;
+  seconds: number;
+  cue: string;
+}
+
+export type BreathingContext = 'calming' | 'focus' | 'energizing' | 'recovery' | 'ready';
+
+export type BreathingPatternId = 'box' | 'four-seven-eight' | 'coherent' | 'bellows' | 'diaphragmatic';
+
+export interface BreathingPattern {
+  id: BreathingPatternId;
+  name: string;
+  description: string;
+  phases: BreathingPhase[];
+  cycleSeconds: number;
+  recommendedFor: readonly BreathingContext[];
+}
+
+function sumPhases(phases: BreathingPhase[]): number {
+  return phases.reduce((acc, p) => acc + p.seconds, 0);
+}
+
+const BOX_PHASES: BreathingPhase[] = [
+  { type: 'inhale', seconds: 4, cue: 'Breathe in' },
+  { type: 'hold-in', seconds: 4, cue: 'Hold' },
+  { type: 'exhale', seconds: 4, cue: 'Breathe out' },
+  { type: 'hold-out', seconds: 4, cue: 'Hold' },
+];
+
+const FOUR_SEVEN_EIGHT_PHASES: BreathingPhase[] = [
+  { type: 'inhale', seconds: 4, cue: 'In through nose' },
+  { type: 'hold-in', seconds: 7, cue: 'Hold' },
+  { type: 'exhale', seconds: 8, cue: 'Out through mouth' },
+];
+
+const COHERENT_PHASES: BreathingPhase[] = [
+  { type: 'inhale', seconds: 5, cue: 'Breathe in' },
+  { type: 'exhale', seconds: 5, cue: 'Breathe out' },
+];
+
+const BELLOWS_PHASES: BreathingPhase[] = [
+  { type: 'inhale', seconds: 1, cue: 'Sharp in' },
+  { type: 'exhale', seconds: 1, cue: 'Sharp out' },
+];
+
+const DIAPHRAGMATIC_PHASES: BreathingPhase[] = [
+  { type: 'inhale', seconds: 3, cue: 'Belly expands' },
+  { type: 'hold-in', seconds: 1, cue: 'Pause' },
+  { type: 'exhale', seconds: 4, cue: 'Belly falls' },
+];
+
+export const BREATHING_PATTERNS: readonly BreathingPattern[] = [
+  {
+    id: 'box',
+    name: 'Box Breathing',
+    description: 'Calms the nervous system and restores focus between heavy sets.',
+    phases: BOX_PHASES,
+    cycleSeconds: sumPhases(BOX_PHASES),
+    recommendedFor: ['calming', 'focus', 'recovery'],
+  },
+  {
+    id: 'four-seven-eight',
+    name: '4-7-8 Breathing',
+    description: 'Down-regulates sympathetic drive after a failure or max set.',
+    phases: FOUR_SEVEN_EIGHT_PHASES,
+    cycleSeconds: sumPhases(FOUR_SEVEN_EIGHT_PHASES),
+    recommendedFor: ['calming', 'recovery'],
+  },
+  {
+    id: 'coherent',
+    name: 'Coherent Breathing',
+    description: 'Even 5-5 cadence for heart-rate recovery during moderate rest.',
+    phases: COHERENT_PHASES,
+    cycleSeconds: sumPhases(COHERENT_PHASES),
+    recommendedFor: ['recovery', 'focus', 'ready'],
+  },
+  {
+    id: 'bellows',
+    name: 'Bellows Breath',
+    description: 'Quick primer to energize before an early compound set.',
+    phases: BELLOWS_PHASES,
+    cycleSeconds: sumPhases(BELLOWS_PHASES),
+    recommendedFor: ['energizing', 'ready'],
+  },
+  {
+    id: 'diaphragmatic',
+    name: 'Diaphragmatic Breathing',
+    description: 'Grounds bracing mechanics before the next lift.',
+    phases: DIAPHRAGMATIC_PHASES,
+    cycleSeconds: sumPhases(DIAPHRAGMATIC_PHASES),
+    recommendedFor: ['ready', 'focus'],
+  },
+] as const;
+
+export function getBreathingPattern(id: BreathingPatternId): BreathingPattern {
+  const pattern = BREATHING_PATTERNS.find((p) => p.id === id);
+  if (!pattern) {
+    throw new Error(`Unknown breathing pattern: ${id}`);
+  }
+  return pattern;
+}
+
+export interface PickBreathingInput {
+  setType: SetType;
+  setIndex: number;
+  totalSets: number;
+  restSeconds: number;
+  fatigueScore: number;
+}
+
+export function pickBreathingPattern(input: PickBreathingInput): BreathingPattern {
+  const { setType, setIndex, totalSets, restSeconds, fatigueScore } = input;
+
+  if (setType === 'failure' || fatigueScore >= 0.8) {
+    return getBreathingPattern('four-seven-eight');
+  }
+
+  if (setType === 'warmup' || (setIndex === 0 && fatigueScore < 0.3)) {
+    return getBreathingPattern('bellows');
+  }
+
+  if (restSeconds >= 150 || fatigueScore >= 0.6) {
+    return getBreathingPattern('box');
+  }
+
+  const isLastSet = totalSets > 0 && setIndex >= totalSets - 1;
+  if (isLastSet || restSeconds >= 75) {
+    return getBreathingPattern('coherent');
+  }
+
+  return getBreathingPattern('diaphragmatic');
+}
+
+export function estimateCyclesInRest(pattern: BreathingPattern, restSeconds: number): number {
+  if (pattern.cycleSeconds <= 0 || restSeconds <= 0) return 0;
+  return Math.max(1, Math.floor(restSeconds / pattern.cycleSeconds));
+}

--- a/lib/services/mobility-drills.ts
+++ b/lib/services/mobility-drills.ts
@@ -1,0 +1,227 @@
+/**
+ * Mobility Drills Library
+ *
+ * Curated list of between-set mobility drills keyed loosely by muscle
+ * group. Picker matches an exercise's `muscle_group` string against
+ * drill tags and picks one that fits the remaining rest window.
+ */
+
+export type MobilityDrillId =
+  | 'thoracic-opener'
+  | 'scap-wall-slide'
+  | 'cat-cow'
+  | 'hip-90-90'
+  | 'hamstring-float'
+  | 'ankle-rocker'
+  | 'dead-bug'
+  | 'band-pull-apart'
+  | 'doorway-pec-stretch'
+  | 'couch-stretch';
+
+export type MobilityIntensity = 'low' | 'moderate';
+
+export interface MobilityDrill {
+  id: MobilityDrillId;
+  name: string;
+  description: string;
+  /**
+   * Lowercase substrings to match against the Exercise.muscle_group field.
+   * Picker returns the first drill whose tags contain the muscle group.
+   */
+  muscleTags: readonly string[];
+  steps: readonly string[];
+  durationSeconds: number;
+  intensity: MobilityIntensity;
+}
+
+export const MOBILITY_DRILLS: readonly MobilityDrill[] = [
+  {
+    id: 'thoracic-opener',
+    name: 'Thoracic Spine Opener',
+    description: 'Wakes up mid-back extension before pressing or pulling.',
+    muscleTags: ['chest', 'shoulders', 'back', 'upper'],
+    steps: [
+      'Kneel on the floor with hands behind your head.',
+      'Rotate elbow toward the ceiling, opening one side of the chest.',
+      'Return and alternate sides smoothly for 6 reps per side.',
+    ],
+    durationSeconds: 45,
+    intensity: 'low',
+  },
+  {
+    id: 'scap-wall-slide',
+    name: 'Scapular Wall Slide',
+    description: 'Primes overhead mechanics and shoulder stability.',
+    muscleTags: ['shoulders', 'back', 'upper', 'chest'],
+    steps: [
+      'Stand with back flat against a wall.',
+      'Press arms into the wall in a "W" shape.',
+      'Slide arms overhead into a "Y", keeping contact with the wall.',
+      'Control the return. 8 slow reps.',
+    ],
+    durationSeconds: 40,
+    intensity: 'low',
+  },
+  {
+    id: 'cat-cow',
+    name: 'Cat-Cow Flow',
+    description: 'Restores spinal segmentation and relaxes bracing muscles.',
+    muscleTags: ['back', 'core', 'spine', 'lower-back'],
+    steps: [
+      'Start on all fours, hands under shoulders.',
+      'Inhale: drop belly, lift chest and tailbone (cow).',
+      'Exhale: round back, tuck chin and tailbone (cat).',
+      '6 slow cycles matching breath.',
+    ],
+    durationSeconds: 40,
+    intensity: 'low',
+  },
+  {
+    id: 'hip-90-90',
+    name: '90/90 Hip Switch',
+    description: 'Opens internal and external hip rotation for squat patterns.',
+    muscleTags: ['glutes', 'hips', 'legs', 'quads', 'lower'],
+    steps: [
+      'Sit with one leg bent in front at 90 degrees, other leg bent behind at 90.',
+      'Keeping torso tall, rotate knees across to switch sides.',
+      'Pause 2 seconds on each side. 5 switches per side.',
+    ],
+    durationSeconds: 50,
+    intensity: 'moderate',
+  },
+  {
+    id: 'hamstring-float',
+    name: 'Active Hamstring Float',
+    description: 'Wakes posterior chain without fatiguing it.',
+    muscleTags: ['hamstrings', 'glutes', 'lower', 'legs'],
+    steps: [
+      'Stand tall, hinge forward keeping back neutral.',
+      'Tap fingers to shins or toes, return under control.',
+      '6 slow reps — no bouncing.',
+    ],
+    durationSeconds: 35,
+    intensity: 'low',
+  },
+  {
+    id: 'ankle-rocker',
+    name: 'Ankle Rocker',
+    description: 'Restores ankle dorsiflexion before squats and deadlifts.',
+    muscleTags: ['calves', 'ankles', 'legs', 'quads', 'lower'],
+    steps: [
+      'Split stance, front knee bent over toe.',
+      'Drive knee forward past the toe, keeping heel down.',
+      '8 rocks per side.',
+    ],
+    durationSeconds: 35,
+    intensity: 'low',
+  },
+  {
+    id: 'dead-bug',
+    name: 'Dead Bug',
+    description: 'Reinforces anti-extension bracing between compound sets.',
+    muscleTags: ['core', 'abs', 'full-body'],
+    steps: [
+      'Lie on back, arms up, knees at 90.',
+      'Lower opposite arm and leg until just above the floor.',
+      'Return and switch. Keep lower back pressed down. 4 per side.',
+    ],
+    durationSeconds: 40,
+    intensity: 'moderate',
+  },
+  {
+    id: 'band-pull-apart',
+    name: 'Band Pull-Apart',
+    description: 'Activates rear delts and mid-traps before pressing work.',
+    muscleTags: ['back', 'shoulders', 'upper', 'chest'],
+    steps: [
+      'Hold a light band at shoulder height, arms straight.',
+      'Pull band apart by squeezing shoulder blades.',
+      'Control the return. 10 reps.',
+    ],
+    durationSeconds: 30,
+    intensity: 'low',
+  },
+  {
+    id: 'doorway-pec-stretch',
+    name: 'Doorway Pec Stretch',
+    description: 'Lengthens pecs after pressing to restore posture.',
+    muscleTags: ['chest', 'shoulders', 'upper'],
+    steps: [
+      'Place forearm on a doorway at shoulder height.',
+      'Step forward until a mild stretch is felt across the chest.',
+      'Hold 20 seconds each side.',
+    ],
+    durationSeconds: 45,
+    intensity: 'low',
+  },
+  {
+    id: 'couch-stretch',
+    name: 'Couch Stretch',
+    description: 'Opens hip flexors before squats, lunges, or deadlifts.',
+    muscleTags: ['quads', 'hips', 'legs', 'lower'],
+    steps: [
+      'Place back foot on a bench or couch, front foot forward.',
+      'Square hips and tuck tailbone to stretch the back hip.',
+      'Hold 20 seconds each side.',
+    ],
+    durationSeconds: 50,
+    intensity: 'moderate',
+  },
+] as const;
+
+const FULL_BODY_FALLBACK: MobilityDrill = {
+  id: 'cat-cow',
+  name: 'Cat-Cow Flow',
+  description: 'Restores spinal segmentation and relaxes bracing muscles.',
+  muscleTags: ['full-body'],
+  steps: [
+    'Start on all fours, hands under shoulders.',
+    'Inhale: drop belly, lift chest and tailbone (cow).',
+    'Exhale: round back, tuck chin and tailbone (cat).',
+    '6 slow cycles matching breath.',
+  ],
+  durationSeconds: 40,
+  intensity: 'low',
+};
+
+export function getMobilityDrill(id: MobilityDrillId): MobilityDrill {
+  const drill = MOBILITY_DRILLS.find((d) => d.id === id);
+  if (!drill) {
+    throw new Error(`Unknown mobility drill: ${id}`);
+  }
+  return drill;
+}
+
+function normalizeMuscleGroup(muscleGroup: string | null | undefined): string {
+  return (muscleGroup ?? '').toLowerCase().trim();
+}
+
+export interface PickMobilityInput {
+  muscleGroup: string | null | undefined;
+  restSeconds: number;
+  previouslyShownIds?: readonly MobilityDrillId[];
+}
+
+export function pickMobilityDrill(input: PickMobilityInput): MobilityDrill {
+  const normalized = normalizeMuscleGroup(input.muscleGroup);
+  const exclude = new Set(input.previouslyShownIds ?? []);
+  const fitsRest = (drill: MobilityDrill) =>
+    input.restSeconds <= 0 || drill.durationSeconds <= input.restSeconds;
+
+  if (normalized) {
+    const matching = MOBILITY_DRILLS.filter(
+      (d) =>
+        d.muscleTags.some((tag) => normalized.includes(tag)) && !exclude.has(d.id) && fitsRest(d),
+    );
+    if (matching.length > 0) {
+      return matching[0];
+    }
+  }
+
+  const notExcluded = MOBILITY_DRILLS.filter((d) => !exclude.has(d.id) && fitsRest(d));
+  if (notExcluded.length > 0) {
+    return notExcluded[0];
+  }
+
+  return FULL_BODY_FALLBACK;
+}

--- a/tests/unit/components/workout/BreathingCueCard.test.tsx
+++ b/tests/unit/components/workout/BreathingCueCard.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import BreathingCueCard from '@/components/workout/BreathingCueCard';
+import { getBreathingPattern } from '@/lib/services/breathing-patterns';
+
+jest.useFakeTimers();
+
+describe('BreathingCueCard', () => {
+  const box = getBreathingPattern('box');
+
+  beforeEach(() => {
+    jest.clearAllTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders the pattern name and description', () => {
+    const { getByTestId, getByText } = render(<BreathingCueCard pattern={box} autoStart={false} />);
+    expect(getByTestId('breathing-pattern-name').props.children).toBe('Box Breathing');
+    expect(getByText(box.description)).toBeTruthy();
+  });
+
+  it('starts on the first phase with full seconds shown', () => {
+    const { getByTestId } = render(<BreathingCueCard pattern={box} autoStart={false} />);
+    const phaseText = getByTestId('breathing-phase');
+    expect(phaseText).toBeTruthy();
+    expect(getByTestId('breathing-seconds').props.children).toEqual([
+      box.phases[0].seconds,
+      's',
+    ]);
+  });
+
+  it('shows the correct toggle label based on autoStart', () => {
+    const stopped = render(<BreathingCueCard pattern={box} autoStart={false} />);
+    expect(stopped.getByTestId('breathing-toggle').props.accessibilityLabel).toBe(
+      'Start breathing guide',
+    );
+    const running = render(<BreathingCueCard pattern={box} autoStart={true} />);
+    expect(running.getByTestId('breathing-toggle').props.accessibilityLabel).toBe(
+      'Pause breathing guide',
+    );
+  });
+
+  it('toggling pause/start flips accessibilityLabel', () => {
+    const { getByTestId } = render(<BreathingCueCard pattern={box} autoStart={true} />);
+    const toggle = getByTestId('breathing-toggle');
+    expect(toggle.props.accessibilityLabel).toBe('Pause breathing guide');
+    fireEvent.press(toggle);
+    expect(toggle.props.accessibilityLabel).toBe('Start breathing guide');
+  });
+
+  it('advances through phases when time elapses', () => {
+    const onPhaseChange = jest.fn();
+    render(
+      <BreathingCueCard pattern={box} autoStart={true} onPhaseChange={onPhaseChange} />,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(box.phases[0].seconds * 1000);
+    });
+    expect(onPhaseChange).toHaveBeenCalled();
+    const firstTransition = onPhaseChange.mock.calls[0];
+    expect(firstTransition[1]).toBe(1);
+  });
+
+  it('loops back to the first phase after cycling through all phases', () => {
+    const onPhaseChange = jest.fn();
+    render(
+      <BreathingCueCard pattern={box} autoStart={true} onPhaseChange={onPhaseChange} />,
+    );
+
+    const total = box.phases.reduce((acc, p) => acc + p.seconds, 0);
+    act(() => {
+      jest.advanceTimersByTime(total * 1000);
+    });
+    const lastCall = onPhaseChange.mock.calls[onPhaseChange.mock.calls.length - 1];
+    expect(lastCall[1]).toBe(0);
+  });
+
+  it('resets when the pattern changes', () => {
+    const { rerender, getByTestId } = render(
+      <BreathingCueCard pattern={box} autoStart={false} />,
+    );
+    const coherent = getBreathingPattern('coherent');
+    rerender(<BreathingCueCard pattern={coherent} autoStart={false} />);
+    expect(getByTestId('breathing-pattern-name').props.children).toBe('Coherent Breathing');
+    expect(getByTestId('breathing-seconds').props.children).toEqual([
+      coherent.phases[0].seconds,
+      's',
+    ]);
+  });
+});

--- a/tests/unit/components/workout/MobilityDrillCard.test.tsx
+++ b/tests/unit/components/workout/MobilityDrillCard.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import MobilityDrillCard from '@/components/workout/MobilityDrillCard';
+import { getMobilityDrill } from '@/lib/services/mobility-drills';
+
+describe('MobilityDrillCard', () => {
+  const drill = getMobilityDrill('hip-90-90');
+
+  it('renders the drill name and description', () => {
+    const { getByTestId, getByText } = render(<MobilityDrillCard drill={drill} />);
+    expect(getByTestId('mobility-drill-name').props.children).toBe(drill.name);
+    expect(getByText(drill.description)).toBeTruthy();
+  });
+
+  it('hides steps by default', () => {
+    const { queryByTestId } = render(<MobilityDrillCard drill={drill} />);
+    expect(queryByTestId('mobility-drill-steps')).toBeNull();
+  });
+
+  it('expands to show the step list when toggled', () => {
+    const { getByTestId, queryByTestId } = render(<MobilityDrillCard drill={drill} />);
+    fireEvent.press(getByTestId('mobility-drill-toggle'));
+    expect(queryByTestId('mobility-drill-steps')).not.toBeNull();
+  });
+
+  it('honors defaultExpanded=true', () => {
+    const { queryByTestId } = render(
+      <MobilityDrillCard drill={drill} defaultExpanded={true} />,
+    );
+    expect(queryByTestId('mobility-drill-steps')).not.toBeNull();
+  });
+
+  it('collapses back when toggled twice', () => {
+    const { getByTestId, queryByTestId } = render(
+      <MobilityDrillCard drill={drill} defaultExpanded={true} />,
+    );
+    fireEvent.press(getByTestId('mobility-drill-toggle'));
+    expect(queryByTestId('mobility-drill-steps')).toBeNull();
+  });
+
+  it('flips accessibilityLabel with expansion', () => {
+    const { getByTestId } = render(<MobilityDrillCard drill={drill} />);
+    const toggle = getByTestId('mobility-drill-toggle');
+    expect(toggle.props.accessibilityLabel).toBe('Expand drill steps');
+    fireEvent.press(toggle);
+    expect(toggle.props.accessibilityLabel).toBe('Collapse drill steps');
+  });
+});

--- a/tests/unit/components/workout/ReflectionPromptCard.test.tsx
+++ b/tests/unit/components/workout/ReflectionPromptCard.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import ReflectionPromptCard from '@/components/workout/ReflectionPromptCard';
+import {
+  REFLECTION_PROMPTS,
+  type ReflectionPrompt,
+} from '@/lib/services/between-sets-coach';
+
+describe('ReflectionPromptCard', () => {
+  const basePrompt: ReflectionPrompt = REFLECTION_PROMPTS.find((p) => p.category === 'form')!;
+
+  it('renders the prompt text', () => {
+    const { getByTestId } = render(<ReflectionPromptCard prompt={basePrompt} />);
+    expect(getByTestId('reflection-prompt-text').props.children).toBe(basePrompt.text);
+  });
+
+  it('renders a form category tag for a form prompt', () => {
+    const { getByText } = render(<ReflectionPromptCard prompt={basePrompt} />);
+    expect(getByText('Form')).toBeTruthy();
+  });
+
+  it('renders a focus tag for mindset category', () => {
+    const mindset = REFLECTION_PROMPTS.find((p) => p.category === 'mindset')!;
+    const { getByText } = render(<ReflectionPromptCard prompt={mindset} />);
+    expect(getByText('Focus')).toBeTruthy();
+  });
+
+  it('renders a breath tag for breathing category', () => {
+    const breath = REFLECTION_PROMPTS.find((p) => p.category === 'breathing')!;
+    const { getByText } = render(<ReflectionPromptCard prompt={breath} />);
+    expect(getByText('Breath')).toBeTruthy();
+  });
+
+  it('renders a progress tag for progress category', () => {
+    const progress = REFLECTION_PROMPTS.find((p) => p.category === 'progress')!;
+    const { getByText } = render(<ReflectionPromptCard prompt={progress} />);
+    expect(getByText('Progress')).toBeTruthy();
+  });
+});

--- a/tests/unit/components/workout/RestActiveRecoveryPanel.test.tsx
+++ b/tests/unit/components/workout/RestActiveRecoveryPanel.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import RestActiveRecoveryPanel from '@/components/workout/RestActiveRecoveryPanel';
+import { buildBetweenSetsRecommendation } from '@/lib/services/between-sets-coach';
+
+describe('RestActiveRecoveryPanel', () => {
+  const rec = buildBetweenSetsRecommendation({
+    setType: 'normal',
+    setIndex: 1,
+    totalSets: 4,
+    restSeconds: 120,
+    muscleGroup: 'chest',
+    plannedReps: 8,
+    actualReps: 8,
+  });
+
+  it('renders the empty state when there is no recommendation', () => {
+    const { getByTestId } = render(<RestActiveRecoveryPanel recommendation={null} />);
+    expect(getByTestId('rest-active-recovery-empty')).toBeTruthy();
+  });
+
+  it('renders the panel with a fatigue label and muscle group', () => {
+    const { getByTestId } = render(<RestActiveRecoveryPanel recommendation={rec} />);
+    expect(getByTestId('rest-active-recovery-panel')).toBeTruthy();
+    expect(getByTestId('rest-fatigue-label')).toBeTruthy();
+    expect(getByTestId('rest-muscle-group').props.children).toBe('chest');
+  });
+
+  it('renders a refresh button only when onRefresh is provided', () => {
+    const { queryByTestId } = render(<RestActiveRecoveryPanel recommendation={rec} />);
+    expect(queryByTestId('rest-recommendation-refresh')).toBeNull();
+  });
+
+  it('invokes onRefresh when the refresh button is pressed', () => {
+    const onRefresh = jest.fn();
+    const { getByTestId } = render(
+      <RestActiveRecoveryPanel recommendation={rec} onRefresh={onRefresh} />,
+    );
+    fireEvent.press(getByTestId('rest-recommendation-refresh'));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Fresh label for low fatigue score', () => {
+    const low = { ...rec, fatigueScore: 0.1 };
+    const { getByTestId } = render(<RestActiveRecoveryPanel recommendation={low} />);
+    expect(getByTestId('rest-fatigue-label').props.children).toBe('Fresh');
+  });
+
+  it('renders Max label for saturated fatigue score', () => {
+    const max = { ...rec, fatigueScore: 0.95 };
+    const { getByTestId } = render(<RestActiveRecoveryPanel recommendation={max} />);
+    expect(getByTestId('rest-fatigue-label').props.children).toBe('Max');
+  });
+
+  it('does not render the muscle badge when muscle group is null', () => {
+    const noMuscle = { ...rec, context: { ...rec.context, muscleGroup: null } };
+    const { queryByTestId } = render(<RestActiveRecoveryPanel recommendation={noMuscle} />);
+    expect(queryByTestId('rest-muscle-group')).toBeNull();
+  });
+
+  it('renders a breathing cue card, mobility card, and reflection card together', () => {
+    const { getByTestId } = render(<RestActiveRecoveryPanel recommendation={rec} />);
+    expect(getByTestId('breathing-cue-card')).toBeTruthy();
+    expect(getByTestId('mobility-drill-card')).toBeTruthy();
+    expect(getByTestId('reflection-prompt-card')).toBeTruthy();
+  });
+});

--- a/tests/unit/components/workout/RestTimerSheet.test.tsx
+++ b/tests/unit/components/workout/RestTimerSheet.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import RestTimerSheet from '@/components/workout/RestTimerSheet';
+
+jest.mock('@gorhom/bottom-sheet', () => {
+  const ReactActual = jest.requireActual('react');
+  const Fragment = ReactActual.Fragment;
+  const Passthrough = ReactActual.forwardRef(
+    ({ children }: { children?: React.ReactNode }, _ref: unknown) =>
+      ReactActual.createElement(Fragment, null, children),
+  );
+  const ScrollPassthrough = ({ children }: { children?: React.ReactNode }) =>
+    ReactActual.createElement(Fragment, null, children);
+  return { __esModule: true, default: Passthrough, BottomSheetScrollView: ScrollPassthrough };
+});
+
+const mockSkipRest = jest.fn(() => Promise.resolve());
+const mockExtendRest = jest.fn();
+
+const mockStoreRef: {
+  value: {
+    restTimer: { targetSeconds: number; startedAt: string; setId: string } | null;
+    exercises: Array<{
+      id: string;
+      exercise?: { id: string; name: string; muscle_group: string };
+    }>;
+    sets: Record<
+      string,
+      Array<{
+        id: string;
+        set_type: string;
+        planned_reps: number | null;
+        actual_reps: number | null;
+        perceived_rpe: number | null;
+      }>
+    >;
+  };
+} = {
+  value: {
+    restTimer: {
+      setId: 'set-1',
+      targetSeconds: 60,
+      startedAt: new Date(Date.now() - 30_000).toISOString(),
+    },
+    exercises: [
+      {
+        id: 'ex-1',
+        exercise: { id: 'e1', name: 'Bench Press', muscle_group: 'chest' },
+      },
+    ],
+    sets: {
+      'ex-1': [
+        {
+          id: 'set-1',
+          set_type: 'normal',
+          planned_reps: 8,
+          actual_reps: 8,
+          perceived_rpe: null,
+        },
+        {
+          id: 'set-2',
+          set_type: 'normal',
+          planned_reps: 8,
+          actual_reps: null,
+          perceived_rpe: null,
+        },
+      ],
+    },
+  },
+};
+
+jest.mock('@/lib/stores/session-runner', () => ({
+  useSessionRunner: (selector: (s: unknown) => unknown) =>
+    selector({
+      get restTimer() {
+        return mockStoreRef.value.restTimer;
+      },
+      get exercises() {
+        return mockStoreRef.value.exercises;
+      },
+      get sets() {
+        return mockStoreRef.value.sets;
+      },
+      skipRest: () => mockSkipRest(),
+      extendRest: (seconds: number) => mockExtendRest(seconds),
+    }),
+}));
+
+const mockImpactAsync = jest.fn(() => Promise.resolve());
+jest.mock('expo-haptics', () => ({
+  ImpactFeedbackStyle: { Medium: 'medium' },
+  impactAsync: () => mockImpactAsync(),
+}));
+
+describe('RestTimerSheet', () => {
+  beforeEach(() => {
+    mockSkipRest.mockClear();
+    mockExtendRest.mockClear();
+    mockImpactAsync.mockClear();
+  });
+
+  it('renders the sheet with a timer display', () => {
+    const { getByTestId } = render(<RestTimerSheet onClose={() => undefined} />);
+    expect(getByTestId('rest-timer-sheet')).toBeTruthy();
+    expect(getByTestId('rest-timer-display')).toBeTruthy();
+  });
+
+  it('renders the active recovery panel with recommendation content', () => {
+    const { getByTestId } = render(<RestTimerSheet onClose={() => undefined} />);
+    expect(getByTestId('rest-active-recovery-panel')).toBeTruthy();
+    expect(getByTestId('breathing-cue-card')).toBeTruthy();
+    expect(getByTestId('mobility-drill-card')).toBeTruthy();
+    expect(getByTestId('reflection-prompt-card')).toBeTruthy();
+  });
+
+  it('invokes extendRest with 15 or 30 seconds on the respective buttons', () => {
+    const { getByTestId } = render(<RestTimerSheet onClose={() => undefined} />);
+    fireEvent.press(getByTestId('rest-timer-extend-15'));
+    fireEvent.press(getByTestId('rest-timer-extend-30'));
+    expect(mockExtendRest).toHaveBeenCalledWith(15);
+    expect(mockExtendRest).toHaveBeenCalledWith(30);
+  });
+
+  it('calls skipRest + onClose when SetReady is pressed', async () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(<RestTimerSheet onClose={onClose} />);
+    fireEvent.press(getByTestId('set-ready-button'));
+    await waitFor(() => expect(mockSkipRest).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+
+  it('calls skipRest + onClose when Skip link is pressed', async () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(<RestTimerSheet onClose={onClose} />);
+    fireEvent.press(getByTestId('rest-timer-skip'));
+    await waitFor(() => expect(mockSkipRest).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+
+  it('renders the empty panel state when there is no active rest', () => {
+    const prev = mockStoreRef.value.restTimer;
+    mockStoreRef.value.restTimer = null;
+    const { getByTestId } = render(<RestTimerSheet onClose={() => undefined} />);
+    expect(getByTestId('rest-active-recovery-empty')).toBeTruthy();
+    mockStoreRef.value.restTimer = prev;
+  });
+});

--- a/tests/unit/components/workout/SetReadyButton.test.tsx
+++ b/tests/unit/components/workout/SetReadyButton.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import SetReadyButton from '@/components/workout/SetReadyButton';
+
+const mockImpactAsync = jest.fn((_style: string) => Promise.resolve());
+
+jest.mock('expo-haptics', () => ({
+  ImpactFeedbackStyle: { Medium: 'medium' },
+  impactAsync: (style: string) => mockImpactAsync(style),
+}));
+
+describe('SetReadyButton', () => {
+  beforeEach(() => {
+    mockImpactAsync.mockClear();
+    mockImpactAsync.mockImplementation(() => Promise.resolve());
+  });
+
+  it('renders the default label', () => {
+    const onReady = jest.fn();
+    const { getByTestId } = render(<SetReadyButton onReady={onReady} />);
+    const button = getByTestId('set-ready-button');
+    expect(button.props.accessibilityLabel).toBe("I'm ready");
+  });
+
+  it('honors a custom label', () => {
+    const onReady = jest.fn();
+    const { getByTestId } = render(<SetReadyButton onReady={onReady} label="Let's go" />);
+    expect(getByTestId('set-ready-button').props.accessibilityLabel).toBe("Let's go");
+  });
+
+  it('calls onReady when pressed', async () => {
+    const onReady = jest.fn();
+    const { getByTestId } = render(<SetReadyButton onReady={onReady} />);
+    fireEvent.press(getByTestId('set-ready-button'));
+    await waitFor(() => expect(onReady).toHaveBeenCalledTimes(1));
+  });
+
+  it('triggers a medium-impact haptic on press', async () => {
+    const onReady = jest.fn();
+    const { getByTestId } = render(<SetReadyButton onReady={onReady} />);
+    fireEvent.press(getByTestId('set-ready-button'));
+    await waitFor(() => expect(mockImpactAsync).toHaveBeenCalledWith('medium'));
+  });
+
+  it('still calls onReady when haptics throw', async () => {
+    mockImpactAsync.mockRejectedValueOnce(new Error('unsupported'));
+    const onReady = jest.fn();
+    const { getByTestId } = render(<SetReadyButton onReady={onReady} />);
+    fireEvent.press(getByTestId('set-ready-button'));
+    await waitFor(() => expect(onReady).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not fire when disabled', async () => {
+    const onReady = jest.fn();
+    const { getByTestId } = render(<SetReadyButton onReady={onReady} disabled={true} />);
+    fireEvent.press(getByTestId('set-ready-button'));
+    expect(onReady).not.toHaveBeenCalled();
+    expect(mockImpactAsync).not.toHaveBeenCalled();
+  });
+
+  it('surfaces accessibility disabled state', () => {
+    const { getByTestId } = render(
+      <SetReadyButton onReady={() => undefined} disabled={true} />,
+    );
+    expect(getByTestId('set-ready-button').props.accessibilityState).toMatchObject({
+      disabled: true,
+    });
+  });
+});

--- a/tests/unit/hooks/use-between-sets-coach.test.tsx
+++ b/tests/unit/hooks/use-between-sets-coach.test.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import { act, render } from '@testing-library/react-native';
+import { useBetweenSetsCoach } from '@/hooks/use-between-sets-coach';
+
+const mockRestTimer = jest.fn();
+const mockExercises = jest.fn();
+const mockSets = jest.fn();
+
+jest.mock('@/lib/stores/session-runner', () => ({
+  useSessionRunner: (selector: (s: unknown) => unknown) =>
+    selector({
+      get restTimer() {
+        return mockRestTimer();
+      },
+      get exercises() {
+        return mockExercises();
+      },
+      get sets() {
+        return mockSets();
+      },
+    }),
+}));
+
+function TestHarness({ onRender }: { onRender: (r: ReturnType<typeof useBetweenSetsCoach>) => void }) {
+  const result = useBetweenSetsCoach();
+  onRender(result);
+  return (
+    <View testID="harness">
+      <Text testID="set-id">{result.setId ?? 'none'}</Text>
+      <Text testID="mobility-id">{result.recommendation?.mobility.id ?? 'none'}</Text>
+      <Text testID="reflection-id">{result.recommendation?.reflection.id ?? 'none'}</Text>
+    </View>
+  );
+}
+
+describe('useBetweenSetsCoach', () => {
+  beforeEach(() => {
+    mockRestTimer.mockReset();
+    mockExercises.mockReset();
+    mockSets.mockReset();
+  });
+
+  it('returns null recommendation when no rest timer is active', () => {
+    mockRestTimer.mockReturnValue(null);
+    mockExercises.mockReturnValue([]);
+    mockSets.mockReturnValue({});
+
+    const onRender = jest.fn();
+    render(<TestHarness onRender={onRender} />);
+
+    const last = onRender.mock.calls[onRender.mock.calls.length - 1][0];
+    expect(last.recommendation).toBeNull();
+    expect(last.setId).toBeNull();
+  });
+
+  it('builds a recommendation for the active set', () => {
+    mockRestTimer.mockReturnValue({
+      setId: 'set-1',
+      targetSeconds: 120,
+      startedAt: '2026-04-16T10:00:00Z',
+    });
+    mockExercises.mockReturnValue([
+      {
+        id: 'ex-1',
+        exercise: { id: 'e1', name: 'Bench Press', muscle_group: 'chest', is_compound: true },
+      },
+    ]);
+    mockSets.mockReturnValue({
+      'ex-1': [
+        {
+          id: 'set-1',
+          set_type: 'normal',
+          planned_reps: 8,
+          actual_reps: 8,
+          planned_weight: null,
+          actual_weight: null,
+          perceived_rpe: null,
+        },
+        {
+          id: 'set-2',
+          set_type: 'normal',
+          planned_reps: 8,
+          actual_reps: null,
+          planned_weight: null,
+          actual_weight: null,
+          perceived_rpe: null,
+        },
+      ],
+    });
+
+    const onRender = jest.fn();
+    render(<TestHarness onRender={onRender} />);
+
+    const last = onRender.mock.calls[onRender.mock.calls.length - 1][0];
+    expect(last.setId).toBe('set-1');
+    expect(last.recommendation).not.toBeNull();
+    expect(last.recommendation?.context.muscleGroup).toBe('chest');
+    expect(last.recommendation?.context.setIndex).toBe(0);
+    expect(last.recommendation?.context.totalSets).toBe(2);
+  });
+
+  it('returns null when the active set cannot be found in any exercise', () => {
+    mockRestTimer.mockReturnValue({
+      setId: 'missing-set',
+      targetSeconds: 90,
+      startedAt: '2026-04-16T10:00:00Z',
+    });
+    mockExercises.mockReturnValue([
+      { id: 'ex-1', exercise: { id: 'e1', muscle_group: 'back' } },
+    ]);
+    mockSets.mockReturnValue({
+      'ex-1': [{ id: 'other-set', set_type: 'normal' }],
+    });
+
+    const onRender = jest.fn();
+    render(<TestHarness onRender={onRender} />);
+
+    const last = onRender.mock.calls[onRender.mock.calls.length - 1][0];
+    expect(last.recommendation).toBeNull();
+  });
+
+  it('refresh() re-derives the recommendation and varies the mobility/reflection picks', () => {
+    mockRestTimer.mockReturnValue({
+      setId: 'set-1',
+      targetSeconds: 180,
+      startedAt: '2026-04-16T10:00:00Z',
+    });
+    mockExercises.mockReturnValue([
+      { id: 'ex-1', exercise: { id: 'e1', muscle_group: 'chest' } },
+    ]);
+    mockSets.mockReturnValue({
+      'ex-1': [
+        {
+          id: 'set-1',
+          set_type: 'normal',
+          planned_reps: 8,
+          actual_reps: 8,
+          perceived_rpe: null,
+        },
+      ],
+    });
+
+    const onRender = jest.fn();
+    const { rerender } = render(<TestHarness onRender={onRender} />);
+
+    const first = onRender.mock.calls[onRender.mock.calls.length - 1][0];
+
+    act(() => {
+      first.refresh();
+    });
+    rerender(<TestHarness onRender={onRender} />);
+
+    const second = onRender.mock.calls[onRender.mock.calls.length - 1][0];
+    expect(second.recommendation?.mobility.id).not.toBe(first.recommendation?.mobility.id);
+  });
+
+  it('passes perceived_rpe into the recommendation to raise fatigue', () => {
+    mockRestTimer.mockReturnValue({
+      setId: 'set-1',
+      targetSeconds: 120,
+      startedAt: '2026-04-16T10:00:00Z',
+    });
+    mockExercises.mockReturnValue([
+      { id: 'ex-1', exercise: { id: 'e1', muscle_group: 'quads' } },
+    ]);
+    mockSets.mockReturnValue({
+      'ex-1': [
+        {
+          id: 'set-1',
+          set_type: 'normal',
+          planned_reps: 5,
+          actual_reps: 5,
+          perceived_rpe: 9,
+        },
+      ],
+    });
+
+    const onRender = jest.fn();
+    render(<TestHarness onRender={onRender} />);
+
+    const last = onRender.mock.calls[onRender.mock.calls.length - 1][0];
+    expect(last.recommendation?.fatigueScore).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/services/between-sets-coach.test.ts
+++ b/tests/unit/services/between-sets-coach.test.ts
@@ -1,0 +1,249 @@
+import {
+  REFLECTION_PROMPTS,
+  buildBetweenSetsRecommendation,
+  computeFatigueScore,
+  pickReflectionPrompt,
+} from '@/lib/services/between-sets-coach';
+
+describe('between-sets-coach', () => {
+  describe('computeFatigueScore', () => {
+    it('returns 0 for a fresh warmup set with no data', () => {
+      const score = computeFatigueScore({
+        setType: 'warmup',
+        setIndex: 0,
+        totalSets: 4,
+        plannedReps: null,
+        actualReps: null,
+      });
+      expect(score).toBe(0);
+    });
+
+    it('grows with set index relative to total sets', () => {
+      const early = computeFatigueScore({
+        setType: 'normal',
+        setIndex: 0,
+        totalSets: 4,
+        plannedReps: 8,
+        actualReps: 8,
+      });
+      const late = computeFatigueScore({
+        setType: 'normal',
+        setIndex: 3,
+        totalSets: 4,
+        plannedReps: 8,
+        actualReps: 8,
+      });
+      expect(late).toBeGreaterThan(early);
+    });
+
+    it('adds a large boost when set type is failure', () => {
+      const normal = computeFatigueScore({
+        setType: 'normal',
+        setIndex: 2,
+        totalSets: 4,
+        plannedReps: 8,
+        actualReps: 8,
+      });
+      const failure = computeFatigueScore({
+        setType: 'failure',
+        setIndex: 2,
+        totalSets: 4,
+        plannedReps: 8,
+        actualReps: 8,
+      });
+      expect(failure).toBeGreaterThanOrEqual(normal + 0.3);
+    });
+
+    it('adds moderate fatigue for dropset or amrap', () => {
+      const base = computeFatigueScore({
+        setType: 'normal',
+        setIndex: 1,
+        totalSets: 4,
+        plannedReps: 8,
+        actualReps: 8,
+      });
+      const dropset = computeFatigueScore({
+        setType: 'dropset',
+        setIndex: 1,
+        totalSets: 4,
+        plannedReps: 8,
+        actualReps: 8,
+      });
+      expect(dropset).toBeGreaterThan(base);
+    });
+
+    it('increases when actual reps fall short of planned', () => {
+      const hit = computeFatigueScore({
+        setType: 'normal',
+        setIndex: 1,
+        totalSets: 3,
+        plannedReps: 10,
+        actualReps: 10,
+      });
+      const missed = computeFatigueScore({
+        setType: 'normal',
+        setIndex: 1,
+        totalSets: 3,
+        plannedReps: 10,
+        actualReps: 6,
+      });
+      expect(missed).toBeGreaterThan(hit);
+    });
+
+    it('incorporates RPE above 5', () => {
+      const rpe5 = computeFatigueScore({
+        setType: 'normal',
+        setIndex: 1,
+        totalSets: 4,
+        plannedReps: 8,
+        actualReps: 8,
+        perceivedRpe: 5,
+      });
+      const rpe9 = computeFatigueScore({
+        setType: 'normal',
+        setIndex: 1,
+        totalSets: 4,
+        plannedReps: 8,
+        actualReps: 8,
+        perceivedRpe: 9,
+      });
+      expect(rpe9).toBeGreaterThan(rpe5);
+    });
+
+    it('clamps the final score into [0, 1]', () => {
+      const score = computeFatigueScore({
+        setType: 'failure',
+        setIndex: 9,
+        totalSets: 10,
+        plannedReps: 20,
+        actualReps: 1,
+        perceivedRpe: 10,
+      });
+      expect(score).toBeLessThanOrEqual(1);
+      expect(score).toBeGreaterThanOrEqual(0);
+    });
+
+    it('returns 0 when internal math produces NaN', () => {
+      const score = computeFatigueScore({
+        setType: 'normal',
+        setIndex: 0,
+        totalSets: 0,
+        plannedReps: 0,
+        actualReps: 0,
+      });
+      expect(Number.isFinite(score)).toBe(true);
+    });
+  });
+
+  describe('REFLECTION_PROMPTS catalog', () => {
+    it('covers all four categories', () => {
+      const categories = new Set(REFLECTION_PROMPTS.map((p) => p.category));
+      expect(categories).toEqual(new Set(['form', 'breathing', 'mindset', 'progress']));
+    });
+
+    it('all ids are unique', () => {
+      const ids = REFLECTION_PROMPTS.map((p) => p.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+
+  describe('pickReflectionPrompt', () => {
+    const base = { setType: 'normal' as const, setIndex: 1, totalSets: 4, fatigueScore: 0.3 };
+
+    it('leads with a form prompt in the middle of a session', () => {
+      const pick = pickReflectionPrompt(base);
+      expect(pick.category).toBe('form');
+    });
+
+    it('leads with a form prompt for warmup sets', () => {
+      const pick = pickReflectionPrompt({ ...base, setType: 'warmup', setIndex: 0 });
+      expect(pick.category).toBe('form');
+    });
+
+    it('leads with a mindset prompt after a failure set', () => {
+      const pick = pickReflectionPrompt({ ...base, setType: 'failure', fatigueScore: 0.7 });
+      expect(pick.category).toBe('mindset');
+    });
+
+    it('leads with a mindset prompt when fatigue is very high', () => {
+      const pick = pickReflectionPrompt({ ...base, fatigueScore: 0.9 });
+      expect(pick.category).toBe('mindset');
+    });
+
+    it('leads with a progress prompt on the last set', () => {
+      const pick = pickReflectionPrompt({ ...base, setIndex: 3, totalSets: 4 });
+      expect(pick.category).toBe('progress');
+    });
+
+    it('skips previously shown prompts', () => {
+      const first = pickReflectionPrompt(base);
+      const second = pickReflectionPrompt({ ...base, previouslyShownIds: [first.id] });
+      expect(second.id).not.toBe(first.id);
+    });
+  });
+
+  describe('buildBetweenSetsRecommendation', () => {
+    const baseInput = {
+      setType: 'normal' as const,
+      setIndex: 1,
+      totalSets: 4,
+      restSeconds: 120,
+      muscleGroup: 'chest',
+      plannedReps: 8,
+      actualReps: 8,
+    };
+
+    it('produces a complete recommendation', () => {
+      const rec = buildBetweenSetsRecommendation(baseInput);
+      expect(rec.breathing.id).toBeDefined();
+      expect(rec.mobility.id).toBeDefined();
+      expect(rec.reflection.id).toBeDefined();
+      expect(rec.fatigueScore).toBeGreaterThanOrEqual(0);
+      expect(rec.fatigueScore).toBeLessThanOrEqual(1);
+    });
+
+    it('propagates input context into the recommendation', () => {
+      const rec = buildBetweenSetsRecommendation(baseInput);
+      expect(rec.context.setType).toBe('normal');
+      expect(rec.context.setIndex).toBe(1);
+      expect(rec.context.muscleGroup).toBe('chest');
+      expect(rec.context.restSeconds).toBe(120);
+    });
+
+    it('picks a chest-tagged mobility drill for a chest exercise', () => {
+      const rec = buildBetweenSetsRecommendation(baseInput);
+      expect(
+        rec.mobility.muscleTags.some((tag) =>
+          ['chest', 'shoulders', 'upper'].includes(tag),
+        ),
+      ).toBe(true);
+    });
+
+    it('surfaces the 4-7-8 pattern after a failure set', () => {
+      const rec = buildBetweenSetsRecommendation({
+        ...baseInput,
+        setType: 'failure',
+        actualReps: 4,
+      });
+      expect(rec.breathing.id).toBe('four-seven-eight');
+    });
+
+    it('excludes previously shown mobility drills', () => {
+      const first = buildBetweenSetsRecommendation(baseInput);
+      const second = buildBetweenSetsRecommendation({
+        ...baseInput,
+        previouslyShownMobilityIds: [first.mobility.id],
+      });
+      expect(second.mobility.id).not.toBe(first.mobility.id);
+    });
+
+    it('excludes previously shown reflection prompts', () => {
+      const first = buildBetweenSetsRecommendation(baseInput);
+      const second = buildBetweenSetsRecommendation({
+        ...baseInput,
+        previouslyShownReflectionIds: [first.reflection.id],
+      });
+      expect(second.reflection.id).not.toBe(first.reflection.id);
+    });
+  });
+});

--- a/tests/unit/services/breathing-patterns.test.ts
+++ b/tests/unit/services/breathing-patterns.test.ts
@@ -1,0 +1,141 @@
+import {
+  BREATHING_PATTERNS,
+  estimateCyclesInRest,
+  getBreathingPattern,
+  pickBreathingPattern,
+} from '@/lib/services/breathing-patterns';
+
+describe('breathing-patterns', () => {
+  describe('BREATHING_PATTERNS catalog', () => {
+    it('exposes five unique patterns', () => {
+      const ids = BREATHING_PATTERNS.map((p) => p.id);
+      expect(ids).toEqual(['box', 'four-seven-eight', 'coherent', 'bellows', 'diaphragmatic']);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('each pattern has positive cycleSeconds matching sum of phases', () => {
+      for (const pattern of BREATHING_PATTERNS) {
+        const actual = pattern.phases.reduce((acc, p) => acc + p.seconds, 0);
+        expect(pattern.cycleSeconds).toBe(actual);
+        expect(pattern.cycleSeconds).toBeGreaterThan(0);
+      }
+    });
+
+    it('every phase has a cue string and positive duration', () => {
+      for (const pattern of BREATHING_PATTERNS) {
+        for (const phase of pattern.phases) {
+          expect(phase.cue.length).toBeGreaterThan(0);
+          expect(phase.seconds).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it('every pattern declares at least one context tag', () => {
+      for (const pattern of BREATHING_PATTERNS) {
+        expect(pattern.recommendedFor.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('getBreathingPattern', () => {
+    it('returns the pattern with matching id', () => {
+      expect(getBreathingPattern('box').id).toBe('box');
+      expect(getBreathingPattern('coherent').id).toBe('coherent');
+    });
+
+    it('throws for unknown id', () => {
+      expect(() => getBreathingPattern('unknown' as 'box')).toThrow(/Unknown breathing pattern/);
+    });
+  });
+
+  describe('pickBreathingPattern', () => {
+    const baseInput = {
+      setType: 'normal' as const,
+      setIndex: 1,
+      totalSets: 4,
+      restSeconds: 90,
+      fatigueScore: 0.4,
+    };
+
+    it('picks 4-7-8 after a failure set', () => {
+      const pick = pickBreathingPattern({ ...baseInput, setType: 'failure' });
+      expect(pick.id).toBe('four-seven-eight');
+    });
+
+    it('picks 4-7-8 when fatigue is very high regardless of set type', () => {
+      const pick = pickBreathingPattern({ ...baseInput, fatigueScore: 0.85 });
+      expect(pick.id).toBe('four-seven-eight');
+    });
+
+    it('picks bellows for fresh warmup set', () => {
+      const pick = pickBreathingPattern({
+        ...baseInput,
+        setType: 'warmup',
+        setIndex: 0,
+        fatigueScore: 0.1,
+      });
+      expect(pick.id).toBe('bellows');
+    });
+
+    it('picks bellows for first normal set while fresh', () => {
+      const pick = pickBreathingPattern({
+        ...baseInput,
+        setIndex: 0,
+        fatigueScore: 0.15,
+      });
+      expect(pick.id).toBe('bellows');
+    });
+
+    it('picks box for long rest windows', () => {
+      const pick = pickBreathingPattern({ ...baseInput, restSeconds: 180 });
+      expect(pick.id).toBe('box');
+    });
+
+    it('picks box for moderate fatigue even on shorter rest', () => {
+      const pick = pickBreathingPattern({ ...baseInput, fatigueScore: 0.65 });
+      expect(pick.id).toBe('box');
+    });
+
+    it('picks coherent for the final set', () => {
+      const pick = pickBreathingPattern({ ...baseInput, setIndex: 3, totalSets: 4 });
+      expect(pick.id).toBe('coherent');
+    });
+
+    it('picks coherent for medium rest windows', () => {
+      const pick = pickBreathingPattern({ ...baseInput, restSeconds: 90 });
+      expect(pick.id).toBe('coherent');
+    });
+
+    it('falls through to diaphragmatic for short rests in the middle of a session', () => {
+      const pick = pickBreathingPattern({
+        ...baseInput,
+        setIndex: 2,
+        totalSets: 5,
+        restSeconds: 45,
+        fatigueScore: 0.4,
+      });
+      expect(pick.id).toBe('diaphragmatic');
+    });
+  });
+
+  describe('estimateCyclesInRest', () => {
+    const box = getBreathingPattern('box');
+
+    it('returns 0 when rest is zero', () => {
+      expect(estimateCyclesInRest(box, 0)).toBe(0);
+    });
+
+    it('returns at least one cycle when rest > 0 but smaller than cycle', () => {
+      expect(estimateCyclesInRest(box, 4)).toBe(1);
+    });
+
+    it('divides rest by cycle length for longer windows', () => {
+      expect(estimateCyclesInRest(box, 64)).toBe(4);
+    });
+
+    it('returns 0 for a pattern with zero cycle seconds', () => {
+      const zero = { ...box, cycleSeconds: 0, phases: [] };
+      expect(estimateCyclesInRest(zero, 60)).toBe(0);
+    });
+  });
+});

--- a/tests/unit/services/mobility-drills.test.ts
+++ b/tests/unit/services/mobility-drills.test.ts
@@ -1,0 +1,95 @@
+import {
+  MOBILITY_DRILLS,
+  getMobilityDrill,
+  pickMobilityDrill,
+} from '@/lib/services/mobility-drills';
+
+describe('mobility-drills', () => {
+  describe('MOBILITY_DRILLS catalog', () => {
+    it('exposes ten unique drills', () => {
+      const ids = MOBILITY_DRILLS.map((d) => d.id);
+      expect(ids.length).toBe(10);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('every drill has positive duration and non-empty steps', () => {
+      for (const drill of MOBILITY_DRILLS) {
+        expect(drill.durationSeconds).toBeGreaterThan(0);
+        expect(drill.steps.length).toBeGreaterThan(0);
+        expect(drill.muscleTags.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('every drill declares a recognized intensity level', () => {
+      for (const drill of MOBILITY_DRILLS) {
+        expect(['low', 'moderate']).toContain(drill.intensity);
+      }
+    });
+  });
+
+  describe('getMobilityDrill', () => {
+    it('returns the drill with matching id', () => {
+      expect(getMobilityDrill('cat-cow').id).toBe('cat-cow');
+      expect(getMobilityDrill('dead-bug').name).toBe('Dead Bug');
+    });
+
+    it('throws for an unknown id', () => {
+      expect(() => getMobilityDrill('unknown-drill' as 'cat-cow')).toThrow(
+        /Unknown mobility drill/,
+      );
+    });
+  });
+
+  describe('pickMobilityDrill', () => {
+    it('matches chest exercises to a chest-tagged drill', () => {
+      const pick = pickMobilityDrill({ muscleGroup: 'chest', restSeconds: 90 });
+      expect(pick.muscleTags).toEqual(expect.arrayContaining(['chest']));
+    });
+
+    it('is case-insensitive and tolerates trailing spaces', () => {
+      const pick = pickMobilityDrill({ muscleGroup: '  SHOULDERS ', restSeconds: 90 });
+      expect(pick.muscleTags.some((tag) => tag === 'shoulders' || tag === 'upper')).toBe(true);
+    });
+
+    it('returns the first non-excluded drill that still fits the rest window', () => {
+      const first = pickMobilityDrill({ muscleGroup: 'back', restSeconds: 120 });
+      const second = pickMobilityDrill({
+        muscleGroup: 'back',
+        restSeconds: 120,
+        previouslyShownIds: [first.id],
+      });
+      expect(second.id).not.toBe(first.id);
+    });
+
+    it('skips drills that would exceed the remaining rest window', () => {
+      const pick = pickMobilityDrill({ muscleGroup: 'legs', restSeconds: 36 });
+      expect(pick.durationSeconds).toBeLessThanOrEqual(36);
+    });
+
+    it('falls back to any drill when muscle group is unknown', () => {
+      const pick = pickMobilityDrill({ muscleGroup: 'tail-feathers', restSeconds: 120 });
+      expect(pick).toBeDefined();
+      expect(pick.id).toBeDefined();
+    });
+
+    it('falls back to any drill when muscle group is null', () => {
+      const pick = pickMobilityDrill({ muscleGroup: null, restSeconds: 120 });
+      expect(pick).toBeDefined();
+    });
+
+    it('returns the fallback drill when every catalog drill is excluded', () => {
+      const pick = pickMobilityDrill({
+        muscleGroup: 'chest',
+        restSeconds: 500,
+        previouslyShownIds: MOBILITY_DRILLS.map((d) => d.id),
+      });
+      expect(pick.id).toBe('cat-cow');
+      expect(pick.muscleTags).toContain('full-body');
+    });
+
+    it('returns a drill even with zero rest seconds (no duration filter applied)', () => {
+      const pick = pickMobilityDrill({ muscleGroup: 'back', restSeconds: 0 });
+      expect(pick).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Wave-14 large-scope PR — **between-sets coaching experience**. Files issue #483 and lands its full scope in one cohesive PR (not a grab bag): the rest-timer sheet now hosts a breathing-pattern visualizer, a muscle-group-aware mobility drill, a context-aware reflection prompt, and a deliberate *SetReady* CTA distinct from *Skip rest*.

Today's rest UX was countdown-only (`RestTimerSheet.tsx:72-119`). Every between-set moment was wasted — no active recovery, no reflection on the prior set, no deliberate transition into the next. Audit against the 22 open form-tracking PRs confirmed zero overlap on this surface.

## What ships

### Pure services (no React, no network, fully deterministic)
- `lib/services/breathing-patterns.ts` — 5 patterns (box / 4-7-8 / coherent / bellows / diaphragmatic) with phase durations, cue strings, and a context-aware picker keyed on set type + set index + rest window + fatigue score.
- `lib/services/mobility-drills.ts` — 10-drill library tagged by muscle group with intensity + duration. Picker matches `Exercise.muscle_group` substring, excludes previously-shown drills, and filters by remaining rest window.
- `lib/services/between-sets-coach.ts` — composer that combines breathing + mobility + reflection + \`computeFatigueScore\`. Fatigue score is clamped to [0, 1] and considers set index, set type (failure / dropset / amrap), rep shortfall, and optional RPE.

### Hook
- \`hooks/use-between-sets-coach.ts\` — subscribes to the session-runner store + rest timer, locates the just-completed set, calls \`buildBetweenSetsRecommendation\`, and LRU-caches the last 6 shown mobility/reflection IDs so consecutive rest periods don't repeat.

### Components
- \`BreathingCueCard\` — cycles through breathing phases with per-second countdown, phase badge color-shifts (inhale / exhale / hold), accessibility-labeled pause/resume toggle, \`onPhaseChange\` callback for future haptic/audio wiring.
- \`MobilityDrillCard\` — intensity + duration tags in header, expandable numbered step list.
- \`ReflectionPromptCard\` — category-tinted left border (form / breath / focus / progress).
- \`RestActiveRecoveryPanel\` — wraps the three cards with a fatigue badge (Fresh / Moderate / High / Max) and muscle-group chip, exposes refresh for re-rolling content.
- \`SetReadyButton\` — deliberate primary CTA with medium-impact haptic, distinct from the quiet *Skip rest* link. Emphasis flips when \`restComplete\`.

### Integration
- \`RestTimerSheet.tsx\` — snap-point grows to 85%, \`BottomSheetView\` → \`BottomSheetScrollView\`, countdown + extend buttons stay at top, then \`SetReadyButton\`, a subtle Skip link, the next-up preview, and the full \`RestActiveRecoveryPanel\`.

## Commits (9 atomic)

\`\`\`
592837f feat(rest-coach): add breathing patterns library
2bf8d26 feat(rest-coach): add mobility drills library
3b766e3 feat(rest-coach): add between-sets coach composer
67bc551 feat(rest-coach): add useBetweenSetsCoach hook
598933a feat(rest-coach): add BreathingCueCard component
ed56a46 feat(rest-coach): add MobilityDrillCard and ReflectionPromptCard
7778812 feat(rest-coach): add RestActiveRecoveryPanel wrapper
3e9dec7 feat(rest-coach): add SetReadyButton affordance
624188a feat(rest-timer): integrate active-recovery panel into RestTimerSheet
\`\`\`

## Test plan

- [x] 98/98 new unit tests pass (\`bun run test\` on the 10 new test files).
- [x] \`bun run lint\` clean (only 2 pre-existing template-builder warnings).
- [x] \`bun run check:types\` clean.
- [x] Pre-commit hook ran on every commit; no hooks skipped.
- [ ] Manual smoke: complete a set on iOS, verify rest sheet expands to 85%, breathing card auto-starts, mobility steps expand on tap, SetReady triggers haptic + closes sheet.
- [ ] Manual smoke: complete a failure set, verify 4-7-8 breathing pattern is selected and fatigue badge reads High / Max.

## Scope call-outs

- **Zero new dependencies** — uses already-installed \`expo-haptics\`, \`@gorhom/bottom-sheet\`, \`@expo/vector-icons\`.
- **Zero migrations** — everything is pure TS + existing session-runner store fields.
- **Zero file overlap** with the other 22 open form-tracking PRs (verified pre-branch).
- **Pre-existing** test failure in \`generic-sync.test.ts:1231\` (issue #422 / PR #474) — pushed with \`CI_LOCAL_SKIP=1\` because the failure is on \`main\`, not introduced here.

## Deferred (tracked in worklog)

- **Audio-environment detector** — needs native mic plumbing; better filed as follow-up to #481.
- **Per-rep FQI badge in SetRow** — needs a schema migration + live tracking data plumbing from #439 / #449.
- **Gemma provider badge** — blocked on #457 merge; will file a ~100-LOC follow-up once that lands.

Closes #483