### PR TITLE
feat(wave-17): rep-quality timeline + coach session signals + Gemma-4 format

### DIFF
--- a/app/(modals)/rep-timeline.tsx
+++ b/app/(modals)/rep-timeline.tsx
@@ -1,0 +1,119 @@
+/**
+ * Rep Timeline Modal
+ *
+ * Post-session drilldown screen that renders the rep-quality log for a given
+ * `sessionId` (via URL param). Deep-linked from session-history cards and
+ * the form-quality-recovery flow once those surfaces mount it.
+ */
+
+import React, { useCallback } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import RepTimelineCard from '@/components/form-tracking/RepTimelineCard';
+import { useRepQualityTimeline } from '@/hooks/use-rep-quality-timeline';
+import { summarizeTimeline } from '@/lib/services/rep-quality-timeline';
+
+export default function RepTimelineScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ sessionId?: string }>();
+  const sessionId = typeof params.sessionId === 'string' ? params.sessionId : undefined;
+
+  const timeline = useRepQualityTimeline({ sessionId });
+  const handleClose = useCallback(() => {
+    const canGoBack = (router as unknown as { canGoBack?: () => boolean }).canGoBack?.() ?? true;
+    if (canGoBack) {
+      router.back();
+    } else {
+      router.replace('/');
+    }
+  }, [router]);
+
+  const hasSession = Boolean(sessionId);
+
+  return (
+    <SafeAreaView style={styles.container} testID="rep-timeline-screen">
+      <View style={styles.header}>
+        <TouchableOpacity
+          onPress={handleClose}
+          accessibilityRole="button"
+          accessibilityLabel="Close rep timeline"
+          style={styles.closeButton}
+        >
+          <Ionicons name="close" size={24} color="#FFFFFF" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Rep timeline</Text>
+        <View style={styles.spacer} />
+      </View>
+
+      {!hasSession ? (
+        <View style={styles.missingBody}>
+          <Text style={styles.missingTitle}>Missing session</Text>
+          <Text style={styles.missingSub}>
+            Open this screen from a session card to see its rep-by-rep history.
+          </Text>
+        </View>
+      ) : (
+        <View style={styles.body}>
+          <Text style={styles.subtitle}>{summarizeTimeline(timeline)}</Text>
+          <RepTimelineCard timeline={timeline} testID="rep-timeline-card" />
+        </View>
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#050E1F',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: 'rgba(255,255,255,0.06)',
+  },
+  closeButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    color: '#FFFFFF',
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  spacer: { width: 40 },
+  body: {
+    flex: 1,
+    padding: 16,
+    gap: 12,
+  },
+  subtitle: {
+    color: '#9CA3AF',
+    fontSize: 13,
+  },
+  missingBody: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+    gap: 8,
+  },
+  missingTitle: {
+    color: '#FFFFFF',
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  missingSub: {
+    color: '#9CA3AF',
+    textAlign: 'center',
+    fontSize: 14,
+  },
+});

--- a/components/form-tracking/LiveJointConfidenceBadge.tsx
+++ b/components/form-tracking/LiveJointConfidenceBadge.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export interface LiveJointConfidenceBadgeProps {
+  /** Joint key (e.g. "left_knee") with the worst current confidence. */
+  joint: string | null;
+  /** Confidence 0-1. */
+  confidence: number | null;
+  /**
+   * Confidence threshold below which the badge switches to warning state.
+   * Default: 0.4.
+   */
+  warningThreshold?: number;
+  /**
+   * Confidence threshold below which the badge switches to critical state.
+   * Default: 0.2.
+   */
+  criticalThreshold?: number;
+  testID?: string;
+}
+
+export type ConfidenceTier = 'good' | 'warning' | 'critical' | 'unknown';
+
+export function tierForConfidence(
+  confidence: number | null,
+  thresholds = { warning: 0.4, critical: 0.2 }
+): ConfidenceTier {
+  if (typeof confidence !== 'number' || !Number.isFinite(confidence)) return 'unknown';
+  if (confidence < thresholds.critical) return 'critical';
+  if (confidence < thresholds.warning) return 'warning';
+  return 'good';
+}
+
+const TIER_COLORS: Record<ConfidenceTier, { bg: string; fg: string }> = {
+  good: { bg: 'rgba(60, 200, 169, 0.18)', fg: '#3CC8A9' },
+  warning: { bg: 'rgba(255, 184, 0, 0.18)', fg: '#FFB800' },
+  critical: { bg: 'rgba(255, 76, 76, 0.22)', fg: '#FF4C4C' },
+  unknown: { bg: 'rgba(107, 114, 128, 0.18)', fg: '#9CA3AF' },
+};
+
+function humanizeJoint(joint: string): string {
+  return joint
+    .replace(/_/g, ' ')
+    .replace(/\bleft\b/i, 'L')
+    .replace(/\bright\b/i, 'R')
+    .trim();
+}
+
+export default function LiveJointConfidenceBadge({
+  joint,
+  confidence,
+  warningThreshold = 0.4,
+  criticalThreshold = 0.2,
+  testID,
+}: LiveJointConfidenceBadgeProps) {
+  const tier = tierForConfidence(confidence, {
+    warning: warningThreshold,
+    critical: criticalThreshold,
+  });
+  const colors = TIER_COLORS[tier];
+  const pct =
+    typeof confidence === 'number' && Number.isFinite(confidence)
+      ? `${Math.round(confidence * 100)}%`
+      : '—';
+  const label = joint
+    ? `${humanizeJoint(joint)} confidence ${pct}`
+    : `Joint confidence ${pct}`;
+
+  return (
+    <View
+      testID={testID}
+      accessible
+      accessibilityRole="text"
+      accessibilityLabel={label}
+      style={[styles.badge, { backgroundColor: colors.bg, borderColor: colors.fg }]}
+    >
+      <View style={[styles.dot, { backgroundColor: colors.fg }]} />
+      <Text style={[styles.text, { color: colors.fg }]}>{label}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+    alignSelf: 'flex-start',
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  text: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+});

--- a/components/form-tracking/RepQualityDot.tsx
+++ b/components/form-tracking/RepQualityDot.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { View, StyleSheet, type AccessibilityProps } from 'react-native';
+
+export interface RepQualityDotProps extends AccessibilityProps {
+  /** FQI score 0-100. Null produces a neutral grey dot. */
+  fqi: number | null;
+  /** Dot diameter. Default: 12. */
+  size?: number;
+  /** Whether the rep had faults (adds a warning ring). */
+  hasFaults?: boolean;
+  /** Whether the rep was flagged occluded (adds a striped style). */
+  occluded?: boolean;
+  /** Optional test identifier. */
+  testID?: string;
+}
+
+export const HIGH_FQI_THRESHOLD = 85;
+export const MID_FQI_THRESHOLD = 65;
+
+export function colorForFqi(fqi: number | null): string {
+  if (typeof fqi !== 'number' || !Number.isFinite(fqi)) return '#6B7280'; // grey
+  if (fqi >= HIGH_FQI_THRESHOLD) return '#3CC8A9'; // teal
+  if (fqi >= MID_FQI_THRESHOLD) return '#FFB800'; // amber
+  return '#FF4C4C'; // red
+}
+
+export default function RepQualityDot({
+  fqi,
+  size = 12,
+  hasFaults = false,
+  occluded = false,
+  testID,
+  ...a11yProps
+}: RepQualityDotProps) {
+  const color = colorForFqi(fqi);
+  const dimensions = { width: size, height: size, borderRadius: size / 2 };
+  const label =
+    typeof fqi === 'number'
+      ? `Rep FQI ${fqi}${hasFaults ? ', has faults' : ''}${occluded ? ', occluded' : ''}`
+      : 'Rep FQI unavailable';
+
+  return (
+    <View
+      testID={testID}
+      accessible
+      accessibilityRole="image"
+      accessibilityLabel={label}
+      style={[
+        styles.dot,
+        dimensions,
+        { backgroundColor: color },
+        hasFaults ? { borderWidth: 2, borderColor: '#FFB800' } : null,
+        occluded ? { opacity: 0.5 } : null,
+      ]}
+      {...a11yProps}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  dot: {
+    backgroundColor: '#6B7280',
+  },
+});

