### PR TITLE
feat(coach): provider transparency — badge + rate-limit UX

### DIFF
--- a/app/(tabs)/coach.tsx
+++ b/app/(tabs)/coach.tsx
@@ -43,6 +43,7 @@ export default function CoachScreen() {
   const [coachInput, setCoachInput] = useState('');
   const [coachError, setCoachError] = useState<string | null>(null);
   const [coachErrorDomain, setCoachErrorDomain] = useState<AppError['domain'] | null>(null);
+  const [coachErrorCode, setCoachErrorCode] = useState<string | null>(null);
   const [coachSending, setCoachSending] = useState(false);
   const [showCoachWelcome, setShowCoachWelcome] = useState(false);
   const [sessionLoading, setSessionLoading] = useState(false);
@@ -91,6 +92,7 @@ export default function CoachScreen() {
     setCoachInput('');
     setCoachError(null);
     setCoachErrorDomain(null);
+    setCoachErrorCode(null);
     setCoachSending(true);
 
     try {
@@ -109,6 +111,7 @@ export default function CoachScreen() {
       const fallback = 'Unable to reach the coach. Please try again.';
       setCoachError(hasDomain ? mapToUserMessage(appErr as AppError) : fallback);
       setCoachErrorDomain(hasDomain ? (appErr as AppError).domain : null);
+      setCoachErrorCode(hasDomain ? (appErr as AppError).code : null);
     } finally {
       setCoachSending(false);
     }
@@ -203,6 +206,7 @@ export default function CoachScreen() {
     setCoachSessionId(Crypto.randomUUID());
     setCoachError(null);
     setCoachErrorDomain(null);
+    setCoachErrorCode(null);
   }, []);
 
   const handleVoiceStart = useCallback(async () => {
@@ -302,13 +306,15 @@ export default function CoachScreen() {
         </View>
 
         {coachError && (
-          <View style={styles.coachError}>
+          <View style={styles.coachError} testID="coach-error-banner">
             <Text style={styles.coachErrorTitle}>
-              {coachErrorDomain === 'network'
-                ? 'Connection error'
-                : coachErrorDomain === 'unknown' || coachErrorDomain == null
-                  ? 'Coach is busy'
-                  : 'Service unavailable'}
+              {coachErrorCode === 'COACH_RATE_LIMITED'
+                ? 'Coach is rate-limited'
+                : coachErrorDomain === 'network'
+                  ? 'Connection error'
+                  : coachErrorDomain === 'unknown' || coachErrorDomain == null
+                    ? 'Coach is busy'
+                    : 'Service unavailable'}
             </Text>
             <Text style={styles.coachErrorText}>{coachError}</Text>
           </View>

--- a/app/(tabs)/coach.tsx
+++ b/app/(tabs)/coach.tsx
@@ -10,6 +10,7 @@ import { useToast } from '@/contexts/ToastContext';
 import { CoachMessage, sendCoachPrompt } from '@/lib/services/coach-service';
 import { fetchTodaySession, fetchCoachSessionMessages } from '@/lib/services/coach-history-service';
 import { AppError, mapToUserMessage } from '@/lib/services/ErrorHandler';
+import { CoachProviderBadge } from '@/components/coach/CoachProviderBadge';
 import { styles } from '../../styles/tabs/_index.styles';
 import { spacing } from '../../styles/tabs/_theme-constants';
 import { tabColors } from '@/styles/tabs/_tab-theme';
@@ -335,6 +336,9 @@ export default function CoachScreen() {
                   >
                     <Text style={styles.coachBubbleText}>{item.content}</Text>
                     <Text style={styles.coachBubbleMeta}>{isUser ? 'You' : 'Coach'}</Text>
+                    {!isUser && item.provider && (
+                      <CoachProviderBadge provider={item.provider} />
+                    )}
                   </View>
                 </View>
               );

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/lib/services/video-service';
 import { CoachMessage, sendCoachPrompt } from '@/lib/services/coach-service';
 import { AppError, mapToUserMessage } from '@/lib/services/ErrorHandler';
+import { CoachProviderBadge } from '@/components/coach/CoachProviderBadge';
 import {
   buildOverlaySummary,
   buildPostText,
@@ -845,6 +846,9 @@ export default function HomeScreen() {
               >
                 <Text style={styles.coachBubbleText}>{item.content}</Text>
                 <Text style={styles.coachBubbleMeta}>{isUser ? 'You' : 'Coach'}</Text>
+                {!isUser && item.provider && (
+                  <CoachProviderBadge provider={item.provider} />
+                )}
               </View>
             </View>
           );

--- a/components/coach/CoachProviderBadge.tsx
+++ b/components/coach/CoachProviderBadge.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import type { CoachProvider } from '@/lib/services/coach-provider-types';
+import { tabColors } from '@/styles/tabs/_tab-theme';
+
+interface CoachProviderBadgeProps {
+  provider: CoachProvider;
+  testID?: string;
+}
+
+interface BadgeVisual {
+  label: string;
+  a11yLabel: string;
+  background: string;
+  border: string;
+  text: string;
+}
+
+const GOOGLE_BLUE = '#4285F4';
+
+function getVisual(provider: CoachProvider): BadgeVisual {
+  switch (provider) {
+    case 'openai':
+      return {
+        label: 'GPT',
+        a11yLabel: 'Response from GPT',
+        background: 'rgba(154, 172, 209, 0.12)',
+        border: 'rgba(154, 172, 209, 0.3)',
+        text: tabColors.textSecondary,
+      };
+    case 'gemma-cloud':
+      return {
+        label: 'Gemma',
+        a11yLabel: 'Response from Gemma by Google',
+        background: 'rgba(66, 133, 244, 0.16)',
+        border: `${GOOGLE_BLUE}55`,
+        text: GOOGLE_BLUE,
+      };
+    case 'gemma-on-device':
+      return {
+        label: 'Gemma • on device',
+        a11yLabel: 'Response from Gemma running on this device',
+        background: 'rgba(66, 133, 244, 0.1)',
+        border: `${GOOGLE_BLUE}44`,
+        text: GOOGLE_BLUE,
+      };
+    case 'local-fallback':
+      return {
+        label: 'Local fallback',
+        a11yLabel: 'Response from local fallback — network unavailable',
+        background: 'rgba(245, 158, 11, 0.16)',
+        border: 'rgba(245, 158, 11, 0.45)',
+        text: '#F59E0B',
+      };
+    case 'cached':
+      return {
+        label: 'From cache',
+        a11yLabel: 'Cached response — not a new call to the coach',
+        background: 'rgba(154, 172, 209, 0.08)',
+        border: 'rgba(154, 172, 209, 0.25)',
+        text: tabColors.textSecondary,
+      };
+    default:
+      return {
+        label: 'Coach',
+        a11yLabel: 'Response from Coach',
+        background: 'rgba(154, 172, 209, 0.12)',
+        border: 'rgba(154, 172, 209, 0.3)',
+        text: tabColors.textSecondary,
+      };
+  }
+}
+
+export function CoachProviderBadge({
+  provider,
+  testID,
+}: CoachProviderBadgeProps): React.ReactElement {
+  const visual = getVisual(provider);
+
+  return (
+    <View
+      style={[
+        styles.badge,
+        { backgroundColor: visual.background, borderColor: visual.border },
+      ]}
+      accessibilityRole="text"
+      accessibilityLabel={visual.a11yLabel}
+      testID={testID ?? `coach-provider-badge-${provider}`}
+    >
+      <Text style={[styles.label, { color: visual.text }]}>{visual.label}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+    marginTop: 4,
+  },
+  label: {
+    fontSize: 10,
+    fontFamily: 'Lexend_700Bold',
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+  },
+});
+
+export default CoachProviderBadge;

--- a/lib/services/ErrorHandler.ts
+++ b/lib/services/ErrorHandler.ts
@@ -34,6 +34,11 @@ export function createError(
 }
 
 export function mapToUserMessage(err: AppError): string {
+  // Specific codes can override the domain-default copy.
+  if (err.code === 'COACH_RATE_LIMITED') {
+    return 'Coach is rate-limited — try again in a moment.';
+  }
+
   switch (err.domain) {
     case 'network':
       return 'Connection issue. Please check your internet and try again.';

--- a/lib/services/coach-provider-types.ts
+++ b/lib/services/coach-provider-types.ts
@@ -1,0 +1,93 @@
+/**
+ * Coach provider discriminator — which AI backend produced a given reply.
+ *
+ * Surfaced in the coach chat UI so users can see which model answered each
+ * message (OpenAI GPT, Google Gemma, local fallback, or a cache hit).
+ */
+export type CoachProvider =
+  | 'openai'
+  | 'gemma-cloud'
+  | 'gemma-on-device'
+  | 'local-fallback'
+  | 'cached';
+
+/**
+ * Coarse signal the edge function / service layer may emit to describe which
+ * source produced a reply. The service normalises this into `CoachProvider`.
+ */
+export interface CoachProviderSignal {
+  /** Explicit provider, if the edge function returns one. */
+  provider?: CoachProvider | string;
+  /** Model identifier string, e.g. `gpt-5.4-mini`, `gemma-2b`. */
+  model?: string;
+  /** Marks the reply as coming from an on-device cache or local fallback path. */
+  source?: 'cache' | 'local' | 'remote';
+}
+
+const KNOWN_PROVIDERS: readonly CoachProvider[] = [
+  'openai',
+  'gemma-cloud',
+  'gemma-on-device',
+  'local-fallback',
+  'cached',
+] as const;
+
+let hasWarnedAboutAmbiguousProvider = false;
+
+/**
+ * Derive a `CoachProvider` from an opaque signal returned by the coach edge
+ * function. Preference order:
+ *   1. Explicit `provider` field (if it is one of the known values).
+ *   2. `source === 'cache'` → `'cached'`.
+ *   3. `source === 'local'` → `'local-fallback'`.
+ *   4. Model-name prefix inference (`gpt-*` → openai, `gemma-*` → gemma-cloud).
+ *
+ * WHY inference: today the edge function stores only `{ model: 'gpt-5.4-mini' }`
+ * in `coach_conversations.metadata`. Until it starts returning an explicit
+ * provider, we infer from the model name so the UI can still show a badge.
+ * If two signals conflict or a model is unrecognised, we default to `'openai'`
+ * (current behaviour) and warn once in dev.
+ */
+export function inferCoachProvider(
+  signal: CoachProviderSignal | null | undefined,
+): CoachProvider {
+  if (!signal) return 'openai';
+
+  const explicit = signal.provider?.toString().trim();
+  if (explicit && (KNOWN_PROVIDERS as readonly string[]).includes(explicit)) {
+    return explicit as CoachProvider;
+  }
+
+  if (signal.source === 'cache') return 'cached';
+  if (signal.source === 'local') return 'local-fallback';
+
+  const model = signal.model?.toString().toLowerCase() ?? '';
+  if (model.startsWith('gpt-') || model.startsWith('o1') || model.startsWith('o3')) {
+    return 'openai';
+  }
+  if (model.startsWith('gemma-')) {
+    // Absent a `source`, cloud Gemma is the common case today.
+    return 'gemma-cloud';
+  }
+  if (model.includes('on-device') || model.includes('ondevice')) {
+    return 'gemma-on-device';
+  }
+
+  if (__DEV__ && !hasWarnedAboutAmbiguousProvider) {
+    hasWarnedAboutAmbiguousProvider = true;
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[coach] Unable to infer coach provider from signal; defaulting to "openai".',
+      { signal },
+    );
+  }
+  return 'openai';
+}
+
+/**
+ * Test-only hook for resetting the once-per-session warn flag.
+ * Not exported from the package barrel — for Jest direct imports only.
+ */
+export function __resetCoachProviderInferenceWarning(): void {
+  hasWarnedAboutAmbiguousProvider = false;
+}

--- a/lib/services/coach-service.ts
+++ b/lib/services/coach-service.ts
@@ -1,6 +1,13 @@
 import { supabase } from '@/lib/supabase';
 import { errorWithTs, warnWithTs } from '@/lib/logger';
 import { createError, logError } from './ErrorHandler';
+import {
+  inferCoachProvider,
+  type CoachProvider,
+  type CoachProviderSignal,
+} from './coach-provider-types';
+
+export type { CoachProvider } from './coach-provider-types';
 
 export type CoachRole = 'user' | 'assistant' | 'system';
 
@@ -8,6 +15,11 @@ export interface CoachMessage {
   role: CoachRole;
   content: string;
   id?: string;
+  /**
+   * The AI backend that produced this message. Set only on assistant replies
+   * returned by `sendCoachPrompt`. Absent on user / system turns.
+   */
+  provider?: CoachProvider;
 }
 
 export interface CoachContext {
@@ -25,8 +37,15 @@ interface RawCoachResponse {
   content?: string;
   reply?: string;
   error?: string;
+  /** Provider discriminator — optional; may be absent from legacy responses. */
+  provider?: CoachProvider | string;
+  /** Model name (e.g. `gpt-5.4-mini`, `gemma-2b`). Used to infer provider. */
+  model?: string;
+  /** Coarse origin marker for cache / local-fallback paths. */
+  source?: 'cache' | 'local' | 'remote';
 }
 
+const DEFAULT_MODEL_ID = 'gpt-5.4-mini';
 const functionName = (process.env.EXPO_PUBLIC_COACH_FUNCTION || 'coach').trim();
 
 export async function sendCoachPrompt(
@@ -101,6 +120,18 @@ export async function sendCoachPrompt(
       );
     }
 
+    // WHY: the edge function today only returns text (no provider field). We
+    // infer the provider from whatever signal it does emit (model name +
+    // optional `source`) so the UI can still show a badge. Once the edge
+    // function starts returning `provider` explicitly, that wins.
+    const signal: CoachProviderSignal = {
+      provider: data?.provider,
+      model: data?.model ?? DEFAULT_MODEL_ID,
+      source: data?.source,
+    };
+    const provider = inferCoachProvider(signal);
+    const modelId = signal.model ?? DEFAULT_MODEL_ID;
+
     if (context?.profile?.id && context.sessionId) {
       const userTurns = messages.filter(m => m.role === 'user');
       const insertPayload = {
@@ -111,7 +142,7 @@ export async function sendCoachPrompt(
         assistant_message: responseText,
         input_messages: messages,
         context: { focus: context.focus },
-        metadata: { model: 'gpt-5.4-mini', timestamp: new Date().toISOString() },
+        metadata: { model: modelId, provider, timestamp: new Date().toISOString() },
       };
       supabase.from('coach_conversations').insert(insertPayload).then(({ error: insertErr }) => {
         if (!insertErr) return;
@@ -137,10 +168,18 @@ export async function sendCoachPrompt(
       });
     }
 
-    return {
-      role: 'assistant',
-      content: responseText,
-    };
+    // WHY non-enumerable: `provider` is a supplementary annotation on the
+    // assistant reply. Keeping it non-enumerable preserves backward-compatible
+    // equality semantics for existing consumers that shallow-compare replies,
+    // while still letting TypeScript + the UI read `msg.provider`.
+    const reply: CoachMessage = { role: 'assistant', content: responseText };
+    Object.defineProperty(reply, 'provider', {
+      value: provider,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+    return reply;
   } catch (err) {
     if (err && typeof err === 'object' && 'domain' in err) {
       throw err;

--- a/lib/services/coach-service.ts
+++ b/lib/services/coach-service.ts
@@ -60,12 +60,18 @@ export async function sendCoachPrompt(
     if (error) {
       // Check for specific error types based on error message or context
       const errorMessage = error.message || '';
-      const isConfigError = errorMessage.includes('not configured') || 
+      const isConfigError = errorMessage.includes('not configured') ||
                            errorMessage.includes('OPENAI_API_KEY') ||
                            errorMessage.includes('missing');
       const hasStatus = typeof error === 'object' && error !== null && 'status' in error;
-      const isNotFound = (hasStatus && (error as { status: unknown }).status === 404) || errorMessage.includes('404');
-      
+      const status = hasStatus ? (error as { status: unknown }).status : undefined;
+      const isNotFound = (status === 404) || errorMessage.includes('404');
+      const isRateLimited =
+        status === 429 ||
+        /\b429\b/.test(errorMessage) ||
+        /rate.?limit/i.test(errorMessage) ||
+        /too many requests/i.test(errorMessage);
+
       if (isNotFound) {
         throw createError(
           'validation',
@@ -74,7 +80,7 @@ export async function sendCoachPrompt(
           { details: error, retryable: false }
         );
       }
-      
+
       if (isConfigError) {
         throw createError(
           'validation',
@@ -83,7 +89,16 @@ export async function sendCoachPrompt(
           { details: error, retryable: false }
         );
       }
-      
+
+      if (isRateLimited) {
+        throw createError(
+          'network',
+          'COACH_RATE_LIMITED',
+          'Coach is rate-limited — try again in a moment.',
+          { details: error, retryable: true }
+        );
+      }
+
       throw createError(
         'network',
         'COACH_INVOKE_FAILED',
@@ -97,8 +112,22 @@ export async function sendCoachPrompt(
 
     // Check if the response itself contains an error field
     if (data?.error) {
-      const isConfigError = data.error.includes('not configured') || 
+      const isConfigError = data.error.includes('not configured') ||
                            data.error.includes('OPENAI_API_KEY');
+      const isRateLimitedPayload =
+        /\b429\b/.test(data.error) ||
+        /rate.?limit/i.test(data.error) ||
+        /too many requests/i.test(data.error);
+
+      if (isRateLimitedPayload) {
+        throw createError(
+          'network',
+          'COACH_RATE_LIMITED',
+          'Coach is rate-limited — try again in a moment.',
+          { details: data.error, retryable: true }
+        );
+      }
+
       throw createError(
         isConfigError ? 'validation' : 'network',
         isConfigError ? 'COACH_NOT_CONFIGURED' : 'COACH_ERROR',

--- a/tests/unit/components/coach/CoachProviderBadge.test.tsx
+++ b/tests/unit/components/coach/CoachProviderBadge.test.tsx
@@ -1,0 +1,45 @@
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+import { CoachProviderBadge } from '@/components/coach/CoachProviderBadge';
+import type { CoachProvider } from '@/lib/services/coach-provider-types';
+
+describe('CoachProviderBadge', () => {
+  it.each<[CoachProvider, string, RegExp]>([
+    ['openai', 'GPT', /gpt/i],
+    ['gemma-cloud', 'Gemma', /gemma by google/i],
+    ['gemma-on-device', 'Gemma • on device', /gemma running on this device/i],
+    ['local-fallback', 'Local fallback', /local fallback/i],
+    ['cached', 'From cache', /cached/i],
+  ])('renders label + a11y for provider=%s', (provider, label, a11yPattern) => {
+    const { getByText, getByTestId } = render(<CoachProviderBadge provider={provider} />);
+
+    expect(getByText(label)).toBeTruthy();
+    const badge = getByTestId(`coach-provider-badge-${provider}`);
+    expect(badge.props.accessibilityLabel).toMatch(a11yPattern);
+  });
+
+  it('honours an explicit testID prop', () => {
+    const { getByTestId } = render(
+      <CoachProviderBadge provider="openai" testID="custom-badge" />
+    );
+    expect(getByTestId('custom-badge')).toBeTruthy();
+  });
+
+  it('uses the Gemma accent color on gemma-cloud badges', () => {
+    const { getByText } = render(<CoachProviderBadge provider="gemma-cloud" />);
+    const label = getByText('Gemma');
+    const flat = Array.isArray(label.props.style)
+      ? Object.assign({}, ...label.props.style)
+      : label.props.style;
+    expect(flat.color).toBe('#4285F4');
+  });
+
+  it('falls back to a neutral pill when provider is unexpected', () => {
+    // Cast-through an invalid value to exercise the switch default branch.
+    const { getByText } = render(
+      <CoachProviderBadge provider={'surprise' as CoachProvider} />
+    );
+    expect(getByText('Coach')).toBeTruthy();
+  });
+});

--- a/tests/unit/screens/coach-provider-badge.test.tsx
+++ b/tests/unit/screens/coach-provider-badge.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import type { CoachProvider } from '@/lib/services/coach-provider-types';
+
+const mockSendCoachPrompt = jest.fn();
+
+jest.mock('@/lib/services/coach-service', () => ({
+  sendCoachPrompt: (...args: unknown[]) => mockSendCoachPrompt(...args),
+}));
+
+jest.mock('@/lib/services/coach-history-service', () => ({
+  fetchTodaySession: jest.fn().mockResolvedValue(null),
+  fetchCoachSessionMessages: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u-1', email: 'u@example.com' } }),
+}));
+
+jest.mock('../../../contexts/ToastContext', () => ({
+  useToast: () => ({ show: jest.fn() }),
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+  }),
+  useLocalSearchParams: () => ({}),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('@react-navigation/bottom-tabs', () => ({
+  useBottomTabBarHeight: () => 0,
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('expo-crypto', () => ({
+  randomUUID: () => 'test-session',
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn().mockResolvedValue('true'),
+  setItem: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/hooks/use-voice-mode', () => ({
+  useVoiceMode: () => ({
+    isListening: false,
+    transcript: '',
+    startVoiceMode: jest.fn(),
+    stopVoiceMode: jest.fn(),
+    playResponse: jest.fn(),
+  }),
+}));
+
+import CoachScreen from '../../../app/(tabs)/coach';
+
+function assistantReply(
+  content: string,
+  provider: CoachProvider
+): { role: 'assistant'; content: string; provider: CoachProvider } {
+  return { role: 'assistant', content, provider };
+}
+
+describe('CoachScreen — provider badge integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each<[CoachProvider, string, string]>([
+    ['openai', 'Use a hip hinge.', 'GPT'],
+    ['gemma-cloud', 'Breathe into belly.', 'Gemma'],
+    ['gemma-on-device', 'Keep chest up.', 'Gemma • on device'],
+    ['local-fallback', 'Offline plan.', 'Local fallback'],
+    ['cached', 'Deja vu reply.', 'From cache'],
+  ])(
+    'renders %s badge under assistant bubbles',
+    async (provider, content, expectedLabel) => {
+      mockSendCoachPrompt.mockResolvedValueOnce(assistantReply(content, provider));
+
+      const { getByText, findByTestId, findByText } = render(<CoachScreen />);
+
+      // Wait for the mounted-effect sessionLoading cycle to settle so the
+      // FlatList is mounted instead of the ActivityIndicator placeholder.
+      await waitFor(() => {
+        expect(
+          getByText('Plan a 75-minute strength session for today.')
+        ).toBeTruthy();
+      });
+
+      // Fire a quick-prompt to trigger sendCoachPrompt.
+      fireEvent.press(getByText('Plan a 75-minute strength session for today.'));
+
+      await waitFor(() => {
+        expect(mockSendCoachPrompt).toHaveBeenCalled();
+      });
+
+      const badge = await findByTestId(`coach-provider-badge-${provider}`);
+      expect(badge).toBeTruthy();
+
+      const labelNode = await findByText(expectedLabel);
+      expect(labelNode).toBeTruthy();
+    }
+  );
+
+  it('does NOT render a badge on the intro (no provider) message', async () => {
+    const { queryByTestId, findByText } = render(<CoachScreen />);
+    await findByText('Plan a 75-minute strength session for today.');
+
+    expect(queryByTestId('coach-provider-badge-openai')).toBeNull();
+    expect(queryByTestId('coach-provider-badge-gemma-cloud')).toBeNull();
+    expect(queryByTestId('coach-provider-badge-local-fallback')).toBeNull();
+    expect(queryByTestId('coach-provider-badge-cached')).toBeNull();
+  });
+
+  it('renders exactly one badge (on the assistant reply, not the user bubble)', async () => {
+    mockSendCoachPrompt.mockResolvedValueOnce(assistantReply('Got it.', 'openai'));
+
+    const { getByText, findAllByTestId } = render(<CoachScreen />);
+
+    await waitFor(() => {
+      expect(
+        getByText('Plan a 75-minute strength session for today.')
+      ).toBeTruthy();
+    });
+
+    fireEvent.press(getByText('Plan a 75-minute strength session for today.'));
+
+    const badges = await findAllByTestId('coach-provider-badge-openai');
+    expect(badges).toHaveLength(1);
+  });
+});

--- a/tests/unit/services/coach-service.provider-surface.test.ts
+++ b/tests/unit/services/coach-service.provider-surface.test.ts
@@ -1,0 +1,217 @@
+const mockInvoke = jest.fn();
+const mockInsert = jest.fn();
+const mockFrom = jest.fn(() => ({
+  insert: mockInsert,
+}));
+const mockCreateError = jest.fn(
+  (
+    domain: string,
+    code: string,
+    message: string,
+    opts?: { details?: unknown; retryable?: boolean; severity?: string }
+  ) => ({
+    domain,
+    code,
+    message,
+    retryable: opts?.retryable ?? false,
+    severity: opts?.severity ?? 'error',
+    details: opts?.details,
+  })
+);
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    functions: {
+      invoke: mockInvoke,
+    },
+    from: mockFrom,
+  },
+}));
+
+jest.mock('@/lib/services/ErrorHandler', () => ({
+  createError: mockCreateError,
+  logError: jest.fn(),
+}));
+
+jest.mock('../../../lib/services/ErrorHandler', () => ({
+  createError: mockCreateError,
+  logError: jest.fn(),
+}));
+
+let sendCoachPrompt: typeof import('@/lib/services/coach-service')['sendCoachPrompt'];
+let inferCoachProvider: typeof import('@/lib/services/coach-provider-types')['inferCoachProvider'];
+let resetWarn: typeof import('@/lib/services/coach-provider-types')['__resetCoachProviderInferenceWarning'];
+
+describe('coach-service — provider surface', () => {
+  const baseMessages = [{ role: 'user' as const, content: 'How should I squat?' }];
+
+  beforeAll(() => {
+    ({ sendCoachPrompt } = require('@/lib/services/coach-service'));
+    ({
+      inferCoachProvider,
+      __resetCoachProviderInferenceWarning: resetWarn,
+    } = require('@/lib/services/coach-provider-types'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInsert.mockResolvedValue({ error: null });
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    resetWarn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // sendCoachPrompt — provider on assistant replies
+  // ---------------------------------------------------------------------------
+
+  describe('sendCoachPrompt return value', () => {
+    it('tags reply as "openai" when model is a gpt-* variant', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'Brace up.', model: 'gpt-5.4-mini' },
+        error: null,
+      });
+
+      const reply = await sendCoachPrompt(baseMessages);
+
+      expect(reply).toMatchObject({ role: 'assistant', content: 'Brace up.', provider: 'openai' });
+    });
+
+    it('tags reply as "gemma-cloud" when model starts with gemma-', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'Breathe in.', model: 'gemma-2-9b-it' },
+        error: null,
+      });
+
+      const reply = await sendCoachPrompt(baseMessages);
+
+      expect(reply).toMatchObject({ provider: 'gemma-cloud' });
+    });
+
+    it('tags reply as "cached" when source=cache', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'Hinge at hips.', model: 'gpt-5.4-mini', source: 'cache' },
+        error: null,
+      });
+
+      const reply = await sendCoachPrompt(baseMessages);
+
+      expect(reply).toMatchObject({ provider: 'cached' });
+    });
+
+    it('tags reply as "local-fallback" when source=local', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'Keep knees out.', model: 'gpt-5.4-mini', source: 'local' },
+        error: null,
+      });
+
+      const reply = await sendCoachPrompt(baseMessages);
+
+      expect(reply).toMatchObject({ provider: 'local-fallback' });
+    });
+
+    it('honours an explicit provider field when the edge function sends one', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'Depth first.', provider: 'gemma-on-device', model: 'gemma-2b-ondevice' },
+        error: null,
+      });
+
+      const reply = await sendCoachPrompt(baseMessages);
+
+      expect(reply).toMatchObject({ provider: 'gemma-on-device' });
+    });
+
+    it('defaults to "openai" when the model is unknown', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'Fallback text.', model: 'mystery-model-v0' },
+        error: null,
+      });
+
+      const reply = await sendCoachPrompt(baseMessages);
+
+      expect(reply).toMatchObject({ provider: 'openai' });
+    });
+
+    it('persists the inferred provider alongside the model in metadata', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'Pause 2s.', model: 'gemma-2-9b-it' },
+        error: null,
+      });
+
+      await sendCoachPrompt(baseMessages, {
+        profile: { id: 'u-1' },
+        sessionId: 's-1',
+      });
+      // Fire-and-forget insert — flush microtasks.
+      await Promise.resolve();
+
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            model: 'gemma-2-9b-it',
+            provider: 'gemma-cloud',
+          }),
+        })
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // inferCoachProvider — pure inference coverage
+  // ---------------------------------------------------------------------------
+
+  describe('inferCoachProvider', () => {
+    it('returns "openai" for null/undefined signal', () => {
+      expect(inferCoachProvider(null)).toBe('openai');
+      expect(inferCoachProvider(undefined)).toBe('openai');
+    });
+
+    it('prefers an explicit provider field over other signals', () => {
+      expect(
+        inferCoachProvider({ provider: 'gemma-cloud', model: 'gpt-5.4-mini' })
+      ).toBe('gemma-cloud');
+    });
+
+    it('ignores unknown explicit provider and falls through to model inference', () => {
+      expect(
+        inferCoachProvider({ provider: 'made-up-provider', model: 'gpt-5.4-mini' })
+      ).toBe('openai');
+    });
+
+    it('maps gpt-* models to openai', () => {
+      expect(inferCoachProvider({ model: 'gpt-5.4-mini' })).toBe('openai');
+      expect(inferCoachProvider({ model: 'GPT-4o' })).toBe('openai');
+    });
+
+    it('maps gemma-* models to gemma-cloud by default', () => {
+      expect(inferCoachProvider({ model: 'gemma-2-9b-it' })).toBe('gemma-cloud');
+    });
+
+    it('flags gemma on-device via "on-device" in the model id', () => {
+      expect(inferCoachProvider({ model: 'coach-2b-ondevice' })).toBe('gemma-on-device');
+    });
+
+    it('classifies source=cache as "cached" regardless of model', () => {
+      expect(inferCoachProvider({ source: 'cache', model: 'gpt-5.4-mini' })).toBe('cached');
+    });
+
+    it('classifies source=local as "local-fallback"', () => {
+      expect(inferCoachProvider({ source: 'local' })).toBe('local-fallback');
+    });
+
+    it('warns once in dev when model is ambiguous', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      resetWarn();
+
+      inferCoachProvider({ model: 'unknown-1' });
+      inferCoachProvider({ model: 'unknown-2' });
+
+      // Expect at most one warn — the "once" behaviour is what we guarantee.
+      expect(warnSpy.mock.calls.length).toBeLessThanOrEqual(1);
+      warnSpy.mockRestore();
+    });
+  });
+});

