### PR TITLE
feat(coach): cost-aware Gemma dispatch scaffold — routing function + flag + telemetry stub

### DIFF
--- a/lib/services/coach-model-dispatch-flag.ts
+++ b/lib/services/coach-model-dispatch-flag.ts
@@ -1,0 +1,25 @@
+/**
+ * coach-model-dispatch-flag
+ *
+ * Feature flag gate for the cost-aware model dispatcher in
+ * `coach-model-dispatch.ts`. The dispatcher itself is pure and safe to
+ * call any time; this flag decides whether callers should respect its
+ * decision or collapse back to the legacy single-model (gpt-5.4-mini)
+ * path.
+ *
+ * Parsing:
+ * - `EXPO_PUBLIC_COACH_DISPATCH=on`  → dispatch enabled
+ * - `EXPO_PUBLIC_COACH_DISPATCH=off` → dispatch disabled
+ * - unset / anything else            → dispatch disabled (fail safe)
+ *
+ * Intentionally strict string matching: we only flip on for the literal
+ * `'on'` value, not "true" / "1" / "yes". Keeps the knob unambiguous.
+ */
+
+const FLAG_ENV_VAR = 'EXPO_PUBLIC_COACH_DISPATCH';
+
+export function isDispatchEnabled(): boolean {
+  const raw = process.env[FLAG_ENV_VAR];
+  if (typeof raw !== 'string') return false;
+  return raw === 'on';
+}

--- a/lib/services/coach-model-dispatch-telemetry.ts
+++ b/lib/services/coach-model-dispatch-telemetry.ts
@@ -1,0 +1,39 @@
+/**
+ * coach-model-dispatch-telemetry
+ *
+ * Stub event recorder for cost-aware model dispatch decisions. Emits a
+ * `coach_dispatch_decision` event with the chosen model, reason, and
+ * whether we fell back to the cloud.
+ *
+ * TODO(#495): When the coach-service rewire lands (post Stack B / PR #502)
+ * this stub should be replaced with a wired call into the real telemetry
+ * pipeline — either the existing `coach-telemetry` module (once it grows
+ * a typed event recorder) or whatever analytics client Stack B introduces.
+ * Until then the stub console.logs behind a `__DEV__` guard so engineers
+ * can trace decisions locally without polluting production logs.
+ *
+ * The `coach-telemetry` module today exposes only `recordCounter` /
+ * `getCounter` + cue-adoption helpers — there is no generic typed event
+ * recorder, so this module intentionally does not import it.
+ */
+
+import { recordCounter } from './coach-telemetry';
+import type { DispatchDecision } from './coach-model-dispatch';
+
+const DISPATCH_EVENT_NAME = 'coach_dispatch_decision';
+
+export function recordDispatchDecision(decision: DispatchDecision): void {
+  // Additive, never-throws counter — safe to call from a hot path.
+  recordCounter(DISPATCH_EVENT_NAME);
+  recordCounter(`${DISPATCH_EVENT_NAME}:${decision.model}`);
+  recordCounter(`${DISPATCH_EVENT_NAME}:reason:${decision.reason}`);
+
+  if (__DEV__) {
+    // eslint-disable-next-line no-console
+    console.log('[coach-dispatch]', DISPATCH_EVENT_NAME, {
+      model: decision.model,
+      reason: decision.reason,
+      fellBackToCloud: decision.fellBackToCloud,
+    });
+  }
+}

