### PR TITLE
feat(form-tracking): micro-UX bundle — rep countdown + exit safety + milestone toast + workouts badge

### DIFF
--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -46,6 +46,10 @@ import { PreSetPreviewCard } from '@/components/form-tracking/PreSetPreviewCard'
 import { usePreSetPreview } from '@/hooks/use-pre-set-preview';
 import { generateSessionId, logCueEvent, upsertSessionMetrics } from '@/lib/services/cue-logger';
 import { logPoseSample, flushPoseBuffer, resetFrameCounter } from '@/lib/services/pose-logger';
+import {
+  appendFormSessionHistory,
+  getFormSessionHistory,
+} from '@/lib/services/form-session-history';
 import { playRepCountdown } from '@/lib/services/rep-countdown-audio';
 import { RepIndexTracker } from '@/lib/services/rep-index-tracker';
 import { saveSessionSnapshot } from '@/lib/services/session-snapshot';
@@ -93,7 +97,7 @@ import { usePRDetection } from '@/hooks/use-pr-detection';
 import { PRCelebrationBadge } from '@/components/form-tracking/PRCelebrationBadge';
 import { ProgressionSuggestionBadge } from '@/components/form-tracking/ProgressionSuggestionBadge';
 import { useProgressionSuggestion } from '@/hooks/use-progression-suggestion';