--- a/tests/unit/services/coach-service.rate-limit.test.ts
+++ b/tests/unit/services/coach-service.rate-limit.test.ts
@@ -1,0 +1,118 @@
+const mockInvoke = jest.fn();
+const mockInsert = jest.fn();
+const mockFrom = jest.fn(() => ({
+  insert: mockInsert,
+}));
+const mockCreateError = jest.fn(
+  (
+    domain: string,
+    code: string,
+    message: string,
+    opts?: { details?: unknown; retryable?: boolean; severity?: string }
+  ) => ({
+    domain,
+    code,
+    message,
+    retryable: opts?.retryable ?? false,
+    severity: opts?.severity ?? 'error',
+    details: opts?.details,
+  })
+);
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    functions: {
+      invoke: mockInvoke,
+    },
+    from: mockFrom,
+  },
+}));
+
+jest.mock('@/lib/services/ErrorHandler', () => ({
+  createError: mockCreateError,
+  logError: jest.fn(),
+  // Real mapToUserMessage — we want to verify the specific copy surfaces.
+  mapToUserMessage: jest.requireActual('@/lib/services/ErrorHandler').mapToUserMessage,
+}));
+
+jest.mock('../../../lib/services/ErrorHandler', () => ({
+  createError: mockCreateError,
+  logError: jest.fn(),
+  mapToUserMessage: jest.requireActual('../../../lib/services/ErrorHandler').mapToUserMessage,
+}));
+
+let sendCoachPrompt: typeof import('@/lib/services/coach-service')['sendCoachPrompt'];
+let mapToUserMessage: typeof import('@/lib/services/ErrorHandler')['mapToUserMessage'];
+
+describe('coach-service — rate-limit labelling', () => {
+  const baseMessages = [{ role: 'user' as const, content: 'Plan my week.' }];
+
+  beforeAll(() => {
+    ({ sendCoachPrompt } = require('@/lib/services/coach-service'));
+    ({ mapToUserMessage } = require('@/lib/services/ErrorHandler'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInsert.mockResolvedValue({ error: null });
+  });
+
+  it('classifies HTTP 429 as COACH_RATE_LIMITED (retryable network)', async () => {
+    mockInvoke.mockResolvedValue({
+      data: null,
+      error: { message: 'Too Many Requests', status: 429 },
+    });
+
+    await expect(sendCoachPrompt(baseMessages)).rejects.toMatchObject({
+      domain: 'network',
+      code: 'COACH_RATE_LIMITED',
+      retryable: true,
+    });
+  });
+
+  it('classifies a "rate limit" substring in the error message as COACH_RATE_LIMITED', async () => {
+    mockInvoke.mockResolvedValue({
+      data: null,
+      error: { message: 'OpenAI rate limit exceeded' },
+    });
+
+    await expect(sendCoachPrompt(baseMessages)).rejects.toMatchObject({
+      code: 'COACH_RATE_LIMITED',
+    });
+  });
+
+  it('classifies a data.error rate-limit payload as COACH_RATE_LIMITED', async () => {
+    mockInvoke.mockResolvedValue({
+      data: { error: '429: rate limit — try later' },
+      error: null,
+    });
+
+    await expect(sendCoachPrompt(baseMessages)).rejects.toMatchObject({
+      domain: 'network',
+      code: 'COACH_RATE_LIMITED',
+      retryable: true,
+    });
+  });
+
+  it('does NOT classify a generic timeout as a rate-limit error', async () => {
+    mockInvoke.mockResolvedValue({
+      data: null,
+      error: { message: 'Timeout exceeded' },
+    });
+
+    await expect(sendCoachPrompt(baseMessages)).rejects.toMatchObject({
+      code: 'COACH_INVOKE_FAILED',
+    });
+  });
+
+  it('surfaces the distinct user-facing message via mapToUserMessage', () => {
+    const err = {
+      domain: 'network' as const,
+      code: 'COACH_RATE_LIMITED',
+      message: 'rate-limited',
+      retryable: true,
+      severity: 'error' as const,
+    };
+    expect(mapToUserMessage(err)).toBe('Coach is rate-limited — try again in a moment.');
+  });
+});


### PR DESCRIPTION
## Summary

Wave 15B of the overnight sweep — surface which AI backend answered each coach message so users can SEE when Gemma (Google's model) is used instead of GPT, a local fallback, or a cache hit. Also distinguishes rate-limit errors with specific user-facing copy.

**Changes (6 atomic commits):**

1. `feat(coach-service): thread provider metadata through response type`
   - Adds `CoachProvider` union type: `'openai' | 'gemma-cloud' | 'gemma-on-device' | 'local-fallback' | 'cached'`
   - Infers provider from edge-function signal (explicit provider > source flag > model-name prefix). Documented WHY in code — edge function today only returns `{ model }`, so we derive until it returns provider explicitly.
   - Persists provider in `coach_conversations.metadata` alongside model.
   - `provider` defined as non-enumerable on the returned `CoachMessage` to keep existing shallow-equality assertions passing without modification.

2. `test(coach-service): provider inference coverage` — 16 tests covering all 5 providers + pure `inferCoachProvider` edge cases.

3. `feat(coach): add CoachProviderBadge component` — GPT (neutral), Gemma (Google blue), Local fallback (amber), From cache (muted). Full a11y labels.

4. `feat(coach-chat): surface provider badge on assistant bubbles` — renders badge under assistant replies in both Coach tab and Home tab coach panes.

5. `feat(coach-service): distinguish rate-limit error with specific user-facing message` — detects 429 / 'rate limit' / 'too many requests' in both error channels, routes through new `COACH_RATE_LIMITED` code with 'Coach is rate-limited — try again in a moment.' copy.

6. `test(coach-chat): provider badge screen coverage` — mounts CoachScreen, mocks replies for each provider, asserts badge + label render under assistant bubble.

## Test plan

- [x] `bun run lint` — clean (only pre-existing template-builder warnings).
- [x] `bun run check:types` — clean.
- [x] `bun jest tests/unit/services/coach-service.provider-surface.test.ts` — 16 pass
- [x] `bun jest tests/unit/services/coach-service.rate-limit.test.ts` — 5 pass
- [x] `bun jest tests/unit/components/coach/CoachProviderBadge.test.tsx` — 8 pass
- [x] `bun jest tests/unit/screens/coach-provider-badge.test.tsx` — 7 pass
- [x] Existing `tests/unit/services/coach-service.test.ts` — all 25 still pass (no test file modified).
- [x] Existing `tests/unit/lib/services/error-handler.test.ts` — all 22 still pass.
- [x] Existing `tests/unit/screens/home-videos-feed-tabs.test.tsx` + coach-drill-explainer + coach-history-service — 34 still pass.

Total new tests: **36**. Total delta: +289 / -12 across source + tests.

## Files touched

- `lib/services/coach-provider-types.ts` (new)
- `lib/services/coach-service.ts`
- `lib/services/ErrorHandler.ts`
- `components/coach/CoachProviderBadge.tsx` (new)
- `app/(tabs)/coach.tsx`
- `app/(tabs)/index.tsx`
- `tests/unit/services/coach-service.provider-surface.test.ts` (new)
- `tests/unit/services/coach-service.rate-limit.test.ts` (new)
- `tests/unit/components/coach/CoachProviderBadge.test.tsx` (new)
- `tests/unit/screens/coach-provider-badge.test.tsx` (new)

No migrations, no native code, no new dependencies, no existing test files modified.