--- a/lib/services/coach-model-dispatch.ts
+++ b/lib/services/coach-model-dispatch.ts
@@ -1,0 +1,154 @@
+/**
+ * coach-model-dispatch
+ *
+ * Cost-aware model routing for coach turns. Given a task kind, session
+ * signals, and user tier, returns which backing model should handle the
+ * request.
+ *
+ * Design goals:
+ * - Pure and synchronous so it is trivially testable and cheap to call on
+ *   every coach turn.
+ * - Independent of any transport — this module does not import the coach
+ *   service, edge function client, or telemetry. Callers handle those.
+ * - Feature-flag friendly: `dispatchDisabled` collapses every decision to
+ *   the existing cloud default (`gpt-5.4-mini`) so the router can ship dark
+ *   until the Gemma edge function (PR #502) lands.
+ *
+ * Decision matrix (see tests for full coverage):
+ * - Tactical tasks (short, factual, deterministic): Gemma. Free tier gets
+ *   the smaller `gemma-4-26b-a4b-it`; pro/premium get `gemma-4-31b-it`.
+ * - Complex tasks (planning, macro reasoning, debriefs): GPT-5.4-mini for
+ *   free/pro, GPT-5.4 for premium.
+ * - `general_chat` falls back to GPT-5.4-mini conservatively.
+ * - High-fault override: a tactical task with `faultCount >= 3` is upgraded
+ *   one rung (Gemma → GPT-5.4-mini) because the user is struggling and
+ *   the extra cost is justified by coaching value.
+ * - `forceCloud`: upgrades any tactical decision to GPT-5.4-mini. Complex
+ *   decisions are already cloud so the flag is a no-op there.
+ *
+ * TODO(#495): Wire this into `coach-service.sendCoachPrompt` once the
+ * `coach-gemma` edge function from Stack B (PR #502) merges. Wiring will
+ * live in `coach-service.ts` and gate on `isCoachModelDispatchEnabled()`.
+ */
+
+export type CoachTaskKind =
+  | 'form_cue_lookup'
+  | 'rest_calc'
+  | 'encouragement'
+  | 'fault_explainer'
+  | 'program_design'
+  | 'nutrition_balance'
+  | 'multi_turn_debrief'
+  | 'session_generator'
+  | 'general_chat';
+
+export type CoachModelId =
+  | 'gemma-4-26b-a4b-it'
+  | 'gemma-4-31b-it'
+  | 'gpt-5.4-mini'
+  | 'gpt-5.4';
+
+export type CoachUserTier = 'free' | 'pro' | 'premium';
+
+export interface CoachSignals {
+  readonly exerciseKey?: string;
+  readonly currentFqi?: number;
+  readonly faultCount?: number;
+  readonly tokenBudgetRemaining?: number;
+}
+
+export interface DispatchDecision {
+  readonly model: CoachModelId;
+  readonly reason: string;
+  readonly fellBackToCloud: boolean;
+}
+
+export interface DispatchOptions {
+  readonly forceCloud?: boolean;
+  readonly dispatchDisabled?: boolean;
+}
+
+const TACTICAL_TASKS: ReadonlySet<CoachTaskKind> = new Set<CoachTaskKind>([
+  'form_cue_lookup',
+  'rest_calc',
+  'encouragement',
+  'fault_explainer',
+]);
+
+const COMPLEX_TASKS: ReadonlySet<CoachTaskKind> = new Set<CoachTaskKind>([
+  'program_design',
+  'nutrition_balance',
+  'multi_turn_debrief',
+  'session_generator',
+]);
+
+const HIGH_FAULT_THRESHOLD = 3;
+
+function tacticalGemmaForTier(tier: CoachUserTier): CoachModelId {
+  return tier === 'free' ? 'gemma-4-26b-a4b-it' : 'gemma-4-31b-it';
+}
+
+function complexCloudForTier(tier: CoachUserTier): CoachModelId {
+  return tier === 'premium' ? 'gpt-5.4' : 'gpt-5.4-mini';
+}
+
+export function decideCoachModel(
+  taskKind: CoachTaskKind,
+  signals: CoachSignals,
+  userTier: CoachUserTier,
+  options?: DispatchOptions,
+): DispatchDecision {
+  // Feature-flag bypass: route every turn to the legacy cloud model so the
+  // module can ship inert until Stack B lands.
+  if (options?.dispatchDisabled === true) {
+    return {
+      model: 'gpt-5.4-mini',
+      reason: 'dispatch_disabled',
+      fellBackToCloud: true,
+    };
+  }
+
+  if (TACTICAL_TASKS.has(taskKind)) {
+    // High-fault heuristic: bump tactical tasks to the cloud mini model
+    // when the user is visibly struggling. Takes precedence over
+    // forceCloud because the reason string is more informative.
+    const faultCount = signals.faultCount ?? 0;
+    if (faultCount >= HIGH_FAULT_THRESHOLD) {
+      return {
+        model: 'gpt-5.4-mini',
+        reason: 'high_fault_upgrade',
+        fellBackToCloud: true,
+      };
+    }
+
+    if (options?.forceCloud === true) {
+      return {
+        model: 'gpt-5.4-mini',
+        reason: 'force_cloud_override',
+        fellBackToCloud: true,
+      };
+    }
+
+    return {
+      model: tacticalGemmaForTier(userTier),
+      reason: 'tactical_gemma',
+      fellBackToCloud: false,
+    };
+  }
+
+  if (COMPLEX_TASKS.has(taskKind)) {
+    return {
+      model: complexCloudForTier(userTier),
+      reason: 'complex_cloud',
+      fellBackToCloud: true,
+    };
+  }
+
+  // `general_chat` and any future unknown task fall back to the cloud
+  // mini default.
+  return {
+    model: 'gpt-5.4-mini',
+    reason: 'general_chat_default',
+    fellBackToCloud: true,
+  };
+}