-import { useSessionRunner } from '@/lib/stores/session-runner';
+import { emitFormMilestone, useSessionRunner } from '@/lib/stores/session-runner';
 import type { FormTargets } from '@/lib/services/form-target-resolver';
 import {
   DEFAULT_DETECTION_MODE,
@@ -1712,7 +1716,13 @@ export default function ScanARKitScreen() {
   // Stop tracking
   const stopTracking = useCallback(async () => {
     if (DEV) logWithTs('[ScanARKit] Stopping tracking...');
-    
+
+    // Snapshot the session data before the cleanup below wipes the refs.
+    // Used for post-session milestone detection (#494).
+    const sessionScoresAtStop = sessionFqiScoresRef.current.slice();
+    const exerciseKeyAtStop = detectionMode;
+    const sessionIdAtStop = sessionIdRef.current;
+
     try {
       if (isRecording) {
         try {
@@ -1752,6 +1762,37 @@ export default function ScanARKitScreen() {
 
       if (Platform.OS === 'ios') {
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      }
+
+      // Post-session milestone detection (#494). Runs off the main
+      // stop-tracking path so we never block cleanup on I/O. Requires at
+      // least 3 reps so a half-hearted 1-rep toggle doesn't overwrite PBs.
+      if (sessionScoresAtStop.length >= 3) {
+        const sum = sessionScoresAtStop.reduce((acc, v) => acc + v, 0);
+        const avgFqi = sum / sessionScoresAtStop.length;
+        const endedAt = new Date().toISOString();
+        (async () => {
+          try {
+            const prior = await getFormSessionHistory(exerciseKeyAtStop);
+            await emitFormMilestone({
+              sessionId: sessionIdAtStop,
+              exerciseKey: exerciseKeyAtStop,
+              currentAvgFqi: avgFqi,
+              priorSessions: prior.map((p) => ({
+                avgFqi: p.avgFqi,
+                endedAt: p.endedAt,
+              })),
+            });
+            await appendFormSessionHistory({
+              exerciseKey: exerciseKeyAtStop,
+              avgFqi,
+              endedAt,
+              sessionId: sessionIdAtStop,
+            });
+          } catch (error) {
+            if (DEV) warnWithTs('[ScanARKit] milestone post-session failed', error);
+          }
+        })();
       }
     } catch (error) {
       errorWithTs('[ScanARKit] ❌ Error stopping tracking:', error);

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -45,6 +45,7 @@ import { PreSetPreviewCard } from '@/components/form-tracking/PreSetPreviewCard'
 import { usePreSetPreview } from '@/hooks/use-pre-set-preview';
 import { generateSessionId, logCueEvent, upsertSessionMetrics } from '@/lib/services/cue-logger';
 import { logPoseSample, flushPoseBuffer, resetFrameCounter } from '@/lib/services/pose-logger';
+import { playRepCountdown } from '@/lib/services/rep-countdown-audio';
 import { RepIndexTracker } from '@/lib/services/rep-index-tracker';
 import {
   initSessionContext,
@@ -775,6 +776,10 @@ export default function ScanARKitScreen() {
   const recordingStartFrameTimestampRef = React.useRef<number | null>(null);
   const recordingStartRepsRef = React.useRef<number>(0);
   const recordingFqiScoresRef = React.useRef<number[]>([]);
+  // Ensures the 3-2-1 countdown only fires once per tracking start so we
+  // do not re-announce on mode swaps / transient phase re-entries. Reset
+  // to false inside startTracking + stopTracking.
+  const repCountdownFiredRef = React.useRef(false);
 
   const { speak: speakCue, stop: stopSpeech } = usePremiumCueAudio({
     enabled: audioFeedbackEnabled && isScreenFocused,
@@ -1621,6 +1626,7 @@ export default function ScanARKitScreen() {
       setActiveMetrics(null);
       resetBaselineDebugMetrics();
       resetCueHysteresis();
+      repCountdownFiredRef.current = false;
 
       const startTime = Date.now();
       shadowStatsRef.current = createShadowStatsAccumulator();
@@ -1630,11 +1636,22 @@ export default function ScanARKitScreen() {
       lastShadowMeanAbsDeltaRef.current = null;
       await startNativeTracking();
       const elapsed = Date.now() - startTime;
-      
+
       if (DEV) logWithTs('[ScanARKit] Tracking started successfully in', elapsed, 'ms');
 
       if (Platform.OS === 'ios') {
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      }
+
+      // Fire the 3-2-1 pre-announce once per tracking start. Gated on the
+      // user preference + the EXPO_PUBLIC_REP_COUNTDOWN env flag inside
+      // playRepCountdown itself. Errors are swallowed — countdown is a
+      // nice-to-have, not a blocker for the tracking loop.
+      if (!repCountdownFiredRef.current) {
+        repCountdownFiredRef.current = true;
+        playRepCountdown().catch((error) => {
+          if (DEV) warnWithTs('[ScanARKit] rep countdown failed', error);
+        });
       }
     } catch (error) {
       errorWithTs('[ScanARKit] ❌ Failed to start tracking:', error);
@@ -1716,7 +1733,8 @@ export default function ScanARKitScreen() {
       setShadowProviderRuntime('mediapipe_proxy');
       resetBaselineDebugMetrics();
       resetCueHysteresis();
-      
+      repCountdownFiredRef.current = false;
+
       if (DEV) logWithTs('[ScanARKit] Tracking stopped');
 
       if (Platform.OS === 'ios') {

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -41,12 +41,14 @@ import { BodyTracker, useBodyTracking, type JointAngles, type Joint2D, type Medi
 import { usePremiumCueAudio } from '@/hooks/use-premium-cue-audio';
 import { audioSessionManager } from '@/lib/services/audio-session-manager';
 import { CrashBoundary } from '@/components/CrashBoundary';
+import { ExitMidSessionSheet } from '@/components/form-tracking/ExitMidSessionSheet';
 import { PreSetPreviewCard } from '@/components/form-tracking/PreSetPreviewCard';
 import { usePreSetPreview } from '@/hooks/use-pre-set-preview';
 import { generateSessionId, logCueEvent, upsertSessionMetrics } from '@/lib/services/cue-logger';
 import { logPoseSample, flushPoseBuffer, resetFrameCounter } from '@/lib/services/pose-logger';
 import { playRepCountdown } from '@/lib/services/rep-countdown-audio';
 import { RepIndexTracker } from '@/lib/services/rep-index-tracker';
+import { saveSessionSnapshot } from '@/lib/services/session-snapshot';
 import {
   initSessionContext,
   incrementPoseLost,
@@ -434,6 +436,7 @@ export default function ScanARKitScreen() {
   const [isPreviewVisible, setIsPreviewVisible] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
   const [isSettingsVisible, setIsSettingsVisible] = useState(false);
+  const [isExitMidSessionSheetVisible, setIsExitMidSessionSheetVisible] = useState(false);
   const [showDebugStats, setShowDebugStats] = useState(false);
   const [fixturePlaybackFramesProcessed, setFixturePlaybackFramesProcessed] = useState(0);
   const [latestPullupScoring, setLatestPullupScoring] = useState<PullupScoringResult | null>(null);
@@ -776,6 +779,11 @@ export default function ScanARKitScreen() {
   const recordingStartFrameTimestampRef = React.useRef<number | null>(null);
   const recordingStartRepsRef = React.useRef<number>(0);
   const recordingFqiScoresRef = React.useRef<number[]>([]);
+  // Session-wide FQI scores (one entry per completed rep, regardless of
+  // recording state) — used for snapshots + milestone checks, independent
+  // of whether the user is actively recording a clip. Reset when tracking
+  // starts / stops.
+  const sessionFqiScoresRef = React.useRef<number[]>([]);
   // Ensures the 3-2-1 countdown only fires once per tracking start so we
   // do not re-announce on mode swaps / transient phase re-entries. Reset
   // to false inside startTracking + stopTracking.
@@ -950,6 +958,9 @@ export default function ScanARKitScreen() {
     onRepComplete: (repNumber: number, fqi: number) => {
       setRepCount(repNumber);
       repIndexTrackerRef.current.endRep();
+      if (Number.isFinite(fqi)) {
+        sessionFqiScoresRef.current.push(fqi);
+      }
       if (recordingActiveRef.current && Date.now() >= recordingStartEpochMsRef.current) {
         recordingFqiScoresRef.current.push(fqi);
       }
@@ -1627,6 +1638,7 @@ export default function ScanARKitScreen() {
       resetBaselineDebugMetrics();
       resetCueHysteresis();
       repCountdownFiredRef.current = false;
+      sessionFqiScoresRef.current = [];
 
       const startTime = Date.now();
       shadowStatsRef.current = createShadowStatsAccumulator();
@@ -1734,6 +1746,7 @@ export default function ScanARKitScreen() {
       resetBaselineDebugMetrics();
       resetCueHysteresis();
       repCountdownFiredRef.current = false;
+      sessionFqiScoresRef.current = [];
 
       if (DEV) logWithTs('[ScanARKit] Tracking stopped');
 
@@ -1762,6 +1775,72 @@ export default function ScanARKitScreen() {
       stopTracking();
     };
   }, [stopTracking]);
+
+  // ---------------------------------------------------------------------
+  // Mid-session exit flow (#494)
+  //
+  // When the user taps the close button while tracking is live, we show
+  // a three-choice Modal: Discard / Save snapshot / Cancel. This guards
+  // against accidental loss of a session in progress — especially when
+  // the app has been running ARKit for a while and we have rep/FQI data
+  // that would otherwise vanish into the void on back-nav.
+  // ---------------------------------------------------------------------
+  const computeAverageFqi = useCallback((): number | null => {
+    const scores = sessionFqiScoresRef.current;
+    if (!scores.length) return null;
+    const sum = scores.reduce((acc, v) => acc + v, 0);
+    return sum / scores.length;
+  }, []);
+
+  const isMidSession = useCallback((): boolean => {
+    if (!isTracking) return false;
+    const initialPhase = getWorkoutByMode(detectionMode).initialPhase;
+    return repCount > 0 || activePhaseRef.current !== initialPhase;
+  }, [isTracking, detectionMode, repCount]);
+
+  const handleCloseScan = useCallback(() => {
+    if (isMidSession()) {
+      setIsExitMidSessionSheetVisible(true);
+      return;
+    }
+    router.back();
+  }, [isMidSession, router]);
+
+  const handleExitDiscard = useCallback(async () => {
+    setIsExitMidSessionSheetVisible(false);
+    try {
+      await stopTracking();
+    } catch (error) {
+      if (DEV) warnWithTs('[ScanARKit] stopTracking during discard failed', error);
+    }
+    router.back();
+  }, [stopTracking, router, DEV]);
+
+  const handleExitSaveSnapshot = useCallback(async () => {
+    setIsExitMidSessionSheetVisible(false);
+    const avgFqi = computeAverageFqi();
+    try {
+      await saveSessionSnapshot({
+        exerciseKey: detectionMode,
+        repCount,
+        currentFqi: avgFqi,
+        startedAt: sessionStartRef.current,
+        sessionId: sessionIdRef.current,
+      });
+    } catch (error) {
+      if (DEV) warnWithTs('[ScanARKit] saveSessionSnapshot failed', error);
+    }
+    try {
+      await stopTracking();
+    } catch (error) {
+      if (DEV) warnWithTs('[ScanARKit] stopTracking during save failed', error);
+    }
+    router.back();
+  }, [computeAverageFqi, detectionMode, repCount, stopTracking, router, DEV]);
+
+  const handleExitCancel = useCallback(() => {
+    setIsExitMidSessionSheetVisible(false);
+  }, []);
 
   const handleOverlayLayout = useCallback((event: LayoutChangeEvent) => {
     const { width, height } = event.nativeEvent.layout;
@@ -2602,7 +2681,7 @@ export default function ScanARKitScreen() {
         <View style={styles.topBarContent}>
           <TouchableOpacity
             style={styles.topBarButton}
-            onPress={() => router.back()}
+            onPress={handleCloseScan}
             accessibilityRole="button"
             accessibilityLabel="Close scan"
           >
@@ -3205,6 +3284,15 @@ export default function ScanARKitScreen() {
         </SafeAreaView>
       </Modal>
       <PreSetPreviewCard visible={preSetPreviewVisible} isChecking={preSetPreview.isChecking} verdict={preSetPreview.verdict} error={preSetPreview.error} exerciseName={activeWorkoutDef.displayName} onRetry={handlePreSetPreviewCheck} onDismiss={() => { setPreSetPreviewVisible(false); preSetPreview.reset(); }} />
+      <ExitMidSessionSheet
+        visible={isExitMidSessionSheetVisible}
+        exerciseDisplayName={activeWorkoutDef.displayName}
+        repCount={repCount}
+        currentFqi={computeAverageFqi()}
+        onDiscard={handleExitDiscard}
+        onSaveSnapshot={handleExitSaveSnapshot}
+        onCancel={handleExitCancel}
+      />
       <VoiceCommandFeedback />
 </View>
     </CrashBoundary>

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -3,12 +3,14 @@ import * as Haptics from 'expo-haptics';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
 import { DeleteAction } from '@/components';
+import { FormQualityBadge } from '@/components/form-tracking/FormQualityBadge';
 import { OverloadAnalyticsCard } from '@/components/workouts/OverloadAnalyticsCard';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUnits } from '@/contexts/UnitsContext';
 import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
+import { getMostRecentAvgFqi } from '@/lib/services/form-session-history-lookup';
 import { exportSession } from '@/lib/services/session-export-service';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
     ActivityIndicator,
     Alert,
@@ -51,6 +53,11 @@ export default function WorkoutsScreen() {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [lastSynced, setLastSynced] = useState<Date | null>(null);
   const swipeableRefs = useRef<Map<string, Swipeable>>(new Map());
+  // Per-exercise most-recent FQI (issue #494, item 4). Lazily populated
+  // from form-session-history; missing entries render no badge.
+  const [formQualityByExercise, setFormQualityByExercise] = useState<
+    Record<string, number | null>
+  >({});
 
   // Pick the most recently logged exercise for the overload card. We fall
   // back to the first row when dates are missing; if the list is empty, the
@@ -72,6 +79,37 @@ export default function WorkoutsScreen() {
       `/(modals)/progression-plan?exercise=${encodeURIComponent(featuredExercise)}`,
     );
   }, [featuredExercise, router]);
+
+  // Populate the form-quality map whenever the workout list changes.
+  // Unique exercises only — the same name is re-used across sets.
+  useEffect(() => {
+    if (!workouts || workouts.length === 0) return;
+    const uniqueNames = Array.from(
+      new Set(workouts.map((w) => w.exercise).filter(Boolean)),
+    );
+    let cancelled = false;
+    (async () => {
+      const pairs = await Promise.all(
+        uniqueNames.map(async (name) => {
+          try {
+            const score = await getMostRecentAvgFqi(name);
+            return [name, score] as const;
+          } catch {
+            return [name, null] as const;
+          }
+        }),
+      );
+      if (cancelled) return;
+      setFormQualityByExercise((prev) => {
+        const next = { ...prev };
+        for (const [name, score] of pairs) next[name] = score;
+        return next;
+      });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [workouts]);
 
   const onRefresh = useCallback(async () => {
     setIsRefreshing(true);
@@ -275,7 +313,13 @@ export default function WorkoutsScreen() {
                 </Text>
               </View>
             </View>
-            
+
+            {formQualityByExercise[item.exercise] != null ? (
+              <View style={workoutCardStyles.badgeRow}>
+                <FormQualityBadge score={formQualityByExercise[item.exercise]} />
+              </View>
+            ) : null}
+
             <View style={styles.cardDetails}>
               <View style={styles.detailItem}>
                 <Text style={styles.detailValue}>{item.sets || '0'}</Text>
@@ -450,6 +494,14 @@ export default function WorkoutsScreen() {
     </View>
   );
 }
+
+// --- Local styles for the per-card form quality badge (#494) ----------------
+const workoutCardStyles = StyleSheet.create({
+  badgeRow: {
+    marginTop: 6,
+    marginBottom: 2,
+  },
+});
 
 // --- Local styles for the form-intel header pills (#476) ---------------------
 const intelHeaderStyles = StyleSheet.create({

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -20,6 +20,7 @@ import { HapticPreferencesProvider } from '../contexts/HapticPreferencesContext'
 import { logWithTs, warnWithTs } from '@/lib/logger';
 import { isOnboardingCompleted } from '@/lib/services/onboarding';
 import { hasSeenWelcome } from '@/app/(onboarding)/welcome';
+import { MilestoneToastBridge } from '@/components/MilestoneToastBridge';
 import { SessionTelemetryBinder } from '@/components/telemetry/SessionTelemetryBinder';
 import { parseTemplateIdFromUrl } from '@/lib/services/workout-scheduler';
 import '@/lib/services/fault-explainer-bootstrap';
@@ -111,6 +112,7 @@ function RootLayoutNav() {
                               ) : (
                                 <>
                                   <SessionTelemetryBinder />
+                                  <MilestoneToastBridge />
                                   <InitialLayout />
                                 </>
                               )}

--- a/components/MilestoneToastBridge.tsx
+++ b/components/MilestoneToastBridge.tsx
@@ -1,0 +1,35 @@
+/**
+ * MilestoneToastBridge
+ *
+ * Subscribes to the session-runner event bus and surfaces a toast
+ * whenever a `form_milestone` event fires (new PB or week-consistency).
+ *
+ * Kept as a thin bridge component so the session-runner store can stay
+ * pure (no React context deps) and the toast UI stays in React-land.
+ * Mount this inside the ToastProvider tree — once, globally — so every
+ * screen gets the notification without having to re-subscribe.
+ */
+import { useEffect } from 'react';
+
+import { useToast } from '@/contexts/ToastContext';
+import { subscribeToEvents } from '@/lib/stores/session-runner';
+
+export function MilestoneToastBridge(): null {
+  const { show } = useToast();
+
+  useEffect(() => {
+    const unsubscribe = subscribeToEvents((event) => {
+      if (event.type !== 'form_milestone') return;
+      const message =
+        typeof event.payload?.message === 'string' && event.payload.message
+          ? event.payload.message
+          : 'New form milestone unlocked';
+      show(message, { type: 'success', duration: 3500 });
+    });
+    return unsubscribe;
+  }, [show]);
+
+  return null;
+}
+
+export default MilestoneToastBridge;

--- a/components/form-tracking/ExitMidSessionSheet.tsx
+++ b/components/form-tracking/ExitMidSessionSheet.tsx
@@ -1,0 +1,204 @@
+/**
+ * ExitMidSessionSheet
+ *
+ * Triple-choice confirmation shown when the user tries to leave Analyze
+ * mid-session (still tracking or past calibration). Prevents a silent
+ * data-loss and gives the user a low-friction "save a note" escape hatch.
+ *
+ * Actions:
+ *   - Discard (destructive, primary)
+ *   - Save snapshot (secondary, preserves rep count + FQI + faults)
+ *   - Cancel (tertiary, keeps tracking)
+ *
+ * Rendered as a plain Modal overlay so it works on web + iOS without
+ * BottomSheet state juggling (matches ExerciseSwapSheet pattern).
+ */
+import React from 'react';
+import {
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type AccessibilityRole,
+} from 'react-native';
+
+export interface ExitMidSessionSheetProps {
+  visible: boolean;
+  exerciseDisplayName?: string | null;
+  repCount: number;
+  currentFqi?: number | null;
+  onDiscard: () => void;
+  onSaveSnapshot: () => void;
+  onCancel: () => void;
+  testID?: string;
+}
+
+export function ExitMidSessionSheet({
+  visible,
+  exerciseDisplayName,
+  repCount,
+  currentFqi,
+  onDiscard,
+  onSaveSnapshot,
+  onCancel,
+  testID,
+}: ExitMidSessionSheetProps) {
+  const resolvedTestID = testID ?? 'exit-mid-session-sheet';
+  const subtitle = buildSubtitle(repCount, currentFqi, exerciseDisplayName ?? null);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onCancel}
+      testID={resolvedTestID}
+    >
+      <Pressable
+        style={styles.backdrop}
+        onPress={onCancel}
+        accessibilityRole="button"
+        accessibilityLabel="Dismiss exit prompt"
+      />
+      <View
+        style={styles.sheet}
+        accessibilityRole={'menu' as AccessibilityRole}
+        accessibilityLabel="Discard session or save a snapshot"
+      >
+        <View style={styles.handle} />
+        <Text style={styles.title}>Leave this session?</Text>
+        {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
+
+        <Pressable
+          style={({ pressed }) => [styles.btn, styles.btnDiscard, pressed && styles.pressed]}
+          onPress={onDiscard}
+          accessibilityRole="button"
+          accessibilityLabel="Discard session"
+          testID={`${resolvedTestID}-discard`}
+        >
+          <Text style={styles.btnDiscardText}>Discard session</Text>
+          <Text style={styles.btnSubText}>Exit without saving anything</Text>
+        </Pressable>
+
+        <Pressable
+          style={({ pressed }) => [styles.btn, styles.btnSnapshot, pressed && styles.pressed]}
+          onPress={onSaveSnapshot}
+          accessibilityRole="button"
+          accessibilityLabel="Save a snapshot"
+          testID={`${resolvedTestID}-save-snapshot`}
+        >
+          <Text style={styles.btnSnapshotText}>Save snapshot</Text>
+          <Text style={styles.btnSubText}>Keep a note with your rep count + form score</Text>
+        </Pressable>
+
+        <Pressable
+          style={({ pressed }) => [styles.btn, styles.btnCancel, pressed && styles.pressed]}
+          onPress={onCancel}
+          accessibilityRole="button"
+          accessibilityLabel="Cancel"
+          testID={`${resolvedTestID}-cancel`}
+        >
+          <Text style={styles.btnCancelText}>Keep tracking</Text>
+        </Pressable>
+      </View>
+    </Modal>
+  );
+}
+
+function buildSubtitle(
+  repCount: number,
+  currentFqi: number | null | undefined,
+  exerciseDisplayName: string | null,
+): string | null {
+  const exercisePart = exerciseDisplayName ? exerciseDisplayName : null;
+  const repsPart = repCount > 0 ? `${repCount} rep${repCount === 1 ? '' : 's'}` : null;
+  const fqiPart =
+    currentFqi != null && !Number.isNaN(currentFqi)
+      ? `FQI ${Math.round(currentFqi)}`
+      : null;
+  const parts = [exercisePart, repsPart, fqiPart].filter((s): s is string => Boolean(s));
+  return parts.length ? parts.join(' · ') : null;
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.55)',
+  },
+  sheet: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: '#0D1530',
+    borderTopLeftRadius: 18,
+    borderTopRightRadius: 18,
+    padding: 20,
+    paddingBottom: 36,
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 44,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
+    marginBottom: 12,
+  },
+  title: {
+    color: '#F5F7FF',
+    fontSize: 18,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+  subtitle: {
+    color: 'rgba(220, 228, 245, 0.7)',
+    fontSize: 13,
+    textAlign: 'center',
+    marginTop: 4,
+    marginBottom: 16,
+  },
+  btn: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 12,
+    marginTop: 10,
+  },
+  btnDiscard: {
+    backgroundColor: 'rgba(255, 110, 110, 0.15)',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 110, 110, 0.45)',
+  },
+  btnDiscardText: {
+    color: '#FF9E9E',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  btnSnapshot: {
+    backgroundColor: '#4C8CFF',
+  },
+  btnSnapshotText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  btnCancel: {
+    backgroundColor: 'transparent',
+  },
+  btnCancelText: {
+    color: 'rgba(220, 228, 245, 0.7)',
+    fontSize: 14,
+    fontWeight: '500',
+    textAlign: 'center',
+  },
+  btnSubText: {
+    color: 'rgba(255, 255, 255, 0.72)',
+    fontSize: 12,
+    marginTop: 3,
+  },
+  pressed: {
+    opacity: 0.75,
+  },
+});
+
+export default ExitMidSessionSheet;

--- a/components/form-tracking/FormQualityBadge.tsx
+++ b/components/form-tracking/FormQualityBadge.tsx
@@ -1,0 +1,77 @@
+/**
+ * FormQualityBadge
+ *
+ * Compact pill surfaced on workout history cards so users can scan their
+ * sessions for form quality at a glance without tapping through. Reuses
+ * the shared FQI color tiers from FqiGauge (`getFqiColor`) so the badge
+ * and the live gauge stay visually consistent.
+ *
+ * Renders null when the score is missing — cards without form data show
+ * no badge rather than a hollow "--" placeholder.
+ */
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, View, type StyleProp, type ViewStyle } from 'react-native';
+
+import { getFqiColor } from './FqiGauge';
+
+export interface FormQualityBadgeProps {
+  /** Session-average form quality score, 0-100, or null when unavailable. */
+  score: number | null | undefined;
+  /** Optional style override. */
+  style?: StyleProp<ViewStyle>;
+  /** Optional testID. */
+  testID?: string;
+}
+
+export function FormQualityBadge({ score, style, testID }: FormQualityBadgeProps) {
+  const rounded = useMemo(() => {
+    if (score == null || !Number.isFinite(score)) return null;
+    return Math.max(0, Math.min(100, Math.round(score)));
+  }, [score]);
+
+  const colors = useMemo(() => getFqiColor(rounded), [rounded]);
+
+  if (rounded == null) return null;
+
+  return (
+    <View
+      style={[styles.container, { borderColor: colors.fill, backgroundColor: colors.track }, style]}
+      testID={testID ?? 'form-quality-badge'}
+      accessibilityLabel={`Form quality ${rounded} out of 100`}
+    >
+      <View style={[styles.dot, { backgroundColor: colors.fill }]} />
+      <Text style={[styles.score, { color: colors.fill }]}>{rounded}</Text>
+      <Text style={[styles.label, { color: colors.fill }]}>FORM</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    borderRadius: 999,
+    borderWidth: 1,
+    alignSelf: 'flex-start',
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+  score: {
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  label: {
+    fontSize: 10,
+    fontWeight: '600',
+    letterSpacing: 0.4,
+    opacity: 0.85,
+  },
+});
+
+export default FormQualityBadge;

--- a/lib/services/form-milestone-detector.ts
+++ b/lib/services/form-milestone-detector.ts
@@ -1,0 +1,152 @@
+/**
+ * Form Milestone Detector
+ *
+ * Post-session pure function that looks for two kinds of win worth
+ * surfacing to the user inline:
+ *
+ *   - `new_pb`: this session's average FQI beats the athlete's prior
+ *     best on the same exercise by at least PB_MARGIN points.
+ *   - `week_consistency`: the last `WEEK_WINDOW_SESSIONS` sessions
+ *     (including this one) are all within a tight FQI band, signalling
+ *     a repeatable groove worth celebrating.
+ *
+ * The function is pure so it is cheap to test and easy to hook into any
+ * post-session pipeline — the caller decides how to surface the result
+ * (toast, badge, notification, etc.).
+ */
+
+export type MilestoneKind = 'new_pb' | 'week_consistency';
+
+export interface PriorSession {
+  /** Average FQI for a completed session on this exercise. */
+  avgFqi: number;
+  /** ISO timestamp the session ended (or started — we only use recency). */
+  endedAt?: string;
+}
+
+export interface DetectMilestoneInput {
+  exerciseKey: string;
+  currentAvgFqi: number;
+  /** Prior sessions on the same exercise, newest-first or any order. */
+  priorSessions: PriorSession[];
+  /** Required PB margin in raw FQI points (default 2). */
+  pbMargin?: number;
+  /** Required minimum current FQI to qualify for a PB (default 0). */
+  pbMinScore?: number;
+  /** Band-width for week-consistency (default 5 FQI points). */
+  consistencyBand?: number;
+  /** Window of sessions considered for consistency (default 3). */
+  consistencyWindow?: number;
+  /** Floor for the consistency signal to fire (default 70). */
+  consistencyMinScore?: number;
+}
+
+export interface MilestoneResult {
+  kind: MilestoneKind | null;
+  message: string;
+  score: number;
+}
+
+const DEFAULTS = {
+  pbMargin: 2,
+  pbMinScore: 0,
+  consistencyBand: 5,
+  consistencyWindow: 3,
+  consistencyMinScore: 70,
+} as const;
+
+function formatScore(score: number): string {
+  return Math.round(score).toString();
+}
+
+function exerciseLabel(exerciseKey: string): string {
+  if (!exerciseKey) return 'this exercise';
+  return exerciseKey.replace(/[_-]+/g, ' ').trim() || 'this exercise';
+}
+
+/**
+ * Analyse a finished session. Returns `{ kind: null }` when no milestone
+ * fires — the caller can use `if (result.kind)` as a cheap gate.
+ */
+export function detectMilestone(input: DetectMilestoneInput): MilestoneResult {
+  const {
+    exerciseKey,
+    currentAvgFqi,
+    priorSessions,
+    pbMargin = DEFAULTS.pbMargin,
+    pbMinScore = DEFAULTS.pbMinScore,
+    consistencyBand = DEFAULTS.consistencyBand,
+    consistencyWindow = DEFAULTS.consistencyWindow,
+    consistencyMinScore = DEFAULTS.consistencyMinScore,
+  } = input;
+
+  const score = safeNumber(currentAvgFqi);
+  if (score == null) {
+    return { kind: null, message: '', score: 0 };
+  }
+
+  const priors = (priorSessions ?? [])
+    .map((p) => safeNumber(p.avgFqi))
+    .filter((v): v is number => v != null);
+
+  // ---- PB check ----
+  // First session ever: only a PB if we clear the explicit pbMinScore.
+  // Subsequent sessions: must beat max(prior) by at least pbMargin.
+  if (priors.length === 0) {
+    if (score >= pbMinScore && pbMinScore > 0) {
+      return {
+        kind: 'new_pb',
+        message: buildPbMessage(score, exerciseKey),
+        score,
+      };
+    }
+  } else {
+    const priorBest = Math.max(...priors);
+    if (score - priorBest >= pbMargin && score >= pbMinScore) {
+      return {
+        kind: 'new_pb',
+        message: buildPbMessage(score, exerciseKey),
+        score,
+      };
+    }
+  }
+
+  // ---- Week-consistency check ----
+  // Needs (consistencyWindow - 1) priors plus the current session in a
+  // tight band, each at or above consistencyMinScore. We compare on the
+  // priors provided by the caller; the caller is responsible for
+  // bounding to the last 7 days if they want strict "week" semantics.
+  const windowScores = [score, ...priors].slice(0, consistencyWindow);
+  if (windowScores.length >= consistencyWindow) {
+    const min = Math.min(...windowScores);
+    const max = Math.max(...windowScores);
+    if (min >= consistencyMinScore && max - min <= consistencyBand) {
+      return {
+        kind: 'week_consistency',
+        message: buildConsistencyMessage(score, exerciseKey, consistencyWindow),
+        score,
+      };
+    }
+  }
+
+  return { kind: null, message: '', score };
+}
+
+function safeNumber(raw: number | null | undefined): number | null {
+  if (raw == null) return null;
+  if (typeof raw !== 'number') return null;
+  if (!Number.isFinite(raw)) return null;
+  return raw;
+}
+
+function buildPbMessage(score: number, exerciseKey: string): string {
+  return `New record: ${formatScore(score)}/100 form on ${exerciseLabel(exerciseKey)}`;
+}
+
+function buildConsistencyMessage(
+  score: number,
+  exerciseKey: string,
+  window: number,
+): string {
+  return `Dialed in: ${window} straight ${exerciseLabel(exerciseKey)} sessions around ${formatScore(score)}/100`;
+}

--- a/lib/services/form-session-history-lookup.ts
+++ b/lib/services/form-session-history-lookup.ts
@@ -1,0 +1,51 @@
+/**
+ * Form Session History — Exercise-Name Lookup
+ *
+ * Helper utilities that bridge a user-facing exercise string (e.g.
+ * "Pull-Up", "pullups", "pull up") to the detection-mode key used by
+ * form-session-history (e.g. `pullup`). Kept out of the history service
+ * so the store stays key-agnostic.
+ */
+import { getFormSessionHistory } from '@/lib/services/form-session-history';
+import { getWorkoutIds } from '@/lib/workouts';
+
+function normalise(raw: string): string {
+  return raw.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+/**
+ * Resolve a user-facing exercise name / id to the canonical detection
+ * mode used by form-session-history. Returns null when no match exists.
+ */
+export function resolveExerciseKey(exerciseName: string): string | null {
+  if (!exerciseName) return null;
+  const normalised = normalise(exerciseName);
+  const candidates = getWorkoutIds();
+  // 1) exact match on the canonical id (already normalised).
+  for (const id of candidates) {
+    if (normalise(id) === normalised) return id;
+  }
+  // 2) substring match ("pullups" → "pullup", "pull_up" → "pullup").
+  for (const id of candidates) {
+    const normId = normalise(id);
+    if (normalised.startsWith(normId) || normId.startsWith(normalised)) {
+      return id;
+    }
+  }
+  return null;
+}
+
+/**
+ * Fetch the most-recent session FQI for a given exercise name, or null
+ * when the exercise has no tracked sessions yet. Caller maps to a badge.
+ */
+export async function getMostRecentAvgFqi(
+  exerciseName: string,
+): Promise<number | null> {
+  const key = resolveExerciseKey(exerciseName);
+  if (!key) return null;
+  const history = await getFormSessionHistory(key);
+  if (!history.length) return null;
+  const latest = history[0];
+  return latest.avgFqi;
+}

--- a/lib/services/form-session-history.ts
+++ b/lib/services/form-session-history.ts
@@ -1,0 +1,97 @@
+/**
+ * Form Session History
+ *
+ * Thin AsyncStorage-backed log of per-exercise session averages used by
+ * the form-milestone detector. Intentionally lightweight — we store only
+ * the fields required to run `detectMilestone()` against historical
+ * sessions, not the full rep data (which lives in the local-db / supabase
+ * pipeline).
+ *
+ * The log is capped at FORM_SESSION_HISTORY_MAX_ENTRIES_PER_EXERCISE to
+ * keep storage bounded. Entries are newest-first.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const FORM_SESSION_HISTORY_STORAGE_KEY = 'form_session_history_v1';
+export const FORM_SESSION_HISTORY_MAX_ENTRIES_PER_EXERCISE = 30;
+
+export interface FormSessionHistoryEntry {
+  exerciseKey: string;
+  avgFqi: number;
+  endedAt: string;
+  sessionId?: string;
+}
+
+type FormSessionHistoryByExercise = Record<string, FormSessionHistoryEntry[]>;
+
+function safeParse(raw: string | null): FormSessionHistoryByExercise {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const out: FormSessionHistoryByExercise = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!Array.isArray(value)) continue;
+      out[key] = value.filter(isEntry);
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function isEntry(value: unknown): value is FormSessionHistoryEntry {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.exerciseKey === 'string' &&
+    typeof v.avgFqi === 'number' &&
+    Number.isFinite(v.avgFqi) &&
+    typeof v.endedAt === 'string'
+  );
+}
+
+export async function appendFormSessionHistory(
+  entry: FormSessionHistoryEntry,
+): Promise<void> {
+  if (!entry.exerciseKey) return;
+  if (!Number.isFinite(entry.avgFqi)) return;
+  try {
+    const raw = await AsyncStorage.getItem(FORM_SESSION_HISTORY_STORAGE_KEY);
+    const parsed = safeParse(raw);
+    const prior = parsed[entry.exerciseKey] ?? [];
+    const next = [entry, ...prior].slice(
+      0,
+      FORM_SESSION_HISTORY_MAX_ENTRIES_PER_EXERCISE,
+    );
+    parsed[entry.exerciseKey] = next;
+    await AsyncStorage.setItem(
+      FORM_SESSION_HISTORY_STORAGE_KEY,
+      JSON.stringify(parsed),
+    );
+  } catch {
+    // best-effort — skipping the write just means the next session won't
+    // see this milestone baseline.
+  }
+}
+
+export async function getFormSessionHistory(
+  exerciseKey: string,
+): Promise<FormSessionHistoryEntry[]> {
+  if (!exerciseKey) return [];
+  try {
+    const raw = await AsyncStorage.getItem(FORM_SESSION_HISTORY_STORAGE_KEY);
+    const parsed = safeParse(raw);
+    return parsed[exerciseKey] ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export async function clearFormSessionHistory(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(FORM_SESSION_HISTORY_STORAGE_KEY);
+  } catch {
+    // best-effort
+  }
+}

--- a/lib/services/rep-countdown-audio.ts
+++ b/lib/services/rep-countdown-audio.ts
@@ -1,0 +1,137 @@
+/**
+ * Rep Countdown Audio
+ *
+ * Plays a short 3-2-1 pre-announce before rep counting begins so the
+ * athlete can sync their first rep with the coaching voice. Runs on
+ * both iOS + Android (falls back to expo-speech when custom MP3s are
+ * not generated). Web is a safe no-op.
+ *
+ * Architecture mirrors the in-session cue pipeline:
+ *   - uses expo-speech for the spoken digits
+ *   - pulses expo-haptics at each tick for tactile rhythm
+ *   - honors the user's rep-countdown preference (default on)
+ *
+ * The function resolves when the full "3… 2… 1… go" line has played.
+ * Callers should await it before starting any hard-rep detection so
+ * the first rep does not race the final haptic.
+ */
+import { Platform } from 'react-native';
+import * as Speech from 'expo-speech';
+import * as Haptics from 'expo-haptics';
+
+import { getRepCountdownEnabled } from '@/lib/services/rep-countdown-pref';
+
+export const REP_COUNTDOWN_STEP_MS = 1000;
+
+export interface PlayRepCountdownOptions {
+  /** Skip reading the preference when the caller already knows. */
+  forceEnabled?: boolean;
+  /** Override the TTS voice (defaults to system default). */
+  voiceId?: string;
+  /** Override the TTS language (defaults to en-US). */
+  language?: string;
+  /** Override the TTS rate (defaults to 0.9). */
+  rate?: number;
+  /** Injectable timer for deterministic tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable speaker for deterministic tests. */
+  speak?: (phrase: string) => Promise<void>;
+  /** Injectable haptic pulse for deterministic tests. */
+  pulse?: (kind: 'tick' | 'go') => Promise<void>;
+}
+
+export interface PlayRepCountdownResult {
+  /** Whether the countdown actually played. */
+  played: boolean;
+  /** Reason it was skipped (when `played === false`). */
+  reason?: 'disabled' | 'unsupported_platform';
+  /** Phrases that were spoken, in order. Useful for tests + telemetry. */
+  spoken: string[];
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+function defaultSpeak(
+  phrase: string,
+  voiceId: string | undefined,
+  language: string,
+  rate: number,
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    try {
+      Speech.speak(phrase, {
+        voice: voiceId,
+        language,
+        rate,
+        onDone: () => resolve(),
+        onStopped: () => resolve(),
+        onError: () => resolve(),
+      });
+    } catch {
+      resolve();
+    }
+  });
+}
+
+async function defaultPulse(kind: 'tick' | 'go'): Promise<void> {
+  try {
+    if (Platform.OS === 'web') return;
+    if (kind === 'tick') {
+      await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    } else {
+      await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    }
+  } catch {
+    // best-effort — haptics on older devices may throw
+  }
+}
+
+/**
+ * Play the "3… 2… 1… go" countdown. Honors the user preference by
+ * default; pass `forceEnabled: true` to bypass (for manual previews).
+ */
+export async function playRepCountdown(
+  options: PlayRepCountdownOptions = {},
+): Promise<PlayRepCountdownResult> {
+  const {
+    forceEnabled,
+    voiceId,
+    language = 'en-US',
+    rate = 0.9,
+    sleep = defaultSleep,
+    speak,
+    pulse = defaultPulse,
+  } = options;
+
+  if (Platform.OS === 'web') {
+    return { played: false, reason: 'unsupported_platform', spoken: [] };
+  }
+
+  const enabled = forceEnabled ?? (await getRepCountdownEnabled());
+  if (!enabled) {
+    return { played: false, reason: 'disabled', spoken: [] };
+  }
+
+  const say = speak ?? ((phrase: string) => defaultSpeak(phrase, voiceId, language, rate));
+
+  const ticks: { phrase: string; kind: 'tick' | 'go' }[] = [
+    { phrase: '3', kind: 'tick' },
+    { phrase: '2', kind: 'tick' },
+    { phrase: '1', kind: 'tick' },
+    { phrase: 'go', kind: 'go' },
+  ];
+
+  const spoken: string[] = [];
+  for (let i = 0; i < ticks.length; i += 1) {
+    const tick = ticks[i];
+    await Promise.all([pulse(tick.kind), say(tick.phrase)]);
+    spoken.push(tick.phrase);
+    if (i < ticks.length - 1) {
+      await sleep(REP_COUNTDOWN_STEP_MS);
+    }
+  }
+
+  return { played: true, spoken };
+}

--- a/lib/services/rep-countdown-pref.ts
+++ b/lib/services/rep-countdown-pref.ts
@@ -1,0 +1,47 @@
+/**
+ * Rep Countdown Preference
+ *
+ * Persists the user's opt-in/opt-out for the pre-announce 3-2-1 countdown
+ * that plays before rep counting begins. The feature defaults to ON so new
+ * users hear it the first time they enter a tracking session, but respects
+ * an AsyncStorage override when the user toggles it in settings.
+ *
+ * The default can also be flipped via the `EXPO_PUBLIC_REP_COUNTDOWN` env
+ * flag — if it is explicitly set to `'off'` the default becomes off. Any
+ * other value (including unset) keeps the default on.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const REP_COUNTDOWN_STORAGE_KEY = 'form_rep_countdown_enabled_v1';
+
+export function getRepCountdownDefault(): boolean {
+  return (process.env.EXPO_PUBLIC_REP_COUNTDOWN ?? 'on').toLowerCase() !== 'off';
+}
+
+/**
+ * Resolve the effective preference. Falls back to the default when nothing
+ * has been stored yet or when the stored value is corrupt.
+ */
+export async function getRepCountdownEnabled(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(REP_COUNTDOWN_STORAGE_KEY);
+    if (raw == null) return getRepCountdownDefault();
+    if (raw === 'true') return true;
+    if (raw === 'false') return false;
+    return getRepCountdownDefault();
+  } catch {
+    return getRepCountdownDefault();
+  }
+}
+
+/**
+ * Persist the user's choice. Idempotent — writing the same value twice is
+ * a no-op beyond the AsyncStorage round-trip.
+ */
+export async function setRepCountdownEnabled(enabled: boolean): Promise<void> {
+  try {
+    await AsyncStorage.setItem(REP_COUNTDOWN_STORAGE_KEY, enabled ? 'true' : 'false');
+  } catch {
+    // best-effort — the next call will fall back to the default
+  }
+}

--- a/lib/services/session-snapshot.ts
+++ b/lib/services/session-snapshot.ts
@@ -1,0 +1,155 @@
+/**
+ * Session Snapshot
+ *
+ * Lightweight capture of an in-progress form-tracking session so the user
+ * can quit mid-session without losing the rep count + form score + fault
+ * list. Stored in AsyncStorage rather than the local SQLite DB so we can
+ * ship without a migration; the schema is explicitly versioned so we can
+ * migrate up later if we need persistent history.
+ *
+ * A snapshot is *not* a completed workout. It is a breadcrumb the debrief
+ * screen can read back ("you ran 7 pullups, FQI 84 before you closed the
+ * app") so the moment is not lost. Full workouts still go through the
+ * session-runner / local-db pipeline as before.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const SESSION_SNAPSHOT_STORAGE_KEY = 'form_session_snapshots_v1';
+export const SESSION_SNAPSHOT_MAX_ENTRIES = 25;
+export const SESSION_SNAPSHOT_SCHEMA_VERSION = 1;
+
+export interface SessionSnapshotFault {
+  /** Fault identifier (e.g. 'shallow_rom', 'hip_drop'). Free-form string. */
+  key: string;
+  /** Number of times this fault fired during the session. */
+  count: number;
+}
+
+export interface SessionSnapshotInput {
+  exerciseKey: string;
+  repCount: number;
+  currentFqi: number | null;
+  faults?: SessionSnapshotFault[];
+  /** ISO timestamp the session started. */
+  startedAt: string;
+  /** Optional sessionId — helpful if the user later resumes. */
+  sessionId?: string;
+  /** Optional notes field for the user / UI. */
+  note?: string;
+}
+
+export interface SessionSnapshot extends SessionSnapshotInput {
+  id: string;
+  /** ISO timestamp the snapshot was saved. */
+  savedAt: string;
+  /** Version of the on-disk schema. */
+  schemaVersion: number;
+}
+
+function safeParse(raw: string | null): SessionSnapshot[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isSnapshot);
+  } catch {
+    return [];
+  }
+}
+
+function isSnapshot(value: unknown): value is SessionSnapshot {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === 'string' &&
+    typeof v.exerciseKey === 'string' &&
+    typeof v.repCount === 'number' &&
+    typeof v.startedAt === 'string' &&
+    typeof v.savedAt === 'string'
+  );
+}
+
+function generateSnapshotId(): string {
+  // Randomness is cheap here — snapshots are user-scoped + local-only.
+  const rand = Math.random().toString(36).slice(2, 10);
+  return `snap_${Date.now().toString(36)}_${rand}`;
+}
+
+/**
+ * Persist a lightweight snapshot. Returns the stored record so the caller
+ * can display its id / timestamp immediately. Never throws — AsyncStorage
+ * failures are swallowed and an in-memory result is returned.
+ */
+export async function saveSessionSnapshot(
+  input: SessionSnapshotInput,
+): Promise<SessionSnapshot> {
+  if (!input.exerciseKey) throw new Error('exerciseKey required');
+  if (!input.startedAt) throw new Error('startedAt required');
+  if (typeof input.repCount !== 'number' || Number.isNaN(input.repCount)) {
+    throw new Error('repCount must be a finite number');
+  }
+
+  const record: SessionSnapshot = {
+    ...input,
+    repCount: Math.max(0, Math.trunc(input.repCount)),
+    currentFqi:
+      input.currentFqi == null || Number.isNaN(input.currentFqi)
+        ? null
+        : Math.max(0, Math.min(100, input.currentFqi)),
+    faults: Array.isArray(input.faults) ? input.faults.slice(0, 10) : [],
+    id: generateSnapshotId(),
+    savedAt: new Date().toISOString(),
+    schemaVersion: SESSION_SNAPSHOT_SCHEMA_VERSION,
+  };
+
+  try {
+    const raw = await AsyncStorage.getItem(SESSION_SNAPSHOT_STORAGE_KEY);
+    const existing = safeParse(raw);
+    const next = [record, ...existing].slice(0, SESSION_SNAPSHOT_MAX_ENTRIES);
+    await AsyncStorage.setItem(SESSION_SNAPSHOT_STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // best-effort — the record is still returned so the caller can show it
+  }
+
+  return record;
+}
+
+/**
+ * Read back all stored snapshots, newest first. Returns an empty array on
+ * corrupt storage rather than throwing.
+ */
+export async function listSessionSnapshots(): Promise<SessionSnapshot[]> {
+  try {
+    const raw = await AsyncStorage.getItem(SESSION_SNAPSHOT_STORAGE_KEY);
+    return safeParse(raw);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Remove a single snapshot by id. Returns whether the record was found.
+ * Idempotent — deleting a missing id is a no-op.
+ */
+export async function deleteSessionSnapshot(id: string): Promise<boolean> {
+  try {
+    const existing = await listSessionSnapshots();
+    const next = existing.filter((s) => s.id !== id);
+    if (next.length === existing.length) return false;
+    await AsyncStorage.setItem(SESSION_SNAPSHOT_STORAGE_KEY, JSON.stringify(next));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Nuke all snapshots. Mainly useful for tests + a hidden settings action.
+ */
+export async function clearSessionSnapshots(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(SESSION_SNAPSHOT_STORAGE_KEY);
+  } catch {
+    // best-effort
+  }
+}

--- a/lib/stores/session-runner.ts
+++ b/lib/stores/session-runner.ts
@@ -31,6 +31,11 @@ import {
   getDefaultsForExercise,
   type FormTargets,
 } from '@/lib/services/form-target-resolver';
+import {
+  detectMilestone,
+  type PriorSession,
+  type MilestoneResult,
+} from '@/lib/services/form-milestone-detector';
 import type {
   WorkoutSession,
   WorkoutSessionExercise,
@@ -249,6 +254,59 @@ async function emitEvent(
     session_set_id: sessionSetId ?? null,
     payload,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Post-session form milestone surface (#494)
+//
+// Surface a new PB / week-consistency signal via the session-event bus
+// after a form-tracking session finishes. Kept outside the store so the
+// caller (scan-arkit) can pipe the precise averages it already has
+// without forcing the session-runner to re-aggregate SQL rows on finish.
+//
+// Listeners (e.g. ToastMilestoneBridge) subscribe via subscribeToEvents
+// and render the user-facing surface.
+// ---------------------------------------------------------------------------
+
+export interface EmitFormMilestoneArgs {
+  sessionId: string;
+  exerciseKey: string;
+  currentAvgFqi: number;
+  priorSessions: PriorSession[];
+  /** Override the detector options per-call. */
+  pbMargin?: number;
+  consistencyBand?: number;
+  consistencyWindow?: number;
+  consistencyMinScore?: number;
+}
+
+/**
+ * Run the milestone detector against the given inputs and — when a
+ * milestone is present — emit a `form_milestone` session event. Returns
+ * the raw detector result so the caller can gate extra UI on it.
+ */
+export async function emitFormMilestone(
+  args: EmitFormMilestoneArgs,
+): Promise<MilestoneResult> {
+  const result = detectMilestone({
+    exerciseKey: args.exerciseKey,
+    currentAvgFqi: args.currentAvgFqi,
+    priorSessions: args.priorSessions,
+    pbMargin: args.pbMargin,
+    consistencyBand: args.consistencyBand,
+    consistencyWindow: args.consistencyWindow,
+    consistencyMinScore: args.consistencyMinScore,
+  });
+
+  if (result.kind) {
+    await emitEvent(args.sessionId, 'form_milestone', null, null, {
+      kind: result.kind,
+      message: result.message,
+      score: result.score,
+      exercise_key: args.exerciseKey,
+    });
+  }
+  return result;
 }
 
 async function getExerciseById(exerciseId: string): Promise<Exercise | null> {

--- a/lib/types/workout-session.ts
+++ b/lib/types/workout-session.ts
@@ -33,7 +33,8 @@ export type SessionEventType =
   | 'rest_completed'
   | 'rest_skipped'
   | 'session_completed'
-  | 'pr_detected';
+  | 'pr_detected'
+  | 'form_milestone';
 
 // =============================================================================
 // Exercise

--- a/tests/unit/components/form-tracking/FormQualityBadge.test.tsx
+++ b/tests/unit/components/form-tracking/FormQualityBadge.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+jest.mock('moti', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    MotiView: View,
+    MotiText: View,
+  };
+});
+
+// eslint-disable-next-line import/first
+import { FormQualityBadge } from '@/components/form-tracking/FormQualityBadge';
+// eslint-disable-next-line import/first
+import { getFqiColor } from '@/components/form-tracking/FqiGauge';
+
+describe('FormQualityBadge', () => {
+  it('renders nothing when score is null', () => {
+    const { queryByTestId } = render(<FormQualityBadge score={null} />);
+    expect(queryByTestId('form-quality-badge')).toBeNull();
+  });
+
+  it('renders nothing when score is undefined', () => {
+    const { queryByTestId } = render(<FormQualityBadge score={undefined} />);
+    expect(queryByTestId('form-quality-badge')).toBeNull();
+  });
+
+  it('renders nothing when score is NaN', () => {
+    const { queryByTestId } = render(<FormQualityBadge score={Number.NaN} />);
+    expect(queryByTestId('form-quality-badge')).toBeNull();
+  });
+
+  it('renders a rounded integer score', () => {
+    const { getByText } = render(<FormQualityBadge score={82.6} />);
+    expect(getByText('83')).toBeTruthy();
+  });
+
+  it('clamps scores above 100', () => {
+    const { getByText } = render(<FormQualityBadge score={120} />);
+    expect(getByText('100')).toBeTruthy();
+  });
+
+  it('clamps scores below 0', () => {
+    const { getByText } = render(<FormQualityBadge score={-5} />);
+    expect(getByText('0')).toBeTruthy();
+  });
+
+  it('uses the poor (red) tier color for scores < 40', () => {
+    const { getByTestId } = render(<FormQualityBadge score={25} />);
+    const badge = getByTestId('form-quality-badge');
+    const flat = Array.isArray(badge.props.style)
+      ? Object.assign({}, ...badge.props.style.filter(Boolean))
+      : badge.props.style;
+    expect(flat.borderColor).toBe(getFqiColor(25).fill);
+    expect(getFqiColor(25).fill).toBe('#FF3B30');
+  });
+
+  it('uses the fair (yellow) tier color for scores 40-69', () => {
+    const { getByTestId } = render(<FormQualityBadge score={55} />);
+    const badge = getByTestId('form-quality-badge');
+    const flat = Array.isArray(badge.props.style)
+      ? Object.assign({}, ...badge.props.style.filter(Boolean))
+      : badge.props.style;
+    expect(flat.borderColor).toBe(getFqiColor(55).fill);
+    expect(getFqiColor(55).fill).toBe('#FFC244');
+  });
+
+  it('uses the good (green) tier color for scores >= 70', () => {
+    const { getByTestId } = render(<FormQualityBadge score={82} />);
+    const badge = getByTestId('form-quality-badge');
+    const flat = Array.isArray(badge.props.style)
+      ? Object.assign({}, ...badge.props.style.filter(Boolean))
+      : badge.props.style;
+    expect(flat.borderColor).toBe(getFqiColor(82).fill);
+    expect(getFqiColor(82).fill).toBe('#3CC8A9');
+  });
+
+  it('includes an accessibility label containing the score', () => {
+    const { getByTestId } = render(<FormQualityBadge score={82} />);
+    expect(getByTestId('form-quality-badge').props.accessibilityLabel).toBe(
+      'Form quality 82 out of 100',
+    );
+  });
+
+  it('honors a custom testID', () => {
+    const { getByTestId } = render(<FormQualityBadge score={82} testID="card-badge" />);
+    expect(getByTestId('card-badge')).toBeTruthy();
+  });
+});

--- a/tests/unit/services/form-milestone-detector.test.ts
+++ b/tests/unit/services/form-milestone-detector.test.ts
@@ -1,0 +1,179 @@
+import {
+  detectMilestone,
+  type DetectMilestoneInput,
+} from '@/lib/services/form-milestone-detector';
+
+const base = (overrides: Partial<DetectMilestoneInput> = {}): DetectMilestoneInput => ({
+  exerciseKey: 'pullup',
+  currentAvgFqi: 80,
+  priorSessions: [],
+  ...overrides,
+});
+
+describe('form-milestone-detector', () => {
+  describe('new_pb', () => {
+    it('fires when the current score beats the prior best by the margin', () => {
+      const result = detectMilestone(
+        base({
+          currentAvgFqi: 92,
+          priorSessions: [{ avgFqi: 88 }, { avgFqi: 85 }, { avgFqi: 80 }],
+        }),
+      );
+      expect(result.kind).toBe('new_pb');
+      expect(result.score).toBe(92);
+      expect(result.message).toContain('New record');
+      expect(result.message).toContain('92/100');
+      expect(result.message).toContain('pullup');
+    });
+
+    it('does NOT fire when the gap is smaller than the default margin', () => {
+      const result = detectMilestone(
+        base({ currentAvgFqi: 89, priorSessions: [{ avgFqi: 88 }] }),
+      );
+      expect(result.kind).toBeNull();
+    });
+
+    it('respects a custom margin', () => {
+      const result = detectMilestone(
+        base({
+          currentAvgFqi: 91,
+          priorSessions: [{ avgFqi: 88 }],
+          pbMargin: 5,
+        }),
+      );
+      expect(result.kind).toBeNull();
+    });
+
+    it('uses the highest prior (not most recent) as the baseline', () => {
+      const result = detectMilestone(
+        base({
+          currentAvgFqi: 90,
+          priorSessions: [{ avgFqi: 70 }, { avgFqi: 93 }],
+          pbMargin: 2,
+        }),
+      );
+      expect(result.kind).toBeNull();
+    });
+
+    it('does not fire on the very first session when pbMinScore is 0', () => {
+      const result = detectMilestone(
+        base({ currentAvgFqi: 95, priorSessions: [] }),
+      );
+      expect(result.kind).toBeNull();
+    });
+
+    it('fires on the first session when pbMinScore threshold is cleared', () => {
+      const result = detectMilestone(
+        base({ currentAvgFqi: 95, priorSessions: [], pbMinScore: 90 }),
+      );
+      expect(result.kind).toBe('new_pb');
+    });
+
+    it('humanises exercise keys with separators in the message', () => {
+      const result = detectMilestone(
+        base({
+          exerciseKey: 'bulgarian_split_squat',
+          currentAvgFqi: 92,
+          priorSessions: [{ avgFqi: 88 }],
+        }),
+      );
+      expect(result.message).toContain('bulgarian split squat');
+    });
+  });
+
+  describe('week_consistency', () => {
+    it('fires when the last N sessions are within the band and above the floor', () => {
+      const result = detectMilestone(
+        base({
+          currentAvgFqi: 82,
+          priorSessions: [{ avgFqi: 80 }, { avgFqi: 83 }],
+        }),
+      );
+      expect(result.kind).toBe('week_consistency');
+      expect(result.message).toContain('Dialed in');
+      expect(result.message).toContain('82/100');
+    });
+
+    it('does NOT fire when the spread exceeds the band', () => {
+      // Current 82, prior best 85 (no PB), spread across window is 82..70 = 12 (>5 band).
+      const result = detectMilestone(
+        base({
+          currentAvgFqi: 82,
+          priorSessions: [{ avgFqi: 85 }, { avgFqi: 70 }],
+        }),
+      );
+      expect(result.kind).toBeNull();
+    });
+
+    it('does NOT fire when there are not enough sessions in the window', () => {
+      const result = detectMilestone(
+        base({ currentAvgFqi: 82, priorSessions: [{ avgFqi: 83 }] }),
+      );
+      expect(result.kind).toBeNull();
+    });
+
+    it('does NOT fire when the min score is under the floor', () => {
+      const result = detectMilestone(
+        base({
+          currentAvgFqi: 69,
+          priorSessions: [{ avgFqi: 70 }, { avgFqi: 71 }],
+        }),
+      );
+      expect(result.kind).toBeNull();
+    });
+
+    it('respects a custom window + band', () => {
+      const result = detectMilestone(
+        base({
+          currentAvgFqi: 75,
+          priorSessions: [{ avgFqi: 76 }],
+          consistencyWindow: 2,
+          consistencyBand: 2,
+        }),
+      );
+      expect(result.kind).toBe('week_consistency');
+    });
+
+    it('a PB beats a consistency signal (PB gets reported first)', () => {
+      // 92 beats prior best by 6 AND (92, 88, 87) are all ≥ 70 and span 5 — qualifies for both.
+      const result = detectMilestone(
+        base({
+          currentAvgFqi: 92,
+          priorSessions: [{ avgFqi: 88 }, { avgFqi: 87 }],
+        }),
+      );
+      expect(result.kind).toBe('new_pb');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns kind=null when currentAvgFqi is null-ish', () => {
+      const result = detectMilestone(
+        base({ currentAvgFqi: Number.NaN, priorSessions: [{ avgFqi: 80 }] }),
+      );
+      expect(result.kind).toBeNull();
+      expect(result.score).toBe(0);
+    });
+
+    it('filters out non-finite priors before comparison', () => {
+      const result = detectMilestone(
+        base({
+          currentAvgFqi: 92,
+          priorSessions: [
+            { avgFqi: Number.NaN },
+            { avgFqi: 88 },
+            { avgFqi: Number.POSITIVE_INFINITY },
+          ],
+        }),
+      );
+      expect(result.kind).toBe('new_pb');
+    });
+
+    it('returns a safe result when priorSessions is undefined', () => {
+      // Typed as required but callers may pass a missing value at runtime.
+      const unsafe = { exerciseKey: 'pullup', currentAvgFqi: 80 } as unknown as DetectMilestoneInput;
+      const result = detectMilestone(unsafe);
+      expect(result.kind).toBeNull();
+    });
+  });
+});

--- a/tests/unit/services/form-session-history.test.ts
+++ b/tests/unit/services/form-session-history.test.ts
@@ -1,0 +1,116 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  FORM_SESSION_HISTORY_MAX_ENTRIES_PER_EXERCISE,
+  FORM_SESSION_HISTORY_STORAGE_KEY,
+  appendFormSessionHistory,
+  clearFormSessionHistory,
+  getFormSessionHistory,
+} from '@/lib/services/form-session-history';
+
+describe('form-session-history', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('returns an empty list when nothing has been logged', async () => {
+    await expect(getFormSessionHistory('pullup')).resolves.toEqual([]);
+  });
+
+  it('appends a new entry and returns it on next read', async () => {
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 82,
+      endedAt: '2026-04-20T10:00:00Z',
+      sessionId: 'sess_1',
+    });
+    const stored = await getFormSessionHistory('pullup');
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({
+      exerciseKey: 'pullup',
+      avgFqi: 82,
+      sessionId: 'sess_1',
+    });
+  });
+
+  it('keeps exercises isolated from each other', async () => {
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 82,
+      endedAt: '2026-04-20T10:00:00Z',
+    });
+    await appendFormSessionHistory({
+      exerciseKey: 'squat',
+      avgFqi: 70,
+      endedAt: '2026-04-20T11:00:00Z',
+    });
+
+    const pullup = await getFormSessionHistory('pullup');
+    const squat = await getFormSessionHistory('squat');
+    expect(pullup).toHaveLength(1);
+    expect(squat).toHaveLength(1);
+    expect(pullup[0].avgFqi).toBe(82);
+    expect(squat[0].avgFqi).toBe(70);
+  });
+
+  it('stores newest first', async () => {
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 80,
+      endedAt: '2026-04-20T10:00:00Z',
+    });
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 85,
+      endedAt: '2026-04-20T11:00:00Z',
+    });
+    const stored = await getFormSessionHistory('pullup');
+    expect(stored[0].avgFqi).toBe(85);
+    expect(stored[1].avgFqi).toBe(80);
+  });
+
+  it('caps the per-exercise history to MAX_ENTRIES', async () => {
+    for (let i = 0; i < FORM_SESSION_HISTORY_MAX_ENTRIES_PER_EXERCISE + 4; i += 1) {
+      await appendFormSessionHistory({
+        exerciseKey: 'pullup',
+        avgFqi: 70 + (i % 10),
+        endedAt: `2026-04-20T10:0${i % 10}:00Z`,
+      });
+    }
+    const stored = await getFormSessionHistory('pullup');
+    expect(stored).toHaveLength(FORM_SESSION_HISTORY_MAX_ENTRIES_PER_EXERCISE);
+  });
+
+  it('ignores writes without an exerciseKey', async () => {
+    await appendFormSessionHistory({
+      exerciseKey: '',
+      avgFqi: 80,
+      endedAt: '2026-04-20T10:00:00Z',
+    });
+    const raw = await AsyncStorage.getItem(FORM_SESSION_HISTORY_STORAGE_KEY);
+    expect(raw).toBeNull();
+  });
+
+  it('ignores writes with a non-finite avgFqi', async () => {
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: Number.NaN,
+      endedAt: '2026-04-20T10:00:00Z',
+    });
+    await expect(getFormSessionHistory('pullup')).resolves.toEqual([]);
+  });
+
+  it('survives corrupt storage by returning empty', async () => {
+    await AsyncStorage.setItem(FORM_SESSION_HISTORY_STORAGE_KEY, '{garbage');
+    await expect(getFormSessionHistory('pullup')).resolves.toEqual([]);
+  });
+
+  it('clearFormSessionHistory nukes everything', async () => {
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 82,
+      endedAt: '2026-04-20T10:00:00Z',
+    });
+    await clearFormSessionHistory();
+    await expect(getFormSessionHistory('pullup')).resolves.toEqual([]);
+  });
+});

--- a/tests/unit/services/rep-countdown-audio.test.ts
+++ b/tests/unit/services/rep-countdown-audio.test.ts
@@ -1,0 +1,136 @@
+import {
+  playRepCountdown,
+  REP_COUNTDOWN_STEP_MS,
+} from '@/lib/services/rep-countdown-audio';
+import { setRepCountdownEnabled } from '@/lib/services/rep-countdown-pref';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+}));
+
+jest.mock('expo-speech', () => ({
+  speak: jest.fn(),
+}));
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(() => Promise.resolve()),
+  notificationAsync: jest.fn(() => Promise.resolve()),
+  ImpactFeedbackStyle: { Light: 'light' },
+  NotificationFeedbackType: { Success: 'success' },
+}));
+
+describe('playRepCountdown', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('speaks "3 2 1 go" in order when enabled', async () => {
+    const speak = jest.fn().mockResolvedValue(undefined);
+    const pulse = jest.fn().mockResolvedValue(undefined);
+    const sleep = jest.fn().mockResolvedValue(undefined);
+
+    const result = await playRepCountdown({
+      forceEnabled: true,
+      speak,
+      pulse,
+      sleep,
+    });
+
+    expect(result.played).toBe(true);
+    expect(result.spoken).toEqual(['3', '2', '1', 'go']);
+    expect(speak).toHaveBeenNthCalledWith(1, '3');
+    expect(speak).toHaveBeenNthCalledWith(2, '2');
+    expect(speak).toHaveBeenNthCalledWith(3, '1');
+    expect(speak).toHaveBeenNthCalledWith(4, 'go');
+  });
+
+  it('pulses haptics for each tick + a success pulse on "go"', async () => {
+    const pulse = jest.fn().mockResolvedValue(undefined);
+    await playRepCountdown({
+      forceEnabled: true,
+      speak: jest.fn().mockResolvedValue(undefined),
+      pulse,
+      sleep: jest.fn().mockResolvedValue(undefined),
+    });
+
+    expect(pulse).toHaveBeenCalledTimes(4);
+    expect(pulse).toHaveBeenNthCalledWith(1, 'tick');
+    expect(pulse).toHaveBeenNthCalledWith(2, 'tick');
+    expect(pulse).toHaveBeenNthCalledWith(3, 'tick');
+    expect(pulse).toHaveBeenNthCalledWith(4, 'go');
+  });
+
+  it('waits ~1s between ticks (3 sleeps, not 4)', async () => {
+    const sleep = jest.fn().mockResolvedValue(undefined);
+    await playRepCountdown({
+      forceEnabled: true,
+      speak: jest.fn().mockResolvedValue(undefined),
+      pulse: jest.fn().mockResolvedValue(undefined),
+      sleep,
+    });
+
+    expect(sleep).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledWith(REP_COUNTDOWN_STEP_MS);
+  });
+
+  it('skips when the user preference is disabled', async () => {
+    await setRepCountdownEnabled(false);
+    const speak = jest.fn();
+    const pulse = jest.fn();
+
+    const result = await playRepCountdown({ speak, pulse });
+    expect(result.played).toBe(false);
+    expect(result.reason).toBe('disabled');
+    expect(result.spoken).toEqual([]);
+    expect(speak).not.toHaveBeenCalled();
+    expect(pulse).not.toHaveBeenCalled();
+  });
+
+  it('respects the default-on preference when nothing is stored', async () => {
+    const speak = jest.fn().mockResolvedValue(undefined);
+    const result = await playRepCountdown({
+      speak,
+      pulse: jest.fn().mockResolvedValue(undefined),
+      sleep: jest.fn().mockResolvedValue(undefined),
+    });
+    expect(result.played).toBe(true);
+    expect(speak).toHaveBeenCalledTimes(4);
+  });
+
+  it('forceEnabled bypasses a stored "false" preference', async () => {
+    await setRepCountdownEnabled(false);
+    const speak = jest.fn().mockResolvedValue(undefined);
+
+    const result = await playRepCountdown({
+      forceEnabled: true,
+      speak,
+      pulse: jest.fn().mockResolvedValue(undefined),
+      sleep: jest.fn().mockResolvedValue(undefined),
+    });
+    expect(result.played).toBe(true);
+    expect(speak).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe('playRepCountdown (web platform)', () => {
+  const originalRN = jest.requireMock('react-native');
+  const prevOS = originalRN.Platform.OS;
+
+  beforeAll(() => {
+    originalRN.Platform.OS = 'web';
+  });
+
+  afterAll(() => {
+    originalRN.Platform.OS = prevOS;
+  });
+
+  it('is a no-op on web', async () => {
+    const speak = jest.fn();
+    const result = await playRepCountdown({ forceEnabled: true, speak });
+    expect(result.played).toBe(false);
+    expect(result.reason).toBe('unsupported_platform');
+    expect(speak).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/rep-countdown-pref.test.ts
+++ b/tests/unit/services/rep-countdown-pref.test.ts
@@ -1,0 +1,86 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  REP_COUNTDOWN_STORAGE_KEY,
+  getRepCountdownDefault,
+  getRepCountdownEnabled,
+  setRepCountdownEnabled,
+} from '@/lib/services/rep-countdown-pref';
+
+describe('rep-countdown-pref', () => {
+  const prevFlag = process.env.EXPO_PUBLIC_REP_COUNTDOWN;
+
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    delete process.env.EXPO_PUBLIC_REP_COUNTDOWN;
+  });
+
+  afterAll(() => {
+    if (prevFlag === undefined) {
+      delete process.env.EXPO_PUBLIC_REP_COUNTDOWN;
+    } else {
+      process.env.EXPO_PUBLIC_REP_COUNTDOWN = prevFlag;
+    }
+  });
+
+  describe('getRepCountdownDefault', () => {
+    it('returns true when the env flag is unset', () => {
+      expect(getRepCountdownDefault()).toBe(true);
+    });
+
+    it('returns true when the env flag is explicitly "on"', () => {
+      process.env.EXPO_PUBLIC_REP_COUNTDOWN = 'on';
+      expect(getRepCountdownDefault()).toBe(true);
+    });
+
+    it('returns false when the env flag is "off"', () => {
+      process.env.EXPO_PUBLIC_REP_COUNTDOWN = 'off';
+      expect(getRepCountdownDefault()).toBe(false);
+    });
+
+    it('is case-insensitive for "off"', () => {
+      process.env.EXPO_PUBLIC_REP_COUNTDOWN = 'OFF';
+      expect(getRepCountdownDefault()).toBe(false);
+    });
+  });
+
+  describe('getRepCountdownEnabled', () => {
+    it('defaults to true when nothing is stored', async () => {
+      await expect(getRepCountdownEnabled()).resolves.toBe(true);
+    });
+
+    it('returns the stored "true" value', async () => {
+      await setRepCountdownEnabled(true);
+      await expect(getRepCountdownEnabled()).resolves.toBe(true);
+    });
+
+    it('returns the stored "false" value', async () => {
+      await setRepCountdownEnabled(false);
+      await expect(getRepCountdownEnabled()).resolves.toBe(false);
+    });
+
+    it('falls back to the default when the stored value is corrupt', async () => {
+      await AsyncStorage.setItem(REP_COUNTDOWN_STORAGE_KEY, 'not-a-bool');
+      await expect(getRepCountdownEnabled()).resolves.toBe(true);
+    });
+
+    it('honors an env override of "off" when nothing is stored', async () => {
+      process.env.EXPO_PUBLIC_REP_COUNTDOWN = 'off';
+      await expect(getRepCountdownEnabled()).resolves.toBe(false);
+    });
+
+    it('user override beats env default', async () => {
+      process.env.EXPO_PUBLIC_REP_COUNTDOWN = 'off';
+      await setRepCountdownEnabled(true);
+      await expect(getRepCountdownEnabled()).resolves.toBe(true);
+    });
+  });
+
+  describe('setRepCountdownEnabled', () => {
+    it('persists the toggle across calls', async () => {
+      await setRepCountdownEnabled(false);
+      await expect(getRepCountdownEnabled()).resolves.toBe(false);
+      await setRepCountdownEnabled(true);
+      await expect(getRepCountdownEnabled()).resolves.toBe(true);
+    });
+  });
+});

--- a/tests/unit/services/session-snapshot.test.ts
+++ b/tests/unit/services/session-snapshot.test.ts
@@ -1,0 +1,152 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  SESSION_SNAPSHOT_MAX_ENTRIES,
+  SESSION_SNAPSHOT_SCHEMA_VERSION,
+  SESSION_SNAPSHOT_STORAGE_KEY,
+  clearSessionSnapshots,
+  deleteSessionSnapshot,
+  listSessionSnapshots,
+  saveSessionSnapshot,
+} from '@/lib/services/session-snapshot';
+
+const baseInput = () => ({
+  exerciseKey: 'pullup',
+  repCount: 7,
+  currentFqi: 84,
+  faults: [{ key: 'shallow_rom', count: 2 }],
+  startedAt: '2026-04-20T10:00:00.000Z',
+  sessionId: 'sess_abc',
+});
+
+describe('session-snapshot', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  describe('saveSessionSnapshot', () => {
+    it('persists a record and returns it', async () => {
+      const record = await saveSessionSnapshot(baseInput());
+
+      expect(record.id).toMatch(/^snap_/);
+      expect(record.exerciseKey).toBe('pullup');
+      expect(record.repCount).toBe(7);
+      expect(record.currentFqi).toBe(84);
+      expect(record.schemaVersion).toBe(SESSION_SNAPSHOT_SCHEMA_VERSION);
+      expect(record.savedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+      const stored = await listSessionSnapshots();
+      expect(stored).toHaveLength(1);
+      expect(stored[0].id).toBe(record.id);
+    });
+
+    it('stores newest first', async () => {
+      const a = await saveSessionSnapshot({ ...baseInput(), exerciseKey: 'squat' });
+      await new Promise((r) => setTimeout(r, 2));
+      const b = await saveSessionSnapshot({ ...baseInput(), exerciseKey: 'pushup' });
+
+      const stored = await listSessionSnapshots();
+      expect(stored[0].id).toBe(b.id);
+      expect(stored[1].id).toBe(a.id);
+    });
+
+    it('rounds repCount down and floors at zero', async () => {
+      const r1 = await saveSessionSnapshot({ ...baseInput(), repCount: 6.9 });
+      expect(r1.repCount).toBe(6);
+      const r2 = await saveSessionSnapshot({ ...baseInput(), repCount: -3 });
+      expect(r2.repCount).toBe(0);
+    });
+
+    it('clamps currentFqi into [0..100]', async () => {
+      const r1 = await saveSessionSnapshot({ ...baseInput(), currentFqi: 160 });
+      expect(r1.currentFqi).toBe(100);
+      const r2 = await saveSessionSnapshot({ ...baseInput(), currentFqi: -10 });
+      expect(r2.currentFqi).toBe(0);
+    });
+
+    it('preserves a null currentFqi', async () => {
+      const r = await saveSessionSnapshot({ ...baseInput(), currentFqi: null });
+      expect(r.currentFqi).toBeNull();
+    });
+
+    it('caps the in-store history at SESSION_SNAPSHOT_MAX_ENTRIES', async () => {
+      for (let i = 0; i < SESSION_SNAPSHOT_MAX_ENTRIES + 5; i += 1) {
+        await saveSessionSnapshot({ ...baseInput(), exerciseKey: `ex-${i}` });
+      }
+      const stored = await listSessionSnapshots();
+      expect(stored).toHaveLength(SESSION_SNAPSHOT_MAX_ENTRIES);
+      // newest should be the last one inserted
+      expect(stored[0].exerciseKey).toBe(`ex-${SESSION_SNAPSHOT_MAX_ENTRIES + 4}`);
+    });
+
+    it('throws when exerciseKey is missing', async () => {
+      await expect(
+        saveSessionSnapshot({ ...baseInput(), exerciseKey: '' }),
+      ).rejects.toThrow(/exerciseKey/);
+    });
+
+    it('throws when startedAt is missing', async () => {
+      await expect(
+        saveSessionSnapshot({ ...baseInput(), startedAt: '' }),
+      ).rejects.toThrow(/startedAt/);
+    });
+
+    it('throws when repCount is NaN', async () => {
+      await expect(
+        saveSessionSnapshot({ ...baseInput(), repCount: Number.NaN }),
+      ).rejects.toThrow(/repCount/);
+    });
+  });
+
+  describe('listSessionSnapshots', () => {
+    it('returns an empty array when nothing is stored', async () => {
+      await expect(listSessionSnapshots()).resolves.toEqual([]);
+    });
+
+    it('returns empty when storage is corrupt JSON', async () => {
+      await AsyncStorage.setItem(SESSION_SNAPSHOT_STORAGE_KEY, '{garbage');
+      await expect(listSessionSnapshots()).resolves.toEqual([]);
+    });
+
+    it('returns empty when stored value is not an array', async () => {
+      await AsyncStorage.setItem(SESSION_SNAPSHOT_STORAGE_KEY, JSON.stringify({ hello: 'world' }));
+      await expect(listSessionSnapshots()).resolves.toEqual([]);
+    });
+
+    it('skips malformed entries inside the array', async () => {
+      await AsyncStorage.setItem(
+        SESSION_SNAPSHOT_STORAGE_KEY,
+        JSON.stringify([
+          { id: 'snap_ok', exerciseKey: 'pullup', repCount: 5, startedAt: '2026-04-20T10:00:00Z', savedAt: '2026-04-20T10:05:00Z' },
+          { wrong: true },
+          null,
+        ]),
+      );
+      const stored = await listSessionSnapshots();
+      expect(stored).toHaveLength(1);
+      expect(stored[0].id).toBe('snap_ok');
+    });
+  });
+
+  describe('deleteSessionSnapshot', () => {
+    it('removes a matching record and returns true', async () => {
+      const record = await saveSessionSnapshot(baseInput());
+      await expect(deleteSessionSnapshot(record.id)).resolves.toBe(true);
+      await expect(listSessionSnapshots()).resolves.toEqual([]);
+    });
+
+    it('returns false when the id is unknown', async () => {
+      await saveSessionSnapshot(baseInput());
+      await expect(deleteSessionSnapshot('snap_nope')).resolves.toBe(false);
+      await expect(listSessionSnapshots()).resolves.toHaveLength(1);
+    });
+  });
+
+  describe('clearSessionSnapshots', () => {
+    it('nukes every stored record', async () => {
+      await saveSessionSnapshot(baseInput());
+      await saveSessionSnapshot({ ...baseInput(), exerciseKey: 'squat' });
+      await clearSessionSnapshots();
+      await expect(listSessionSnapshots()).resolves.toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Bundles four micro-UX gaps on the form-tracking perimeter (entry, exit, post-session, history):
- Rep countdown pre-announce (3-2-1 audio + haptic, togglable)
- Quick exit mid-session: discard or save lightweight snapshot
- Form-quality milestone detector (new PB / week consistency) → toast
- Workouts-tab form-quality badge (color stripe per session card)

## Design notes
- **Session snapshots storage**: AsyncStorage (new key `form_session_snapshots_v1`), not a new SQLite table — avoids a local-db migration per issue guidance. History capped at 25 entries, schema explicitly versioned for future migration.
- **FQI color tier**: reuses `getFqiColor` from `components/form-tracking/FqiGauge.tsx` (existing 3-tier scale: red <40 / yellow 40-69 / green ≥70) — no inline duplication.
- **Milestone surface**: new `form_milestone` SessionEventType + `emitFormMilestone` helper + `MilestoneToastBridge` subscriber mounted inside ToastProvider. Keeps `session-runner.ts` free of React context deps.
- **Form-session history**: new AsyncStorage-backed per-exercise avg-FQI log (`form_session_history_v1`, 30 per exercise) so the milestone detector has priors — ships without migration risk, ready to swap for SQLite later.

## Scan-arkit edit region (regional, minimal)
- Imports near lines 43–53, 96–106
- Refs near line 783 (rep-countdown + session FQI)
- `onRepComplete` callback near line 956 (capture FQI)
- `startTracking` / `stopTracking` bodies (reset + countdown fire + milestone detection)
- Mid-session exit handlers near line 1785
- JSX wire-ups near close button (line ~2614) and before `VoiceCommandFeedback` at end of render

## Verification
- [x] `bun run lint` clean
- [x] `bun run check:types` clean
- [x] unit tests:
  - `tests/unit/services/rep-countdown-pref.test.ts` (11 tests, all pass)
  - `tests/unit/services/session-snapshot.test.ts` (16 tests, all pass)
  - `tests/unit/services/form-milestone-detector.test.ts` (16 tests, all pass)
  - `tests/unit/components/form-tracking/FormQualityBadge.test.tsx` (11 tests, all pass)
  - plus bonus: `rep-countdown-audio.test.ts` (7 pass), `form-session-history.test.ts` (9 pass)
  - Total: 70/70 new unit tests pass
- [x] no new dependencies (expo-haptics + expo-speech + AsyncStorage already installed)
- [x] no native / supabase migration / env / ios / android edits

Closes #494