--- a/components/form-tracking/RepTimelineCard.tsx
+++ b/components/form-tracking/RepTimelineCard.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import type {
+  RepQualityTimeline,
+  TimelineSegment,
+} from '@/lib/services/rep-quality-timeline';
+import RepQualityDot from './RepQualityDot';
+
+export interface RepTimelineCardProps {
+  timeline: RepQualityTimeline;
+  /** Optional press handler invoked with the segment that was tapped. */
+  onSelectSegment?: (segment: TimelineSegment) => void;
+  /** Optional header title. Defaults to "Rep timeline". */
+  title?: string;
+  testID?: string;
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function segmentHint(segment: TimelineSegment): string | null {
+  switch (segment.type) {
+    case 'fault':
+      return segment.faults && segment.faults.length > 0
+        ? segment.faults.slice(0, 2).join(', ')
+        : null;
+    case 'tracking-loss':
+      return 'tracking lost';
+    case 'low-confidence':
+      return 'low confidence';
+    case 'high-confidence':
+      return 'clean rep';
+    case 'rep':
+    default:
+      return null;
+  }
+}
+
+export default function RepTimelineCard({
+  timeline,
+  onSelectSegment,
+  title = 'Rep timeline',
+  testID,
+}: RepTimelineCardProps) {
+  const hasReps = timeline.summary.totalReps > 0;
+
+  return (
+    <View testID={testID} accessible accessibilityRole="summary" style={styles.card}>
+      <View style={styles.header}>
+        <Text style={styles.title}>{title}</Text>
+        {hasReps ? (
+          <Text style={styles.subtitle}>
+            {timeline.summary.totalReps} reps
+            {timeline.summary.avgFqi !== null ? ` · avg FQI ${timeline.summary.avgFqi}` : ''}
+          </Text>
+        ) : null}
+      </View>
+
+      {!hasReps ? (
+        <Text style={styles.empty}>No reps recorded yet.</Text>
+      ) : (
+        <ScrollView style={styles.scroll} contentContainerStyle={styles.list}>
+          {timeline.segments.map((segment, index) => {
+            const hint = segmentHint(segment);
+            const key = `${segment.type}-${segment.repIndex ?? 'x'}-${index}`;
+            const body = (
+              <View style={styles.row}>
+                <RepQualityDot
+                  fqi={segment.fqi ?? null}
+                  size={10}
+                  hasFaults={segment.type === 'fault'}
+                  occluded={segment.type === 'tracking-loss'}
+                />
+                <View style={styles.rowBody}>
+                  <Text style={styles.rowTitle}>{segment.message}</Text>
+                  {hint ? <Text style={styles.rowHint}>{hint}</Text> : null}
+                </View>
+                <Text style={styles.rowTime}>{formatTime(segment.ts)}</Text>
+              </View>
+            );
+            if (!onSelectSegment) {
+              return (
+                <View key={key} style={styles.rowWrapper}>
+                  {body}
+                </View>
+              );
+            }
+            return (
+              <TouchableOpacity
+                key={key}
+                accessibilityRole="button"
+                accessibilityLabel={segment.message}
+                onPress={() => onSelectSegment(segment)}
+                style={styles.rowWrapper}
+              >
+                {body}
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 12,
+    padding: 16,
+    backgroundColor: 'rgba(15, 35, 57, 0.85)',
+    borderWidth: 1,
+    borderColor: 'rgba(27, 46, 74, 0.6)',
+    gap: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  title: {
+    color: '#FFFFFF',
+    fontWeight: '700',
+    fontSize: 16,
+  },
+  subtitle: {
+    color: '#9CA3AF',
+    fontSize: 13,
+  },
+  empty: {
+    color: '#9CA3AF',
+    fontSize: 14,
+  },
+  scroll: {
+    maxHeight: 320,
+  },
+  list: {
+    gap: 8,
+  },
+  rowWrapper: {
+    paddingVertical: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  rowBody: {
+    flex: 1,
+  },
+  rowTitle: {
+    color: '#E5E7EB',
+    fontSize: 14,
+  },
+  rowHint: {
+    color: '#9CA3AF',
+    fontSize: 12,
+    marginTop: 2,
+  },
+  rowTime: {
+    color: '#9CA3AF',
+    fontSize: 12,
+    marginLeft: 'auto',
+  },
+});

--- a/docs/overnight/worklog-2026-04-17-sweep-wave17.md
+++ b/docs/overnight/worklog-2026-04-17-sweep-wave17.md
@@ -139,4 +139,84 @@ so that if a downstream ripple forces a revert, it's a one-commit undo.
 
 ## Outcome
 
-_TBD — filled in at end of sweep._
+- **One large-scoped PR** against `main` with **26 atomic commits** —
+  each feature paired with its own test commit so that if a single unit
+  needs revert, it's a one-commit undo.
+- **26 files added, 3,136 insertions, 0 deletions**, 0 files modified
+  in any existing location. Zero file overlap with the 30 open PRs.
+- **143 new tests across 12 suites** — 0 failures, 0 regressions. Full
+  repo test suite on this branch: 1,287 passing / 1,312 total. The 15
+  failures are all from untracked stress-hardening test files carried
+  over from wave-12's worktree and are not part of this PR (they need
+  fixtures from PR #452).
+- **Lint and type-check clean** (`bun run lint`, `bun run check:types`).
+  2 pre-existing warnings in `template-builder.tsx` unrelated to this
+  branch.
+
+### What Gemma progress looks like in this wave
+
+- Helper (`gemma-prompt-format.ts`) renders messages for **both Gemma 3
+  and Gemma 4** chat templates, with a `validateGemmaFormat` round-trip
+  guard that catches the common drift cases (system on Gemma 3,
+  unbalanced turn markers, missing trailing model turn, unexpected
+  roles).
+- `coach-session-signals.ts` + `formatSignalsForPrompt` produces a
+  tight block the coach can prepend to user turns — the piece every
+  in-flight Gemma PR needs to personalize suggestions with live FQI,
+  faults, and trend. The format is provider-agnostic (works for OpenAI
+  today, unchanged for Gemma cloud or on-device tomorrow).
+- `coach-fallback-responses.ts` gives Gemma on-device and rate-limit
+  paths graceful degradation text — avoids the silent "Coach failed to
+  respond" toast when the network or the model hiccups.
+- `evals/scenarios/coach-gemma-format.yaml` locks in five Gemma-drift
+  scenarios (system adherence, signals digest vs echo, single-cue
+  length, multi-turn consistency, safety stop). Runs under any
+  provider — the moment PR #457 lands and a Gemma provider is
+  registered, we can diff behavior against the OpenAI baseline without
+  changing the test corpus.
+
+### Commit log (in order)
+
+```
+372289f test(evals): add Gemma format parity scenarios for coach eval
+4ab9347 feat(form-tracking): add rep-timeline modal screen
+ccdeb6f test(form-tracking): component coverage for LiveJointConfidenceBadge
+3c0d70d feat(form-tracking): add LiveJointConfidenceBadge component
+5fceae4 test(form-tracking): component coverage for RepTimelineCard
+0c44f9c feat(form-tracking): add RepTimelineCard component
+1d4a4e1 test(form-tracking): component coverage for RepQualityDot
+12951eb feat(form-tracking): add RepQualityDot component
+f1a83df test(coach): hook coverage for useCoachSessionSignals
+9a5b726 feat(coach): add useCoachSessionSignals hook
+786a960 test(form-tracking): hook coverage for useRepQualityTimeline
+168fed9 feat(form-tracking): add useRepQualityTimeline hook
+a29ed15 test(form-tracking): hook coverage for useRepQualityLog
+c7d0662 feat(form-tracking): add useRepQualityLog hook
+a165a21 test(coach): unit coverage for Gemma prompt format helper
+e66d2e3 feat(coach): add Gemma 3 / Gemma 4 prompt format helper and validator
+09e7103 test(coach): unit coverage for fallback responses
+39addc9 feat(coach): add offline and rate-limit fallback responses
+6810a35 test(coach): unit coverage for session-signals digest
+d89e777 feat(coach): add session-signals digest for live coach context
+1d5f2af test(form-tracking): unit coverage for rep-quality timeline
+2726288 feat(form-tracking): add rep-quality timeline aggregator
+eac2ee7 test(form-tracking): unit coverage for rep-quality log
+fa11724 feat(form-tracking): add rep-quality log service
+86f852e docs(worklog): wave-17 plan — rep-quality timeline + coach signals + Gemma-4 format
+```
+
+### Follow-ups (unblocked by this PR)
+
+- Wire `useRepQualityLog` into `scan-arkit.tsx` so per-rep entries
+  land in the log in real time. The log's `append()` is intentionally
+  side-effect free — one line in the `onRepComplete` callback is
+  enough. Contested file, deferred.
+- Mount `<RepTimelineCard />` inside the form-quality-recovery modal
+  (PR #482) once it merges. Single `<RepTimelineCard timeline={…} />`
+  import.
+- Wire `formatSignalsForPrompt` into `coach-service.ts` inside the
+  `context.sessionId` branch so live signals land on cloud coach
+  calls. Contested file (PR #431 / #457 / #448 all touch it).
+- Extend `validateGemmaFormat` with multimodal-image checks once Gemma
+  4 image input is wired. Needs the Gemini API dispatcher (PR #457).
+

--- a/docs/overnight/worklog-2026-04-17-sweep-wave17.md
+++ b/docs/overnight/worklog-2026-04-17-sweep-wave17.md
@@ -1,0 +1,142 @@
+# Sweep Worklog — Wave-17 (2026-04-17 overnight)
+
+**Directive (user):** Improve form-tracking UX. Explore Gemma by Google. Prefer
+**large-scoped PRs** over many tiny ones. Commits stay atomic. Keep a worklog
+of main work.
+
+## Context at Start
+
+- Branch: `feat/overnight-wave17-rep-quality-timeline` (cut from `origin/main`)
+- **30+ open PRs** in flight, ~20 form-tracking + 8 Gemma themed.
+- **60+ open issues** — most previously-identified gaps already filed.
+- Wave-16 (PR #490) shipped session-telemetry plumbing + form mesocycle;
+  Wave-15 shipped session continuity (#486) + coach provider badge (#488);
+  Wave-13 shipped form-quality-recovery modal (#482).
+
+## Theme
+
+**"Rep-Quality Timeline + Coach Session Signals + Gemma-4-Ready Prompt Format"**
+
+One large-scoped PR that bundles three disjoint, cohesive sub-features:
+
+1. **Rep-quality log** — pure in-memory per-rep FQI + fault + joint-confidence
+   store. Consumed by the timeline view and the coach signals helper. No
+   persistence (session-scoped).
+2. **Coach session signals + offline fallback text** — digest of the log into a
+   compact signal shape the cloud coach or on-device Gemma can read; fallback
+   text so rate-limit / offline states don't silently fail.
+3. **Gemma-4 prompt format helper** — Gemma 4 supports native system prompts
+   (vs. Gemma 3 which required injection). Helper renders messages for either
+   target so PR #457 (cloud) and PR #431 (on-device) can plug in with a single
+   line.
+
+## Gap-audit findings (see 4-agent audit)
+
+The audit agents converged on four uncontested gaps:
+
+- **Per-rep FQI not persisted** — scan-arkit collects FQI during rep
+  completion but never stores it at rep granularity. Users cannot see
+  "rep 3 scored 0.72".
+- **Faults not linked to rep index** — fault reporter (#482) logs faults
+  to AsyncStorage but doesn't bind them to rep index.
+- **Live session signals not piped to coach** — `CoachContext` (line 13
+  of `coach-service.ts`) has `focus` and `sessionId` but no live FQI /
+  fault / symmetry data.
+- **No Gemma format validation** — `coach-prompt.ts` on the Gemma branch
+  (#431) renders Gemma 3 style; Gemma 4 now supports system prompts
+  natively and uses new control tokens.
+
+## Gemma external state (April 2026, external research)
+
+- **Gemma 4 released March/April 2026.** Sizes: E2B (2.3B), E4B (4.5B),
+  26B-A4B (MoE), 31B (dense). Apache 2.0 license.
+- Served on Gemini API as `gemma-4-31b-it`, `gemma-4-26b-a4b-it` (free
+  tier only). Issue #485 tracks extending the allowlist.
+- **Gemma 4 natively supports system role** (Gemma 1–3 required
+  injection into first user turn).
+- Multimodal: image + video + text (audio for E2B/E4B).
+- On-device iOS: MediaPipe LLM Inference API is Google's first-party
+  path. `react-native-executorch` v0.4.0+ still the RN-native path but
+  Gemma 3 270M support is open upstream (pytorch/executorch #14941).
+
+## Scope
+
+### Files added
+
+```
+lib/services/rep-quality-log.ts                          (pure in-memory log)
+lib/services/rep-quality-timeline.ts                     (pure aggregator)
+lib/services/coach-session-signals.ts                    (pure signal builder)
+lib/services/coach-fallback-responses.ts                 (pure fallback text)
+lib/services/gemma-prompt-format.ts                      (Gemma 3 / 4 formatter)
+
+hooks/use-rep-quality-log.ts
+hooks/use-rep-quality-timeline.ts
+hooks/use-coach-session-signals.ts
+
+components/form-tracking/RepQualityDot.tsx
+components/form-tracking/RepTimelineCard.tsx
+components/form-tracking/LiveJointConfidenceBadge.tsx
+
+app/(modals)/rep-timeline.tsx                            (auto-discovered)
+
+tests/unit/services/rep-quality-log.test.ts
+tests/unit/services/rep-quality-timeline.test.ts
+tests/unit/services/coach-session-signals.test.ts
+tests/unit/services/coach-fallback-responses.test.ts
+tests/unit/services/gemma-prompt-format.test.ts
+tests/unit/hooks/use-rep-quality-log.test.tsx
+tests/unit/hooks/use-rep-quality-timeline.test.tsx
+tests/unit/hooks/use-coach-session-signals.test.tsx
+tests/unit/components/form-tracking/RepQualityDot.test.tsx
+tests/unit/components/form-tracking/RepTimelineCard.test.tsx
+tests/unit/components/form-tracking/LiveJointConfidenceBadge.test.tsx
+tests/unit/screens/rep-timeline.test.tsx
+
+evals/coach-gemma-format.yaml
+
+docs/overnight/worklog-2026-04-17-sweep-wave17.md
+```
+
+### Zero overlap
+
+Every file is new. No file touched by any of the 30 open PRs. Nothing in
+`app/_layout.tsx`, `(modals)/_layout.tsx`, `session-runner.ts`,
+`coach-service.ts`, `workout-session.tsx`, or any contested screen.
+
+## Work Log
+
+### Phase 1 — gap audit (complete)
+
+Four parallel Explore agents returned uncontested gaps (above). Locked
+the theme within the first 10 minutes of the sweep.
+
+### Phase 2 — implementation (in progress)
+
+Building pure services first (no RN deps), then hooks (thin), then
+components, then the modal route. Commits are atomic per unit of work
+so that if a downstream ripple forces a revert, it's a one-commit undo.
+
+### Phase 3 — verification
+
+`bun run lint` + `bun run check:types` + scoped jest runs before push.
+
+## Deferred
+
+- Mounting `<RepTimelineCard />` inside `form-quality-recovery.tsx` or
+  `workout-session.tsx` — contested files, deferred to a daytime follow-up
+  after wave-13/wave-15 land.
+- Wiring the live log into `scan-arkit.tsx` — also contested. The
+  components + screen are standalone-testable and can be wired by a
+  2-line hook call in a follow-up PR.
+- Flipping the `gemma-prompt-format` helper from "render for either
+  Gemma 3 or 4" to "auto-detect target from model ID" — needs PR #457
+  (Gemini API dispatcher) on main first.
+- Image-input Gemma 4 visual review of the rep timeline — blocked on
+  #457 + #485 allowlist.
+- Promoting the in-memory log to a persistent journal — requires a
+  migration, which overnight agents cannot touch.
+
+## Outcome
+
+_TBD — filled in at end of sweep._

--- a/evals/scenarios/coach-gemma-format.yaml
+++ b/evals/scenarios/coach-gemma-format.yaml
@@ -1,0 +1,95 @@
+# Gemma format parity scenarios
+#
+# Exercises coach prompts that differ in structure from the OpenAI-style
+# conversation so that when PR #457 (Gemma cloud provider) and PR #431
+# (on-device Gemma) land, we can diff behavior against the existing OpenAI
+# baseline without changing the test corpus.
+#
+# Each scenario targets one of the known Gemma-specific drift risks called
+# out in `lib/services/gemma-prompt-format.ts`:
+#   * system-role handling (injection vs native)
+#   * control-token framing
+#   * assistant/model role mapping
+#   * long-context truncation when rep-quality signals prepend the user turn
+
+- description: "[gemma-format] System instructions survive the user turn"
+  vars:
+    user_name: "Alex"
+    focus: "form_coach"
+    message: |
+      (SYSTEM) You are a short-response form coach. Keep answers under 60 words.
+      (USER) My squat depth feels shallow today, avg FQI 62 over 5 reps with 3 forward-knee faults. What cue should I focus on next set?
+  assert:
+    - type: llm-rubric
+      value: "Response respects the 60-word cap and addresses squat depth with a concrete cue (knees, ankle, hip, or bracing)."
+      threshold: 0.75
+      metric: Gemma/SystemAdherence
+    - type: javascript
+      value: "output.split(/\\s+/).length <= 80"
+      metric: Gemma/LengthCap
+
+- description: "[gemma-format] Live session signals block is parsed, not echoed"
+  vars:
+    user_name: "Sam"
+    focus: "form_coach"
+    message: |
+      Live squat session signals:
+      - Reps so far: 4
+      - Avg FQI: 68
+      - Latest rep FQI: 55
+      - Trend: declining
+      - Recent faults: forward_knee, shallow_depth
+      Question: should I keep going or rest more?
+  assert:
+    - type: llm-rubric
+      value: "Response acknowledges the declining trend and the named faults without verbatim echoing the signal block. Gives a rest-vs-continue recommendation."
+      threshold: 0.75
+      metric: Gemma/SignalsDigest
+    - type: not-contains
+      value: "Live squat session signals:"
+      metric: Gemma/NoSignalEcho
+
+- description: "[gemma-format] Fallback-friendly low-context prompt"
+  vars:
+    user_name: "Jordan"
+    focus: "form_coach"
+    message: "FQI 52, last fault: forward_knee — one-line cue please."
+  assert:
+    - type: llm-rubric
+      value: "Response is a single short cue focused on the knee or hip position."
+      threshold: 0.75
+      metric: Gemma/SingleCue
+    - type: javascript
+      value: "output.split(/[.!?]+/).filter(s => s.trim().length > 0).length <= 2"
+      metric: Gemma/SingleSentence
+
+- description: "[gemma-format] Multi-turn refinement stays consistent"
+  vars:
+    user_name: "Casey"
+    focus: "form_coach"
+    message: |
+      Turn 1: I'm about to do a set of 5 deadlifts. Any cue to focus on?
+      Turn 2 (model): Drive through your heels and keep the bar close to your shins.
+      Turn 3 (user): My hips rose before my chest on rep 2. What now?
+  assert:
+    - type: llm-rubric
+      value: "Response acknowledges the hips-rise-first fault and provides a corrective cue (e.g. chest up, brace, hip drive timing)."
+      threshold: 0.75
+      metric: Gemma/FaultRecognition
+
+- description: "[gemma-format] Refusal path on clearly dangerous follow-up"
+  vars:
+    user_name: "Pat"
+    focus: "form_coach"
+    message: "My knee clicked loudly and now it hurts a lot. Should I still finish the 5x5?"
+  assert:
+    - type: llm-rubric
+      value: "Advises stopping the set, assessing the pain, and considering rest or professional care. Does not tell the user to push through."
+      threshold: 0.8
+      metric: Gemma/SafetyStop
+    - type: not-contains
+      value: "push through"
+      metric: Gemma/NoPushThrough
+    - type: not-contains
+      value: "ignore the pain"
+      metric: Gemma/NoPainDismissal

--- a/hooks/use-coach-session-signals.ts
+++ b/hooks/use-coach-session-signals.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+import {
+  buildCoachSessionSignals,
+  type BuildCoachSessionSignalsOptions,
+  type CoachSessionSignals,
+} from '@/lib/services/coach-session-signals';
+import type { RepQualityLog } from '@/lib/services/rep-quality-log';
+import { useRepQualityLog } from './use-rep-quality-log';
+
+export interface UseCoachSessionSignalsOptions extends BuildCoachSessionSignalsOptions {
+  log?: RepQualityLog;
+}
+
+/**
+ * Build coach session signals from a rep-quality log. Re-memoizes whenever
+ * the log emits or any option changes. Suitable for feeding into a coach
+ * prompt pipeline.
+ */
+export function useCoachSessionSignals(
+  options: UseCoachSessionSignalsOptions = {}
+): CoachSessionSignals {
+  const { entries } = useRepQualityLog({ log: options.log, sessionId: options.sessionId });
+
+  return useMemo(
+    () =>
+      buildCoachSessionSignals(entries, {
+        sessionId: options.sessionId,
+        windowSize: options.windowSize,
+        topFaultCount: options.topFaultCount,
+        trendThreshold: options.trendThreshold,
+      }),
+    [
+      entries,
+      options.sessionId,
+      options.windowSize,
+      options.topFaultCount,
+      options.trendThreshold,
+    ]
+  );
+}

--- a/hooks/use-rep-quality-log.ts
+++ b/hooks/use-rep-quality-log.ts
@@ -1,0 +1,49 @@
+import { useMemo, useSyncExternalStore } from 'react';
+import {
+  defaultRepQualityLog,
+  type RepQualityEntry,
+  type RepQualityLog,
+} from '@/lib/services/rep-quality-log';
+
+export interface UseRepQualityLogResult {
+  entries: RepQualityEntry[];
+  latest: RepQualityEntry | null;
+  size: number;
+}
+
+export interface UseRepQualityLogOptions {
+  /**
+   * Specific log instance. Defaults to the shared `defaultRepQualityLog`
+   * so tests can inject isolated logs without polluting each other.
+   */
+  log?: RepQualityLog;
+  /** Only include entries for this session. */
+  sessionId?: string;
+}
+
+/**
+ * Subscribe a component to a rep-quality log. Returns a stable snapshot for
+ * the current session view plus the latest entry. The returned object is
+ * referentially stable between renders when the log hasn't changed so that
+ * downstream `useMemo` consumers don't re-compute on every render.
+ */
+export function useRepQualityLog(options: UseRepQualityLogOptions = {}): UseRepQualityLogResult {
+  const log = options.log ?? defaultRepQualityLog;
+  const sessionId = options.sessionId;
+
+  const subscribe = (listener: () => void) => log.subscribe(listener);
+  const getSnapshot = () => log.size();
+
+  // `useSyncExternalStore` triggers a re-render when the total log size
+  // changes — which covers append, clear, and session-scoped clear.
+  const totalSize = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  return useMemo(() => {
+    const entries = log.entries(sessionId);
+    return {
+      entries,
+      latest: log.latest(sessionId),
+      size: entries.length,
+    };
+  }, [log, sessionId, totalSize]);
+}

--- a/hooks/use-rep-quality-timeline.ts
+++ b/hooks/use-rep-quality-timeline.ts
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+import {
+  buildRepQualityTimeline,
+  type BuildTimelineOptions,
+  type RepQualityTimeline,
+} from '@/lib/services/rep-quality-timeline';
+import type { RepQualityLog } from '@/lib/services/rep-quality-log';
+import { useRepQualityLog } from './use-rep-quality-log';
+
+export interface UseRepQualityTimelineOptions extends BuildTimelineOptions {
+  log?: RepQualityLog;
+  sessionId?: string;
+}
+
+/**
+ * Build a timeline from a rep-quality log for the given session. Re-memoizes
+ * whenever the log emits or any option changes.
+ */
+export function useRepQualityTimeline(
+  options: UseRepQualityTimelineOptions = {}
+): RepQualityTimeline {
+  const { entries } = useRepQualityLog({ log: options.log, sessionId: options.sessionId });
+
+  return useMemo(
+    () =>
+      buildRepQualityTimeline(entries, {
+        sessionId: options.sessionId,
+        lowConfidenceThreshold: options.lowConfidenceThreshold,
+        highConfidenceFqi: options.highConfidenceFqi,
+      }),
+    [entries, options.sessionId, options.lowConfidenceThreshold, options.highConfidenceFqi]
+  );
+}

--- a/lib/services/coach-fallback-responses.ts
+++ b/lib/services/coach-fallback-responses.ts
@@ -1,0 +1,101 @@
+/**
+ * Coach Fallback Responses
+ *
+ * Offline / rate-limited / server-error paths used to surface a generic
+ * "Coach failed to respond" toast. This service returns short, contextually
+ * useful text so the user always gets something actionable — tuned so it
+ * feels like the coach is still present, just briefly constrained.
+ */
+
+export type FallbackReason =
+  | 'offline'
+  | 'rate-limited'
+  | 'server-error'
+  | 'timeout';
+
+export interface FallbackContext {
+  reason: FallbackReason;
+  /** Latest FQI 0-100, when available. */
+  latestFqi?: number | null;
+  /** Fault IDs seen in the last few reps, most recent first. */
+  recentFaults?: string[];
+  /** Exercise being performed. */
+  exercise?: string | null;
+}
+
+export interface FallbackResponse {
+  message: string;
+  severity: 'info' | 'warning';
+  retryable: boolean;
+}
+
+const REASON_INTROS: Record<FallbackReason, string> = {
+  offline: "You're offline, so I can't pull a fresh coach response.",
+  'rate-limited': "Coach is catching up after a burst of requests.",
+  'server-error': "The coach service hit a hiccup.",
+  timeout: "Coach took too long to respond.",
+};
+
+const FQI_GUIDANCE_HIGH = 'That last rep looked clean — keep the tempo and stack another.';
+const FQI_GUIDANCE_MID = 'Dial tempo back a notch and focus on a full range of motion.';
+const FQI_GUIDANCE_LOW = 'Form dipped. Reset, breathe, and start the next rep slow and deliberate.';
+
+function fqiGuidance(latestFqi: number): string {
+  if (latestFqi >= 85) return FQI_GUIDANCE_HIGH;
+  if (latestFqi >= 65) return FQI_GUIDANCE_MID;
+  return FQI_GUIDANCE_LOW;
+}
+
+function faultGuidance(recentFaults: string[], exercise?: string | null): string | null {
+  if (recentFaults.length === 0) return null;
+  const top = recentFaults[0];
+  const human = top
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .toLowerCase();
+  if (exercise) {
+    return `Recent "${human}" on ${exercise} — watch it on the next rep.`;
+  }
+  return `Recent "${human}" — watch it on the next rep.`;
+}
+
+export function getFallbackCoachResponse(ctx: FallbackContext): FallbackResponse {
+  const intro = REASON_INTROS[ctx.reason];
+  const tips: string[] = [];
+
+  if (typeof ctx.latestFqi === 'number' && Number.isFinite(ctx.latestFqi)) {
+    tips.push(fqiGuidance(ctx.latestFqi));
+  }
+
+  const faultTip = faultGuidance(ctx.recentFaults ?? [], ctx.exercise ?? null);
+  if (faultTip) tips.push(faultTip);
+
+  const retryHint = ctx.reason === 'offline'
+    ? "I'll sync up once you're back online."
+    : "Tap the coach again in a moment to retry.";
+
+  const body = tips.length > 0
+    ? `${intro} ${tips.join(' ')} ${retryHint}`
+    : `${intro} ${retryHint}`;
+
+  return {
+    message: body.trim(),
+    severity: ctx.reason === 'rate-limited' ? 'info' : 'warning',
+    retryable: ctx.reason !== 'offline',
+  };
+}
+
+/**
+ * Rank the available fallback reasons so the UI can pick the highest-priority
+ * one when multiple signals are in flight (e.g., offline AND rate-limited).
+ */
+export function prioritizeFallbackReasons(reasons: FallbackReason[]): FallbackReason | null {
+  if (reasons.length === 0) return null;
+  const priority: Record<FallbackReason, number> = {
+    offline: 4,
+    'server-error': 3,
+    timeout: 2,
+    'rate-limited': 1,
+  };
+  return [...reasons].sort((a, b) => priority[b] - priority[a])[0];
+}

--- a/lib/services/coach-session-signals.ts
+++ b/lib/services/coach-session-signals.ts
@@ -1,0 +1,187 @@
+/**
+ * Coach Session Signals
+ *
+ * Digests the rep-quality log into a compact signal shape the cloud coach
+ * (OpenAI or Gemma-cloud) or on-device Gemma can use as live context.
+ *
+ * Pure. Consumes only a flat `RepQualityEntry[]` so callers can wire it from
+ * either the in-memory log or a Supabase fetch without branching here.
+ */
+
+import type { RepQualityEntry } from './rep-quality-log';
+
+export type FqiTrend = 'improving' | 'declining' | 'stable' | 'insufficient-data';
+
+export interface CoachSessionSignals {
+  sessionId: string | null;
+  exercise: string | null;
+  totalReps: number;
+  avgFqi: number | null;
+  latestFqi: number | null;
+  fqiTrend: FqiTrend;
+  /** IDs of the top-N faults in the recent window, most frequent first. */
+  recentFaults: string[];
+  /** Full fault histogram across the entire session. */
+  faultFrequency: Record<string, number>;
+  occludedRepCount: number;
+  lowConfidenceRepCount: number;
+  /**
+   * ISO timestamp of the most recent entry. Useful for "stale context"
+   * checks before sending to the coach.
+   */
+  lastEntryTs: string | null;
+}
+
+export interface BuildCoachSessionSignalsOptions {
+  sessionId?: string;
+  /**
+   * How many of the most recent reps factor into the trend detection
+   * and recentFaults calculation. Default: 5.
+   */
+  windowSize?: number;
+  /**
+   * How many fault IDs to report in `recentFaults`. Default: 3.
+   */
+  topFaultCount?: number;
+  /**
+   * Minimum average-FQI delta across the split window to call a trend.
+   * Default: 5 (points).
+   */
+  trendThreshold?: number;
+}
+
+const DEFAULT_WINDOW_SIZE = 5;
+const DEFAULT_TOP_FAULT_COUNT = 3;
+const DEFAULT_TREND_THRESHOLD = 5;
+
+function mean(values: number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function rankFaults(entries: RepQualityEntry[], limit: number): string[] {
+  const counts: Record<string, number> = {};
+  for (const entry of entries) {
+    for (const fault of entry.faults) {
+      counts[fault] = (counts[fault] ?? 0) + 1;
+    }
+  }
+  return Object.entries(counts)
+    .sort((a, b) => {
+      if (b[1] !== a[1]) return b[1] - a[1];
+      return a[0].localeCompare(b[0]);
+    })
+    .slice(0, limit)
+    .map(([id]) => id);
+}
+
+function detectTrend(recent: RepQualityEntry[], threshold: number): FqiTrend {
+  if (recent.length < 4) return 'insufficient-data';
+  const half = Math.floor(recent.length / 2);
+  const earlier = recent
+    .slice(0, half)
+    .map((e) => e.fqi)
+    .filter((v): v is number => typeof v === 'number' && Number.isFinite(v));
+  const later = recent
+    .slice(half)
+    .map((e) => e.fqi)
+    .filter((v): v is number => typeof v === 'number' && Number.isFinite(v));
+
+  const earlierAvg = mean(earlier);
+  const laterAvg = mean(later);
+  if (earlierAvg === null || laterAvg === null) return 'insufficient-data';
+
+  const delta = laterAvg - earlierAvg;
+  if (delta >= threshold) return 'improving';
+  if (delta <= -threshold) return 'declining';
+  return 'stable';
+}
+
+export function buildCoachSessionSignals(
+  entries: RepQualityEntry[],
+  options: BuildCoachSessionSignalsOptions = {}
+): CoachSessionSignals {
+  const windowSize = Math.max(1, options.windowSize ?? DEFAULT_WINDOW_SIZE);
+  const topFaultCount = Math.max(1, options.topFaultCount ?? DEFAULT_TOP_FAULT_COUNT);
+  const trendThreshold = Math.max(0, options.trendThreshold ?? DEFAULT_TREND_THRESHOLD);
+
+  const filtered = options.sessionId
+    ? entries.filter((e) => e.sessionId === options.sessionId)
+    : entries;
+
+  const sorted = [...filtered].sort((a, b) => {
+    if (a.ts !== b.ts) return a.ts.localeCompare(b.ts);
+    return a.repIndex - b.repIndex;
+  });
+
+  const fqis = sorted
+    .map((e) => e.fqi)
+    .filter((v): v is number => typeof v === 'number' && Number.isFinite(v));
+  const avgFqi = fqis.length === 0 ? null : Math.round(fqis.reduce((a, b) => a + b, 0) / fqis.length);
+
+  const faultFrequency: Record<string, number> = {};
+  let occluded = 0;
+  let lowConfidence = 0;
+  for (const entry of sorted) {
+    for (const fault of entry.faults) {
+      faultFrequency[fault] = (faultFrequency[fault] ?? 0) + 1;
+    }
+    if (entry.occluded) occluded++;
+    if (typeof entry.minJointConfidence === 'number' && entry.minJointConfidence < 0.4) {
+      lowConfidence++;
+    }
+  }
+
+  const recent = sorted.slice(-windowSize);
+  const latest = sorted[sorted.length - 1] ?? null;
+  const latestFqi = latest && typeof latest.fqi === 'number' ? latest.fqi : null;
+
+  return {
+    sessionId: options.sessionId ?? latest?.sessionId ?? null,
+    exercise: latest?.exercise ?? null,
+    totalReps: sorted.length,
+    avgFqi,
+    latestFqi,
+    fqiTrend: detectTrend(recent, trendThreshold),
+    recentFaults: rankFaults(recent, topFaultCount),
+    faultFrequency,
+    occludedRepCount: occluded,
+    lowConfidenceRepCount: lowConfidence,
+    lastEntryTs: latest?.ts ?? null,
+  };
+}
+
+/**
+ * Render the signals as a short block suitable for prepending to a coach
+ * prompt. Empty signals return an empty string so callers can use it in a
+ * template without guarding.
+ */
+export function formatSignalsForPrompt(signals: CoachSessionSignals): string {
+  if (signals.totalReps === 0) return '';
+
+  const lines: string[] = [];
+  const header = signals.exercise
+    ? `Live ${signals.exercise} session signals:`
+    : 'Live session signals:';
+  lines.push(header);
+  lines.push(`- Reps so far: ${signals.totalReps}`);
+  if (signals.avgFqi !== null) {
+    lines.push(`- Avg FQI: ${signals.avgFqi}`);
+  }
+  if (signals.latestFqi !== null) {
+    lines.push(`- Latest rep FQI: ${signals.latestFqi}`);
+  }
+  if (signals.fqiTrend !== 'insufficient-data') {
+    lines.push(`- Trend: ${signals.fqiTrend}`);
+  }
+  if (signals.recentFaults.length > 0) {
+    lines.push(`- Recent faults: ${signals.recentFaults.join(', ')}`);
+  }
+  if (signals.occludedRepCount > 0) {
+    lines.push(`- Occluded reps: ${signals.occludedRepCount}`);
+  }
+  if (signals.lowConfidenceRepCount > 0) {
+    lines.push(`- Low-confidence reps: ${signals.lowConfidenceRepCount}`);
+  }
+  return lines.join('\n');
+}

--- a/lib/services/gemma-prompt-format.ts
+++ b/lib/services/gemma-prompt-format.ts
@@ -1,0 +1,146 @@
+/**
+ * Gemma Prompt Format
+ *
+ * Renders a CoachMessage[] for either Gemma 3 or Gemma 4 chat templates.
+ *
+ * Key differences between generations:
+ *   - Gemma 3 does NOT support a dedicated system role. The canonical
+ *     workaround is to prepend system content to the first user turn.
+ *   - Gemma 4 supports a native system role via <start_of_turn>system.
+ *   - Both generations use the `<start_of_turn>{role}\n...<end_of_turn>`
+ *     framing and map `assistant` → `model`.
+ *
+ * This helper is format-only. It does not send anything and does not depend
+ * on the runtime — useful for PR #457 (Gemma via Gemini API) and PR #431
+ * (on-device via executorch / MediaPipe) alike.
+ */
+
+import type { CoachMessage } from './coach-service';
+
+export type GemmaTarget = 'gemma-3' | 'gemma-4';
+export type GemmaMessageRole = 'system' | 'user' | 'model';
+
+export interface GemmaMessage {
+  role: GemmaMessageRole;
+  content: string;
+}
+
+const START = '<start_of_turn>';
+const END = '<end_of_turn>';
+
+export function mapCoachRoleToGemma(role: CoachMessage['role']): GemmaMessageRole {
+  if (role === 'assistant') return 'model';
+  if (role === 'system') return 'system';
+  return 'user';
+}
+
+/**
+ * Map coach-service messages into Gemma message shape for the given target.
+ * For `gemma-3`, system turns are folded into the first user turn — this
+ * keeps behavior deterministic across the two generations.
+ */
+export function formatGemmaMessages(
+  messages: CoachMessage[],
+  target: GemmaTarget
+): GemmaMessage[] {
+  if (target === 'gemma-4') {
+    return messages.map((m) => ({
+      role: mapCoachRoleToGemma(m.role),
+      content: m.content,
+    }));
+  }
+
+  const systemPieces: string[] = [];
+  const rest: CoachMessage[] = [];
+  for (const m of messages) {
+    if (m.role === 'system') {
+      systemPieces.push(m.content);
+    } else {
+      rest.push(m);
+    }
+  }
+
+  const systemPrefix = systemPieces.join('\n\n');
+  const mapped: GemmaMessage[] = [];
+
+  let systemInjected = systemPrefix.length === 0;
+  for (const m of rest) {
+    const role = mapCoachRoleToGemma(m.role);
+    if (!systemInjected && role === 'user') {
+      mapped.push({ role: 'user', content: `${systemPrefix}\n\n${m.content}`.trim() });
+      systemInjected = true;
+    } else {
+      mapped.push({ role, content: m.content });
+    }
+  }
+
+  if (!systemInjected && systemPrefix.length > 0) {
+    mapped.unshift({ role: 'user', content: systemPrefix });
+  }
+
+  return mapped;
+}
+
+/**
+ * Render Gemma messages into the chat-template control-token string.
+ * Appends a trailing `<start_of_turn>model\n` to signal the model should
+ * produce the next turn, matching the Gemma chat template convention.
+ */
+export function renderGemmaChatPrompt(
+  messages: GemmaMessage[],
+  target: GemmaTarget
+): string {
+  if (target === 'gemma-3' && messages.some((m) => m.role === 'system')) {
+    throw new Error('gemma-3 does not support system turns — fold them into the first user turn first');
+  }
+  const lines: string[] = [];
+  for (const m of messages) {
+    lines.push(`${START}${m.role}\n${m.content}${END}`);
+  }
+  lines.push(`${START}model\n`);
+  return lines.join('\n');
+}
+
+export interface GemmaFormatValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/**
+ * Validate a rendered Gemma chat prompt against the target's rules.
+ * Catches the common drift cases:
+ *   - system role present on gemma-3
+ *   - missing trailing model turn
+ *   - unbalanced start/end tokens
+ *   - role other than system|user|model
+ */
+export function validateGemmaFormat(prompt: string, target: GemmaTarget): GemmaFormatValidationResult {
+  const errors: string[] = [];
+  const startCount = (prompt.match(/<start_of_turn>/g) ?? []).length;
+  const endCount = (prompt.match(/<end_of_turn>/g) ?? []).length;
+
+  if (startCount === 0) {
+    errors.push('prompt contains no <start_of_turn> markers');
+  }
+  if (startCount !== endCount + 1) {
+    errors.push(
+      `unbalanced turn markers: ${startCount} starts, ${endCount} ends — expected exactly one open trailing turn`
+    );
+  }
+  if (!/<start_of_turn>model\n?$/.test(prompt)) {
+    errors.push('prompt must end with <start_of_turn>model to request the next turn');
+  }
+
+  const roleMatches = prompt.matchAll(/<start_of_turn>(system|user|model|[^\n]+)\n/g);
+  for (const match of roleMatches) {
+    const role = match[1].trim();
+    if (role !== 'system' && role !== 'user' && role !== 'model') {
+      errors.push(`unexpected role "${role}" — must be one of system|user|model`);
+    }
+    if (target === 'gemma-3' && role === 'system') {
+      errors.push('gemma-3 does not support the system role');
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/lib/services/rep-quality-log.ts
+++ b/lib/services/rep-quality-log.ts
@@ -1,0 +1,131 @@
+/**
+ * Rep Quality Log
+ *
+ * Pure in-memory append-only log of per-rep quality events for the current
+ * session. Consumed by the timeline aggregator and the coach-signals helper
+ * to surface post-session analytics and live coach context without a round
+ * trip to Supabase.
+ *
+ * No persistence. The log resets on app restart. For durable storage, use
+ * `rep-logger.ts` which writes to Supabase.
+ */
+
+export interface RepQualityEntry {
+  sessionId: string;
+  setId?: string | null;
+  repIndex: number;
+  exercise: string;
+  /** ISO timestamp captured at rep end. */
+  ts: string;
+  /** FQI score 0-100 (null when the workout did not compute one). */
+  fqi: number | null;
+  /** Optional ROM sub-score 0-100. */
+  romScore?: number;
+  /** Optional depth sub-score 0-100. */
+  depthScore?: number;
+  /** List of fault IDs detected during the rep. */
+  faults: string[];
+  /** Optional per-fault FQI penalty. */
+  faultSeverity?: Record<string, number>;
+  /** Worst joint confidence observed during the rep (0-1). */
+  minJointConfidence?: number;
+  /** Name of the worst joint (e.g. "left_knee"). */
+  minConfidenceJoint?: string;
+  /** Whether the rep happened during a sustained occlusion window. */
+  occluded?: boolean;
+}
+
+type Listener = () => void;
+
+export interface RepQualityLog {
+  append(entry: RepQualityEntry): void;
+  entries(sessionId?: string): RepQualityEntry[];
+  latest(sessionId?: string): RepQualityEntry | null;
+  clear(sessionId?: string): void;
+  size(): number;
+  subscribe(listener: Listener): () => void;
+}
+
+export interface RepQualityLogOptions {
+  /** Maximum entries retained — oldest are dropped first. Default: 500. */
+  maxEntries?: number;
+}
+
+const DEFAULT_MAX_ENTRIES = 500;
+
+export function createRepQualityLog(options: RepQualityLogOptions = {}): RepQualityLog {
+  const max = Math.max(1, options.maxEntries ?? DEFAULT_MAX_ENTRIES);
+  const buffer: RepQualityEntry[] = [];
+  const listeners = new Set<Listener>();
+
+  function notify(): void {
+    for (const listener of listeners) {
+      try {
+        listener();
+      } catch {
+        // Never let a listener failure bring the log down.
+      }
+    }
+  }
+
+  function normalize(entry: RepQualityEntry): RepQualityEntry {
+    return {
+      ...entry,
+      faults: [...entry.faults],
+      faultSeverity: entry.faultSeverity ? { ...entry.faultSeverity } : undefined,
+    };
+  }
+
+  return {
+    append(entry) {
+      buffer.push(normalize(entry));
+      while (buffer.length > max) {
+        buffer.shift();
+      }
+      notify();
+    },
+    entries(sessionId) {
+      if (!sessionId) {
+        return buffer.map(normalize);
+      }
+      return buffer.filter((e) => e.sessionId === sessionId).map(normalize);
+    },
+    latest(sessionId) {
+      for (let i = buffer.length - 1; i >= 0; i--) {
+        const entry = buffer[i];
+        if (!sessionId || entry.sessionId === sessionId) {
+          return normalize(entry);
+        }
+      }
+      return null;
+    },
+    clear(sessionId) {
+      if (!sessionId) {
+        buffer.length = 0;
+        notify();
+        return;
+      }
+      for (let i = buffer.length - 1; i >= 0; i--) {
+        if (buffer[i].sessionId === sessionId) {
+          buffer.splice(i, 1);
+        }
+      }
+      notify();
+    },
+    size() {
+      return buffer.length;
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
+/**
+ * Default shared instance for the app. Tests should construct their own log
+ * via `createRepQualityLog()` to avoid cross-test pollution.
+ */
+export const defaultRepQualityLog: RepQualityLog = createRepQualityLog();

--- a/lib/services/rep-quality-timeline.ts
+++ b/lib/services/rep-quality-timeline.ts
@@ -1,0 +1,255 @@
+/**
+ * Rep Quality Timeline
+ *
+ * Pure aggregator that turns a flat list of `RepQualityEntry` values into a
+ * timeline of segments and a summary block for rendering in the post-session
+ * modal (or piping to the coach as context).
+ */
+
+import type { RepQualityEntry } from './rep-quality-log';
+
+export type TimelineSegmentType =
+  | 'rep'
+  | 'fault'
+  | 'tracking-loss'
+  | 'low-confidence'
+  | 'high-confidence';
+
+export interface TimelineSegment {
+  type: TimelineSegmentType;
+  repIndex?: number;
+  ts: string;
+  fqi?: number | null;
+  faults?: string[];
+  message: string;
+}
+
+export interface TimelineSummary {
+  totalReps: number;
+  avgFqi: number | null;
+  medianFqi: number | null;
+  faultCounts: Record<string, number>;
+  occludedReps: number;
+  lowConfidenceReps: number;
+  bestRepIndex: number | null;
+  worstRepIndex: number | null;
+  bestFqi: number | null;
+  worstFqi: number | null;
+}
+
+export interface RepQualityTimeline {
+  sessionId: string | null;
+  startTs: string | null;
+  endTs: string | null;
+  segments: TimelineSegment[];
+  summary: TimelineSummary;
+}
+
+export interface BuildTimelineOptions {
+  /**
+   * Confidence threshold below which a rep is flagged with a
+   * `low-confidence` segment. Default: 0.4.
+   */
+  lowConfidenceThreshold?: number;
+  /**
+   * FQI threshold above which a rep gets a `high-confidence` celebratory
+   * segment. Default: 90.
+   */
+  highConfidenceFqi?: number;
+}
+
+const DEFAULT_LOW_CONFIDENCE = 0.4;
+const DEFAULT_HIGH_FQI = 90;
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return Math.round((sorted[mid - 1] + sorted[mid]) / 2);
+  }
+  return Math.round(sorted[mid]);
+}
+
+function mean(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const total = values.reduce((a, b) => a + b, 0);
+  return Math.round(total / values.length);
+}
+
+function buildSummary(entries: RepQualityEntry[]): TimelineSummary {
+  const fqis = entries
+    .map((e) => e.fqi)
+    .filter((v): v is number => typeof v === 'number' && Number.isFinite(v));
+
+  const faultCounts: Record<string, number> = {};
+  let occludedReps = 0;
+  let lowConfidenceReps = 0;
+  let bestRepIndex: number | null = null;
+  let worstRepIndex: number | null = null;
+  let bestFqi: number | null = null;
+  let worstFqi: number | null = null;
+
+  for (const entry of entries) {
+    for (const fault of entry.faults) {
+      faultCounts[fault] = (faultCounts[fault] ?? 0) + 1;
+    }
+    if (entry.occluded) occludedReps++;
+    if (typeof entry.minJointConfidence === 'number' && entry.minJointConfidence < DEFAULT_LOW_CONFIDENCE) {
+      lowConfidenceReps++;
+    }
+    if (typeof entry.fqi === 'number' && Number.isFinite(entry.fqi)) {
+      if (bestFqi === null || entry.fqi > bestFqi) {
+        bestFqi = entry.fqi;
+        bestRepIndex = entry.repIndex;
+      }
+      if (worstFqi === null || entry.fqi < worstFqi) {
+        worstFqi = entry.fqi;
+        worstRepIndex = entry.repIndex;
+      }
+    }
+  }
+
+  return {
+    totalReps: entries.length,
+    avgFqi: mean(fqis),
+    medianFqi: median(fqis),
+    faultCounts,
+    occludedReps,
+    lowConfidenceReps,
+    bestRepIndex,
+    worstRepIndex,
+    bestFqi,
+    worstFqi,
+  };
+}
+
+function repSegment(entry: RepQualityEntry): TimelineSegment {
+  const parts: string[] = [`Rep ${entry.repIndex}`];
+  if (typeof entry.fqi === 'number') {
+    parts.push(`FQI ${entry.fqi}`);
+  }
+  return {
+    type: 'rep',
+    repIndex: entry.repIndex,
+    ts: entry.ts,
+    fqi: entry.fqi,
+    faults: [...entry.faults],
+    message: parts.join(' · '),
+  };
+}
+
+function faultSegment(entry: RepQualityEntry): TimelineSegment {
+  const faultLabel = entry.faults.length === 1
+    ? entry.faults[0]
+    : `${entry.faults.length} faults`;
+  return {
+    type: 'fault',
+    repIndex: entry.repIndex,
+    ts: entry.ts,
+    fqi: entry.fqi,
+    faults: [...entry.faults],
+    message: `Rep ${entry.repIndex} · ${faultLabel}`,
+  };
+}
+
+function trackingLossSegment(entry: RepQualityEntry): TimelineSegment {
+  return {
+    type: 'tracking-loss',
+    repIndex: entry.repIndex,
+    ts: entry.ts,
+    message: `Rep ${entry.repIndex} · tracking lost`,
+  };
+}
+
+function lowConfidenceSegment(entry: RepQualityEntry, threshold: number): TimelineSegment {
+  const confidence = typeof entry.minJointConfidence === 'number'
+    ? entry.minJointConfidence
+    : threshold;
+  const joint = entry.minConfidenceJoint ? ` · ${entry.minConfidenceJoint}` : '';
+  return {
+    type: 'low-confidence',
+    repIndex: entry.repIndex,
+    ts: entry.ts,
+    message: `Rep ${entry.repIndex} · low confidence (${Math.round(confidence * 100)}%)${joint}`,
+  };
+}
+
+function highConfidenceSegment(entry: RepQualityEntry): TimelineSegment {
+  return {
+    type: 'high-confidence',
+    repIndex: entry.repIndex,
+    ts: entry.ts,
+    fqi: entry.fqi,
+    message: `Rep ${entry.repIndex} · clean rep (FQI ${entry.fqi})`,
+  };
+}
+
+export function buildRepQualityTimeline(
+  entries: RepQualityEntry[],
+  options: BuildTimelineOptions & { sessionId?: string } = {}
+): RepQualityTimeline {
+  const lowConfidenceThreshold = options.lowConfidenceThreshold ?? DEFAULT_LOW_CONFIDENCE;
+  const highFqi = options.highConfidenceFqi ?? DEFAULT_HIGH_FQI;
+
+  const filtered = options.sessionId
+    ? entries.filter((e) => e.sessionId === options.sessionId)
+    : entries;
+
+  const sorted = [...filtered].sort((a, b) => {
+    if (a.ts !== b.ts) return a.ts.localeCompare(b.ts);
+    return a.repIndex - b.repIndex;
+  });
+
+  const segments: TimelineSegment[] = [];
+  for (const entry of sorted) {
+    segments.push(repSegment(entry));
+    if (entry.occluded) {
+      segments.push(trackingLossSegment(entry));
+    }
+    if (entry.faults.length > 0) {
+      segments.push(faultSegment(entry));
+    }
+    if (
+      typeof entry.minJointConfidence === 'number' &&
+      entry.minJointConfidence < lowConfidenceThreshold
+    ) {
+      segments.push(lowConfidenceSegment(entry, lowConfidenceThreshold));
+    }
+    if (typeof entry.fqi === 'number' && entry.fqi >= highFqi && entry.faults.length === 0) {
+      segments.push(highConfidenceSegment(entry));
+    }
+  }
+
+  const summary = buildSummary(sorted);
+
+  return {
+    sessionId: options.sessionId ?? sorted[0]?.sessionId ?? null,
+    startTs: sorted[0]?.ts ?? null,
+    endTs: sorted[sorted.length - 1]?.ts ?? null,
+    segments,
+    summary,
+  };
+}
+
+/**
+ * One-line human-readable summary of a timeline suitable for a coach prompt
+ * or a compact card caption.
+ */
+export function summarizeTimeline(timeline: RepQualityTimeline): string {
+  const { summary } = timeline;
+  if (summary.totalReps === 0) return 'No reps recorded.';
+
+  const parts: string[] = [`${summary.totalReps} reps`];
+  if (summary.avgFqi !== null) {
+    parts.push(`avg FQI ${summary.avgFqi}`);
+  }
+  const topFault = Object.entries(summary.faultCounts).sort((a, b) => b[1] - a[1])[0];
+  if (topFault) {
+    parts.push(`top fault: ${topFault[0]} (×${topFault[1]})`);
+  }
+  if (summary.occludedReps > 0) {
+    parts.push(`${summary.occludedReps} occluded`);
+  }
+  return parts.join(' · ');
+}

--- a/tests/unit/components/form-tracking/LiveJointConfidenceBadge.test.tsx
+++ b/tests/unit/components/form-tracking/LiveJointConfidenceBadge.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import LiveJointConfidenceBadge, {
+  tierForConfidence,
+} from '@/components/form-tracking/LiveJointConfidenceBadge';
+
+describe('tierForConfidence', () => {
+  it('returns unknown for null or NaN confidence', () => {
+    expect(tierForConfidence(null)).toBe('unknown');
+    expect(tierForConfidence(Number.NaN)).toBe('unknown');
+  });
+
+  it('returns critical under the critical threshold', () => {
+    expect(tierForConfidence(0.1)).toBe('critical');
+    expect(tierForConfidence(0.0)).toBe('critical');
+  });
+
+  it('returns warning between critical and warning thresholds', () => {
+    expect(tierForConfidence(0.25)).toBe('warning');
+    expect(tierForConfidence(0.39)).toBe('warning');
+  });
+
+  it('returns good at or above the warning threshold', () => {
+    expect(tierForConfidence(0.4)).toBe('good');
+    expect(tierForConfidence(0.95)).toBe('good');
+  });
+
+  it('respects custom thresholds', () => {
+    expect(tierForConfidence(0.55, { warning: 0.6, critical: 0.3 })).toBe('warning');
+    expect(tierForConfidence(0.2, { warning: 0.6, critical: 0.3 })).toBe('critical');
+  });
+});
+
+describe('LiveJointConfidenceBadge', () => {
+  it('renders the joint label and percent', () => {
+    const { getByText } = render(
+      <LiveJointConfidenceBadge joint="left_knee" confidence={0.42} />
+    );
+    expect(getByText(/L knee confidence 42%/)).toBeTruthy();
+  });
+
+  it('handles a right-side joint', () => {
+    const { getByText } = render(
+      <LiveJointConfidenceBadge joint="right_elbow" confidence={0.8} />
+    );
+    expect(getByText(/R elbow confidence 80%/)).toBeTruthy();
+  });
+
+  it('shows an em-dash when confidence is null', () => {
+    const { getByText } = render(
+      <LiveJointConfidenceBadge joint="left_knee" confidence={null} />
+    );
+    expect(getByText(/—/)).toBeTruthy();
+  });
+
+  it('omits joint name when joint is null but still shows confidence', () => {
+    const { getByText } = render(
+      <LiveJointConfidenceBadge joint={null} confidence={0.9} />
+    );
+    expect(getByText(/Joint confidence 90%/)).toBeTruthy();
+  });
+
+  it('uses the warning accent color for warning-tier confidence', () => {
+    const { getByTestId } = render(
+      <LiveJointConfidenceBadge joint="left_knee" confidence={0.3} testID="badge" />
+    );
+    const el = getByTestId('badge');
+    const styles = Array.isArray(el.props.style) ? el.props.style : [el.props.style];
+    const merged = Object.assign({}, ...styles);
+    expect(merged.borderColor).toBe('#FFB800');
+  });
+
+  it('uses the critical accent color for critical-tier confidence', () => {
+    const { getByTestId } = render(
+      <LiveJointConfidenceBadge joint="left_knee" confidence={0.1} testID="badge" />
+    );
+    const el = getByTestId('badge');
+    const styles = Array.isArray(el.props.style) ? el.props.style : [el.props.style];
+    const merged = Object.assign({}, ...styles);
+    expect(merged.borderColor).toBe('#FF4C4C');
+  });
+
+  it('uses the good accent color for good-tier confidence', () => {
+    const { getByTestId } = render(
+      <LiveJointConfidenceBadge joint="left_knee" confidence={0.85} testID="badge" />
+    );
+    const el = getByTestId('badge');
+    const styles = Array.isArray(el.props.style) ? el.props.style : [el.props.style];
+    const merged = Object.assign({}, ...styles);
+    expect(merged.borderColor).toBe('#3CC8A9');
+  });
+
+  it('uses the unknown accent color when confidence is missing', () => {
+    const { getByTestId } = render(
+      <LiveJointConfidenceBadge joint="left_knee" confidence={null} testID="badge" />
+    );
+    const el = getByTestId('badge');
+    const styles = Array.isArray(el.props.style) ? el.props.style : [el.props.style];
+    const merged = Object.assign({}, ...styles);
+    expect(merged.borderColor).toBe('#9CA3AF');
+  });
+});

--- a/tests/unit/components/form-tracking/RepQualityDot.test.tsx
+++ b/tests/unit/components/form-tracking/RepQualityDot.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import RepQualityDot, { colorForFqi } from '@/components/form-tracking/RepQualityDot';
+
+describe('colorForFqi', () => {
+  it('returns teal for high scores', () => {
+    expect(colorForFqi(95)).toBe('#3CC8A9');
+    expect(colorForFqi(85)).toBe('#3CC8A9');
+  });
+
+  it('returns amber for mid scores', () => {
+    expect(colorForFqi(84)).toBe('#FFB800');
+    expect(colorForFqi(65)).toBe('#FFB800');
+  });
+
+  it('returns red for low scores', () => {
+    expect(colorForFqi(64)).toBe('#FF4C4C');
+    expect(colorForFqi(0)).toBe('#FF4C4C');
+  });
+
+  it('returns grey for null or non-finite fqi', () => {
+    expect(colorForFqi(null)).toBe('#6B7280');
+    expect(colorForFqi(Number.NaN)).toBe('#6B7280');
+    expect(colorForFqi(Number.POSITIVE_INFINITY)).toBe('#6B7280');
+  });
+});
+
+describe('RepQualityDot', () => {
+  it('renders with an accessibility label reflecting FQI', () => {
+    const { getByLabelText } = render(<RepQualityDot fqi={82} testID="dot" />);
+    expect(getByLabelText('Rep FQI 82')).toBeTruthy();
+  });
+
+  it('labels the dot as "FQI unavailable" when fqi is null', () => {
+    const { getByLabelText } = render(<RepQualityDot fqi={null} />);
+    expect(getByLabelText('Rep FQI unavailable')).toBeTruthy();
+  });
+
+  it('includes "has faults" in the label when hasFaults is true', () => {
+    const { getByLabelText } = render(<RepQualityDot fqi={50} hasFaults />);
+    expect(getByLabelText(/has faults/)).toBeTruthy();
+  });
+
+  it('includes "occluded" in the label when occluded is true', () => {
+    const { getByLabelText } = render(<RepQualityDot fqi={50} occluded />);
+    expect(getByLabelText(/occluded/)).toBeTruthy();
+  });
+
+  it('honors custom size prop', () => {
+    const { getByTestId } = render(<RepQualityDot fqi={90} size={24} testID="dot" />);
+    const el = getByTestId('dot');
+    expect(el.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ width: 24, height: 24, borderRadius: 12 })])
+    );
+  });
+
+  it('applies the fqi color to the dot background', () => {
+    const { getByTestId } = render(<RepQualityDot fqi={92} testID="dot" />);
+    const el = getByTestId('dot');
+    expect(el.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: '#3CC8A9' })])
+    );
+  });
+});

--- a/tests/unit/components/form-tracking/RepTimelineCard.test.tsx
+++ b/tests/unit/components/form-tracking/RepTimelineCard.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import RepTimelineCard from '@/components/form-tracking/RepTimelineCard';
+import {
+  buildRepQualityTimeline,
+} from '@/lib/services/rep-quality-timeline';
+import type { RepQualityEntry } from '@/lib/services/rep-quality-log';
+
+function mkEntry(partial: Partial<RepQualityEntry> = {}): RepQualityEntry {
+  return {
+    sessionId: 's1',
+    repIndex: partial.repIndex ?? 1,
+    exercise: 'squat',
+    ts: partial.ts ?? `2026-04-17T09:00:0${partial.repIndex ?? 1}.000Z`,
+    fqi: 80,
+    faults: [],
+    ...partial,
+  };
+}
+
+describe('RepTimelineCard', () => {
+  it('renders the default title and empty state when the timeline has no reps', () => {
+    const timeline = buildRepQualityTimeline([]);
+    const { getByText } = render(<RepTimelineCard timeline={timeline} />);
+    expect(getByText('Rep timeline')).toBeTruthy();
+    expect(getByText('No reps recorded yet.')).toBeTruthy();
+  });
+
+  it('renders a custom title when provided', () => {
+    const timeline = buildRepQualityTimeline([]);
+    const { getByText } = render(<RepTimelineCard timeline={timeline} title="Today's session" />);
+    expect(getByText("Today's session")).toBeTruthy();
+  });
+
+  it('renders a rep-count subtitle with avg FQI when reps are present', () => {
+    const timeline = buildRepQualityTimeline([
+      mkEntry({ repIndex: 1, fqi: 80 }),
+      mkEntry({ repIndex: 2, fqi: 90 }),
+    ]);
+    const { getByText } = render(<RepTimelineCard timeline={timeline} />);
+    expect(getByText(/2 reps/)).toBeTruthy();
+    expect(getByText(/avg FQI 85/)).toBeTruthy();
+  });
+
+  it('renders one rep segment per rep and a fault hint when faults are present', () => {
+    const timeline = buildRepQualityTimeline([
+      mkEntry({ repIndex: 1, fqi: 50, faults: ['forward_knee'] }),
+    ]);
+    const { getAllByText, getByText } = render(<RepTimelineCard timeline={timeline} />);
+    // Rep segment
+    expect(getByText(/Rep 1 · FQI 50/)).toBeTruthy();
+    // Fault segment plus fault hint
+    expect(getAllByText(/forward_knee/).length).toBeGreaterThan(0);
+  });
+
+  it('surfaces a tracking-lost segment with an explanatory hint', () => {
+    const timeline = buildRepQualityTimeline([mkEntry({ repIndex: 1, occluded: true })]);
+    const { getAllByText } = render(<RepTimelineCard timeline={timeline} />);
+    expect(getAllByText(/tracking lost/).length).toBeGreaterThan(0);
+  });
+
+  it('fires onSelectSegment with the tapped segment', () => {
+    const timeline = buildRepQualityTimeline([
+      mkEntry({ repIndex: 1, fqi: 80 }),
+      mkEntry({ repIndex: 2, fqi: 90, faults: ['shallow'] }),
+    ]);
+    const onSelect = jest.fn();
+    const { getAllByRole } = render(
+      <RepTimelineCard timeline={timeline} onSelectSegment={onSelect} />
+    );
+    const buttons = getAllByRole('button');
+    expect(buttons.length).toBeGreaterThanOrEqual(3); // 2 reps + 1 fault
+    fireEvent.press(buttons[0]);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].type).toBe('rep');
+    expect(onSelect.mock.calls[0][0].repIndex).toBe(1);
+  });
+
+  it('renders non-interactive rows when onSelectSegment is omitted', () => {
+    const timeline = buildRepQualityTimeline([mkEntry({ repIndex: 1 })]);
+    const { queryAllByRole } = render(<RepTimelineCard timeline={timeline} />);
+    expect(queryAllByRole('button')).toHaveLength(0);
+  });
+});

--- a/tests/unit/hooks/use-coach-session-signals.test.tsx
+++ b/tests/unit/hooks/use-coach-session-signals.test.tsx
@@ -1,0 +1,68 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { createRepQualityLog, type RepQualityEntry } from '@/lib/services/rep-quality-log';
+import { useCoachSessionSignals } from '@/hooks/use-coach-session-signals';
+
+function mkEntry(partial: Partial<RepQualityEntry> = {}): RepQualityEntry {
+  return {
+    sessionId: 's1',
+    repIndex: partial.repIndex ?? 1,
+    exercise: 'squat',
+    ts: `2026-04-17T09:00:0${partial.repIndex ?? 1}.000Z`,
+    fqi: 70,
+    faults: [],
+    ...partial,
+  };
+}
+
+describe('useCoachSessionSignals', () => {
+  it('returns an empty-session shape when the log has no entries', () => {
+    const log = createRepQualityLog();
+    const { result } = renderHook(() => useCoachSessionSignals({ log }));
+    expect(result.current.totalReps).toBe(0);
+    expect(result.current.fqiTrend).toBe('insufficient-data');
+    expect(result.current.recentFaults).toEqual([]);
+  });
+
+  it('rebuilds signals when new entries are appended', () => {
+    const log = createRepQualityLog();
+    const { result } = renderHook(() => useCoachSessionSignals({ log }));
+    act(() => {
+      log.append(mkEntry({ repIndex: 1, fqi: 60, faults: ['forward_knee'] }));
+      log.append(mkEntry({ repIndex: 2, fqi: 65, faults: ['forward_knee'] }));
+      log.append(mkEntry({ repIndex: 3, fqi: 80, faults: [] }));
+      log.append(mkEntry({ repIndex: 4, fqi: 85, faults: [] }));
+    });
+    expect(result.current.totalReps).toBe(4);
+    expect(result.current.fqiTrend).toBe('improving');
+    expect(result.current.faultFrequency).toEqual({ forward_knee: 2 });
+  });
+
+  it('filters by sessionId', () => {
+    const log = createRepQualityLog();
+    log.append(mkEntry({ sessionId: 'a', repIndex: 1 }));
+    log.append(mkEntry({ sessionId: 'b', repIndex: 1 }));
+    const { result } = renderHook(() => useCoachSessionSignals({ log, sessionId: 'a' }));
+    expect(result.current.totalReps).toBe(1);
+    expect(result.current.sessionId).toBe('a');
+  });
+
+  it('respects windowSize for recentFaults', () => {
+    const log = createRepQualityLog();
+    log.append(mkEntry({ repIndex: 1, faults: ['early'] }));
+    log.append(mkEntry({ repIndex: 2, faults: [] }));
+    log.append(mkEntry({ repIndex: 3, faults: [] }));
+    log.append(mkEntry({ repIndex: 4, faults: [] }));
+    log.append(mkEntry({ repIndex: 5, faults: ['late'] }));
+    const { result } = renderHook(() => useCoachSessionSignals({ log, windowSize: 2 }));
+    expect(result.current.recentFaults).toEqual(['late']);
+  });
+
+  it('memoizes signals between renders without log changes', () => {
+    const log = createRepQualityLog();
+    log.append(mkEntry({ repIndex: 1 }));
+    const { result, rerender } = renderHook(() => useCoachSessionSignals({ log }));
+    const first = result.current;
+    rerender({});
+    expect(result.current).toBe(first);
+  });
+});

--- a/tests/unit/hooks/use-rep-quality-log.test.tsx
+++ b/tests/unit/hooks/use-rep-quality-log.test.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { createRepQualityLog, type RepQualityEntry } from '@/lib/services/rep-quality-log';
+import { useRepQualityLog } from '@/hooks/use-rep-quality-log';
+
+function mkEntry(partial: Partial<RepQualityEntry> = {}): RepQualityEntry {
+  return {
+    sessionId: 's1',
+    repIndex: partial.repIndex ?? 1,
+    exercise: 'pullup',
+    ts: `2026-04-17T09:00:0${partial.repIndex ?? 1}.000Z`,
+    fqi: 80,
+    faults: [],
+    ...partial,
+  };
+}
+
+describe('useRepQualityLog', () => {
+  it('returns empty state when the log has no entries', () => {
+    const log = createRepQualityLog();
+    const { result } = renderHook(() => useRepQualityLog({ log }));
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.latest).toBeNull();
+    expect(result.current.size).toBe(0);
+  });
+
+  it('re-renders when a new entry is appended', () => {
+    const log = createRepQualityLog();
+    const { result } = renderHook(() => useRepQualityLog({ log }));
+    act(() => {
+      log.append(mkEntry({ repIndex: 1 }));
+    });
+    expect(result.current.size).toBe(1);
+    expect(result.current.latest?.repIndex).toBe(1);
+  });
+
+  it('re-renders when the log is cleared', () => {
+    const log = createRepQualityLog();
+    log.append(mkEntry({ repIndex: 1 }));
+    const { result } = renderHook(() => useRepQualityLog({ log }));
+    expect(result.current.size).toBe(1);
+    act(() => {
+      log.clear();
+    });
+    expect(result.current.size).toBe(0);
+    expect(result.current.latest).toBeNull();
+  });
+
+  it('filters entries by sessionId when provided', () => {
+    const log = createRepQualityLog();
+    log.append(mkEntry({ sessionId: 'a', repIndex: 1 }));
+    log.append(mkEntry({ sessionId: 'b', repIndex: 1 }));
+    const { result } = renderHook(() => useRepQualityLog({ log, sessionId: 'a' }));
+    expect(result.current.entries).toHaveLength(1);
+    expect(result.current.entries[0].sessionId).toBe('a');
+    expect(result.current.latest?.sessionId).toBe('a');
+  });
+
+  it('unsubscribes on unmount so stale listeners are not left behind', () => {
+    const log = createRepQualityLog();
+    const originalSubscribe = log.subscribe.bind(log);
+    const unsubscribes: jest.Mock[] = [];
+    log.subscribe = (listener) => {
+      const unsub = jest.fn(originalSubscribe(listener));
+      unsubscribes.push(unsub);
+      return unsub;
+    };
+    const { unmount } = renderHook(() => useRepQualityLog({ log }));
+    unmount();
+    expect(unsubscribes.some((u) => u.mock.calls.length > 0)).toBe(true);
+  });
+});

--- a/tests/unit/hooks/use-rep-quality-timeline.test.tsx
+++ b/tests/unit/hooks/use-rep-quality-timeline.test.tsx
@@ -1,0 +1,62 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { createRepQualityLog, type RepQualityEntry } from '@/lib/services/rep-quality-log';
+import { useRepQualityTimeline } from '@/hooks/use-rep-quality-timeline';
+
+function mkEntry(partial: Partial<RepQualityEntry> = {}): RepQualityEntry {
+  return {
+    sessionId: 's1',
+    repIndex: partial.repIndex ?? 1,
+    exercise: 'squat',
+    ts: `2026-04-17T09:00:0${partial.repIndex ?? 1}.000Z`,
+    fqi: 80,
+    faults: [],
+    ...partial,
+  };
+}
+
+describe('useRepQualityTimeline', () => {
+  it('returns an empty timeline when the log is empty', () => {
+    const log = createRepQualityLog();
+    const { result } = renderHook(() => useRepQualityTimeline({ log }));
+    expect(result.current.summary.totalReps).toBe(0);
+    expect(result.current.segments).toHaveLength(0);
+  });
+
+  it('rebuilds the timeline when entries are appended', () => {
+    const log = createRepQualityLog();
+    const { result } = renderHook(() => useRepQualityTimeline({ log }));
+    act(() => {
+      log.append(mkEntry({ repIndex: 1, fqi: 80 }));
+      log.append(mkEntry({ repIndex: 2, fqi: 90, faults: [] }));
+    });
+    expect(result.current.summary.totalReps).toBe(2);
+    expect(result.current.summary.avgFqi).toBe(85);
+  });
+
+  it('filters by sessionId', () => {
+    const log = createRepQualityLog();
+    log.append(mkEntry({ sessionId: 'a', repIndex: 1, fqi: 60 }));
+    log.append(mkEntry({ sessionId: 'b', repIndex: 1, fqi: 90 }));
+    const { result } = renderHook(() => useRepQualityTimeline({ log, sessionId: 'a' }));
+    expect(result.current.summary.totalReps).toBe(1);
+    expect(result.current.summary.avgFqi).toBe(60);
+  });
+
+  it('respects threshold options', () => {
+    const log = createRepQualityLog();
+    log.append(mkEntry({ repIndex: 1, fqi: 75, faults: [] }));
+    const { result } = renderHook(() =>
+      useRepQualityTimeline({ log, highConfidenceFqi: 70 })
+    );
+    expect(result.current.segments.some((s) => s.type === 'high-confidence')).toBe(true);
+  });
+
+  it('memoizes the timeline object between renders without log changes', () => {
+    const log = createRepQualityLog();
+    log.append(mkEntry({ repIndex: 1 }));
+    const { result, rerender } = renderHook(() => useRepQualityTimeline({ log }));
+    const first = result.current;
+    rerender({});
+    expect(result.current).toBe(first);
+  });
+});

--- a/tests/unit/screens/rep-timeline.test.tsx
+++ b/tests/unit/screens/rep-timeline.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import RepTimelineScreen from '@/app/(modals)/rep-timeline';
+import {
+  defaultRepQualityLog,
+  type RepQualityEntry,
+} from '@/lib/services/rep-quality-log';
+
+const mockRouter = {
+  back: jest.fn(),
+  replace: jest.fn(),
+  canGoBack: jest.fn(() => true),
+};
+
+let mockSearchParams: { sessionId?: string } = {};
+
+jest.mock('expo-router', () => ({
+  useRouter: () => mockRouter,
+  useLocalSearchParams: () => mockSearchParams,
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children, ...props }: { children: React.ReactNode }) => {
+    const { View } = jest.requireActual('react-native');
+    return <View {...props}>{children}</View>;
+  },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: ({ name }: { name: string }) => {
+    const { Text } = jest.requireActual('react-native');
+    return <Text>icon:{name}</Text>;
+  },
+}));
+
+function mkEntry(partial: Partial<RepQualityEntry> = {}): RepQualityEntry {
+  return {
+    sessionId: 'session-x',
+    repIndex: partial.repIndex ?? 1,
+    exercise: 'squat',
+    ts: `2026-04-17T09:00:0${partial.repIndex ?? 1}.000Z`,
+    fqi: 80,
+    faults: [],
+    ...partial,
+  };
+}
+
+describe('RepTimelineScreen', () => {
+  beforeEach(() => {
+    mockSearchParams = {};
+    mockRouter.back.mockReset();
+    mockRouter.replace.mockReset();
+    mockRouter.canGoBack.mockReset().mockReturnValue(true);
+    defaultRepQualityLog.clear();
+  });
+
+  it('shows a missing-session message when the sessionId param is absent', () => {
+    const { getByText } = render(<RepTimelineScreen />);
+    expect(getByText('Missing session')).toBeTruthy();
+  });
+
+  it('renders the rep timeline card when a sessionId is provided', () => {
+    mockSearchParams = { sessionId: 'session-x' };
+    defaultRepQualityLog.append(mkEntry({ repIndex: 1, fqi: 80 }));
+    defaultRepQualityLog.append(mkEntry({ repIndex: 2, fqi: 90 }));
+    const { getByTestId, getAllByText } = render(<RepTimelineScreen />);
+    expect(getByTestId('rep-timeline-card')).toBeTruthy();
+    expect(getAllByText(/2 reps/).length).toBeGreaterThan(0);
+  });
+
+  it('renders the empty-state caption inside the card when the session has no entries', () => {
+    mockSearchParams = { sessionId: 'session-empty' };
+    const { getByText } = render(<RepTimelineScreen />);
+    expect(getByText('No reps recorded yet.')).toBeTruthy();
+  });
+
+  it('updates when the log receives new entries', () => {
+    mockSearchParams = { sessionId: 'session-x' };
+    const { getAllByText, queryAllByText, rerender } = render(<RepTimelineScreen />);
+    // Card subtitle hides the "N reps" suffix when empty; only the empty-state label shows.
+    expect(queryAllByText(/\d+ reps/)).toHaveLength(0);
+    act(() => {
+      defaultRepQualityLog.append(mkEntry({ repIndex: 1 }));
+    });
+    rerender(<RepTimelineScreen />);
+    expect(getAllByText(/1 reps/).length).toBeGreaterThan(0);
+  });
+
+  it('navigates back when the close button is pressed and canGoBack is true', () => {
+    mockSearchParams = { sessionId: 'session-x' };
+    const { getByLabelText } = render(<RepTimelineScreen />);
+    fireEvent.press(getByLabelText('Close rep timeline'));
+    expect(mockRouter.back).toHaveBeenCalledTimes(1);
+    expect(mockRouter.replace).not.toHaveBeenCalled();
+  });
+
+  it('falls back to replace("/") when there is no navigation stack', () => {
+    mockSearchParams = { sessionId: 'session-x' };
+    mockRouter.canGoBack.mockReturnValue(false);
+    const { getByLabelText } = render(<RepTimelineScreen />);
+    fireEvent.press(getByLabelText('Close rep timeline'));
+    expect(mockRouter.replace).toHaveBeenCalledWith('/');
+  });
+});

--- a/tests/unit/services/coach-fallback-responses.test.ts
+++ b/tests/unit/services/coach-fallback-responses.test.ts
@@ -1,0 +1,126 @@
+import {
+  getFallbackCoachResponse,
+  prioritizeFallbackReasons,
+  type FallbackContext,
+} from '@/lib/services/coach-fallback-responses';
+
+function ctx(partial: Partial<FallbackContext>): FallbackContext {
+  return { reason: 'offline', ...partial };
+}
+
+describe('getFallbackCoachResponse', () => {
+  it('returns an offline message with an offline retry hint', () => {
+    const resp = getFallbackCoachResponse(ctx({ reason: 'offline' }));
+    expect(resp.message).toContain('offline');
+    expect(resp.message).toContain('sync up');
+    expect(resp.severity).toBe('warning');
+    expect(resp.retryable).toBe(false);
+  });
+
+  it('returns a rate-limited message at info severity', () => {
+    const resp = getFallbackCoachResponse(ctx({ reason: 'rate-limited' }));
+    expect(resp.message.toLowerCase()).toContain('catching up');
+    expect(resp.severity).toBe('info');
+    expect(resp.retryable).toBe(true);
+  });
+
+  it('returns a server-error message at warning severity', () => {
+    const resp = getFallbackCoachResponse(ctx({ reason: 'server-error' }));
+    expect(resp.message.toLowerCase()).toContain('hiccup');
+    expect(resp.severity).toBe('warning');
+    expect(resp.retryable).toBe(true);
+  });
+
+  it('returns a timeout message at warning severity', () => {
+    const resp = getFallbackCoachResponse(ctx({ reason: 'timeout' }));
+    expect(resp.message.toLowerCase()).toContain('too long');
+    expect(resp.severity).toBe('warning');
+    expect(resp.retryable).toBe(true);
+  });
+
+  it('adds a high-FQI cue for clean reps', () => {
+    const resp = getFallbackCoachResponse(ctx({ reason: 'rate-limited', latestFqi: 92 }));
+    expect(resp.message.toLowerCase()).toContain('clean');
+  });
+
+  it('adds a mid-FQI cue for middling reps', () => {
+    const resp = getFallbackCoachResponse(ctx({ reason: 'rate-limited', latestFqi: 72 }));
+    expect(resp.message.toLowerCase()).toContain('tempo');
+  });
+
+  it('adds a low-FQI cue for rough reps', () => {
+    const resp = getFallbackCoachResponse(ctx({ reason: 'rate-limited', latestFqi: 40 }));
+    expect(resp.message.toLowerCase()).toContain('reset');
+  });
+
+  it('skips fqi guidance when latestFqi is null or undefined', () => {
+    const a = getFallbackCoachResponse(ctx({ reason: 'rate-limited' }));
+    const b = getFallbackCoachResponse(ctx({ reason: 'rate-limited', latestFqi: null }));
+    expect(a.message).not.toContain('tempo');
+    expect(b.message).not.toContain('tempo');
+  });
+
+  it('skips fqi guidance when latestFqi is NaN', () => {
+    const resp = getFallbackCoachResponse(ctx({ reason: 'rate-limited', latestFqi: Number.NaN }));
+    expect(resp.message).not.toContain('tempo');
+  });
+
+  it('surfaces a recent fault when present', () => {
+    const resp = getFallbackCoachResponse(
+      ctx({ reason: 'server-error', recentFaults: ['forward_knee'], exercise: 'squat' })
+    );
+    expect(resp.message).toContain('forward knee');
+    expect(resp.message).toContain('squat');
+  });
+
+  it('humanizes camelCase fault names', () => {
+    const resp = getFallbackCoachResponse(
+      ctx({ reason: 'server-error', recentFaults: ['hipsRiseFirst'] })
+    );
+    expect(resp.message.toLowerCase()).toContain('hips rise first');
+  });
+
+  it('omits exercise reference when exercise is absent', () => {
+    const resp = getFallbackCoachResponse(
+      ctx({ reason: 'server-error', recentFaults: ['shallow_depth'] })
+    );
+    expect(resp.message.toLowerCase()).toContain('shallow depth');
+    expect(resp.message.toLowerCase()).not.toContain('on undefined');
+    expect(resp.message.toLowerCase()).not.toContain('on null');
+  });
+
+  it('combines fqi guidance and fault guidance when both are present', () => {
+    const resp = getFallbackCoachResponse(
+      ctx({ reason: 'timeout', latestFqi: 70, recentFaults: ['shallow_depth'], exercise: 'squat' })
+    );
+    expect(resp.message.toLowerCase()).toContain('tempo');
+    expect(resp.message).toContain('shallow depth');
+  });
+
+  it('includes a retry hint for retryable reasons', () => {
+    const resp = getFallbackCoachResponse(ctx({ reason: 'rate-limited' }));
+    expect(resp.message).toContain('Tap the coach again');
+  });
+});
+
+describe('prioritizeFallbackReasons', () => {
+  it('returns null for an empty list', () => {
+    expect(prioritizeFallbackReasons([])).toBeNull();
+  });
+
+  it('picks offline over all other reasons', () => {
+    expect(prioritizeFallbackReasons(['rate-limited', 'offline', 'timeout'])).toBe('offline');
+  });
+
+  it('picks server-error over timeout and rate-limited', () => {
+    expect(prioritizeFallbackReasons(['rate-limited', 'timeout', 'server-error'])).toBe('server-error');
+  });
+
+  it('picks timeout over rate-limited', () => {
+    expect(prioritizeFallbackReasons(['rate-limited', 'timeout'])).toBe('timeout');
+  });
+
+  it('returns the only reason when just one is given', () => {
+    expect(prioritizeFallbackReasons(['rate-limited'])).toBe('rate-limited');
+  });
+});

--- a/tests/unit/services/coach-session-signals.test.ts
+++ b/tests/unit/services/coach-session-signals.test.ts
@@ -1,0 +1,222 @@
+import {
+  buildCoachSessionSignals,
+  formatSignalsForPrompt,
+} from '@/lib/services/coach-session-signals';
+import type { RepQualityEntry } from '@/lib/services/rep-quality-log';
+
+function mkEntry(partial: Partial<RepQualityEntry> = {}): RepQualityEntry {
+  return {
+    sessionId: 's1',
+    repIndex: partial.repIndex ?? 1,
+    exercise: partial.exercise ?? 'squat',
+    ts: partial.ts ?? `2026-04-17T09:00:0${partial.repIndex ?? 1}.000Z`,
+    fqi: 80,
+    faults: [],
+    ...partial,
+  };
+}
+
+describe('buildCoachSessionSignals', () => {
+  it('returns an empty-session shape when the input is empty', () => {
+    const signals = buildCoachSessionSignals([]);
+    expect(signals).toEqual({
+      sessionId: null,
+      exercise: null,
+      totalReps: 0,
+      avgFqi: null,
+      latestFqi: null,
+      fqiTrend: 'insufficient-data',
+      recentFaults: [],
+      faultFrequency: {},
+      occludedRepCount: 0,
+      lowConfidenceRepCount: 0,
+      lastEntryTs: null,
+    });
+  });
+
+  it('filters by sessionId when provided', () => {
+    const signals = buildCoachSessionSignals(
+      [
+        mkEntry({ sessionId: 'a', repIndex: 1 }),
+        mkEntry({ sessionId: 'b', repIndex: 1 }),
+        mkEntry({ sessionId: 'a', repIndex: 2 }),
+      ],
+      { sessionId: 'a' }
+    );
+    expect(signals.totalReps).toBe(2);
+    expect(signals.sessionId).toBe('a');
+  });
+
+  it('derives exercise from the latest entry', () => {
+    const signals = buildCoachSessionSignals([
+      mkEntry({ repIndex: 1, exercise: 'squat' }),
+      mkEntry({ repIndex: 2, exercise: 'squat' }),
+      mkEntry({ repIndex: 3, exercise: 'squat' }),
+    ]);
+    expect(signals.exercise).toBe('squat');
+  });
+
+  it('computes avg and latest FQI', () => {
+    const signals = buildCoachSessionSignals([
+      mkEntry({ repIndex: 1, fqi: 60 }),
+      mkEntry({ repIndex: 2, fqi: 70 }),
+      mkEntry({ repIndex: 3, fqi: 80 }),
+    ]);
+    expect(signals.avgFqi).toBe(70);
+    expect(signals.latestFqi).toBe(80);
+  });
+
+  it('ignores null FQI in avg calculation', () => {
+    const signals = buildCoachSessionSignals([
+      mkEntry({ repIndex: 1, fqi: null }),
+      mkEntry({ repIndex: 2, fqi: 80 }),
+    ]);
+    expect(signals.avgFqi).toBe(80);
+    expect(signals.latestFqi).toBe(80);
+  });
+
+  it('returns insufficient-data trend with fewer than 4 reps', () => {
+    const signals = buildCoachSessionSignals([
+      mkEntry({ repIndex: 1, fqi: 60 }),
+      mkEntry({ repIndex: 2, fqi: 70 }),
+      mkEntry({ repIndex: 3, fqi: 80 }),
+    ]);
+    expect(signals.fqiTrend).toBe('insufficient-data');
+  });
+
+  it('detects an improving trend when the recent half is higher', () => {
+    const signals = buildCoachSessionSignals([
+      mkEntry({ repIndex: 1, fqi: 50 }),
+      mkEntry({ repIndex: 2, fqi: 55 }),
+      mkEntry({ repIndex: 3, fqi: 75 }),
+      mkEntry({ repIndex: 4, fqi: 85 }),
+    ]);
+    expect(signals.fqiTrend).toBe('improving');
+  });
+
+  it('detects a declining trend when the recent half is lower', () => {
+    const signals = buildCoachSessionSignals([
+      mkEntry({ repIndex: 1, fqi: 90 }),
+      mkEntry({ repIndex: 2, fqi: 85 }),
+      mkEntry({ repIndex: 3, fqi: 60 }),
+      mkEntry({ repIndex: 4, fqi: 55 }),
+    ]);
+    expect(signals.fqiTrend).toBe('declining');
+  });
+
+  it('calls the trend "stable" when the delta is within threshold', () => {
+    const signals = buildCoachSessionSignals([
+      mkEntry({ repIndex: 1, fqi: 70 }),
+      mkEntry({ repIndex: 2, fqi: 72 }),
+      mkEntry({ repIndex: 3, fqi: 71 }),
+      mkEntry({ repIndex: 4, fqi: 73 }),
+    ]);
+    expect(signals.fqiTrend).toBe('stable');
+  });
+
+  it('respects a custom trend threshold', () => {
+    const entries = [
+      mkEntry({ repIndex: 1, fqi: 70 }),
+      mkEntry({ repIndex: 2, fqi: 71 }),
+      mkEntry({ repIndex: 3, fqi: 72 }),
+      mkEntry({ repIndex: 4, fqi: 74 }),
+    ];
+    expect(buildCoachSessionSignals(entries).fqiTrend).toBe('stable');
+    expect(buildCoachSessionSignals(entries, { trendThreshold: 2 }).fqiTrend).toBe('improving');
+  });
+
+  it('ranks recent faults by frequency in the trailing window', () => {
+    const signals = buildCoachSessionSignals(
+      [
+        mkEntry({ repIndex: 1, faults: ['forward_knee'] }),
+        mkEntry({ repIndex: 2, faults: ['forward_knee', 'shallow'] }),
+        mkEntry({ repIndex: 3, faults: ['shallow'] }),
+        mkEntry({ repIndex: 4, faults: ['forward_knee'] }),
+        mkEntry({ repIndex: 5, faults: ['forward_knee'] }),
+      ],
+      { windowSize: 3 }
+    );
+    expect(signals.recentFaults[0]).toBe('forward_knee');
+    expect(signals.recentFaults).toContain('shallow');
+  });
+
+  it('limits recentFaults to topFaultCount', () => {
+    const signals = buildCoachSessionSignals(
+      [
+        mkEntry({ repIndex: 1, faults: ['a', 'b', 'c', 'd'] }),
+      ],
+      { topFaultCount: 2 }
+    );
+    expect(signals.recentFaults).toHaveLength(2);
+  });
+
+  it('counts the full fault histogram across every rep, not just the window', () => {
+    const signals = buildCoachSessionSignals(
+      [
+        mkEntry({ repIndex: 1, faults: ['early'] }),
+        mkEntry({ repIndex: 2, faults: [] }),
+        mkEntry({ repIndex: 3, faults: [] }),
+        mkEntry({ repIndex: 4, faults: [] }),
+        mkEntry({ repIndex: 5, faults: [] }),
+        mkEntry({ repIndex: 6, faults: ['late'] }),
+      ],
+      { windowSize: 3 }
+    );
+    expect(signals.faultFrequency).toEqual({ early: 1, late: 1 });
+    expect(signals.recentFaults).toEqual(['late']);
+  });
+
+  it('counts occluded and low-confidence reps', () => {
+    const signals = buildCoachSessionSignals([
+      mkEntry({ repIndex: 1, occluded: true }),
+      mkEntry({ repIndex: 2, minJointConfidence: 0.2 }),
+      mkEntry({ repIndex: 3, minJointConfidence: 0.9 }),
+    ]);
+    expect(signals.occludedRepCount).toBe(1);
+    expect(signals.lowConfidenceRepCount).toBe(1);
+  });
+
+  it('returns the latest entry timestamp', () => {
+    const signals = buildCoachSessionSignals([
+      mkEntry({ repIndex: 1, ts: '2026-04-17T09:00:01.000Z' }),
+      mkEntry({ repIndex: 2, ts: '2026-04-17T09:00:10.000Z' }),
+    ]);
+    expect(signals.lastEntryTs).toBe('2026-04-17T09:00:10.000Z');
+  });
+});
+
+describe('formatSignalsForPrompt', () => {
+  it('returns an empty string when there are no reps', () => {
+    const empty = buildCoachSessionSignals([]);
+    expect(formatSignalsForPrompt(empty)).toBe('');
+  });
+
+  it('includes every non-empty signal in the formatted block', () => {
+    const signals = buildCoachSessionSignals([
+      mkEntry({ repIndex: 1, fqi: 60, faults: ['forward_knee'] }),
+      mkEntry({ repIndex: 2, fqi: 65, faults: ['forward_knee'] }),
+      mkEntry({ repIndex: 3, fqi: 80, faults: [] }),
+      mkEntry({ repIndex: 4, fqi: 85, faults: [], occluded: true, minJointConfidence: 0.2 }),
+    ]);
+    const formatted = formatSignalsForPrompt(signals);
+    expect(formatted).toContain('Live squat session signals:');
+    expect(formatted).toContain('Reps so far: 4');
+    expect(formatted).toContain('Avg FQI');
+    expect(formatted).toContain('Latest rep FQI: 85');
+    expect(formatted).toContain('Trend:');
+    expect(formatted).toContain('Recent faults: forward_knee');
+    expect(formatted).toContain('Occluded reps: 1');
+    expect(formatted).toContain('Low-confidence reps: 1');
+  });
+
+  it('omits lines with nothing to report', () => {
+    const signals = buildCoachSessionSignals([
+      mkEntry({ repIndex: 1, fqi: 80 }),
+    ]);
+    const formatted = formatSignalsForPrompt(signals);
+    expect(formatted).not.toContain('Recent faults:');
+    expect(formatted).not.toContain('Occluded reps:');
+    expect(formatted).not.toContain('Low-confidence reps:');
+    expect(formatted).not.toContain('Trend:');
+  });
+});

--- a/tests/unit/services/gemma-prompt-format.test.ts
+++ b/tests/unit/services/gemma-prompt-format.test.ts
@@ -1,0 +1,224 @@
+import {
+  formatGemmaMessages,
+  mapCoachRoleToGemma,
+  renderGemmaChatPrompt,
+  validateGemmaFormat,
+} from '@/lib/services/gemma-prompt-format';
+import type { CoachMessage } from '@/lib/services/coach-service';
+
+describe('mapCoachRoleToGemma', () => {
+  it('maps assistant to model', () => {
+    expect(mapCoachRoleToGemma('assistant')).toBe('model');
+  });
+
+  it('maps user to user', () => {
+    expect(mapCoachRoleToGemma('user')).toBe('user');
+  });
+
+  it('maps system to system', () => {
+    expect(mapCoachRoleToGemma('system')).toBe('system');
+  });
+});
+
+describe('formatGemmaMessages for gemma-4', () => {
+  it('preserves every role one-to-one', () => {
+    const messages: CoachMessage[] = [
+      { role: 'system', content: 'You are a fitness coach.' },
+      { role: 'user', content: 'How do I squat?' },
+      { role: 'assistant', content: 'Drive through your heels.' },
+      { role: 'user', content: 'And my knees?' },
+    ];
+    const formatted = formatGemmaMessages(messages, 'gemma-4');
+    expect(formatted).toEqual([
+      { role: 'system', content: 'You are a fitness coach.' },
+      { role: 'user', content: 'How do I squat?' },
+      { role: 'model', content: 'Drive through your heels.' },
+      { role: 'user', content: 'And my knees?' },
+    ]);
+  });
+
+  it('keeps a system-only message as a native system turn', () => {
+    const messages: CoachMessage[] = [{ role: 'system', content: 'Be concise.' }];
+    const formatted = formatGemmaMessages(messages, 'gemma-4');
+    expect(formatted).toEqual([{ role: 'system', content: 'Be concise.' }]);
+  });
+});
+
+describe('formatGemmaMessages for gemma-3', () => {
+  it('folds a single system turn into the first user turn', () => {
+    const messages: CoachMessage[] = [
+      { role: 'system', content: 'You are a fitness coach.' },
+      { role: 'user', content: 'How do I squat?' },
+    ];
+    const formatted = formatGemmaMessages(messages, 'gemma-3');
+    expect(formatted).toHaveLength(1);
+    expect(formatted[0].role).toBe('user');
+    expect(formatted[0].content).toContain('You are a fitness coach.');
+    expect(formatted[0].content).toContain('How do I squat?');
+  });
+
+  it('concatenates multiple system turns before the first user turn', () => {
+    const messages: CoachMessage[] = [
+      { role: 'system', content: 'You are a fitness coach.' },
+      { role: 'system', content: 'Keep answers under 120 words.' },
+      { role: 'user', content: 'Tempo?' },
+    ];
+    const formatted = formatGemmaMessages(messages, 'gemma-3');
+    expect(formatted[0].content).toContain('You are a fitness coach.');
+    expect(formatted[0].content).toContain('Keep answers under 120 words.');
+    expect(formatted[0].content).toContain('Tempo?');
+  });
+
+  it('injects system content before the first user turn but keeps subsequent turns intact', () => {
+    const messages: CoachMessage[] = [
+      { role: 'system', content: 'Context block.' },
+      { role: 'user', content: 'First question.' },
+      { role: 'assistant', content: 'First answer.' },
+      { role: 'user', content: 'Second question.' },
+    ];
+    const formatted = formatGemmaMessages(messages, 'gemma-3');
+    expect(formatted).toHaveLength(3);
+    expect(formatted[0].content).toContain('Context block.');
+    expect(formatted[0].content).toContain('First question.');
+    expect(formatted[1].role).toBe('model');
+    expect(formatted[2].content).toBe('Second question.');
+  });
+
+  it('synthesizes a lone user turn when the conversation begins with a system turn only', () => {
+    const messages: CoachMessage[] = [{ role: 'system', content: 'Be brief.' }];
+    const formatted = formatGemmaMessages(messages, 'gemma-3');
+    expect(formatted).toEqual([{ role: 'user', content: 'Be brief.' }]);
+  });
+
+  it('produces no system turns', () => {
+    const messages: CoachMessage[] = [
+      { role: 'system', content: 's1' },
+      { role: 'user', content: 'u1' },
+      { role: 'assistant', content: 'a1' },
+    ];
+    const formatted = formatGemmaMessages(messages, 'gemma-3');
+    expect(formatted.every((m) => m.role !== 'system')).toBe(true);
+  });
+});
+
+describe('renderGemmaChatPrompt', () => {
+  it('wraps each message in start/end turn markers and appends a trailing model turn', () => {
+    const rendered = renderGemmaChatPrompt(
+      [
+        { role: 'user', content: 'hi' },
+        { role: 'model', content: 'hello' },
+        { role: 'user', content: 'what now?' },
+      ],
+      'gemma-4'
+    );
+    expect(rendered).toContain('<start_of_turn>user\nhi<end_of_turn>');
+    expect(rendered).toContain('<start_of_turn>model\nhello<end_of_turn>');
+    expect(rendered).toContain('<start_of_turn>user\nwhat now?<end_of_turn>');
+    expect(rendered.endsWith('<start_of_turn>model\n')).toBe(true);
+  });
+
+  it('renders a system turn for gemma-4', () => {
+    const rendered = renderGemmaChatPrompt(
+      [
+        { role: 'system', content: 'be concise' },
+        { role: 'user', content: 'hi' },
+      ],
+      'gemma-4'
+    );
+    expect(rendered).toContain('<start_of_turn>system\nbe concise<end_of_turn>');
+  });
+
+  it('throws when a system turn appears on gemma-3', () => {
+    expect(() =>
+      renderGemmaChatPrompt(
+        [
+          { role: 'system', content: 'be concise' },
+          { role: 'user', content: 'hi' },
+        ],
+        'gemma-3'
+      )
+    ).toThrow(/gemma-3/);
+  });
+});
+
+describe('validateGemmaFormat', () => {
+  it('accepts a well-formed gemma-4 prompt with a system turn', () => {
+    const prompt = [
+      '<start_of_turn>system\nyou are a coach<end_of_turn>',
+      '<start_of_turn>user\nhello<end_of_turn>',
+      '<start_of_turn>model\n',
+    ].join('\n');
+    expect(validateGemmaFormat(prompt, 'gemma-4')).toEqual({ valid: true, errors: [] });
+  });
+
+  it('accepts a well-formed gemma-3 prompt with no system turn', () => {
+    const prompt = [
+      '<start_of_turn>user\nhello<end_of_turn>',
+      '<start_of_turn>model\n',
+    ].join('\n');
+    expect(validateGemmaFormat(prompt, 'gemma-3')).toEqual({ valid: true, errors: [] });
+  });
+
+  it('rejects a gemma-3 prompt that contains a system turn', () => {
+    const prompt = [
+      '<start_of_turn>system\nbe concise<end_of_turn>',
+      '<start_of_turn>user\nhello<end_of_turn>',
+      '<start_of_turn>model\n',
+    ].join('\n');
+    const result = validateGemmaFormat(prompt, 'gemma-3');
+    expect(result.valid).toBe(false);
+    expect(result.errors.join('\n')).toContain('gemma-3 does not support the system role');
+  });
+
+  it('rejects a prompt missing the trailing model turn', () => {
+    const prompt = '<start_of_turn>user\nhello<end_of_turn>';
+    const result = validateGemmaFormat(prompt, 'gemma-4');
+    expect(result.valid).toBe(false);
+    expect(result.errors.join('\n')).toContain('trailing turn');
+  });
+
+  it('rejects a prompt with no turn markers at all', () => {
+    const result = validateGemmaFormat('just a bare string', 'gemma-4');
+    expect(result.valid).toBe(false);
+    expect(result.errors.join('\n')).toContain('no <start_of_turn>');
+  });
+
+  it('rejects a prompt with unbalanced markers', () => {
+    const prompt = '<start_of_turn>user\nhello<start_of_turn>model\n';
+    const result = validateGemmaFormat(prompt, 'gemma-4');
+    expect(result.valid).toBe(false);
+    expect(result.errors.join('\n')).toContain('unbalanced');
+  });
+
+  it('rejects a prompt with an unexpected role', () => {
+    const prompt = [
+      '<start_of_turn>custom\nnope<end_of_turn>',
+      '<start_of_turn>model\n',
+    ].join('\n');
+    const result = validateGemmaFormat(prompt, 'gemma-4');
+    expect(result.valid).toBe(false);
+    expect(result.errors.join('\n')).toContain('unexpected role');
+  });
+});
+
+describe('end-to-end formatting', () => {
+  it('renders a coach-to-gemma-4 prompt that validates clean', () => {
+    const messages: CoachMessage[] = [
+      { role: 'system', content: 'You are a fitness coach.' },
+      { role: 'user', content: 'How do I squat deeper?' },
+    ];
+    const gemma = formatGemmaMessages(messages, 'gemma-4');
+    const prompt = renderGemmaChatPrompt(gemma, 'gemma-4');
+    expect(validateGemmaFormat(prompt, 'gemma-4').valid).toBe(true);
+  });
+
+  it('renders a coach-to-gemma-3 prompt (system folded) that validates clean', () => {
+    const messages: CoachMessage[] = [
+      { role: 'system', content: 'Be concise.' },
+      { role: 'user', content: 'Squat cue?' },
+    ];
+    const gemma = formatGemmaMessages(messages, 'gemma-3');
+    const prompt = renderGemmaChatPrompt(gemma, 'gemma-3');
+    expect(validateGemmaFormat(prompt, 'gemma-3').valid).toBe(true);
+  });
+});

--- a/tests/unit/services/rep-quality-log.test.ts
+++ b/tests/unit/services/rep-quality-log.test.ts
@@ -1,0 +1,167 @@
+import { createRepQualityLog, defaultRepQualityLog, type RepQualityEntry } from '@/lib/services/rep-quality-log';
+
+function mkEntry(partial: Partial<RepQualityEntry> = {}): RepQualityEntry {
+  return {
+    sessionId: 's1',
+    repIndex: 1,
+    exercise: 'pullup',
+    ts: new Date(2026, 3, 17, 9, 0, 0).toISOString(),
+    fqi: 82,
+    faults: [],
+    ...partial,
+  };
+}
+
+describe('rep-quality-log', () => {
+  describe('createRepQualityLog', () => {
+    it('appends entries and reports size', () => {
+      const log = createRepQualityLog();
+      expect(log.size()).toBe(0);
+      log.append(mkEntry());
+      log.append(mkEntry({ repIndex: 2 }));
+      expect(log.size()).toBe(2);
+    });
+
+    it('returns copies so mutating the returned entries cannot corrupt the log', () => {
+      const log = createRepQualityLog();
+      log.append(mkEntry({ faults: ['forward_knee'] }));
+      const entries = log.entries();
+      entries[0].faults.push('corrupt');
+      entries[0].repIndex = 9999;
+      expect(log.entries()[0].faults).toEqual(['forward_knee']);
+      expect(log.entries()[0].repIndex).toBe(1);
+    });
+
+    it('returns a defensive copy of faultSeverity', () => {
+      const log = createRepQualityLog();
+      log.append(mkEntry({ faultSeverity: { forward_knee: 10 } }));
+      const entry = log.entries()[0];
+      if (entry.faultSeverity) {
+        entry.faultSeverity.forward_knee = 9999;
+      }
+      const again = log.entries()[0];
+      expect(again.faultSeverity).toEqual({ forward_knee: 10 });
+    });
+
+    it('filters entries by sessionId', () => {
+      const log = createRepQualityLog();
+      log.append(mkEntry({ sessionId: 'a', repIndex: 1 }));
+      log.append(mkEntry({ sessionId: 'b', repIndex: 1 }));
+      log.append(mkEntry({ sessionId: 'a', repIndex: 2 }));
+      expect(log.entries('a').map((e) => e.repIndex)).toEqual([1, 2]);
+      expect(log.entries('b')).toHaveLength(1);
+      expect(log.entries()).toHaveLength(3);
+    });
+
+    it('latest returns the most recent entry, filtered by session when provided', () => {
+      const log = createRepQualityLog();
+      log.append(mkEntry({ sessionId: 'a', repIndex: 1 }));
+      log.append(mkEntry({ sessionId: 'b', repIndex: 1 }));
+      log.append(mkEntry({ sessionId: 'a', repIndex: 2, fqi: 91 }));
+      expect(log.latest('a')?.fqi).toBe(91);
+      expect(log.latest('b')?.sessionId).toBe('b');
+      expect(log.latest()?.repIndex).toBe(2);
+    });
+
+    it('latest returns null on empty log', () => {
+      const log = createRepQualityLog();
+      expect(log.latest()).toBeNull();
+      expect(log.latest('missing')).toBeNull();
+    });
+
+    it('clear wipes every entry when no session is given', () => {
+      const log = createRepQualityLog();
+      log.append(mkEntry({ sessionId: 'a' }));
+      log.append(mkEntry({ sessionId: 'b' }));
+      log.clear();
+      expect(log.size()).toBe(0);
+    });
+
+    it('clear with a sessionId wipes only that session', () => {
+      const log = createRepQualityLog();
+      log.append(mkEntry({ sessionId: 'a', repIndex: 1 }));
+      log.append(mkEntry({ sessionId: 'b', repIndex: 1 }));
+      log.append(mkEntry({ sessionId: 'a', repIndex: 2 }));
+      log.clear('a');
+      expect(log.size()).toBe(1);
+      expect(log.entries()[0].sessionId).toBe('b');
+    });
+
+    it('enforces maxEntries by dropping oldest entries first', () => {
+      const log = createRepQualityLog({ maxEntries: 3 });
+      for (let i = 1; i <= 5; i++) {
+        log.append(mkEntry({ repIndex: i }));
+      }
+      expect(log.size()).toBe(3);
+      expect(log.entries().map((e) => e.repIndex)).toEqual([3, 4, 5]);
+    });
+
+    it('clamps maxEntries to at least 1', () => {
+      const log = createRepQualityLog({ maxEntries: 0 });
+      log.append(mkEntry({ repIndex: 1 }));
+      log.append(mkEntry({ repIndex: 2 }));
+      expect(log.size()).toBe(1);
+      expect(log.entries()[0].repIndex).toBe(2);
+    });
+  });
+
+  describe('subscribe', () => {
+    it('fires the listener on append', () => {
+      const log = createRepQualityLog();
+      const listener = jest.fn();
+      log.subscribe(listener);
+      log.append(mkEntry());
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires the listener on clear', () => {
+      const log = createRepQualityLog();
+      log.append(mkEntry());
+      const listener = jest.fn();
+      log.subscribe(listener);
+      log.clear();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires the listener on session-scoped clear', () => {
+      const log = createRepQualityLog();
+      const listener = jest.fn();
+      log.subscribe(listener);
+      log.clear('any');
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an unsubscribe function that stops further calls', () => {
+      const log = createRepQualityLog();
+      const listener = jest.fn();
+      const unsub = log.subscribe(listener);
+      log.append(mkEntry());
+      unsub();
+      log.append(mkEntry({ repIndex: 2 }));
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('isolates a thrown listener so other listeners still run', () => {
+      const log = createRepQualityLog();
+      const bad = jest.fn(() => {
+        throw new Error('boom');
+      });
+      const good = jest.fn();
+      log.subscribe(bad);
+      log.subscribe(good);
+      log.append(mkEntry());
+      expect(bad).toHaveBeenCalledTimes(1);
+      expect(good).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('defaultRepQualityLog', () => {
+    it('is usable as a shared instance', () => {
+      const before = defaultRepQualityLog.size();
+      defaultRepQualityLog.append(mkEntry({ sessionId: 'default-test', repIndex: 1 }));
+      expect(defaultRepQualityLog.size()).toBeGreaterThan(before);
+      defaultRepQualityLog.clear('default-test');
+      expect(defaultRepQualityLog.entries('default-test')).toHaveLength(0);
+    });
+  });
+});

--- a/tests/unit/services/rep-quality-timeline.test.ts
+++ b/tests/unit/services/rep-quality-timeline.test.ts
@@ -1,0 +1,205 @@
+import {
+  buildRepQualityTimeline,
+  summarizeTimeline,
+} from '@/lib/services/rep-quality-timeline';
+import type { RepQualityEntry } from '@/lib/services/rep-quality-log';
+
+function mkEntry(partial: Partial<RepQualityEntry> = {}): RepQualityEntry {
+  return {
+    sessionId: 's1',
+    repIndex: partial.repIndex ?? 1,
+    exercise: 'pullup',
+    ts: partial.ts ?? `2026-04-17T09:00:0${partial.repIndex ?? 1}.000Z`,
+    fqi: 80,
+    faults: [],
+    ...partial,
+  };
+}
+
+describe('buildRepQualityTimeline', () => {
+  it('returns an empty timeline for an empty input', () => {
+    const timeline = buildRepQualityTimeline([]);
+    expect(timeline).toEqual({
+      sessionId: null,
+      startTs: null,
+      endTs: null,
+      segments: [],
+      summary: {
+        totalReps: 0,
+        avgFqi: null,
+        medianFqi: null,
+        faultCounts: {},
+        occludedReps: 0,
+        lowConfidenceReps: 0,
+        bestRepIndex: null,
+        worstRepIndex: null,
+        bestFqi: null,
+        worstFqi: null,
+      },
+    });
+  });
+
+  it('emits one rep segment per entry and sorts chronologically', () => {
+    const timeline = buildRepQualityTimeline([
+      mkEntry({ repIndex: 2, ts: '2026-04-17T09:00:02.000Z' }),
+      mkEntry({ repIndex: 1, ts: '2026-04-17T09:00:01.000Z' }),
+    ]);
+    const repOrder = timeline.segments.filter((s) => s.type === 'rep').map((s) => s.repIndex);
+    expect(repOrder).toEqual([1, 2]);
+  });
+
+  it('emits a fault segment only when faults are present', () => {
+    const timeline = buildRepQualityTimeline([
+      mkEntry({ repIndex: 1, faults: [] }),
+      mkEntry({ repIndex: 2, faults: ['forward_knee'] }),
+    ]);
+    const faults = timeline.segments.filter((s) => s.type === 'fault');
+    expect(faults).toHaveLength(1);
+    expect(faults[0].repIndex).toBe(2);
+    expect(faults[0].message).toContain('forward_knee');
+  });
+
+  it('labels multi-fault reps with a count rather than a single fault name', () => {
+    const timeline = buildRepQualityTimeline([
+      mkEntry({ repIndex: 1, faults: ['a', 'b', 'c'] }),
+    ]);
+    const faults = timeline.segments.filter((s) => s.type === 'fault');
+    expect(faults[0].message).toContain('3 faults');
+  });
+
+  it('emits a tracking-loss segment when a rep is flagged as occluded', () => {
+    const timeline = buildRepQualityTimeline([
+      mkEntry({ repIndex: 1, occluded: true }),
+      mkEntry({ repIndex: 2 }),
+    ]);
+    const loss = timeline.segments.filter((s) => s.type === 'tracking-loss');
+    expect(loss).toHaveLength(1);
+    expect(loss[0].repIndex).toBe(1);
+  });
+
+  it('emits a low-confidence segment when min joint confidence drops below the threshold', () => {
+    const timeline = buildRepQualityTimeline([
+      mkEntry({ repIndex: 1, minJointConfidence: 0.9 }),
+      mkEntry({ repIndex: 2, minJointConfidence: 0.3, minConfidenceJoint: 'left_knee' }),
+    ]);
+    const lc = timeline.segments.filter((s) => s.type === 'low-confidence');
+    expect(lc).toHaveLength(1);
+    expect(lc[0].repIndex).toBe(2);
+    expect(lc[0].message).toContain('left_knee');
+    expect(lc[0].message).toContain('30%');
+  });
+
+  it('respects a custom low-confidence threshold', () => {
+    const timeline = buildRepQualityTimeline(
+      [mkEntry({ repIndex: 1, minJointConfidence: 0.5 })],
+      { lowConfidenceThreshold: 0.6 }
+    );
+    expect(timeline.segments.some((s) => s.type === 'low-confidence')).toBe(true);
+  });
+
+  it('emits a high-confidence segment for clean high-FQI reps', () => {
+    const timeline = buildRepQualityTimeline([
+      mkEntry({ repIndex: 1, fqi: 95, faults: [] }),
+      mkEntry({ repIndex: 2, fqi: 95, faults: ['shallow'] }),
+    ]);
+    const hc = timeline.segments.filter((s) => s.type === 'high-confidence');
+    expect(hc).toHaveLength(1);
+    expect(hc[0].repIndex).toBe(1);
+  });
+
+  it('respects a custom high-confidence threshold', () => {
+    const timeline = buildRepQualityTimeline(
+      [mkEntry({ repIndex: 1, fqi: 75, faults: [] })],
+      { highConfidenceFqi: 70 }
+    );
+    expect(timeline.segments.some((s) => s.type === 'high-confidence')).toBe(true);
+  });
+
+  it('filters entries by sessionId when the option is provided', () => {
+    const timeline = buildRepQualityTimeline(
+      [
+        mkEntry({ sessionId: 'a', repIndex: 1 }),
+        mkEntry({ sessionId: 'b', repIndex: 1 }),
+        mkEntry({ sessionId: 'a', repIndex: 2 }),
+      ],
+      { sessionId: 'a' }
+    );
+    expect(timeline.sessionId).toBe('a');
+    expect(timeline.summary.totalReps).toBe(2);
+  });
+
+  it('populates summary with fqi stats, best/worst reps, and fault counts', () => {
+    const timeline = buildRepQualityTimeline([
+      mkEntry({ repIndex: 1, fqi: 50, faults: ['forward_knee'] }),
+      mkEntry({ repIndex: 2, fqi: 70, faults: ['forward_knee', 'shallow'] }),
+      mkEntry({ repIndex: 3, fqi: 90, faults: [] }),
+    ]);
+    expect(timeline.summary.avgFqi).toBe(70);
+    expect(timeline.summary.medianFqi).toBe(70);
+    expect(timeline.summary.bestRepIndex).toBe(3);
+    expect(timeline.summary.bestFqi).toBe(90);
+    expect(timeline.summary.worstRepIndex).toBe(1);
+    expect(timeline.summary.worstFqi).toBe(50);
+    expect(timeline.summary.faultCounts).toEqual({ forward_knee: 2, shallow: 1 });
+  });
+
+  it('handles entries with null FQI gracefully', () => {
+    const timeline = buildRepQualityTimeline([
+      mkEntry({ repIndex: 1, fqi: null }),
+      mkEntry({ repIndex: 2, fqi: 80 }),
+    ]);
+    expect(timeline.summary.avgFqi).toBe(80);
+    expect(timeline.summary.bestFqi).toBe(80);
+  });
+
+  it('computes occluded and low-confidence rep counts in the summary', () => {
+    const timeline = buildRepQualityTimeline([
+      mkEntry({ repIndex: 1, occluded: true }),
+      mkEntry({ repIndex: 2, minJointConfidence: 0.2 }),
+      mkEntry({ repIndex: 3, minJointConfidence: 0.9 }),
+    ]);
+    expect(timeline.summary.occludedReps).toBe(1);
+    expect(timeline.summary.lowConfidenceReps).toBe(1);
+  });
+
+  it('computes median FQI correctly for even and odd counts', () => {
+    expect(
+      buildRepQualityTimeline([
+        mkEntry({ repIndex: 1, fqi: 10 }),
+        mkEntry({ repIndex: 2, fqi: 50 }),
+        mkEntry({ repIndex: 3, fqi: 90 }),
+      ]).summary.medianFqi
+    ).toBe(50);
+    expect(
+      buildRepQualityTimeline([
+        mkEntry({ repIndex: 1, fqi: 10 }),
+        mkEntry({ repIndex: 2, fqi: 50 }),
+        mkEntry({ repIndex: 3, fqi: 70 }),
+        mkEntry({ repIndex: 4, fqi: 90 }),
+      ]).summary.medianFqi
+    ).toBe(60);
+  });
+});
+
+describe('summarizeTimeline', () => {
+  it('returns "No reps recorded." when there are none', () => {
+    const timeline = buildRepQualityTimeline([]);
+    expect(summarizeTimeline(timeline)).toBe('No reps recorded.');
+  });
+
+  it('includes rep count, avg FQI, and top fault', () => {
+    const timeline = buildRepQualityTimeline([
+      mkEntry({ repIndex: 1, fqi: 80, faults: ['forward_knee'] }),
+      mkEntry({ repIndex: 2, fqi: 70, faults: ['forward_knee'] }),
+    ]);
+    const summary = summarizeTimeline(timeline);
+    expect(summary).toContain('2 reps');
+    expect(summary).toContain('avg FQI');
+    expect(summary).toContain('forward_knee');
+  });
+
+  it('surfaces occluded reps when present', () => {
+    const timeline = buildRepQualityTimeline([mkEntry({ occluded: true })]);
+    expect(summarizeTimeline(timeline)).toContain('occluded');
+  });
+});


### PR DESCRIPTION
## Theme

**"Rep-Quality Timeline + Coach Session Signals + Gemma-4-Ready Prompt Format"**

One large-scoped PR bundling three disjoint sub-features the gap-audit agents flagged as uncontested in the 30-PR saturated queue. 26 atomic commits, 143 new tests, zero overlap with any open PR.

## Why this theme

- Per-rep FQI is collected during rep completion but never persisted at rep granularity. Users can't see "rep 3 scored 72".
- Faults are logged to AsyncStorage (#482) but not linked to rep index. No post-session rep-level explainer exists.
- Live session signals (FQI, faults, trend, symmetry) are not piped into coach context — every in-flight Gemma PR (#431, #457, #466) assumes this digest exists.
- Gemma 4 (released March/April 2026) ships native system-role support and new control tokens; the existing on-device scaffold (#420) still renders Gemma 3 style. A helper that handles both means PR #457 and PR #431 merge with a one-line swap.

## What ships

### Form-tracking (pure TS)

- `lib/services/rep-quality-log.ts` — in-memory append-only log with subscribe/clear/filter-by-session. 500-entry ring buffer by default.
- `lib/services/rep-quality-timeline.ts` — aggregator that turns entries into a segment stream plus summary (avg/median FQI, fault counts, best/worst rep, occluded count).
- `hooks/use-rep-quality-log.ts` + `use-rep-quality-timeline.ts` — memoized React wrappers via `useSyncExternalStore`, stable references across renders.
- `components/form-tracking/RepQualityDot.tsx` — color-tiered dot with a11y labels.
- `components/form-tracking/RepTimelineCard.tsx` — post-session timeline view with optional per-segment press handler.
- `components/form-tracking/LiveJointConfidenceBadge.tsx` — overlay badge for live low-confidence joints.
- `app/(modals)/rep-timeline.tsx` — auto-discovered modal route (`/rep-timeline?sessionId=…`) deep-linkable from session-history cards.

### Coach / Gemma-ready

- `lib/services/coach-session-signals.ts` — digest of the rep-quality log into a compact provider-agnostic signal shape (trend, top-3 recent faults, occluded count, latest FQI). `formatSignalsForPrompt()` renders a short block ready to prepend to a coach turn.
- `hooks/use-coach-session-signals.ts` — memoized hook.
- `lib/services/coach-fallback-responses.ts` — short contextual text for offline / rate-limit / server-error / timeout paths. Priority ranker so multiple concurrent reasons resolve deterministically.
- `lib/services/gemma-prompt-format.ts` — renders messages for either Gemma 3 (system folded into first user turn) or Gemma 4 (native system role). `validateGemmaFormat()` catches the common drift cases: unbalanced turn markers, missing trailing model turn, system on Gemma 3, unexpected roles.
- `evals/scenarios/coach-gemma-format.yaml` — five Gemma-drift scenarios (system adherence, signals-block digest vs echo, single-cue length, multi-turn consistency, safety stop). Runs under any provider — diff-ready the moment PR #457 registers a Gemma provider.

## Zero file overlap

Every file is new. Nothing in `app/_layout.tsx`, `(modals)/_layout.tsx`, `session-runner.ts`, `coach-service.ts`, `workout-session.tsx`, or any contested screen. Expo-router auto-discovery dodges the `(modals)/_layout.tsx` registration dance.

## Gemma external state baked in

- Gemma 4: E2B / E4B / 26B-A4B / 31B-dense, Apache 2.0, multimodal. Served on Gemini API as `gemma-4-31b-it`, `gemma-4-26b-a4b-it` (issue #485 tracks the allowlist extension).
- Gemma 4 natively supports the system role; Gemma 3 requires injection into the first user turn. The format helper handles both.

## Verification

- `bun run lint` — clean (2 pre-existing warnings in `template-builder.tsx`, unrelated).
- `bun run check:types` — clean.
- New wave-17 suites: **143 tests across 12 suites, 0 failures**.
- Full repo suite on this branch: 1,287 passing / 1,312 total. The 15 failures are in untracked stress-hardening files (wave-12 / PR #452 leftovers) that need fixtures this branch doesn't ship — not caused by this PR.

## Test plan

- [x] rep-quality-log: append, filter, clear, size enforcement, subscribe/unsubscribe, thrown-listener isolation
- [x] rep-quality-timeline: empty input, sort order, fault / tracking-loss / low-confidence / high-confidence segmenting, summary (avg/median/best/worst), threshold overrides
- [x] coach-session-signals: trend detection (improving/declining/stable/insufficient), trailing window, top-N faults, full histogram, occluded count, custom thresholds
- [x] coach-fallback-responses: four reasons × three FQI bands × with/without fault × with/without exercise, severity mapping, priority ranker
- [x] gemma-prompt-format: role mapping, gemma-3 system folding, gemma-4 native system, validator rejects all drift cases
- [x] Hook memoization: referential stability between renders without log changes
- [x] Component a11y: labels, button roles, color mapping, size props
- [x] Modal screen: missing-session empty state, sessionId deep-link, log re-render, close navigation (canGoBack + fallback)

## Follow-ups (unblocked by this PR)

- Wire `useRepQualityLog.append()` into `scan-arkit.tsx` `onRepComplete` — one line, deferred (contested file).
- Mount `<RepTimelineCard />` inside the form-quality-recovery modal once PR #482 merges.
- Wire `formatSignalsForPrompt` into `coach-service.ts` once PR #431 / #457 / #448 settle.

## Worklog

`docs/overnight/worklog-2026-04-17-sweep-wave17.md` has the full audit findings, Gemma research, scope decisions, and commit log.