--- a/tests/unit/services/coach-model-dispatch-flag.test.ts
+++ b/tests/unit/services/coach-model-dispatch-flag.test.ts
@@ -1,0 +1,42 @@
+import { isDispatchEnabled } from '@/lib/services/coach-model-dispatch-flag';
+
+const FLAG_ENV_VAR = 'EXPO_PUBLIC_COACH_DISPATCH';
+
+describe('coach-model-dispatch-flag', () => {
+  const originalValue = process.env[FLAG_ENV_VAR];
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env[FLAG_ENV_VAR];
+    } else {
+      process.env[FLAG_ENV_VAR] = originalValue;
+    }
+  });
+
+  it('returns false when EXPO_PUBLIC_COACH_DISPATCH is unset', () => {
+    delete process.env[FLAG_ENV_VAR];
+    expect(isDispatchEnabled()).toBe(false);
+  });
+
+  it('returns true when EXPO_PUBLIC_COACH_DISPATCH is "on"', () => {
+    process.env[FLAG_ENV_VAR] = 'on';
+    expect(isDispatchEnabled()).toBe(true);
+  });
+
+  it('returns false when EXPO_PUBLIC_COACH_DISPATCH is "off"', () => {
+    process.env[FLAG_ENV_VAR] = 'off';
+    expect(isDispatchEnabled()).toBe(false);
+  });
+
+  it('returns false for adjacent truthy-looking strings (strict parse)', () => {
+    for (const value of ['true', '1', 'yes', 'ON', 'On', 'enabled', '']) {
+      process.env[FLAG_ENV_VAR] = value;
+      expect(isDispatchEnabled()).toBe(false);
+    }
+  });
+
+  it('returns false for whitespace-padded "on"', () => {
+    process.env[FLAG_ENV_VAR] = ' on ';
+    expect(isDispatchEnabled()).toBe(false);
+  });
+});

