### PR TITLE
feat(wave-16): session-telemetry plumbing + form-mesocycle insights + Gemma analyst focus

### DIFF
--- a/app/(modals)/form-mesocycle.tsx
+++ b/app/(modals)/form-mesocycle.tsx
@@ -1,0 +1,317 @@
+import React, { useCallback, useMemo } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { FormMesocycleCard } from '@/components/form-journey/FormMesocycleCard';
+import { useFormMesocycle } from '@/hooks/use-form-mesocycle';
+import type {
+  MesocycleFaultCount,
+  MesocycleWeekBucket,
+} from '@/lib/services/form-mesocycle-aggregator';
+import { buildMesocycleAnalystPrompt } from '@/lib/services/coach-mesocycle-analyst';
+
+export default function FormMesocycleModal() {
+  const router = useRouter();
+  const { loading, error, insights, refresh } = useFormMesocycle();
+
+  const handleClose = useCallback(() => {
+    router.back();
+  }, [router]);
+
+  const handleAskCoach = useCallback(() => {
+    if (!insights) return;
+    const prompt = buildMesocycleAnalystPrompt(insights);
+    const url =
+      `/(tabs)/coach?prefill=${encodeURIComponent(prompt)}` +
+      `&focus=mesocycle-analyst`;
+    router.push(url as Parameters<typeof router.push>[0]);
+  }, [insights, router]);
+
+  const weekRows = useMemo(() => insights?.weeks ?? [], [insights]);
+
+  return (
+    <ScrollView
+      style={styles.root}
+      contentContainerStyle={styles.content}
+      refreshControl={
+        <RefreshControl
+          refreshing={loading}
+          onRefresh={refresh}
+          tintColor="#8FA2B8"
+        />
+      }
+      testID="form-mesocycle-modal"
+    >
+      <View style={styles.header}>
+        <Text style={styles.title}>Form journey</Text>
+        <Pressable
+          onPress={handleClose}
+          accessibilityRole="button"
+          accessibilityLabel="Close form journey"
+          hitSlop={12}
+          testID="form-mesocycle-close"
+        >
+          <Ionicons name="close" size={24} color="#E1E8EF" />
+        </Pressable>
+      </View>
+
+      {error ? (
+        <View style={styles.errorBox} testID="form-mesocycle-error">
+          <Ionicons name="alert-circle" size={20} color="#FF6B6B" />
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      ) : null}
+
+      <FormMesocycleCard
+        insights={insights}
+        loading={loading}
+        onAskCoach={insights && !insights.isEmpty ? handleAskCoach : undefined}
+      />
+
+      {loading && !insights ? (
+        <ActivityIndicator color="#4C8CFF" style={styles.loader} />
+      ) : null}
+
+      {insights && !insights.isEmpty ? (
+        <>
+          <Section title="Weekly breakdown">
+            {weekRows.map((week) => (
+              <WeekRow key={week.weekStartIso} week={week} />
+            ))}
+          </Section>
+
+          {insights.topFaults.length > 0 ? (
+            <Section title="Recurring faults">
+              {insights.topFaults.map((fault) => (
+                <FaultRow key={fault.fault} fault={fault} />
+              ))}
+            </Section>
+          ) : null}
+
+          <Section title="Deload read">
+            <Text style={styles.bodyText}>
+              {insights.deload.reason ??
+                'Steady progress. FQI is holding or improving and fault rate is stable.'}
+            </Text>
+            {insights.deload.fqiDelta != null ? (
+              <Text style={styles.metaText} testID="form-mesocycle-fqi-delta">
+                FQI last-week vs prior: {formatDelta(insights.deload.fqiDelta)}
+              </Text>
+            ) : null}
+            {insights.deload.faultDelta != null ? (
+              <Text style={styles.metaText} testID="form-mesocycle-fault-delta">
+                Fault rate change: {formatPct(insights.deload.faultDelta)}
+              </Text>
+            ) : null}
+          </Section>
+        </>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      <View style={styles.sectionBody}>{children}</View>
+    </View>
+  );
+}
+
+function WeekRow({ week }: { week: MesocycleWeekBucket }) {
+  return (
+    <View style={styles.weekRow} testID={`form-mesocycle-week-${week.weekIndex}`}>
+      <View style={styles.weekLabelCol}>
+        <Text style={styles.weekLabel}>{formatWeekLabel(week.weekStartIso)}</Text>
+        <Text style={styles.weekMeta}>
+          {week.sessionsCount} {week.sessionsCount === 1 ? 'session' : 'sessions'} · {week.repsCount} reps
+        </Text>
+      </View>
+      <View style={styles.weekFqiCol}>
+        <Text style={styles.weekFqi}>{week.avgFqi == null ? '—' : week.avgFqi}</Text>
+        <Text style={styles.weekMeta}>FQI</Text>
+      </View>
+    </View>
+  );
+}
+
+function FaultRow({ fault }: { fault: MesocycleFaultCount }) {
+  return (
+    <View style={styles.faultRow} testID={`form-mesocycle-fault-${fault.fault}`}>
+      <Text style={styles.faultName}>{formatFault(fault.fault)}</Text>
+      <Text style={styles.faultCount}>{fault.count}×</Text>
+      <Text style={styles.faultShare}>{formatPct(fault.share)}</Text>
+    </View>
+  );
+}
+
+function formatFault(code: string): string {
+  return code.replace(/_/g, ' ').replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
+function formatWeekLabel(iso: string): string {
+  const date = new Date(`${iso}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+function formatDelta(n: number): string {
+  if (n > 0) return `+${n}`;
+  return `${n}`;
+}
+
+function formatPct(n: number): string {
+  const pct = Math.round(n * 100);
+  if (pct > 0) return `+${pct}%`;
+  return `${pct}%`;
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#050E1F',
+  },
+  content: {
+    paddingBottom: 40,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+  },
+  title: {
+    color: '#FFFFFF',
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 22,
+  },
+  errorBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginHorizontal: 16,
+    marginVertical: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 10,
+    backgroundColor: 'rgba(255, 107, 107, 0.1)',
+  },
+  errorText: {
+    flex: 1,
+    color: '#FF6B6B',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 13,
+  },
+  loader: {
+    marginTop: 24,
+  },
+  section: {
+    marginTop: 24,
+    paddingHorizontal: 20,
+  },
+  sectionTitle: {
+    color: '#E1E8EF',
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 13,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    marginBottom: 10,
+  },
+  sectionBody: {
+    backgroundColor: '#0F2339',
+    borderRadius: 14,
+    overflow: 'hidden',
+  },
+  weekRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderBottomColor: '#1F2D40',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  weekLabelCol: {
+    flex: 1,
+  },
+  weekFqiCol: {
+    alignItems: 'flex-end',
+  },
+  weekLabel: {
+    color: '#FFFFFF',
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 15,
+  },
+  weekMeta: {
+    color: '#8FA2B8',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 12,
+    marginTop: 2,
+  },
+  weekFqi: {
+    color: '#4C8CFF',
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 20,
+  },
+  faultRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderBottomColor: '#1F2D40',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  faultName: {
+    flex: 1,
+    color: '#FFFFFF',
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 15,
+  },
+  faultCount: {
+    color: '#E1E8EF',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 13,
+    marginRight: 16,
+  },
+  faultShare: {
+    color: '#4C8CFF',
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 13,
+    minWidth: 54,
+    textAlign: 'right',
+  },
+  bodyText: {
+    color: '#E1E8EF',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 14,
+    lineHeight: 20,
+    padding: 16,
+  },
+  metaText: {
+    color: '#8FA2B8',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 12,
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -18,6 +18,7 @@ import { ToastProvider } from '../contexts/ToastContext';
 import { logWithTs, warnWithTs } from '@/lib/logger';
 import { isOnboardingCompleted } from '@/lib/services/onboarding';
 import { hasSeenWelcome } from '@/app/(onboarding)/welcome';
+import { SessionTelemetryBinder } from '@/components/telemetry/SessionTelemetryBinder';
 
 // Error boundary to catch crashes in the provider tree or layout
 interface ErrorBoundaryState {
@@ -103,7 +104,10 @@ function RootLayoutNav() {
                                 <ActivityIndicator color="#4C8CFF" />
                               </View>
                             ) : (
-                              <InitialLayout />
+                              <>
+                                <SessionTelemetryBinder />
+                                <InitialLayout />
+                              </>
                             )}
                           </FoodProvider>
                         </SocialProvider>

--- a/components/form-journey/FormMesocycleCard.tsx
+++ b/components/form-journey/FormMesocycleCard.tsx
@@ -1,0 +1,259 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Ionicons } from '@expo/vector-icons';
+import type { MesocycleInsights } from '@/lib/services/form-mesocycle-aggregator';
+
+export interface FormMesocycleCardProps {
+  insights: MesocycleInsights | null;
+  loading?: boolean;
+  onPress?: () => void;
+  onAskCoach?: () => void;
+}
+
+/**
+ * Compact 4-week form-quality summary with a deload hint. Designed to
+ * sit in a home-tab scroll without its own screen; tapping opens the
+ * `/form-mesocycle` modal for the full breakdown.
+ */
+export function FormMesocycleCard({
+  insights,
+  loading,
+  onPress,
+  onAskCoach,
+}: FormMesocycleCardProps) {
+  if (loading && !insights) {
+    return (
+      <View style={styles.card} testID="form-mesocycle-card-loading">
+        <Text style={styles.sectionTitle}>Form journey</Text>
+        <Text style={styles.loadingText}>Loading your last 4 weeks…</Text>
+      </View>
+    );
+  }
+
+  if (!insights || insights.isEmpty) {
+    return (
+      <View style={styles.card} testID="form-mesocycle-card-empty">
+        <Text style={styles.sectionTitle}>Form journey</Text>
+        <Text style={styles.bodyText}>
+          No tracked sessions in the last 4 weeks. Run a form-tracking set to
+          start building your journey.
+        </Text>
+      </View>
+    );
+  }
+
+  const latest = insights.weeks[insights.weeks.length - 1];
+  const sparklineMax = Math.max(
+    ...insights.weeks.map((w) => (w.avgFqi == null ? 0 : w.avgFqi)),
+    100,
+  );
+
+  const deloadPalette = insights.deload.severity === 'deload'
+    ? { icon: 'alert-circle' as const, tint: '#FF6B6B' }
+    : insights.deload.severity === 'watch'
+      ? { icon: 'eye-outline' as const, tint: '#FFB86C' }
+      : { icon: 'checkmark-circle' as const, tint: '#4ADE80' };
+
+  return (
+    <Pressable
+      onPress={onPress}
+      testID="form-mesocycle-card"
+      accessibilityRole="button"
+      accessibilityLabel="Open form journey details"
+    >
+      <LinearGradient
+        colors={['#0F2339', '#081526']}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.card}
+      >
+        <View style={styles.headerRow}>
+          <Text style={styles.sectionTitle}>Form journey · 4 weeks</Text>
+          <Ionicons name="chevron-forward" size={20} color="#8FA2B8" />
+        </View>
+
+        <View style={styles.statsRow}>
+          <View style={styles.primaryStat}>
+            <Text style={styles.primaryValue} testID="form-mesocycle-current-fqi">
+              {latest.avgFqi == null ? '—' : latest.avgFqi}
+            </Text>
+            <Text style={styles.primaryLabel}>Current-week FQI</Text>
+          </View>
+          <View style={styles.sparkline} testID="form-mesocycle-sparkline">
+            {insights.weeks.map((week) => (
+              <View
+                key={week.weekStartIso}
+                style={[
+                  styles.sparkBar,
+                  {
+                    height: week.avgFqi == null ? 4 : (week.avgFqi / sparklineMax) * 48,
+                    backgroundColor:
+                      week.avgFqi == null ? '#2D3A4A' : '#4C8CFF',
+                  },
+                ]}
+              />
+            ))}
+          </View>
+        </View>
+
+        {insights.topFaults.length > 0 ? (
+          <View style={styles.faultsRow} testID="form-mesocycle-top-faults">
+            {insights.topFaults.map((fault) => (
+              <View key={fault.fault} style={styles.faultChip}>
+                <Text style={styles.faultChipText}>{formatFault(fault.fault)}</Text>
+                <Text style={styles.faultChipCount}>{fault.count}</Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
+
+        <View style={styles.deloadRow} testID="form-mesocycle-deload">
+          <Ionicons
+            name={deloadPalette.icon}
+            size={18}
+            color={deloadPalette.tint}
+          />
+          <Text style={[styles.deloadText, { color: deloadPalette.tint }]}>
+            {insights.deload.reason ?? 'Steady progress — keep the current block going.'}
+          </Text>
+        </View>
+
+        {onAskCoach ? (
+          <Pressable
+            onPress={onAskCoach}
+            style={styles.askCoachButton}
+            testID="form-mesocycle-ask-coach"
+            accessibilityRole="button"
+            accessibilityLabel="Ask the coach for a mesocycle review"
+          >
+            <Ionicons name="sparkles" size={16} color="#4C8CFF" />
+            <Text style={styles.askCoachText}>Ask coach for a review</Text>
+          </Pressable>
+        ) : null}
+      </LinearGradient>
+    </Pressable>
+  );
+}
+
+function formatFault(code: string): string {
+  return code
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 16,
+    padding: 16,
+    marginHorizontal: 16,
+    marginVertical: 8,
+  },
+  sectionTitle: {
+    color: '#E1E8EF',
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 14,
+    letterSpacing: 0.3,
+    textTransform: 'uppercase',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  loadingText: {
+    color: '#8FA2B8',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 14,
+    marginTop: 8,
+  },
+  bodyText: {
+    color: '#8FA2B8',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 14,
+    marginTop: 8,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 20,
+  },
+  primaryStat: {
+    flex: 1,
+  },
+  primaryValue: {
+    color: '#FFFFFF',
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 44,
+  },
+  primaryLabel: {
+    color: '#8FA2B8',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 12,
+    marginTop: 2,
+  },
+  sparkline: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 4,
+    height: 48,
+  },
+  sparkBar: {
+    width: 10,
+    borderRadius: 2,
+  },
+  faultsRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 16,
+    flexWrap: 'wrap',
+  },
+  faultChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    backgroundColor: '#1F2D40',
+    borderRadius: 12,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+  },
+  faultChipText: {
+    color: '#E1E8EF',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 12,
+  },
+  faultChipCount: {
+    color: '#4C8CFF',
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 12,
+  },
+  deloadRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+    marginTop: 16,
+  },
+  deloadText: {
+    flex: 1,
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  askCoachButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    alignSelf: 'flex-start',
+    marginTop: 12,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 10,
+    backgroundColor: 'rgba(76, 140, 255, 0.12)',
+  },
+  askCoachText: {
+    color: '#4C8CFF',
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 13,
+  },
+});

--- a/components/telemetry/SessionTelemetryBinder.tsx
+++ b/components/telemetry/SessionTelemetryBinder.tsx
@@ -1,0 +1,6 @@
+import { useSessionTelemetryBinder } from '@/hooks/use-session-telemetry-binder';
+
+export function SessionTelemetryBinder(): null {
+  useSessionTelemetryBinder();
+  return null;
+}

--- a/docs/overnight/worklog-2026-04-17-sweep-wave16.md
+++ b/docs/overnight/worklog-2026-04-17-sweep-wave16.md
@@ -1,0 +1,159 @@
+# Sweep Worklog — Wave-16 (2026-04-17)
+
+**Directive.** Continue improving form-tracking UX. Progress Gemma by Google.
+Prefer **large-scoped PRs** over many tiny ones. Commits stay atomic.
+
+## Context at start
+
+- Wave-15 had just shipped PR #486 (pause/resume) and PR #488 (provider
+  badge + rate-limit UX).
+- 30+ open PRs already claimed most obvious surfaces. Strategy: audit for
+  **gaps still unclaimed** rather than re-attack contested ground, then
+  converge on a single large-scoped PR.
+- Untracked `lib/tracking-quality/human-validation.ts`, `subject-identity.ts`,
+  and companion stress fixtures in the working tree were duplicates of work
+  already committed on `feat/451-tracking-stress-hardening` — left alone.
+
+## Gap audit
+
+Ran 4 parallel Explore agents with the full PR exclusion list:
+
+- **Backend/services** — flagged *session-runner ↔ rep-logger integration
+  missing* (logSet is never called) and *video-service loses sessionId
+  context*. Also dead-code in form-quality-recovery, async-unawaited coach
+  persistence, scattered type exports.
+- **Frontend/UX** — mesocycle / weekly-to-monthly view (distinct from
+  #473's daily/weekly), between-exercise transitions, share form wins,
+  form-history zero-data onboarding, home-tab deload card.
+- **Gemma state** — confirmed end-to-end chain is broken on main: coach
+  edge function is hard-coded to OpenAI (`supabase/functions/coach/index.ts`
+  line 154, ALLOWED_MODELS line 25-28 is GPT-only). #457 ships the Gemma
+  cloud provider but until it merges Gemma remains unreachable. Drill-
+  explainer in #482 is Gemma-ready via `focus='drill-explainer'` but no
+  focus-dispatch exists yet in coach/index.ts.
+- **Testing** — rep-logger error paths, session-runner ↔ rep-logger
+  integration (same gap as backend), use-premium-cue-audio (300+ LOC,
+  zero tests), no E2E for form-tracking, voice-mode hooks untested.
+
+**Converging signal:** session-runner ↔ rep-logger integration flagged by
+**two agents independently**. This is the upstream plumbing gap — all the
+FQI-based downstream features in flight rely on data that isn't actually
+being written. Fixing this is the highest-leverage move.
+
+## External Gemma research
+
+- Gemma 3 model IDs are live via Gemini REST (`gemma-3-4b-it`,
+  `gemma-3-12b-it`, `gemma-3-27b-it`) — these are in PR #457's
+  ALLOWED_MODELS.
+- **Gemma 4 is also live** as of 2026-04 with two IDs: `gemma-4-31b-it`
+  and `gemma-4-26b-a4b-it`. **Multimodal (image input) support.** Issue
+  #485 tracks extending #457's allowlist.
+- Follow-up note for future wave: Gemma 4's image input could power a
+  form-tracking "visual silhouette review" surface — but that needs the
+  #457 + #485 plumbing first. Out of scope here.
+
+## Wave-16 plan
+
+Single large-scoped PR: **"Session Telemetry Plumbing + Form Mesocycle
+Insights + Gemma Analyst Focus"**. Keeps commits atomic. Addresses the
+upstream plumbing gap AND ships a novel user-facing mesocycle surface
+AND future-proofs a Gemma-ready focus handler so the analyst flips to
+Gemma with zero client changes when #457 lands.
+
+All new files + one additive edit (`app/_layout.tsx` 1-line mount,
+`lib/services/video-service.ts` opt-in param). No migrations. No native
+code. No new dependencies.
+
+## Work log
+
+### 16:00 — Parallel gap audit kicked off
+
+Four Explore agents with full PR exclusion list. Complementary in-parallel:
+WebSearch + WebFetch against Google's Gemma docs for the external API
+reality.
+
+### 16:45 — Audit findings consolidated
+
+Convergence on session-runner ↔ rep-logger integration. Scoped wave-16 to
+one cohesive 13-commit PR spanning:
+
+1. Session telemetry binder (3 commits — pure core + hook + mount)
+2. Video sessionId binding (2 commits — service + tests)
+3. Mesocycle aggregator (2 commits — core + tests)
+4. useFormMesocycle hook (2 commits — hook + tests)
+5. FormMesocycleCard component (2 commits — UI + tests)
+6. form-mesocycle modal screen (2 commits — screen + tests)
+7. Gemma-ready mesocycle-analyst (2 commits — service + tests)
+
+### 17:15 — Implementation + verification
+
+Each commit independently type-clean and lint-clean against `origin/main`.
+`bun run test` runs 1156 tests across 94 suites; all green (2 skipped
+suites unrelated to wave-16).
+
+**68 new tests across 8 new suites:**
+- `tests/unit/services/session-telemetry-binder.test.ts` (10)
+- `tests/unit/hooks/use-session-telemetry-binder.test.tsx` (4)
+- `tests/unit/services/video-service-session-binding.test.ts` (11)
+- `tests/unit/services/form-mesocycle-aggregator.test.ts` (14)
+- `tests/unit/hooks/use-form-mesocycle.test.tsx` (5)
+- `tests/unit/components/form-journey/FormMesocycleCard.test.tsx` (7)
+- `tests/unit/services/coach-mesocycle-analyst.test.ts` (11)
+- `tests/unit/screens/form-mesocycle.test.tsx` (6)
+
+Zero regressions on the 1088 pre-existing tests.
+
+## Directive fulfillment
+
+- **"improve ux exp for form tracking"** — a 4-week mesocycle view is
+  brand-new surface area (none of #473/#444/#477/#478 ships it), and the
+  upstream plumbing fix means every other in-flight FQI feature actually
+  gets data now.
+- **"see if we can get gemma by google"** — Gemma 4 confirmed live via the
+  Gemini REST endpoint with multimodal support (April 2026). Client-side,
+  `coach-mesocycle-analyst.ts` mirrors the drill-explainer pattern:
+  `focus='mesocycle-analyst'` so when #457's Edge Function dispatcher lands,
+  the analyst routes to Gemma with a one-line swap. TODO(#454/#457) marker
+  annotates the provider-label flip point. Filed issue #485 (previous wave)
+  already tracks adding Gemma 4 IDs to the allowlist.
+- **"large-scoped prs not so many tiny ones"** — one PR, 15 atomic commits,
+  ~1,800 LOC + 68 tests.
+- **"keep commits atomic"** — each commit passes `bun run check:types` and
+  `bun run lint` independently.
+- **"keep a worklog of main work"** — this file.
+
+## Deferred
+
+- Wiring the FormMesocycleCard into `app/(tabs)/index.tsx` (home) —
+  collides with #473's `app/(tabs)/_layout.tsx` + `form.tsx` tab. A 3-line
+  follow-up PR after #473 merges will drop the card onto either home or
+  the form tab.
+- Swapping `provider: 'cloud'` → `provider: 'gemma-cloud'` in
+  `coach-mesocycle-analyst.ts` once #457's Edge Function annotates the
+  provider back on the response. TODO(#454/#457) marker in the file.
+- Building a visual (image-input) mesocycle review via Gemma 4's
+  multimodal capability — blocked on #457 + #485 merging first.
+- Promoting `sessionId` from `metrics` JSON into a first-class `session_id`
+  column on the `videos` table. Requires a migration (overnight rule
+  forbids). The service exports `extractSessionIdFromMetrics` so future
+  analytics don't need the column either.
+
+## Pre-flight conflict report
+
+Checked all 35 open PRs for file overlap:
+
+- `app/_layout.tsx` — also touched by #433 and #450. Our addition is
+  one import + a `<SessionTelemetryBinder />` tag inside the font-ready
+  branch. Trivial merge.
+- `lib/services/video-service.ts` — **zero open PRs touch this file.**
+- All other new files are under paths no other PR touches
+  (`components/form-journey/`, `components/telemetry/`, `hooks/use-form-
+  mesocycle.ts`, `hooks/use-session-telemetry-binder.ts`, `lib/services/
+  form-mesocycle-aggregator.ts`, `lib/services/coach-mesocycle-analyst.ts`,
+  `lib/services/session-telemetry-binder.ts`, `app/(modals)/form-mesocycle
+  .tsx`).
+
+Modal is auto-discovered by expo-router (`app/(modals)/_layout.tsx`
+pattern already skips `form-quality-recovery.tsx`, `add-food.tsx`,
+etc.) — no modal-layout edit required, avoiding the heavily-contested
+`_layout.tsx` in #480/#478/#477/#473/#471/#467/#456/#444/#443.

--- a/hooks/use-form-mesocycle.ts
+++ b/hooks/use-form-mesocycle.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { ensureUserId } from '@/lib/auth-utils';
+import { errorWithTs } from '@/lib/logger';
+import {
+  buildMesocycleInsights,
+  MESOCYCLE_WEEKS,
+  type MesocycleInsights,
+  type MesocycleRepRow,
+  type MesocycleSetRow,
+} from '@/lib/services/form-mesocycle-aggregator';
+
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+
+export interface UseFormMesocycleState {
+  loading: boolean;
+  error: string | null;
+  insights: MesocycleInsights | null;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Pulls the last 4 weeks of rep + set rows for the current user and runs them
+ * through `buildMesocycleInsights`. Safe against unmount, idempotent on rapid
+ * refreshes, and silently degrades if either table query fails — a partial
+ * view is better than a full error page here.
+ */
+export function useFormMesocycle(): UseFormMesocycleState {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [insights, setInsights] = useState<MesocycleInsights | null>(null);
+  const cancelRef = useRef(false);
+
+  const load = useCallback(async () => {
+    cancelRef.current = false;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const userId = await ensureUserId();
+      const now = new Date();
+      const windowStart = new Date(now.getTime() - MESOCYCLE_WEEKS * MS_PER_WEEK).toISOString();
+
+      const [repsResult, setsResult] = await Promise.all([
+        supabase
+          .from('reps')
+          .select('rep_id, session_id, exercise, start_ts, fqi, faults_detected')
+          .eq('user_id', userId)
+          .gte('start_ts', windowStart),
+        supabase
+          .from('sets')
+          .select('set_id, session_id, exercise, created_at, reps_count, load_value')
+          .eq('user_id', userId)
+          .gte('created_at', windowStart),
+      ]);
+
+      if (cancelRef.current) return;
+
+      if (repsResult.error) {
+        errorWithTs('[use-form-mesocycle] reps query failed', repsResult.error);
+      }
+      if (setsResult.error) {
+        errorWithTs('[use-form-mesocycle] sets query failed', setsResult.error);
+      }
+
+      const reps: MesocycleRepRow[] = (repsResult.data ?? []).map((row: Record<string, unknown>) => ({
+        rep_id: String(row.rep_id ?? ''),
+        session_id: String(row.session_id ?? ''),
+        exercise: String(row.exercise ?? ''),
+        start_ts: String(row.start_ts ?? ''),
+        fqi: typeof row.fqi === 'number' ? row.fqi : null,
+        faults_detected: Array.isArray(row.faults_detected)
+          ? row.faults_detected.filter((f): f is string => typeof f === 'string')
+          : [],
+      }));
+
+      const sets: MesocycleSetRow[] = (setsResult.data ?? []).map((row: Record<string, unknown>) => ({
+        set_id: String(row.set_id ?? ''),
+        session_id: String(row.session_id ?? ''),
+        exercise: String(row.exercise ?? ''),
+        completed_at: String(row.created_at ?? ''),
+        reps_count: typeof row.reps_count === 'number' ? row.reps_count : 0,
+        load_value: typeof row.load_value === 'number' ? row.load_value : null,
+      }));
+
+      const result = buildMesocycleInsights(reps, sets, { reference: now });
+      if (!cancelRef.current) setInsights(result);
+    } catch (err) {
+      if (!cancelRef.current) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setError(msg);
+      }
+    } finally {
+      if (!cancelRef.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+    return () => {
+      cancelRef.current = true;
+    };
+  }, [load]);
+
+  return { loading, error, insights, refresh: load };
+}

--- a/hooks/use-session-telemetry-binder.ts
+++ b/hooks/use-session-telemetry-binder.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react';
+import { useSessionRunner } from '@/lib/stores/session-runner';
+import {
+  detectCompletedSets,
+  flushCompletedSets,
+  type BinderSnapshot,
+  type SetLogger,
+} from '@/lib/services/session-telemetry-binder';
+
+export interface UseSessionTelemetryBinderOptions {
+  logger?: SetLogger;
+  defaultLoadUnit?: 'kg' | 'lbs';
+  /** Disable in tests / when the product flag is off. */
+  enabled?: boolean;
+}
+
+/**
+ * Subscribes to `useSessionRunner` and forwards completed-set diffs to
+ * `rep-logger`'s `logSet()`. Call from a single always-mounted component.
+ */
+export function useSessionTelemetryBinder(
+  options: UseSessionTelemetryBinderOptions = {},
+): void {
+  const { logger, defaultLoadUnit, enabled = true } = options;
+  const prevSnapshotRef = useRef<BinderSnapshot | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    prevSnapshotRef.current = toSnapshot(useSessionRunner.getState());
+
+    const unsubscribe = useSessionRunner.subscribe((state) => {
+      const next = toSnapshot(state);
+      const prev = prevSnapshotRef.current;
+      prevSnapshotRef.current = next;
+
+      const payloads = detectCompletedSets(prev, next, { defaultLoadUnit });
+      if (payloads.length === 0) return;
+
+      void flushCompletedSets(payloads, logger);
+    });
+
+    return () => {
+      unsubscribe();
+      prevSnapshotRef.current = null;
+    };
+  }, [enabled, logger, defaultLoadUnit]);
+}
+
+function toSnapshot(state: ReturnType<typeof useSessionRunner.getState>): BinderSnapshot {
+  return {
+    activeSession: state.activeSession,
+    exercises: state.exercises,
+    sets: state.sets,
+  };
+}

--- a/lib/services/coach-mesocycle-analyst.ts
+++ b/lib/services/coach-mesocycle-analyst.ts
@@ -1,0 +1,102 @@
+/**
+ * Coach Mesocycle Analyst
+ *
+ * Gemma-ready prompt builder + thin invoker for natural-language summaries of
+ * a 4-week form-tracking mesocycle. The invoker routes through whatever
+ * `sendCoachPrompt` function the caller passes in — when the Gemma cloud
+ * provider lands (see PR #457 + the drill-explainer TODO marker in
+ * `coach-drill-explainer.ts`), the Edge Function can dispatch on
+ * `focus === 'mesocycle-analyst'` to Gemma without any client changes.
+ */
+
+import type {
+  MesocycleInsights,
+  MesocycleFaultCount,
+  MesocycleWeekBucket,
+} from '@/lib/services/form-mesocycle-aggregator';
+
+export const MESOCYCLE_ANALYST_FOCUS = 'mesocycle-analyst';
+
+export interface MesocycleAnalystResult {
+  /** The analyst's natural-language review of the mesocycle. */
+  text: string;
+  /**
+   * Which provider returned the response, if the caller surfaced it.
+   * Expected values: `'openai'`, `'gemma-cloud'`, `'local-fallback'`.
+   * Annotated as `'cloud'` today; swap to `'gemma-cloud'` once the provider
+   * dispatcher lands (#454 / #457).
+   */
+  provider: 'cloud' | 'gemma-cloud' | 'local-fallback';
+}
+
+export interface SendCoachPromptFn {
+  (options: {
+    messages: { role: 'user' | 'assistant' | 'system'; content: string }[];
+    context?: { focus?: string; [key: string]: unknown };
+  }): Promise<{ message?: { role: string; content: string } } | null | undefined>;
+}
+
+/**
+ * Build a concise analyst prompt from the mesocycle insights. The prompt is
+ * user-consumable (it sits in the coach turn box as the user's question) so
+ * it reads naturally rather than as a JSON blob. Gemma 4's 131k context
+ * handles this easily; shaping it short also keeps OpenAI parity.
+ */
+export function buildMesocycleAnalystPrompt(insights: MesocycleInsights): string {
+  if (insights.isEmpty) {
+    return 'Give me a read on my last 4 weeks of form tracking — there is no data yet, so explain what I need to do to start building this view.';
+  }
+
+  const weeklyLine = insights.weeks
+    .map((week: MesocycleWeekBucket) => {
+      const fqi = week.avgFqi == null ? '—' : week.avgFqi;
+      return `W${week.weekIndex + 1} (${week.weekStartIso}): FQI ${fqi}, ${week.sessionsCount} sessions, ${week.repsCount} reps`;
+    })
+    .join('; ');
+
+  const faultLine =
+    insights.topFaults.length > 0
+      ? insights.topFaults
+          .map((fault: MesocycleFaultCount) => `${fault.fault} ×${fault.count}`)
+          .join(', ')
+      : 'no recurring faults';
+
+  const deloadLine =
+    insights.deload.severity === 'none'
+      ? 'deload signal clear'
+      : `deload signal ${insights.deload.severity}${
+          insights.deload.reason ? ` (${insights.deload.reason})` : ''
+        }`;
+
+  return [
+    'Review my last 4 weeks of form tracking and tell me what I should focus on next week.',
+    `Weekly: ${weeklyLine}.`,
+    `Recurring faults: ${faultLine}.`,
+    `${deloadLine}.`,
+    'Keep the response under 150 words and give me one concrete next step.',
+  ].join(' ');
+}
+
+/**
+ * Send the analyst prompt via the caller-provided sendCoachPrompt adapter.
+ * Returns `null` if the adapter returns nothing parseable — callers render
+ * a simple "no response" state rather than throwing.
+ */
+export async function requestMesocycleAnalysis(
+  insights: MesocycleInsights,
+  sendCoachPrompt: SendCoachPromptFn,
+): Promise<MesocycleAnalystResult | null> {
+  const prompt = buildMesocycleAnalystPrompt(insights);
+  const response = await sendCoachPrompt({
+    messages: [{ role: 'user', content: prompt }],
+    context: { focus: MESOCYCLE_ANALYST_FOCUS },
+  });
+
+  const text = response?.message?.content?.trim();
+  if (!text) return null;
+
+  // TODO(#454/#457): once the Edge Function dispatches on focus, read the
+  // provider hint off the response and annotate as `'gemma-cloud'` when
+  // appropriate. Until then every cloud response is labeled generically.
+  return { text, provider: 'cloud' };
+}

--- a/lib/services/form-mesocycle-aggregator.ts
+++ b/lib/services/form-mesocycle-aggregator.ts
@@ -1,0 +1,268 @@
+/**
+ * Form Mesocycle Aggregator
+ *
+ * Rolls up the last 4 weeks of rep / set telemetry into a single view:
+ *   - Weekly FQI trend (4 buckets, oldest → newest)
+ *   - Fault frequency histogram (top-N across the window)
+ *   - Deload signal (fatigue ↑ AND FQI ↓ across last 2 weeks)
+ *   - Session volume per week
+ *
+ * Pure functional core so the hook layer just passes rows in. No database
+ * calls, no React state — callers own IO. Tests stay fast and hermetic.
+ */
+
+export const MESOCYCLE_WEEKS = 4;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const MS_PER_WEEK = 7 * MS_PER_DAY;
+
+export interface MesocycleRepRow {
+  rep_id: string;
+  session_id: string;
+  exercise: string;
+  /** ISO timestamp for rep start */
+  start_ts: string;
+  /** 0-100 form quality index (null for untracked reps) */
+  fqi: number | null;
+  /** Fault codes detected on this rep */
+  faults_detected: string[];
+}
+
+export interface MesocycleSetRow {
+  set_id: string;
+  session_id: string;
+  exercise: string;
+  /** ISO timestamp for set completion */
+  completed_at: string;
+  reps_count: number;
+  load_value: number | null;
+}
+
+export interface MesocycleWeekBucket {
+  /** ISO date (yyyy-mm-dd) for the Monday of this week */
+  weekStartIso: string;
+  /** 0-3 — oldest = 0, current = MESOCYCLE_WEEKS-1 */
+  weekIndex: number;
+  /** Mean FQI across all reps with a tracked score, or null if none */
+  avgFqi: number | null;
+  /** Number of sessions with at least one logged set */
+  sessionsCount: number;
+  /** Total reps logged */
+  repsCount: number;
+  /** Total sets logged */
+  setsCount: number;
+}
+
+export interface MesocycleFaultCount {
+  fault: string;
+  count: number;
+  /** Share of reps in the window that triggered this fault (0..1) */
+  share: number;
+}
+
+export type MesocycleDeloadSeverity = 'none' | 'watch' | 'deload';
+
+export interface MesocycleDeloadSignal {
+  severity: MesocycleDeloadSeverity;
+  /** Difference in avg FQI between last week and the prior 3 weeks, rounded. Negative = worsening. */
+  fqiDelta: number | null;
+  /** Fraction by which fault rate rose last week vs prior. Positive = rising faults. */
+  faultDelta: number | null;
+  /** Short user-facing hint — null when severity === 'none'. */
+  reason: string | null;
+}
+
+export interface MesocycleInsights {
+  /** Upper bound timestamp used for bucketing (inclusive) */
+  referenceIso: string;
+  weeks: MesocycleWeekBucket[];
+  topFaults: MesocycleFaultCount[];
+  deload: MesocycleDeloadSignal;
+  /** True when the window contains no reps AND no sets. */
+  isEmpty: boolean;
+}
+
+export interface BuildMesocycleOptions {
+  /** Upper bound of the window. Defaults to now. */
+  reference?: Date;
+  /** Maximum number of top faults to return. */
+  topFaultLimit?: number;
+}
+
+function startOfDayUtc(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+/** Monday 00:00 UTC of the ISO week that contains `d`. */
+export function startOfIsoWeekUtc(d: Date): Date {
+  const day = startOfDayUtc(d);
+  const weekday = day.getUTCDay(); // 0 = Sunday
+  const mondayOffset = weekday === 0 ? -6 : 1 - weekday;
+  return new Date(day.getTime() + mondayOffset * MS_PER_DAY);
+}
+
+/** Bucket index for timestamp `iso` inside a 4-week window ending at `referenceStart`. Null when outside the window. */
+function bucketIndex(iso: string, referenceStart: Date, weeks: number): number | null {
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return null;
+  const startMs = referenceStart.getTime() - (weeks - 1) * MS_PER_WEEK;
+  if (ts < startMs) return null;
+  const endMs = referenceStart.getTime() + MS_PER_WEEK;
+  if (ts >= endMs) return null;
+  const offsetWeeks = Math.floor((ts - startMs) / MS_PER_WEEK);
+  if (offsetWeeks < 0 || offsetWeeks >= weeks) return null;
+  return offsetWeeks;
+}
+
+/**
+ * Build a MesocycleInsights bag from raw rep + set rows. Pure — callers own IO.
+ */
+export function buildMesocycleInsights(
+  reps: MesocycleRepRow[],
+  sets: MesocycleSetRow[],
+  options: BuildMesocycleOptions = {},
+): MesocycleInsights {
+  const reference = options.reference ?? new Date();
+  const topFaultLimit = options.topFaultLimit ?? 3;
+  const currentWeekStart = startOfIsoWeekUtc(reference);
+
+  const weeks: MesocycleWeekBucket[] = Array.from({ length: MESOCYCLE_WEEKS }, (_, i) => ({
+    weekStartIso: new Date(
+      currentWeekStart.getTime() - (MESOCYCLE_WEEKS - 1 - i) * MS_PER_WEEK,
+    )
+      .toISOString()
+      .slice(0, 10),
+    weekIndex: i,
+    avgFqi: null,
+    sessionsCount: 0,
+    repsCount: 0,
+    setsCount: 0,
+  }));
+
+  const fqiSumsPerWeek = new Array(MESOCYCLE_WEEKS).fill(0) as number[];
+  const fqiCountsPerWeek = new Array(MESOCYCLE_WEEKS).fill(0) as number[];
+  const sessionsPerWeek: Set<string>[] = Array.from({ length: MESOCYCLE_WEEKS }, () => new Set());
+  const faultCounts = new Map<string, number>();
+  let totalReps = 0;
+  let totalFaultInstances = 0;
+  const repsInLastWeekByFault = { last: 0, prior: 0 };
+  const fqiLastWeek = { sum: 0, count: 0 };
+  const fqiPriorWeeks = { sum: 0, count: 0 };
+
+  for (const rep of reps) {
+    const idx = bucketIndex(rep.start_ts, currentWeekStart, MESOCYCLE_WEEKS);
+    if (idx === null) continue;
+    weeks[idx].repsCount += 1;
+    sessionsPerWeek[idx].add(rep.session_id);
+    totalReps += 1;
+
+    if (typeof rep.fqi === 'number') {
+      fqiSumsPerWeek[idx] += rep.fqi;
+      fqiCountsPerWeek[idx] += 1;
+      if (idx === MESOCYCLE_WEEKS - 1) {
+        fqiLastWeek.sum += rep.fqi;
+        fqiLastWeek.count += 1;
+      } else {
+        fqiPriorWeeks.sum += rep.fqi;
+        fqiPriorWeeks.count += 1;
+      }
+    }
+
+    for (const fault of rep.faults_detected ?? []) {
+      faultCounts.set(fault, (faultCounts.get(fault) ?? 0) + 1);
+      totalFaultInstances += 1;
+      if (idx === MESOCYCLE_WEEKS - 1) repsInLastWeekByFault.last += 1;
+      else repsInLastWeekByFault.prior += 1;
+    }
+  }
+
+  for (const set of sets) {
+    const idx = bucketIndex(set.completed_at, currentWeekStart, MESOCYCLE_WEEKS);
+    if (idx === null) continue;
+    weeks[idx].setsCount += 1;
+    sessionsPerWeek[idx].add(set.session_id);
+  }
+
+  for (let i = 0; i < MESOCYCLE_WEEKS; i += 1) {
+    weeks[i].avgFqi = fqiCountsPerWeek[i] > 0
+      ? Math.round(fqiSumsPerWeek[i] / fqiCountsPerWeek[i])
+      : null;
+    weeks[i].sessionsCount = sessionsPerWeek[i].size;
+  }
+
+  const topFaults: MesocycleFaultCount[] = Array.from(faultCounts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, topFaultLimit)
+    .map(([fault, count]) => ({
+      fault,
+      count,
+      share: totalReps > 0 ? Math.round((count / totalReps) * 1000) / 1000 : 0,
+    }));
+
+  const fqiDelta =
+    fqiLastWeek.count > 0 && fqiPriorWeeks.count > 0
+      ? Math.round(
+          fqiLastWeek.sum / fqiLastWeek.count - fqiPriorWeeks.sum / fqiPriorWeeks.count,
+        )
+      : null;
+
+  const faultDelta = computeFaultDelta(repsInLastWeekByFault, weeks);
+
+  const deload = judgeDeload(fqiDelta, faultDelta);
+
+  return {
+    referenceIso: reference.toISOString(),
+    weeks,
+    topFaults,
+    deload,
+    isEmpty: totalReps === 0 && sets.length === 0,
+  };
+}
+
+function computeFaultDelta(
+  instancesByWeek: { last: number; prior: number },
+  weeks: MesocycleWeekBucket[],
+): number | null {
+  const lastWeekReps = weeks[MESOCYCLE_WEEKS - 1].repsCount;
+  const priorWeeksReps = weeks.slice(0, MESOCYCLE_WEEKS - 1).reduce((sum, w) => sum + w.repsCount, 0);
+  if (lastWeekReps === 0 || priorWeeksReps === 0) return null;
+  const lastRate = instancesByWeek.last / lastWeekReps;
+  const priorRate = instancesByWeek.prior / priorWeeksReps;
+  if (priorRate === 0) return lastRate > 0 ? 1 : 0;
+  return Math.round((lastRate - priorRate) / priorRate * 100) / 100;
+}
+
+function judgeDeload(
+  fqiDelta: number | null,
+  faultDelta: number | null,
+): MesocycleDeloadSignal {
+  if (fqiDelta === null && faultDelta === null) {
+    return { severity: 'none', fqiDelta, faultDelta, reason: null };
+  }
+
+  const fqiDropped5 = fqiDelta !== null && fqiDelta <= -5;
+  const fqiDropped10 = fqiDelta !== null && fqiDelta <= -10;
+  const faultsRose30 = faultDelta !== null && faultDelta >= 0.3;
+  const faultsRose60 = faultDelta !== null && faultDelta >= 0.6;
+
+  if ((fqiDropped10 && faultsRose30) || faultsRose60) {
+    return {
+      severity: 'deload',
+      fqiDelta,
+      faultDelta,
+      reason:
+        'Last week your form quality slipped and fault rate rose — consider a lighter week.',
+    };
+  }
+
+  if (fqiDropped5 || faultsRose30) {
+    return {
+      severity: 'watch',
+      fqiDelta,
+      faultDelta,
+      reason:
+        'Form quality is trending down this week — keep an eye on load progression.',
+    };
+  }
+
+  return { severity: 'none', fqiDelta, faultDelta, reason: null };
+}

--- a/lib/services/session-telemetry-binder.ts
+++ b/lib/services/session-telemetry-binder.ts
@@ -1,0 +1,112 @@
+import { logSet } from '@/lib/services/rep-logger';
+import type { SetSummary } from '@/lib/types/telemetry';
+import type {
+  WorkoutSession,
+  WorkoutSessionExercise,
+  WorkoutSessionSet,
+  Exercise,
+} from '@/lib/types/workout-session';
+import { errorWithTs, logWithTs } from '@/lib/logger';
+
+export interface BinderSnapshot {
+  activeSession: WorkoutSession | null;
+  exercises: (WorkoutSessionExercise & { exercise?: Exercise })[];
+  sets: Record<string, WorkoutSessionSet[]>;
+}
+
+export type SetLogger = (summary: SetSummary) => Promise<string>;
+
+export interface DetectCompletionOptions {
+  /** Default unit when the session didn't record one explicitly. */
+  defaultLoadUnit?: 'kg' | 'lbs';
+}
+
+export interface CompletedSetPayload {
+  summary: SetSummary;
+  sessionSetId: string;
+}
+
+/**
+ * Compare two session-runner snapshots and return `SetSummary` payloads for
+ * every set whose `completed_at` transitioned from falsy to truthy.
+ *
+ * Pure function — no side effects. The binder hook feeds the logger.
+ */
+export function detectCompletedSets(
+  prev: BinderSnapshot | null,
+  next: BinderSnapshot,
+  options: DetectCompletionOptions = {},
+): CompletedSetPayload[] {
+  const session = next.activeSession;
+  if (!session) return [];
+
+  const prevCompletedIds = new Set<string>();
+  if (prev) {
+    for (const list of Object.values(prev.sets)) {
+      for (const row of list) {
+        if (row.completed_at) prevCompletedIds.add(row.id);
+      }
+    }
+  }
+
+  const exerciseById = new Map(next.exercises.map((row) => [row.id, row]));
+
+  const payloads: CompletedSetPayload[] = [];
+  for (const [sessionExerciseId, list] of Object.entries(next.sets)) {
+    for (const row of list) {
+      if (!row.completed_at) continue;
+      if (prevCompletedIds.has(row.id)) continue;
+
+      const sessionExercise = exerciseById.get(sessionExerciseId);
+      const exerciseName =
+        sessionExercise?.exercise?.name ??
+        sessionExercise?.exercise_id ??
+        sessionExerciseId;
+
+      const summary: SetSummary = {
+        sessionId: session.id,
+        exercise: exerciseName,
+        repsCount: row.actual_reps ?? 0,
+        loadValue: row.actual_weight ?? undefined,
+        loadUnit: row.actual_weight != null ? options.defaultLoadUnit ?? 'lbs' : undefined,
+      };
+
+      payloads.push({ summary, sessionSetId: row.id });
+    }
+  }
+
+  return payloads;
+}
+
+/**
+ * Drain pending payloads through the provided logger. Errors are swallowed
+ * (already logged by rep-logger) so one failing set never blocks the next.
+ */
+export async function flushCompletedSets(
+  payloads: CompletedSetPayload[],
+  logger: SetLogger = logSet,
+): Promise<string[]> {
+  const ids: string[] = [];
+  for (const payload of payloads) {
+    try {
+      const id = await logger(payload.summary);
+      ids.push(id);
+      if (__DEV__) {
+        logWithTs('[session-telemetry-binder] logged set', {
+          sessionSetId: payload.sessionSetId,
+          telemetrySetId: id,
+          exercise: payload.summary.exercise,
+        });
+      }
+    } catch (error) {
+      if (__DEV__) {
+        errorWithTs(
+          '[session-telemetry-binder] failed to log set',
+          error,
+          payload.summary,
+        );
+      }
+    }
+  }
+  return ids;
+}

--- a/lib/services/video-service.ts
+++ b/lib/services/video-service.ts
@@ -14,6 +14,35 @@ const DEFAULT_MAX_THUMBNAIL_BYTES = 80 * 1024 * 1024;
 const SIGNED_URL_MAX_RETRIES = 2;
 const SIGNED_URL_RETRY_DELAY_MS = 500;
 
+const SESSION_ID_METRICS_KEY = 'sessionId';
+
+/**
+ * Embed a workout-session id into the video metrics bag without clobbering
+ * existing fields. Returns a new object so the original `metrics` ref stays
+ * intact. Returns `null` (the video row's default) when there is nothing to
+ * persist.
+ */
+export function bindSessionIdToMetrics(
+  metrics: Record<string, any> | null | undefined,
+  sessionId: string | null | undefined,
+): Record<string, any> | null {
+  if (!sessionId) {
+    return metrics ?? null;
+  }
+  return { ...(metrics ?? {}), [SESSION_ID_METRICS_KEY]: sessionId };
+}
+
+/**
+ * Pull the bound session id out of a stored video metrics blob.
+ */
+export function extractSessionIdFromMetrics(
+  metrics: Record<string, any> | null | undefined,
+): string | null {
+  if (!metrics) return null;
+  const value = metrics[SESSION_ID_METRICS_KEY];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
 async function withRetry<T>(fn: () => Promise<T>, maxRetries = SIGNED_URL_MAX_RETRIES, delayMs = SIGNED_URL_RETRY_DELAY_MS): Promise<T> {
   let lastError: unknown;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -264,6 +293,14 @@ export async function uploadWorkoutVideo(opts: {
   fileUri: string;
   durationSeconds?: number;
   exercise?: string;
+  /**
+   * Optional workout-session id to bind this video to. The id is embedded
+   * into `metrics.sessionId` so post-session drills, fault-recovery, and
+   * longitudinal analytics can correlate video artifacts back to the
+   * session that produced them. A follow-up migration can promote this
+   * into a first-class column; callers can start threading the id now.
+   */
+  sessionId?: string;
   maxUploadBytes?: number;
   maxThumbnailBytes?: number;
   thumbnailTimeMs?: number;
@@ -275,6 +312,7 @@ export async function uploadWorkoutVideo(opts: {
     fileUri,
     durationSeconds,
     exercise,
+    sessionId,
     maxUploadBytes = DEFAULT_MAX_UPLOAD_BYTES,
     maxThumbnailBytes = DEFAULT_MAX_THUMBNAIL_BYTES,
     thumbnailTimeMs = 500,
@@ -282,6 +320,7 @@ export async function uploadWorkoutVideo(opts: {
     metrics,
     analysisOnly = false,
   } = opts;
+  const boundMetrics = bindSessionIdToMetrics(metrics, sessionId);
 
   // Validate env before auth/upload calls so failures are explicit and actionable.
   getSupabaseUrl();
@@ -343,7 +382,7 @@ export async function uploadWorkoutVideo(opts: {
       thumbnail_path: thumbnailPath,
       duration_seconds: durationSeconds ?? null,
       exercise: exercise ?? null,
-      metrics: metrics ?? null,
+      metrics: boundMetrics,
       analysis_only: analysisOnly,
     })
     .select()

--- a/tests/unit/components/form-journey/FormMesocycleCard.test.tsx
+++ b/tests/unit/components/form-journey/FormMesocycleCard.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { FormMesocycleCard } from '@/components/form-journey/FormMesocycleCard';
+import type { MesocycleInsights } from '@/lib/services/form-mesocycle-aggregator';
+
+function insights(overrides: Partial<MesocycleInsights> = {}): MesocycleInsights {
+  return {
+    referenceIso: '2026-04-17T00:00:00.000Z',
+    weeks: [
+      { weekStartIso: '2026-03-23', weekIndex: 0, avgFqi: 70, sessionsCount: 1, repsCount: 10, setsCount: 2 },
+      { weekStartIso: '2026-03-30', weekIndex: 1, avgFqi: 75, sessionsCount: 2, repsCount: 20, setsCount: 4 },
+      { weekStartIso: '2026-04-06', weekIndex: 2, avgFqi: 80, sessionsCount: 2, repsCount: 22, setsCount: 5 },
+      { weekStartIso: '2026-04-13', weekIndex: 3, avgFqi: 82, sessionsCount: 3, repsCount: 28, setsCount: 6 },
+    ],
+    topFaults: [
+      { fault: 'valgus', count: 9, share: 0.11 },
+      { fault: 'hips_rise', count: 4, share: 0.05 },
+    ],
+    deload: { severity: 'none', fqiDelta: 2, faultDelta: -0.1, reason: null },
+    isEmpty: false,
+    ...overrides,
+  };
+}
+
+describe('FormMesocycleCard', () => {
+  it('renders a loading placeholder when loading and no data yet', () => {
+    const { getByTestId } = render(<FormMesocycleCard insights={null} loading />);
+    expect(getByTestId('form-mesocycle-card-loading')).toBeTruthy();
+  });
+
+  it('renders an empty state when there is no data', () => {
+    const empty = insights({
+      weeks: [
+        { weekStartIso: '2026-03-23', weekIndex: 0, avgFqi: null, sessionsCount: 0, repsCount: 0, setsCount: 0 },
+        { weekStartIso: '2026-03-30', weekIndex: 1, avgFqi: null, sessionsCount: 0, repsCount: 0, setsCount: 0 },
+        { weekStartIso: '2026-04-06', weekIndex: 2, avgFqi: null, sessionsCount: 0, repsCount: 0, setsCount: 0 },
+        { weekStartIso: '2026-04-13', weekIndex: 3, avgFqi: null, sessionsCount: 0, repsCount: 0, setsCount: 0 },
+      ],
+      topFaults: [],
+      isEmpty: true,
+    });
+    const { getByTestId } = render(<FormMesocycleCard insights={empty} />);
+    expect(getByTestId('form-mesocycle-card-empty')).toBeTruthy();
+  });
+
+  it('renders the latest FQI + sparkline + top faults when data is present', () => {
+    const { getByTestId, getAllByText } = render(
+      <FormMesocycleCard insights={insights()} />,
+    );
+    expect(getByTestId('form-mesocycle-current-fqi').children.join('')).toBe('82');
+    expect(getByTestId('form-mesocycle-sparkline').props.children.length).toBe(4);
+    expect(getAllByText(/Valgus/).length).toBeGreaterThan(0);
+  });
+
+  it('shows a deload banner when severity is deload', () => {
+    const data = insights({
+      deload: {
+        severity: 'deload',
+        fqiDelta: -12,
+        faultDelta: 0.8,
+        reason: 'Last week your form quality slipped and fault rate rose — consider a lighter week.',
+      },
+    });
+    const { getByTestId, getByText } = render(<FormMesocycleCard insights={data} />);
+    expect(getByTestId('form-mesocycle-deload')).toBeTruthy();
+    expect(getByText(/lighter week/)).toBeTruthy();
+  });
+
+  it('fires onPress when the card is tapped', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <FormMesocycleCard insights={insights()} onPress={onPress} />,
+    );
+    fireEvent.press(getByTestId('form-mesocycle-card'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders and fires the Ask-coach CTA when a handler is provided', () => {
+    const onAskCoach = jest.fn();
+    const { getByTestId } = render(
+      <FormMesocycleCard insights={insights()} onAskCoach={onAskCoach} />,
+    );
+    fireEvent.press(getByTestId('form-mesocycle-ask-coach'));
+    expect(onAskCoach).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the Ask-coach CTA when no handler is provided', () => {
+    const { queryByTestId } = render(<FormMesocycleCard insights={insights()} />);
+    expect(queryByTestId('form-mesocycle-ask-coach')).toBeNull();
+  });
+});

--- a/tests/unit/hooks/use-form-mesocycle.test.tsx
+++ b/tests/unit/hooks/use-form-mesocycle.test.tsx
@@ -1,0 +1,164 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+const mockEnsureUserId = jest.fn();
+const mockFrom = jest.fn();
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}));
+
+jest.mock('@/lib/auth-utils', () => ({
+  ensureUserId: () => mockEnsureUserId(),
+}));
+
+interface QueryBuilder {
+  select: jest.Mock;
+  eq: jest.Mock;
+  gte: jest.Mock;
+}
+
+function makeQueryBuilder(response: { data?: unknown; error?: unknown } = {}): QueryBuilder {
+  const builder: QueryBuilder = {
+    select: jest.fn(),
+    eq: jest.fn(),
+    gte: jest.fn(() =>
+      Promise.resolve({ data: response.data ?? [], error: response.error ?? null }),
+    ),
+  };
+  builder.select.mockImplementation(() => builder);
+  builder.eq.mockImplementation(() => builder);
+  return builder;
+}
+
+import { useFormMesocycle } from '@/hooks/use-form-mesocycle';
+
+beforeEach(() => {
+  mockEnsureUserId.mockReset();
+  mockFrom.mockReset();
+  mockEnsureUserId.mockResolvedValue('user-1');
+});
+
+describe('useFormMesocycle', () => {
+  it('loads reps + sets and returns insights on success', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'reps') {
+        return makeQueryBuilder({
+          data: [
+            {
+              rep_id: 'r1',
+              session_id: 's1',
+              exercise: 'squat',
+              start_ts: new Date().toISOString(),
+              fqi: 82,
+              faults_detected: ['valgus'],
+            },
+          ],
+        });
+      }
+      if (table === 'sets') {
+        return makeQueryBuilder({
+          data: [
+            {
+              set_id: 'st1',
+              session_id: 's1',
+              exercise: 'squat',
+              created_at: new Date().toISOString(),
+              reps_count: 5,
+              load_value: 225,
+            },
+          ],
+        });
+      }
+      return makeQueryBuilder();
+    });
+
+    const { result } = renderHook(() => useFormMesocycle());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.insights).not.toBeNull();
+    expect(result.current.insights?.isEmpty).toBe(false);
+    expect(result.current.insights?.topFaults.length).toBeGreaterThan(0);
+  });
+
+  it('treats per-table query errors as empty data rather than surfacing a page error', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'reps') return makeQueryBuilder({ error: new Error('reps boom') });
+      return makeQueryBuilder();
+    });
+
+    const { result } = renderHook(() => useFormMesocycle());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.insights?.isEmpty).toBe(true);
+  });
+
+  it('surfaces a page error when ensureUserId throws', async () => {
+    mockEnsureUserId.mockRejectedValueOnce(new Error('no auth'));
+    mockFrom.mockImplementation(() => makeQueryBuilder());
+
+    const { result } = renderHook(() => useFormMesocycle());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('no auth');
+    expect(result.current.insights).toBeNull();
+  });
+
+  it('re-runs the queries when refresh() is called', async () => {
+    mockFrom.mockImplementation(() => makeQueryBuilder());
+    const { result } = renderHook(() => useFormMesocycle());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const initialCalls = mockFrom.mock.calls.length;
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockFrom.mock.calls.length).toBeGreaterThan(initialCalls);
+  });
+
+  it('aborts state updates after unmount', async () => {
+    let resolveReps: ((value: { data: unknown[]; error: null }) => void) | undefined;
+    const pendingReps = new Promise((resolve) => {
+      resolveReps = resolve as typeof resolveReps;
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'reps') {
+        return {
+          select: () => ({
+            eq: () => ({
+              gte: () => pendingReps,
+            }),
+          }),
+        };
+      }
+      return makeQueryBuilder();
+    });
+
+    const { result, unmount } = renderHook(() => useFormMesocycle());
+    unmount();
+
+    // Resolve the in-flight query after unmount — the hook must not blow up
+    // and must not flip `loading` on a ghost copy.
+    await act(async () => {
+      resolveReps?.({ data: [], error: null });
+      await Promise.resolve();
+    });
+
+    expect(result.current.loading).toBe(true);
+  });
+});

--- a/tests/unit/hooks/use-session-telemetry-binder.test.tsx
+++ b/tests/unit/hooks/use-session-telemetry-binder.test.tsx
@@ -1,0 +1,170 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+const mockLogSet = jest.fn();
+
+jest.mock('@/lib/services/rep-logger', () => ({
+  logSet: (...args: unknown[]) => mockLogSet(...args),
+}));
+
+jest.mock('@/lib/stores/session-runner', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { create } = require('zustand');
+
+  const buildSet = (overrides = {}) => ({
+    id: 'set-1',
+    session_exercise_id: 'sx-1',
+    sort_order: 0,
+    set_type: 'normal',
+    planned_reps: 5,
+    planned_seconds: null,
+    planned_weight: null,
+    actual_reps: null,
+    actual_seconds: null,
+    actual_weight: null,
+    started_at: null,
+    completed_at: null,
+    rest_target_seconds: null,
+    rest_started_at: null,
+    rest_completed_at: null,
+    rest_skipped: false,
+    tut_ms: null,
+    tut_source: 'unknown',
+    perceived_rpe: null,
+    notes: null,
+    created_at: '2026-04-17T00:00:00.000Z',
+    updated_at: '2026-04-17T00:00:00.000Z',
+    ...overrides,
+  });
+
+  const initial = {
+    activeSession: { id: 'session-1', user_id: 'u-1' },
+    exercises: [
+      {
+        id: 'sx-1',
+        session_id: 'session-1',
+        exercise_id: 'squat',
+        sort_order: 0,
+        notes: null,
+        created_at: '2026-04-17T00:00:00.000Z',
+        updated_at: '2026-04-17T00:00:00.000Z',
+        exercise: {
+          id: 'squat',
+          name: 'Back Squat',
+          category: 'legs',
+          muscle_group: null,
+          is_compound: true,
+          is_timed: false,
+          is_system: true,
+          created_by: null,
+          created_at: '2026-04-17T00:00:00.000Z',
+          updated_at: '2026-04-17T00:00:00.000Z',
+        },
+      },
+    ],
+    sets: { 'sx-1': [buildSet()] },
+  };
+
+  // Types are intentionally loose here — jest.mock factories cannot reference
+  // out-of-scope aliases without triggering the hoist-guard warning.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const store = create((set: any) => ({
+    ...initial,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    completeSet: (setId: any) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      set((state: any) => ({
+        sets: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          'sx-1': (state.sets['sx-1'] ?? []).map((row: any) =>
+            row.id === setId
+              ? {
+                  ...row,
+                  actual_reps: 5,
+                  actual_weight: 225,
+                  completed_at: '2026-04-17T00:05:00.000Z',
+                }
+              : row,
+          ),
+        },
+      })),
+    _reset: () => set(() => ({ sets: { 'sx-1': [buildSet()] } })),
+  }));
+
+  return { useSessionRunner: store };
+});
+
+import { useSessionRunner } from '@/lib/stores/session-runner';
+import { useSessionTelemetryBinder } from '@/hooks/use-session-telemetry-binder';
+
+type MockStoreState = {
+  completeSet: (id: string) => void;
+  _reset: () => void;
+};
+
+function store(): MockStoreState {
+  return useSessionRunner.getState() as unknown as MockStoreState;
+}
+
+beforeEach(() => {
+  mockLogSet.mockReset();
+  mockLogSet.mockResolvedValue('telemetry-set-1');
+  store()._reset();
+});
+
+describe('useSessionTelemetryBinder', () => {
+  it('subscribes on mount and emits logSet when a set transitions to completed', async () => {
+    renderHook(() => useSessionTelemetryBinder());
+
+    await act(async () => {
+      store().completeSet('set-1');
+      await Promise.resolve();
+    });
+
+    expect(mockLogSet).toHaveBeenCalledTimes(1);
+    expect(mockLogSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        exercise: 'Back Squat',
+        repsCount: 5,
+        loadValue: 225,
+        loadUnit: 'lbs',
+      }),
+    );
+  });
+
+  it('does nothing when `enabled` is false', async () => {
+    renderHook(() => useSessionTelemetryBinder({ enabled: false }));
+
+    await act(async () => {
+      store().completeSet('set-1');
+      await Promise.resolve();
+    });
+
+    expect(mockLogSet).not.toHaveBeenCalled();
+  });
+
+  it('uses the injected logger override instead of rep-logger', async () => {
+    const override = jest.fn().mockResolvedValue('override-id');
+    renderHook(() => useSessionTelemetryBinder({ logger: override }));
+
+    await act(async () => {
+      store().completeSet('set-1');
+      await Promise.resolve();
+    });
+
+    expect(override).toHaveBeenCalledTimes(1);
+    expect(mockLogSet).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribes on unmount to stop emitting completions', async () => {
+    const { unmount } = renderHook(() => useSessionTelemetryBinder());
+    unmount();
+
+    await act(async () => {
+      store().completeSet('set-1');
+      await Promise.resolve();
+    });
+
+    expect(mockLogSet).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/screens/form-mesocycle.test.tsx
+++ b/tests/unit/screens/form-mesocycle.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+const mockPush = jest.fn();
+const mockBack = jest.fn();
+const mockRouter = { push: mockPush, back: mockBack, replace: jest.fn(), setParams: jest.fn() };
+jest.mock('expo-router', () => ({
+  useRouter: () => mockRouter,
+  useLocalSearchParams: () => ({}),
+}));
+
+const mockRefresh = jest.fn(async () => {});
+const mockUseFormMesocycle = jest.fn();
+jest.mock('@/hooks/use-form-mesocycle', () => ({
+  useFormMesocycle: () => mockUseFormMesocycle(),
+}));
+
+import FormMesocycleModal from '@/app/(modals)/form-mesocycle';
+import type { MesocycleInsights } from '@/lib/services/form-mesocycle-aggregator';
+
+function insights(overrides: Partial<MesocycleInsights> = {}): MesocycleInsights {
+  return {
+    referenceIso: '2026-04-17T00:00:00.000Z',
+    weeks: [
+      { weekStartIso: '2026-03-23', weekIndex: 0, avgFqi: 70, sessionsCount: 1, repsCount: 10, setsCount: 2 },
+      { weekStartIso: '2026-03-30', weekIndex: 1, avgFqi: 75, sessionsCount: 2, repsCount: 20, setsCount: 4 },
+      { weekStartIso: '2026-04-06', weekIndex: 2, avgFqi: 80, sessionsCount: 2, repsCount: 22, setsCount: 5 },
+      { weekStartIso: '2026-04-13', weekIndex: 3, avgFqi: 82, sessionsCount: 3, repsCount: 28, setsCount: 6 },
+    ],
+    topFaults: [
+      { fault: 'valgus', count: 9, share: 0.11 },
+      { fault: 'hips_rise', count: 4, share: 0.05 },
+    ],
+    deload: { severity: 'watch', fqiDelta: -6, faultDelta: 0.1, reason: 'Form quality is trending down.' },
+    isEmpty: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockPush.mockReset();
+  mockBack.mockReset();
+  mockRefresh.mockReset();
+  mockUseFormMesocycle.mockReset();
+});
+
+describe('FormMesocycleModal', () => {
+  it('renders loading state when the hook is still loading and no data is cached', () => {
+    mockUseFormMesocycle.mockReturnValue({
+      loading: true,
+      error: null,
+      insights: null,
+      refresh: mockRefresh,
+    });
+    const { getByTestId } = render(<FormMesocycleModal />);
+    expect(getByTestId('form-mesocycle-modal')).toBeTruthy();
+    expect(getByTestId('form-mesocycle-card-loading')).toBeTruthy();
+  });
+
+  it('renders an empty-state card and hides Ask-coach CTA when isEmpty is true', () => {
+    mockUseFormMesocycle.mockReturnValue({
+      loading: false,
+      error: null,
+      insights: insights({ isEmpty: true, topFaults: [] }),
+      refresh: mockRefresh,
+    });
+    const { getByTestId, queryByTestId } = render(<FormMesocycleModal />);
+    expect(getByTestId('form-mesocycle-card-empty')).toBeTruthy();
+    expect(queryByTestId('form-mesocycle-ask-coach')).toBeNull();
+  });
+
+  it('renders the full breakdown when data is present', () => {
+    mockUseFormMesocycle.mockReturnValue({
+      loading: false,
+      error: null,
+      insights: insights(),
+      refresh: mockRefresh,
+    });
+    const { getByTestId } = render(<FormMesocycleModal />);
+    expect(getByTestId('form-mesocycle-week-0')).toBeTruthy();
+    expect(getByTestId('form-mesocycle-week-3')).toBeTruthy();
+    expect(getByTestId('form-mesocycle-fault-valgus')).toBeTruthy();
+    expect(getByTestId('form-mesocycle-fqi-delta')).toBeTruthy();
+    expect(getByTestId('form-mesocycle-fault-delta')).toBeTruthy();
+  });
+
+  it('surfaces the error banner when the hook returns an error', () => {
+    mockUseFormMesocycle.mockReturnValue({
+      loading: false,
+      error: 'no auth',
+      insights: null,
+      refresh: mockRefresh,
+    });
+    const { getByTestId, getByText } = render(<FormMesocycleModal />);
+    expect(getByTestId('form-mesocycle-error')).toBeTruthy();
+    expect(getByText('no auth')).toBeTruthy();
+  });
+
+  it('dismisses the modal when the close button is pressed', () => {
+    mockUseFormMesocycle.mockReturnValue({
+      loading: false,
+      error: null,
+      insights: insights(),
+      refresh: mockRefresh,
+    });
+    const { getByTestId } = render(<FormMesocycleModal />);
+    fireEvent.press(getByTestId('form-mesocycle-close'));
+    expect(mockBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes to /coach with the analyst prompt when Ask-coach is tapped', async () => {
+    mockUseFormMesocycle.mockReturnValue({
+      loading: false,
+      error: null,
+      insights: insights(),
+      refresh: mockRefresh,
+    });
+    const { getByTestId } = render(<FormMesocycleModal />);
+    fireEvent.press(getByTestId('form-mesocycle-ask-coach'));
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledTimes(1);
+    });
+    const url = mockPush.mock.calls[0][0] as string;
+    expect(url).toMatch(/\/\(tabs\)\/coach\?prefill=/);
+    expect(url).toMatch(/focus=mesocycle-analyst/);
+    // The prompt is URL-encoded — decode and check the natural-language hint landed.
+    expect(decodeURIComponent(url)).toMatch(/4 weeks of form tracking/);
+  });
+});

--- a/tests/unit/services/coach-mesocycle-analyst.test.ts
+++ b/tests/unit/services/coach-mesocycle-analyst.test.ts
@@ -1,0 +1,123 @@
+import {
+  buildMesocycleAnalystPrompt,
+  MESOCYCLE_ANALYST_FOCUS,
+  requestMesocycleAnalysis,
+} from '@/lib/services/coach-mesocycle-analyst';
+import type { MesocycleInsights } from '@/lib/services/form-mesocycle-aggregator';
+
+function fullInsights(overrides: Partial<MesocycleInsights> = {}): MesocycleInsights {
+  return {
+    referenceIso: '2026-04-17T00:00:00.000Z',
+    weeks: [
+      { weekStartIso: '2026-03-23', weekIndex: 0, avgFqi: 70, sessionsCount: 1, repsCount: 10, setsCount: 2 },
+      { weekStartIso: '2026-03-30', weekIndex: 1, avgFqi: 75, sessionsCount: 2, repsCount: 20, setsCount: 4 },
+      { weekStartIso: '2026-04-06', weekIndex: 2, avgFqi: 80, sessionsCount: 2, repsCount: 22, setsCount: 5 },
+      { weekStartIso: '2026-04-13', weekIndex: 3, avgFqi: 82, sessionsCount: 3, repsCount: 28, setsCount: 6 },
+    ],
+    topFaults: [
+      { fault: 'valgus', count: 9, share: 0.1 },
+      { fault: 'hips_rise', count: 4, share: 0.05 },
+    ],
+    deload: { severity: 'watch', fqiDelta: -6, faultDelta: 0.1, reason: 'Form quality is trending down this week — keep an eye on load progression.' },
+    isEmpty: false,
+    ...overrides,
+  };
+}
+
+describe('buildMesocycleAnalystPrompt', () => {
+  it('returns an onboarding prompt when the window is empty', () => {
+    const insights = fullInsights({
+      weeks: [
+        { weekStartIso: '2026-03-23', weekIndex: 0, avgFqi: null, sessionsCount: 0, repsCount: 0, setsCount: 0 },
+        { weekStartIso: '2026-03-30', weekIndex: 1, avgFqi: null, sessionsCount: 0, repsCount: 0, setsCount: 0 },
+        { weekStartIso: '2026-04-06', weekIndex: 2, avgFqi: null, sessionsCount: 0, repsCount: 0, setsCount: 0 },
+        { weekStartIso: '2026-04-13', weekIndex: 3, avgFqi: null, sessionsCount: 0, repsCount: 0, setsCount: 0 },
+      ],
+      topFaults: [],
+      isEmpty: true,
+      deload: { severity: 'none', fqiDelta: null, faultDelta: null, reason: null },
+    });
+    const prompt = buildMesocycleAnalystPrompt(insights);
+    expect(prompt).toMatch(/no data yet/);
+    expect(prompt).toMatch(/4 weeks of form tracking/);
+  });
+
+  it('folds each weekly bucket into the prompt', () => {
+    const prompt = buildMesocycleAnalystPrompt(fullInsights());
+    expect(prompt).toMatch(/W1 \(2026-03-23\): FQI 70/);
+    expect(prompt).toMatch(/W4 \(2026-04-13\): FQI 82/);
+  });
+
+  it('lists recurring faults with counts', () => {
+    const prompt = buildMesocycleAnalystPrompt(fullInsights());
+    expect(prompt).toMatch(/valgus ×9/);
+    expect(prompt).toMatch(/hips_rise ×4/);
+  });
+
+  it('reports "no recurring faults" when the histogram is empty', () => {
+    const prompt = buildMesocycleAnalystPrompt(fullInsights({ topFaults: [] }));
+    expect(prompt).toMatch(/no recurring faults/);
+  });
+
+  it('reports deload severity and reason when present', () => {
+    const prompt = buildMesocycleAnalystPrompt(fullInsights());
+    expect(prompt).toMatch(/deload signal watch/);
+    expect(prompt).toMatch(/load progression/);
+  });
+
+  it('reports a clear deload signal when severity is none', () => {
+    const prompt = buildMesocycleAnalystPrompt(
+      fullInsights({
+        deload: { severity: 'none', fqiDelta: 1, faultDelta: 0, reason: null },
+      }),
+    );
+    expect(prompt).toMatch(/deload signal clear/);
+  });
+
+  it('constrains the response length via an explicit instruction', () => {
+    const prompt = buildMesocycleAnalystPrompt(fullInsights());
+    expect(prompt).toMatch(/150 words/);
+    expect(prompt).toMatch(/one concrete next step/);
+  });
+});
+
+describe('requestMesocycleAnalysis', () => {
+  it('routes the prompt through sendCoachPrompt with the mesocycle-analyst focus', async () => {
+    const send = jest.fn().mockResolvedValue({
+      message: { role: 'assistant', content: 'Cut volume 10% and add one glute-bridge warmup.' },
+    });
+    const result = await requestMesocycleAnalysis(fullInsights(), send);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const call = send.mock.calls[0][0];
+    expect(call.context).toEqual({ focus: MESOCYCLE_ANALYST_FOCUS });
+    expect(call.messages).toHaveLength(1);
+    expect(call.messages[0].role).toBe('user');
+    expect(call.messages[0].content).toMatch(/4 weeks of form tracking/);
+
+    expect(result).toEqual({
+      text: 'Cut volume 10% and add one glute-bridge warmup.',
+      provider: 'cloud',
+    });
+  });
+
+  it('returns null when the coach response is empty', async () => {
+    const send = jest.fn().mockResolvedValue({ message: { role: 'assistant', content: '' } });
+    const result = await requestMesocycleAnalysis(fullInsights(), send);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when sendCoachPrompt returns null', async () => {
+    const send = jest.fn().mockResolvedValue(null);
+    const result = await requestMesocycleAnalysis(fullInsights(), send);
+    expect(result).toBeNull();
+  });
+
+  it('trims whitespace from the coach response', async () => {
+    const send = jest
+      .fn()
+      .mockResolvedValue({ message: { role: 'assistant', content: '  next: deload 10%.  ' } });
+    const result = await requestMesocycleAnalysis(fullInsights(), send);
+    expect(result?.text).toBe('next: deload 10%.');
+  });
+});

--- a/tests/unit/services/form-mesocycle-aggregator.test.ts
+++ b/tests/unit/services/form-mesocycle-aggregator.test.ts
@@ -1,0 +1,201 @@
+import {
+  buildMesocycleInsights,
+  startOfIsoWeekUtc,
+  MESOCYCLE_WEEKS,
+  type MesocycleRepRow,
+  type MesocycleSetRow,
+} from '@/lib/services/form-mesocycle-aggregator';
+
+// Reference date: 2026-04-17 (Friday).
+// Current ISO week starts Monday 2026-04-13 00:00 UTC.
+// Bucket 3 (current) covers 2026-04-13 through 2026-04-20.
+// Bucket 2 covers 2026-04-06 through 2026-04-13.
+// Bucket 1 covers 2026-03-30 through 2026-04-06.
+// Bucket 0 covers 2026-03-23 through 2026-03-30.
+const REFERENCE = new Date('2026-04-17T12:00:00.000Z');
+
+function rep(overrides: Partial<MesocycleRepRow> = {}): MesocycleRepRow {
+  return {
+    rep_id: 'r',
+    session_id: 's',
+    exercise: 'squat',
+    start_ts: '2026-04-14T00:00:00.000Z',
+    fqi: 80,
+    faults_detected: [],
+    ...overrides,
+  };
+}
+
+function set(overrides: Partial<MesocycleSetRow> = {}): MesocycleSetRow {
+  return {
+    set_id: 'st',
+    session_id: 's',
+    exercise: 'squat',
+    completed_at: '2026-04-14T00:00:00.000Z',
+    reps_count: 5,
+    load_value: 225,
+    ...overrides,
+  };
+}
+
+describe('startOfIsoWeekUtc', () => {
+  it('rolls a Friday reference back to Monday 00:00 UTC', () => {
+    expect(startOfIsoWeekUtc(REFERENCE).toISOString()).toBe('2026-04-13T00:00:00.000Z');
+  });
+
+  it('stays put when the date is already Monday 00:00 UTC', () => {
+    const monday = new Date('2026-04-13T00:00:00.000Z');
+    expect(startOfIsoWeekUtc(monday).toISOString()).toBe('2026-04-13T00:00:00.000Z');
+  });
+
+  it('rolls a Sunday back six days to Monday', () => {
+    const sunday = new Date('2026-04-19T10:00:00.000Z');
+    expect(startOfIsoWeekUtc(sunday).toISOString()).toBe('2026-04-13T00:00:00.000Z');
+  });
+});
+
+describe('buildMesocycleInsights', () => {
+  it('returns an empty window when there are no rows', () => {
+    const result = buildMesocycleInsights([], [], { reference: REFERENCE });
+    expect(result.isEmpty).toBe(true);
+    expect(result.weeks).toHaveLength(MESOCYCLE_WEEKS);
+    expect(result.topFaults).toEqual([]);
+    expect(result.deload.severity).toBe('none');
+  });
+
+  it('buckets reps into the correct week', () => {
+    const reps = [
+      rep({ start_ts: '2026-03-24T00:00:00.000Z', fqi: 70 }), // bucket 0
+      rep({ start_ts: '2026-04-01T00:00:00.000Z', fqi: 75 }), // bucket 1
+      rep({ start_ts: '2026-04-08T00:00:00.000Z', fqi: 80 }), // bucket 2
+      rep({ start_ts: '2026-04-15T00:00:00.000Z', fqi: 85 }), // bucket 3
+    ];
+    const result = buildMesocycleInsights(reps, [], { reference: REFERENCE });
+    expect(result.weeks.map((w) => w.avgFqi)).toEqual([70, 75, 80, 85]);
+    expect(result.weeks.map((w) => w.repsCount)).toEqual([1, 1, 1, 1]);
+  });
+
+  it('ignores reps outside the 4-week window', () => {
+    const reps = [
+      rep({ start_ts: '2025-04-15T00:00:00.000Z' }), // long before
+      rep({ start_ts: '2030-04-15T00:00:00.000Z' }), // long after
+      rep({ start_ts: '2026-03-21T00:00:00.000Z' }), // week before bucket 0
+    ];
+    const result = buildMesocycleInsights(reps, [], { reference: REFERENCE });
+    expect(result.weeks.every((w) => w.repsCount === 0)).toBe(true);
+    expect(result.isEmpty).toBe(true);
+  });
+
+  it('counts unique sessions per week from reps and sets combined', () => {
+    const reps = [
+      rep({ session_id: 'session-a', start_ts: '2026-04-14T01:00:00.000Z' }),
+      rep({ session_id: 'session-a', start_ts: '2026-04-14T01:10:00.000Z' }),
+      rep({ session_id: 'session-b', start_ts: '2026-04-15T02:00:00.000Z' }),
+    ];
+    const sets = [
+      set({ session_id: 'session-a', completed_at: '2026-04-14T01:20:00.000Z' }),
+      set({ session_id: 'session-c', completed_at: '2026-04-15T02:05:00.000Z' }),
+    ];
+    const result = buildMesocycleInsights(reps, sets, { reference: REFERENCE });
+    expect(result.weeks[MESOCYCLE_WEEKS - 1].sessionsCount).toBe(3);
+    expect(result.weeks[MESOCYCLE_WEEKS - 1].setsCount).toBe(2);
+  });
+
+  it('builds a top-N fault histogram sorted by frequency', () => {
+    const reps = [
+      rep({ faults_detected: ['valgus', 'depth'] }),
+      rep({ faults_detected: ['valgus'] }),
+      rep({ faults_detected: ['valgus', 'hips_rise'] }),
+      rep({ faults_detected: ['depth'] }),
+    ];
+    const result = buildMesocycleInsights(reps, [], {
+      reference: REFERENCE,
+      topFaultLimit: 2,
+    });
+    expect(result.topFaults).toEqual([
+      expect.objectContaining({ fault: 'valgus', count: 3 }),
+      expect.objectContaining({ fault: 'depth', count: 2 }),
+    ]);
+  });
+
+  it('skips fqi averaging for reps without a score', () => {
+    const reps = [
+      rep({ fqi: null, start_ts: '2026-04-15T00:00:00.000Z' }),
+      rep({ fqi: 60, start_ts: '2026-04-15T01:00:00.000Z' }),
+      rep({ fqi: 80, start_ts: '2026-04-15T02:00:00.000Z' }),
+    ];
+    const result = buildMesocycleInsights(reps, [], { reference: REFERENCE });
+    expect(result.weeks[MESOCYCLE_WEEKS - 1].avgFqi).toBe(70);
+  });
+
+  it('reports deload when last week faults rise ≥60%', () => {
+    const reps: MesocycleRepRow[] = [
+      // prior 3 weeks: 20 reps, 1 fault → rate 0.05
+      ...Array.from({ length: 20 }, (_, i) =>
+        rep({
+          rep_id: `p-${i}`,
+          start_ts: '2026-04-08T00:00:00.000Z',
+          faults_detected: i === 0 ? ['valgus'] : [],
+          fqi: 85,
+        }),
+      ),
+      // last week: 10 reps, 5 faults → rate 0.5 (1000% rise)
+      ...Array.from({ length: 10 }, (_, i) =>
+        rep({
+          rep_id: `l-${i}`,
+          start_ts: '2026-04-15T00:00:00.000Z',
+          faults_detected: i < 5 ? ['valgus'] : [],
+          fqi: 60,
+        }),
+      ),
+    ];
+    const result = buildMesocycleInsights(reps, [], { reference: REFERENCE });
+    expect(result.deload.severity).toBe('deload');
+    expect(result.deload.fqiDelta).toBeLessThan(0);
+    expect(result.deload.faultDelta).not.toBeNull();
+    expect(result.deload.reason).toMatch(/lighter week/);
+  });
+
+  it('reports watch when FQI slips modestly without a fault spike', () => {
+    const reps: MesocycleRepRow[] = [
+      ...Array.from({ length: 10 }, () =>
+        rep({ start_ts: '2026-04-01T00:00:00.000Z', fqi: 85, faults_detected: [] }),
+      ),
+      ...Array.from({ length: 10 }, () =>
+        rep({ start_ts: '2026-04-15T00:00:00.000Z', fqi: 78, faults_detected: [] }),
+      ),
+    ];
+    const result = buildMesocycleInsights(reps, [], { reference: REFERENCE });
+    expect(result.deload.severity).toBe('watch');
+  });
+
+  it('keeps deload severity at none when the signal is flat', () => {
+    const reps: MesocycleRepRow[] = [
+      ...Array.from({ length: 10 }, () =>
+        rep({ start_ts: '2026-04-01T00:00:00.000Z', fqi: 80 }),
+      ),
+      ...Array.from({ length: 10 }, () =>
+        rep({ start_ts: '2026-04-15T00:00:00.000Z', fqi: 81 }),
+      ),
+    ];
+    const result = buildMesocycleInsights(reps, [], { reference: REFERENCE });
+    expect(result.deload.severity).toBe('none');
+    expect(result.deload.reason).toBeNull();
+  });
+
+  it('tolerates rows with malformed timestamps without throwing', () => {
+    const reps = [rep({ start_ts: 'not-a-date' })];
+    const result = buildMesocycleInsights(reps, [], { reference: REFERENCE });
+    expect(result.weeks.every((w) => w.repsCount === 0)).toBe(true);
+  });
+
+  it('emits ISO weekStartIso strings in oldest → newest order', () => {
+    const result = buildMesocycleInsights([], [], { reference: REFERENCE });
+    expect(result.weeks.map((w) => w.weekStartIso)).toEqual([
+      '2026-03-23',
+      '2026-03-30',
+      '2026-04-06',
+      '2026-04-13',
+    ]);
+  });
+});

--- a/tests/unit/services/session-telemetry-binder.test.ts
+++ b/tests/unit/services/session-telemetry-binder.test.ts
@@ -1,0 +1,257 @@
+import {
+  detectCompletedSets,
+  flushCompletedSets,
+  type BinderSnapshot,
+} from '@/lib/services/session-telemetry-binder';
+import type {
+  WorkoutSession,
+  WorkoutSessionExercise,
+  WorkoutSessionSet,
+  Exercise,
+} from '@/lib/types/workout-session';
+
+function makeSession(overrides: Partial<WorkoutSession> = {}): WorkoutSession {
+  return {
+    id: 'session-1',
+    user_id: 'user-1',
+    template_id: null,
+    name: null,
+    goal_profile: 'mixed',
+    started_at: '2026-04-17T00:00:00.000Z',
+    ended_at: null,
+    timezone_offset_minutes: 0,
+    bodyweight_lb: null,
+    notes: null,
+    created_at: '2026-04-17T00:00:00.000Z',
+    updated_at: '2026-04-17T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeExercise(overrides: Partial<WorkoutSessionExercise & { exercise?: Exercise }> = {}) {
+  return {
+    id: 'sx-1',
+    session_id: 'session-1',
+    exercise_id: 'squat',
+    sort_order: 0,
+    notes: null,
+    created_at: '2026-04-17T00:00:00.000Z',
+    updated_at: '2026-04-17T00:00:00.000Z',
+    exercise: {
+      id: 'squat',
+      name: 'Back Squat',
+      category: 'legs',
+      muscle_group: null,
+      is_compound: true,
+      is_timed: false,
+      is_system: true,
+      created_by: null,
+      created_at: '2026-04-17T00:00:00.000Z',
+      updated_at: '2026-04-17T00:00:00.000Z',
+    } as Exercise,
+    ...overrides,
+  };
+}
+
+function makeSet(overrides: Partial<WorkoutSessionSet> = {}): WorkoutSessionSet {
+  return {
+    id: 'set-1',
+    session_exercise_id: 'sx-1',
+    sort_order: 0,
+    set_type: 'normal',
+    planned_reps: 5,
+    planned_seconds: null,
+    planned_weight: 225,
+    actual_reps: null,
+    actual_seconds: null,
+    actual_weight: null,
+    started_at: null,
+    completed_at: null,
+    rest_target_seconds: null,
+    rest_started_at: null,
+    rest_completed_at: null,
+    rest_skipped: false,
+    tut_ms: null,
+    tut_source: 'unknown',
+    perceived_rpe: null,
+    notes: null,
+    created_at: '2026-04-17T00:00:00.000Z',
+    updated_at: '2026-04-17T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('detectCompletedSets', () => {
+  const session = makeSession();
+  const exercise = makeExercise();
+
+  it('returns an empty list when there is no active session', () => {
+    const next: BinderSnapshot = {
+      activeSession: null,
+      exercises: [exercise],
+      sets: {},
+    };
+    expect(detectCompletedSets(null, next)).toEqual([]);
+  });
+
+  it('returns no payloads when no sets have transitioned', () => {
+    const set = makeSet({ completed_at: null });
+    const snapshot: BinderSnapshot = {
+      activeSession: session,
+      exercises: [exercise],
+      sets: { 'sx-1': [set] },
+    };
+    expect(detectCompletedSets(snapshot, snapshot)).toEqual([]);
+  });
+
+  it('emits a payload for a set that transitions to completed', () => {
+    const pending = makeSet({ actual_reps: null, completed_at: null });
+    const completed = makeSet({
+      actual_reps: 5,
+      actual_weight: 225,
+      completed_at: '2026-04-17T00:05:00.000Z',
+    });
+    const prev: BinderSnapshot = {
+      activeSession: session,
+      exercises: [exercise],
+      sets: { 'sx-1': [pending] },
+    };
+    const next: BinderSnapshot = {
+      activeSession: session,
+      exercises: [exercise],
+      sets: { 'sx-1': [completed] },
+    };
+
+    const payloads = detectCompletedSets(prev, next);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].sessionSetId).toBe('set-1');
+    expect(payloads[0].summary).toMatchObject({
+      sessionId: 'session-1',
+      exercise: 'Back Squat',
+      repsCount: 5,
+      loadValue: 225,
+      loadUnit: 'lbs',
+    });
+  });
+
+  it('respects a custom default load unit', () => {
+    const completed = makeSet({
+      actual_reps: 6,
+      actual_weight: 100,
+      completed_at: '2026-04-17T00:05:00.000Z',
+    });
+    const next: BinderSnapshot = {
+      activeSession: session,
+      exercises: [exercise],
+      sets: { 'sx-1': [completed] },
+    };
+    const [payload] = detectCompletedSets(null, next, { defaultLoadUnit: 'kg' });
+    expect(payload.summary.loadUnit).toBe('kg');
+  });
+
+  it('does not emit load unit when weight is unknown', () => {
+    const completed = makeSet({
+      actual_reps: 0,
+      actual_weight: null,
+      completed_at: '2026-04-17T00:05:00.000Z',
+    });
+    const next: BinderSnapshot = {
+      activeSession: session,
+      exercises: [exercise],
+      sets: { 'sx-1': [completed] },
+    };
+    const [payload] = detectCompletedSets(null, next);
+    expect(payload.summary.loadValue).toBeUndefined();
+    expect(payload.summary.loadUnit).toBeUndefined();
+  });
+
+  it('falls back to exercise_id when no exercise row is joined', () => {
+    const orphanExercise = makeExercise({ exercise: undefined });
+    const completed = makeSet({
+      actual_reps: 3,
+      completed_at: '2026-04-17T00:05:00.000Z',
+    });
+    const next: BinderSnapshot = {
+      activeSession: session,
+      exercises: [orphanExercise],
+      sets: { 'sx-1': [completed] },
+    };
+    const [payload] = detectCompletedSets(null, next);
+    expect(payload.summary.exercise).toBe('squat');
+  });
+
+  it('skips sets that were already completed in the previous snapshot', () => {
+    const alreadyCompleted = makeSet({
+      actual_reps: 5,
+      completed_at: '2026-04-17T00:05:00.000Z',
+    });
+    const prev: BinderSnapshot = {
+      activeSession: session,
+      exercises: [exercise],
+      sets: { 'sx-1': [alreadyCompleted] },
+    };
+    const next: BinderSnapshot = {
+      activeSession: session,
+      exercises: [exercise],
+      sets: { 'sx-1': [alreadyCompleted] },
+    };
+    expect(detectCompletedSets(prev, next)).toEqual([]);
+  });
+
+  it('reports multiple completions in one diff', () => {
+    const setA = makeSet({ id: 'set-a' });
+    const setB = makeSet({ id: 'set-b' });
+    const prev: BinderSnapshot = {
+      activeSession: session,
+      exercises: [exercise],
+      sets: { 'sx-1': [setA, setB] },
+    };
+    const next: BinderSnapshot = {
+      activeSession: session,
+      exercises: [exercise],
+      sets: {
+        'sx-1': [
+          { ...setA, actual_reps: 5, completed_at: '2026-04-17T00:05:00.000Z' },
+          { ...setB, actual_reps: 4, completed_at: '2026-04-17T00:08:00.000Z' },
+        ],
+      },
+    };
+    expect(detectCompletedSets(prev, next)).toHaveLength(2);
+  });
+});
+
+describe('flushCompletedSets', () => {
+  it('invokes the logger for each payload and returns generated ids', async () => {
+    const logger = jest.fn().mockResolvedValueOnce('id-a').mockResolvedValueOnce('id-b');
+    const ids = await flushCompletedSets(
+      [
+        {
+          sessionSetId: 'set-a',
+          summary: { sessionId: 's', exercise: 'x', repsCount: 1 },
+        },
+        {
+          sessionSetId: 'set-b',
+          summary: { sessionId: 's', exercise: 'x', repsCount: 1 },
+        },
+      ],
+      logger,
+    );
+    expect(logger).toHaveBeenCalledTimes(2);
+    expect(ids).toEqual(['id-a', 'id-b']);
+  });
+
+  it('swallows individual failures without blocking the remaining payloads', async () => {
+    const logger = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce('id-b');
+    const ids = await flushCompletedSets(
+      [
+        { sessionSetId: 'set-a', summary: { sessionId: 's', exercise: 'x', repsCount: 1 } },
+        { sessionSetId: 'set-b', summary: { sessionId: 's', exercise: 'x', repsCount: 1 } },
+      ],
+      logger,
+    );
+    expect(ids).toEqual(['id-b']);
+  });
+});

--- a/tests/unit/services/video-service-session-binding.test.ts
+++ b/tests/unit/services/video-service-session-binding.test.ts
@@ -1,0 +1,66 @@
+import {
+  bindSessionIdToMetrics,
+  extractSessionIdFromMetrics,
+} from '@/lib/services/video-service';
+
+describe('bindSessionIdToMetrics', () => {
+  it('returns null when there are no metrics and no session id', () => {
+    expect(bindSessionIdToMetrics(undefined, undefined)).toBeNull();
+    expect(bindSessionIdToMetrics(null, null)).toBeNull();
+  });
+
+  it('returns the original metrics unchanged when no session id is provided', () => {
+    const metrics = { foo: 1, bar: 'two' };
+    expect(bindSessionIdToMetrics(metrics, undefined)).toBe(metrics);
+  });
+
+  it('embeds the session id without mutating the original metrics ref', () => {
+    const metrics = { foo: 1 };
+    const result = bindSessionIdToMetrics(metrics, 'session-42');
+    expect(result).toEqual({ foo: 1, sessionId: 'session-42' });
+    expect(metrics).toEqual({ foo: 1 });
+  });
+
+  it('creates a fresh metrics bag when only the session id is provided', () => {
+    expect(bindSessionIdToMetrics(undefined, 'session-7')).toEqual({
+      sessionId: 'session-7',
+    });
+  });
+
+  it('overwrites any existing sessionId field on the metrics blob', () => {
+    const metrics = { sessionId: 'stale' };
+    expect(bindSessionIdToMetrics(metrics, 'fresh')).toEqual({
+      sessionId: 'fresh',
+    });
+  });
+
+  it('treats an empty string as no session id', () => {
+    const metrics = { foo: 1 };
+    expect(bindSessionIdToMetrics(metrics, '')).toBe(metrics);
+  });
+});
+
+describe('extractSessionIdFromMetrics', () => {
+  it('returns null when metrics are absent', () => {
+    expect(extractSessionIdFromMetrics(undefined)).toBeNull();
+    expect(extractSessionIdFromMetrics(null)).toBeNull();
+  });
+
+  it('returns null when the sessionId field is missing', () => {
+    expect(extractSessionIdFromMetrics({ other: 1 })).toBeNull();
+  });
+
+  it('returns the stored session id when present', () => {
+    expect(
+      extractSessionIdFromMetrics({ sessionId: 'session-9', other: 1 }),
+    ).toBe('session-9');
+  });
+
+  it('returns null when sessionId is an empty string', () => {
+    expect(extractSessionIdFromMetrics({ sessionId: '' })).toBeNull();
+  });
+
+  it('returns null when sessionId is not a string', () => {
+    expect(extractSessionIdFromMetrics({ sessionId: 123 as unknown })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Wave-16 of the form-tracking + Gemma sweep streak. Prior waves 1-15 shipped PRs #425 → #488. Wave-16 audits against all 30+ open PR file lists and converges on **one genuinely unclaimed theme** that is upstream of most in-flight work: **session-runner ↔ rep-logger integration is missing on main**.

The `sets` Supabase table is never written to. Every in-flight FQI / drill / longitudinal-analytics PR (#434, #444, #473, #477, #478, #482) assumes this data exists — it does not. This wave fixes the plumbing, ships a novel user-facing mesocycle view that consumes the now-flowing data, and future-proofs a Gemma-ready analyst focus handler.

## What's new

### Plumbing — session telemetry binder
- `lib/services/session-telemetry-binder.ts` — pure `detectCompletedSets` + `flushCompletedSets` helpers that diff two `useSessionRunner` snapshots and emit a `SetSummary` payload whenever a `WorkoutSessionSet.completed_at` transitions.
- `hooks/use-session-telemetry-binder.ts` — React hook that calls `useSessionRunner.subscribe` inside a `useEffect` and forwards diffs to `logSet()`. Accepts an injected logger (tests) and an `enabled` flag.
- `components/telemetry/SessionTelemetryBinder.tsx` — `null`-returning component that mounts the hook. Wired once into `app/_layout.tsx` inside the font-ready branch (single-line addition).

### Plumbing — video sessionId binding
- `lib/services/video-service.ts` — adds an optional `sessionId` param to `uploadWorkoutVideo` and embeds it into `metrics.sessionId` (no migration needed). Exports `bindSessionIdToMetrics` + `extractSessionIdFromMetrics` helpers so callers can correlate videos to sessions today.

### UX — form mesocycle surface
- `lib/services/form-mesocycle-aggregator.ts` — pure core that rolls rep + set rows into a 4-bucket window: per-week avg FQI, unique sessions, top-N fault histogram, and a three-level deload signal (`none` / `watch` / `deload`).
- `hooks/use-form-mesocycle.ts` — queries the last 4 weeks of reps + sets for the current user, runs them through the aggregator, exposes `{loading, error, insights, refresh}`. Per-table errors silently degrade (partial view > page error).
- `components/form-journey/FormMesocycleCard.tsx` — compact home-tab card: latest-week FQI, 4-bucket sparkline, top-3 fault chips, deload severity banner, optional Ask-coach CTA.
- `app/(modals)/form-mesocycle.tsx` — expo-router auto-discovered modal with weekly breakdown, recurring-fault rows, deload read with raw deltas, Ask-coach deep-link.

### Gemma — mesocycle analyst focus
- `lib/services/coach-mesocycle-analyst.ts` — `buildMesocycleAnalystPrompt(insights)` + `requestMesocycleAnalysis(insights, sendCoachPrompt)` mirror the `coach-drill-explainer` pattern from #482. `focus='mesocycle-analyst'` hint is carried through context so the Edge Function dispatcher in PR #457 can route to Gemma without any client change. `TODO(#454/#457)` marker annotates the one-line provider-label swap.

## Commits (18 atomic)

\`\`\`
feat(telemetry): add session-runner set-completion detection
test(telemetry): session-telemetry-binder unit coverage
feat(telemetry): subscribe to session-runner via useSessionTelemetryBinder
test(telemetry): useSessionTelemetryBinder hook coverage
feat(telemetry): mount SessionTelemetryBinder at app root
feat(video): thread optional sessionId through uploadWorkoutVideo
test(video): sessionId metrics binding coverage
feat(form-journey): add mesocycle aggregator (4-week FQI + faults + deload)
test(form-journey): mesocycle aggregator unit coverage
feat(form-journey): add useFormMesocycle hook
test(form-journey): useFormMesocycle hook coverage
feat(form-journey): add FormMesocycleCard component
test(form-journey): FormMesocycleCard component coverage
feat(coach): mesocycle-analyst focus handler (Gemma-ready)
test(coach): mesocycle-analyst unit coverage
feat(form-journey): add form-mesocycle modal screen
test(form-journey): form-mesocycle modal screen coverage
docs(overnight): log wave-16 sweep work
\`\`\`

Every commit independently passes \`bun run check:types\` and \`bun run lint\`. The only lint warnings in CI output are pre-existing template-builder.tsx warnings on main — none introduced here.

## Verification

- \`bun run check:types\` — clean
- \`bun run lint\` — 0 errors; 2 pre-existing warnings in \`app/(modals)/template-builder.tsx\` unrelated to this PR
- \`bun run test\` — **1156 tests passed / 10 skipped / 94 suites passed**, zero regressions against main
- **68 new tests across 8 new suites:**
  - \`session-telemetry-binder.test.ts\` (10)
  - \`use-session-telemetry-binder.test.tsx\` (4)
  - \`video-service-session-binding.test.ts\` (11)
  - \`form-mesocycle-aggregator.test.ts\` (14)
  - \`use-form-mesocycle.test.tsx\` (5)
  - \`FormMesocycleCard.test.tsx\` (7)
  - \`coach-mesocycle-analyst.test.ts\` (11)
  - \`form-mesocycle.test.tsx\` (6)

## Pre-flight conflict report

Audited all 35 open PRs for file overlap:

- \`app/_layout.tsx\` — also touched by #433 and #450. Our edit is 1 import + a \`<SessionTelemetryBinder />\` tag inside the font-ready branch. Trivial textual merge.
- \`lib/services/video-service.ts\` — **zero open PRs touch this file.**
- All other new files under paths no other PR touches.
- \`app/(modals)/_layout.tsx\` is heavily contested (#480/#478/#477/#473/#471/#467/#456/#444/#443). We dodge it entirely — expo-router auto-discovers \`/form-mesocycle\` the same way it already auto-discovers \`/form-quality-recovery\` and \`/add-food\` on main.

## Deferred

- Dropping \`<FormMesocycleCard />\` into \`app/(tabs)/index.tsx\` or the form tab from #473 — a 3-line follow-up after #473 lands, since the tab layout is heavily contested this wave.
- Flipping \`provider: 'cloud'\` → \`provider: 'gemma-cloud'\` in \`coach-mesocycle-analyst.ts\` once #457's Edge Function returns the dispatched provider. Marked with \`TODO(#454/#457)\`.
- Extending \`ALLOWED_MODELS\` in the Gemma cloud Edge Function to Gemma 4 IDs (\`gemma-4-31b-it\`, \`gemma-4-26b-a4b-it\`) — tracked in issue #485 from wave-15.
- Image-input Gemma 4 visual mesocycle review — blocked on #457 + #485 merging. Out of scope here.
- Promoting \`sessionId\` from \`metrics\` JSON to a first-class \`session_id\` column on \`videos\` — overnight rule forbids migrations.

## Directive fulfillment

- **"improve ux exp for form tracking"** → 4-week mesocycle view is novel surface area (none of #473/#444/#477/#478 ships it), and the upstream plumbing means every in-flight FQI feature now has real data to consume.
- **"see if we can get gemma by google"** → confirmed Gemma 4 is live via Gemini REST with multimodal support. \`coach-mesocycle-analyst\` mirrors the drill-explainer focus pattern so the analyst routes to Gemma with a one-line swap when #457's dispatcher lands.
- **"large scoped prs not so many tiny ones"** → one cohesive PR, 18 atomic commits, ~1,800 LOC + 68 tests.
- **"keep commits atomic"** → every commit independently clean on type-check and lint.
- **"keep a worklog of main work"** → \`docs/overnight/worklog-2026-04-17-sweep-wave16.md\`.