--- a/tests/unit/services/coach-model-dispatch.test.ts
+++ b/tests/unit/services/coach-model-dispatch.test.ts
@@ -1,0 +1,221 @@
+import {
+  decideCoachModel,
+  type CoachSignals,
+  type CoachTaskKind,
+  type CoachUserTier,
+} from '@/lib/services/coach-model-dispatch';
+
+const TACTICAL_KINDS: CoachTaskKind[] = [
+  'form_cue_lookup',
+  'rest_calc',
+  'encouragement',
+  'fault_explainer',
+];
+
+const COMPLEX_KINDS: CoachTaskKind[] = [
+  'program_design',
+  'nutrition_balance',
+  'multi_turn_debrief',
+  'session_generator',
+];
+
+const NO_SIGNALS: CoachSignals = {};
+
+describe('decideCoachModel', () => {
+  describe('dispatchDisabled bypass', () => {
+    it.each<[CoachTaskKind, CoachUserTier]>([
+      ['form_cue_lookup', 'free'],
+      ['program_design', 'premium'],
+      ['general_chat', 'pro'],
+      ['session_generator', 'free'],
+    ])('routes every task (%s, tier=%s) to gpt-5.4-mini when dispatchDisabled', (task, tier) => {
+      const decision = decideCoachModel(task, NO_SIGNALS, tier, { dispatchDisabled: true });
+      expect(decision).toEqual({
+        model: 'gpt-5.4-mini',
+        reason: 'dispatch_disabled',
+        fellBackToCloud: true,
+      });
+    });
+
+    it('dispatchDisabled wins over forceCloud and high-fault signals', () => {
+      const decision = decideCoachModel(
+        'form_cue_lookup',
+        { faultCount: 10 },
+        'premium',
+        { dispatchDisabled: true, forceCloud: true },
+      );
+      expect(decision.reason).toBe('dispatch_disabled');
+      expect(decision.model).toBe('gpt-5.4-mini');
+    });
+  });
+
+  describe('tactical tasks → Gemma', () => {
+    it.each(TACTICAL_KINDS)('routes %s to gemma-4-26b-a4b-it for free tier', (task) => {
+      const decision = decideCoachModel(task, NO_SIGNALS, 'free');
+      expect(decision).toEqual({
+        model: 'gemma-4-26b-a4b-it',
+        reason: 'tactical_gemma',
+        fellBackToCloud: false,
+      });
+    });
+
+    it.each(TACTICAL_KINDS)('routes %s to gemma-4-31b-it for pro tier', (task) => {
+      const decision = decideCoachModel(task, NO_SIGNALS, 'pro');
+      expect(decision).toEqual({
+        model: 'gemma-4-31b-it',
+        reason: 'tactical_gemma',
+        fellBackToCloud: false,
+      });
+    });
+
+    it.each(TACTICAL_KINDS)('routes %s to gemma-4-31b-it for premium tier', (task) => {
+      const decision = decideCoachModel(task, NO_SIGNALS, 'premium');
+      expect(decision).toEqual({
+        model: 'gemma-4-31b-it',
+        reason: 'tactical_gemma',
+        fellBackToCloud: false,
+      });
+    });
+
+    it('faultCount below threshold does not upgrade', () => {
+      const decision = decideCoachModel('form_cue_lookup', { faultCount: 2 }, 'free');
+      expect(decision.model).toBe('gemma-4-26b-a4b-it');
+      expect(decision.reason).toBe('tactical_gemma');
+    });
+  });
+
+  describe('complex tasks → OpenAI', () => {
+    it.each(COMPLEX_KINDS)('routes %s to gpt-5.4-mini for free tier', (task) => {
+      const decision = decideCoachModel(task, NO_SIGNALS, 'free');
+      expect(decision).toEqual({
+        model: 'gpt-5.4-mini',
+        reason: 'complex_cloud',
+        fellBackToCloud: true,
+      });
+    });
+
+    it.each(COMPLEX_KINDS)('routes %s to gpt-5.4-mini for pro tier', (task) => {
+      const decision = decideCoachModel(task, NO_SIGNALS, 'pro');
+      expect(decision).toEqual({
+        model: 'gpt-5.4-mini',
+        reason: 'complex_cloud',
+        fellBackToCloud: true,
+      });
+    });
+
+    it.each(COMPLEX_KINDS)('routes %s to gpt-5.4 for premium tier', (task) => {
+      const decision = decideCoachModel(task, NO_SIGNALS, 'premium');
+      expect(decision).toEqual({
+        model: 'gpt-5.4',
+        reason: 'complex_cloud',
+        fellBackToCloud: true,
+      });
+    });
+
+    it('forceCloud is a no-op for complex tasks (already cloud)', () => {
+      const decision = decideCoachModel(
+        'program_design',
+        NO_SIGNALS,
+        'free',
+        { forceCloud: true },
+      );
+      expect(decision.model).toBe('gpt-5.4-mini');
+      expect(decision.reason).toBe('complex_cloud');
+    });
+  });
+
+  describe('general_chat fallback', () => {
+    it.each<CoachUserTier>(['free', 'pro', 'premium'])(
+      'general_chat on tier=%s routes to gpt-5.4-mini conservative default',
+      (tier) => {
+        const decision = decideCoachModel('general_chat', NO_SIGNALS, tier);
+        expect(decision).toEqual({
+          model: 'gpt-5.4-mini',
+          reason: 'general_chat_default',
+          fellBackToCloud: true,
+        });
+      },
+    );
+  });
+
+  describe('forceCloud override on tactical tasks', () => {
+    it.each(TACTICAL_KINDS)('bumps %s to gpt-5.4-mini with force_cloud_override reason', (task) => {
+      const decision = decideCoachModel(task, NO_SIGNALS, 'pro', { forceCloud: true });
+      expect(decision).toEqual({
+        model: 'gpt-5.4-mini',
+        reason: 'force_cloud_override',
+        fellBackToCloud: true,
+      });
+    });
+
+    it('forceCloud on tactical wins over the tier that would have picked Gemma', () => {
+      const decision = decideCoachModel(
+        'encouragement',
+        NO_SIGNALS,
+        'premium',
+        { forceCloud: true },
+      );
+      expect(decision.model).toBe('gpt-5.4-mini');
+      expect(decision.reason).toBe('force_cloud_override');
+    });
+  });
+
+  describe('high-fault upgrade heuristic', () => {
+    it.each(TACTICAL_KINDS)(
+      'upgrades tactical task %s when faultCount >= 3',
+      (task) => {
+        const decision = decideCoachModel(task, { faultCount: 3 }, 'free');
+        expect(decision).toEqual({
+          model: 'gpt-5.4-mini',
+          reason: 'high_fault_upgrade',
+          fellBackToCloud: true,
+        });
+      },
+    );
+
+    it('upgrade triggers on much-higher fault counts too', () => {
+      const decision = decideCoachModel('form_cue_lookup', { faultCount: 99 }, 'premium');
+      expect(decision.reason).toBe('high_fault_upgrade');
+      expect(decision.model).toBe('gpt-5.4-mini');
+    });
+
+    it('high-fault upgrade takes precedence over forceCloud reason', () => {
+      const decision = decideCoachModel(
+        'rest_calc',
+        { faultCount: 5 },
+        'free',
+        { forceCloud: true },
+      );
+      expect(decision.reason).toBe('high_fault_upgrade');
+      expect(decision.model).toBe('gpt-5.4-mini');
+    });
+
+    it('high-fault heuristic does NOT apply to complex tasks', () => {
+      const decision = decideCoachModel('program_design', { faultCount: 10 }, 'free');
+      expect(decision.reason).toBe('complex_cloud');
+      expect(decision.model).toBe('gpt-5.4-mini');
+    });
+  });
+
+  describe('signal/option shape handling', () => {
+    it('treats missing faultCount as 0 (no upgrade)', () => {
+      const decision = decideCoachModel('form_cue_lookup', {}, 'free');
+      expect(decision.reason).toBe('tactical_gemma');
+    });
+
+    it('ignores unrelated signal fields', () => {
+      const decision = decideCoachModel(
+        'encouragement',
+        { exerciseKey: 'squat', currentFqi: 72, tokenBudgetRemaining: 1000 },
+        'pro',
+      );
+      expect(decision.model).toBe('gemma-4-31b-it');
+      expect(decision.reason).toBe('tactical_gemma');
+    });
+
+    it('options argument is optional', () => {
+      const decision = decideCoachModel('form_cue_lookup', NO_SIGNALS, 'free');
+      expect(decision.model).toBe('gemma-4-26b-a4b-it');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Scaffolds item 2 of #495 (cost-aware model dispatch). Pure routing function that picks a model based on task kind, signals, and user tier. Feature-flagged via `EXPO_PUBLIC_COACH_DISPATCH` (default off). Zero runtime impact until Stack B (#502) lands and `coach-service` is wired.

Files are named `coach-model-dispatch*.ts` (not `coach-dispatch*.ts` as the issue sketches) because the repo already has a `coach-dispatch.ts` that handles local-vs-cloud transport routing. The new module is about cost-aware *model selection*, so the extra qualifier keeps both concerns clear.

## Decision tree
- Tactical (`form_cue_lookup`, `rest_calc`, `encouragement`, `fault_explainer`) → Gemma 4 (26b for free, 31b for pro/premium)
- Complex (`program_design`, `nutrition_balance`, `multi_turn_debrief`, `session_generator`) → GPT-5.4-mini (free/pro) / GPT-5.4 (premium)
- `general_chat` → GPT-5.4-mini conservative default
- High-fault override: tactical + `faultCount >= 3` → upgrade to GPT-5.4-mini (reason `high_fault_upgrade`, takes precedence over `forceCloud`)
- `forceCloud` override: bumps tactical to GPT-5.4-mini (no-op on complex, which is already cloud)
- `dispatchDisabled` bypass: collapses every decision to GPT-5.4-mini with reason `dispatch_disabled`; wins over every other input

## Files added
- `lib/services/coach-model-dispatch.ts` — pure `decideCoachModel(taskKind, signals, userTier, options?)` fn
- `lib/services/coach-model-dispatch-flag.ts` — strict env parse of `EXPO_PUBLIC_COACH_DISPATCH` ('on' → enabled, else disabled)
- `lib/services/coach-model-dispatch-telemetry.ts` — stub `recordDispatchDecision()`; emits counters via existing `coach-telemetry.recordCounter` + `__DEV__`-guarded console log. TODO(#495) marks the real wire-up target for post-Stack B.
- `tests/unit/services/coach-model-dispatch.test.ts` — 49 tests across every decision branch, tier, flag, and signal edge case
- `tests/unit/services/coach-model-dispatch-flag.test.ts` — 5 tests covering env parse (unset / on / off / adjacent truthy / whitespace)

Item 1 (`coach-vision.ts` multimodal form-check) deferred — depends on the `coach-gemma` edge function from #502 which is still open.

## Verification
- [x] `bun run lint` clean
- [x] `bun run check:types` clean
- [x] `bun run test -- --testPathPattern=coach-model-dispatch` — 54/54 passing
- [x] `coach-service.ts` NOT modified (wiring deferred until #502 merges)

Partial for #495 (item 2). Item 1 tracked separately once #502 merges.