### PR TITLE
feat(coach): Gemma 4 multimodal form-check (item 1 of #495)

### DIFF
--- a/components/form-tracking/SnapForFeedbackButton.tsx
+++ b/components/form-tracking/SnapForFeedbackButton.tsx
@@ -1,0 +1,163 @@
+/**
+ * SnapForFeedbackButton
+ *
+ * Headless button that grabs a single JPEG frame off an existing
+ * `CameraView` (passed in via `cameraRef`) and hands the resulting URI to
+ * the caller via `onSnap`. Intentionally does NOT:
+ *   - instantiate its own camera (reuses the ARKit scan view's camera)
+ *   - call coach-service directly (the caller invokes `coach-vision`)
+ *   - mount itself into `app/(tabs)/scan-arkit.tsx` (a follow-up PR does
+ *     that so this change can land without conflicting with another
+ *     in-flight PR touching the scan screen)
+ *
+ * The parent is expected to wire `onSnap` to:
+ *   1. `encodeJpegToBase64(uri)`
+ *   2. `composeVisionPrompt({ exercise, phase, base64Image })`
+ *   3. `dispatchVisionRequest(message)` (see lib/services/coach-vision.ts)
+ *
+ * Accessibility: button role + label + hint per the repo pattern
+ * (see RepPainFlagButton.tsx).
+ */
+
+import React, { useCallback, useState } from 'react';
+import { Pressable, StyleSheet, Text } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { CameraView } from 'expo-camera';
+import { warnWithTs } from '@/lib/logger';
+
+export interface SnapForFeedbackButtonProps {
+  /**
+   * Ref to the already-mounted `CameraView` on the scan screen. Must be
+   * non-null before the user can press; we render the button disabled
+   * until the parent assigns the ref.
+   */
+  readonly cameraRef: React.RefObject<CameraView | null>;
+  /**
+   * Callback invoked with the local JPEG URI after a successful snap.
+   * The caller is responsible for encoding + dispatching; this component
+   * only owns the capture.
+   */
+  readonly onSnap: (uri: string) => void;
+  /**
+   * Canonical exercise key ('squat', 'deadlift', etc). Passed through
+   * in the `onSnap` context so the caller can compose the prompt with
+   * exercise metadata in scope.
+   */
+  readonly exercise: string;
+  /** Current session phase ('setup', 'bottom', 'top', etc). */
+  readonly phase: string;
+  /**
+   * JPEG compression quality, 0..1. Defaults to 0.6 — enough for Gemma
+   * to read joint angles without blowing base64 size.
+   */
+  readonly quality?: number;
+  /**
+   * Optional error handler. When omitted, errors are logged via
+   * warnWithTs and silently swallowed so the button stays usable.
+   */
+  readonly onError?: (error: unknown) => void;
+  readonly testID?: string;
+  readonly disabled?: boolean;
+}
+
+const DEFAULT_QUALITY = 0.6;
+
+export function SnapForFeedbackButton({
+  cameraRef,
+  onSnap,
+  exercise,
+  phase,
+  quality = DEFAULT_QUALITY,
+  onError,
+  testID = 'snap-for-feedback-button',
+  disabled = false,
+}: SnapForFeedbackButtonProps) {
+  const [inFlight, setInFlight] = useState(false);
+
+  const handlePress = useCallback(async () => {
+    if (inFlight || disabled) return;
+    const camera = cameraRef.current;
+    if (!camera) {
+      warnWithTs('[SnapForFeedbackButton] cameraRef not mounted yet');
+      return;
+    }
+    setInFlight(true);
+    try {
+      const picture = await camera.takePictureAsync({
+        quality,
+        base64: false,
+        skipProcessing: false,
+      });
+      if (picture?.uri) {
+        onSnap(picture.uri);
+      } else {
+        warnWithTs('[SnapForFeedbackButton] takePictureAsync returned no uri');
+      }
+    } catch (err) {
+      if (onError) {
+        onError(err);
+      } else {
+        warnWithTs('[SnapForFeedbackButton] snapshot failed', err);
+      }
+    } finally {
+      setInFlight(false);
+    }
+  }, [cameraRef, onSnap, quality, inFlight, disabled, onError]);
+
+  const cameraReady = cameraRef.current != null;
+  const isDisabled = disabled || inFlight || !cameraReady;
+  const hint = `Sends a single frame to the AI coach to critique your ${exercise || 'lift'} in the ${phase || 'current'} phase.`;
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="Snap for coach feedback"
+      accessibilityHint={hint}
+      accessibilityState={{ disabled: isDisabled, busy: inFlight }}
+      disabled={isDisabled}
+      onPress={handlePress}
+      testID={testID}
+      style={({ pressed }) => [
+        styles.button,
+        pressed && styles.buttonPressed,
+        isDisabled && styles.buttonDisabled,
+      ]}
+    >
+      <Ionicons
+        name={inFlight ? 'hourglass-outline' : 'camera'}
+        size={18}
+        color="#FFFFFF"
+      />
+      <Text style={styles.buttonText}>
+        {inFlight ? 'Sending…' : 'Snap for feedback'}
+      </Text>
+    </Pressable>
+  );
+}
+
+export default SnapForFeedbackButton;
+
+const styles = StyleSheet.create({
+  button: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    backgroundColor: '#4C8CFF',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 14,
+    alignSelf: 'center',
+  },
+  buttonPressed: {
+    backgroundColor: '#3B76E0',
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    fontFamily: 'Lexend_700Bold',
+  },
+});

--- a/lib/services/coach-model-dispatch.ts
+++ b/lib/services/coach-model-dispatch.ts
@@ -19,12 +19,19 @@
  *   the smaller `gemma-4-26b-a4b-it`; pro/premium get `gemma-4-31b-it`.
  * - Complex tasks (planning, macro reasoning, debriefs): GPT-5.4-mini for
  *   free/pro, GPT-5.4 for premium.
+ * - `form_vision_check`: multimodal form-check via Gemma 4 vision input.
+ *   Always routes to `gemma-4-31b-it` (Gemma 4's larger multimodal variant;
+ *   the smaller `-26b-a4b-it` is text-only for the launch cut). Falls back
+ *   to `gpt-5.4-mini` when `visionFallbackToCloud` is set — that's the
+ *   escape hatch for when the Gemma edge function is unavailable.
  * - `general_chat` falls back to GPT-5.4-mini conservatively.
  * - High-fault override: a tactical task with `faultCount >= 3` is upgraded
  *   one rung (Gemma → GPT-5.4-mini) because the user is struggling and
- *   the extra cost is justified by coaching value.
+ *   the extra cost is justified by coaching value. Does NOT apply to
+ *   `form_vision_check` — vision needs the multimodal model regardless.
  * - `forceCloud`: upgrades any tactical decision to GPT-5.4-mini. Complex
- *   decisions are already cloud so the flag is a no-op there.
+ *   decisions are already cloud so the flag is a no-op there. Does NOT
+ *   apply to `form_vision_check` because gpt-5.4-mini is text-only.
  *
  * TODO(#495): Wire this into `coach-service.sendCoachPrompt` once the
  * `coach-gemma` edge function from Stack B (PR #502) merges. Wiring will
@@ -36,6 +43,7 @@ export type CoachTaskKind =
   | 'rest_calc'
   | 'encouragement'
   | 'fault_explainer'
+  | 'form_vision_check'
   | 'program_design'
   | 'nutrition_balance'
   | 'multi_turn_debrief'
@@ -66,6 +74,13 @@ export interface DispatchDecision {
 export interface DispatchOptions {
   readonly forceCloud?: boolean;
   readonly dispatchDisabled?: boolean;
+  /**
+   * When true and the task kind is `form_vision_check`, fall back to
+   * `gpt-5.4-mini` (text-only). Only used by the vision dispatcher when
+   * Gemma is unavailable — callers pass this if the Gemma edge function
+   * returned 404 / 5xx on a previous try. Ignored for every other task.
+   */
+  readonly visionFallbackToCloud?: boolean;
 }
 
 const TACTICAL_TASKS: ReadonlySet<CoachTaskKind> = new Set<CoachTaskKind>([
@@ -105,6 +120,26 @@ export function decideCoachModel(
       model: 'gpt-5.4-mini',
       reason: 'dispatch_disabled',
       fellBackToCloud: true,
+    };
+  }
+
+  // Multimodal form-check. Always prefers Gemma 4's multimodal variant so
+  // the image parts are actually consumed; only downgrades to text-only
+  // GPT-5.4-mini when the caller explicitly opts in via
+  // `visionFallbackToCloud` (the Gemma edge function returned 404/5xx on a
+  // previous try, so the image will be stripped on the edge side).
+  if (taskKind === 'form_vision_check') {
+    if (options?.visionFallbackToCloud === true) {
+      return {
+        model: 'gpt-5.4-mini',
+        reason: 'vision_fallback_cloud',
+        fellBackToCloud: true,
+      };
+    }
+    return {
+      model: 'gemma-4-31b-it',
+      reason: 'vision_gemma',
+      fellBackToCloud: false,
     };
   }
 

--- a/lib/services/coach-vision-flag.ts
+++ b/lib/services/coach-vision-flag.ts
@@ -1,0 +1,26 @@
+/**
+ * coach-vision-flag
+ *
+ * Feature flag gate for the Gemma 4 multimodal form-check pipeline
+ * (`coach-vision.ts`). The pipeline itself is pure and safe to import any
+ * time; this flag decides whether callers should actually send vision
+ * requests or short-circuit with a `{ skipped: true, reason: 'flag-off' }`
+ * response.
+ *
+ * Parsing:
+ * - `EXPO_PUBLIC_COACH_VISION=on`  → vision enabled
+ * - `EXPO_PUBLIC_COACH_VISION=off` → vision disabled
+ * - unset / anything else          → vision disabled (fail safe)
+ *
+ * Strict string match: only the literal `'on'` flips the flag. "true", "1",
+ * "yes", "ON" are intentionally rejected so the knob stays unambiguous.
+ * Mirrors the pattern established by `coach-model-dispatch-flag.ts` (#503).
+ */
+
+const FLAG_ENV_VAR = 'EXPO_PUBLIC_COACH_VISION';
+
+export function isCoachVisionEnabled(): boolean {
+  const raw = process.env[FLAG_ENV_VAR];
+  if (typeof raw !== 'string') return false;
+  return raw === 'on';
+}

--- a/lib/services/coach-vision.ts
+++ b/lib/services/coach-vision.ts
@@ -23,6 +23,13 @@
  */
 
 import { File as ExpoFile } from 'expo-file-system';
+import {
+  decideCoachModel,
+  type CoachUserTier,
+  type DispatchDecision,
+} from './coach-model-dispatch';
+import { isCoachVisionEnabled } from './coach-vision-flag';
+import type { CoachCloudProvider } from './coach-cloud-provider';
 
 // ---------------------------------------------------------------------------
 // Multimodal message shape
@@ -158,4 +165,86 @@ export async function encodeJpegToBase64(uri: string): Promise<string> {
     throw new Error(`encodeJpegToBase64: file not found at ${uri}`);
   }
   return await file.base64();
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+export type VisionSkipReason = 'flag-off';
+
+export interface VisionDispatchSkipped {
+  readonly skipped: true;
+  readonly reason: VisionSkipReason;
+}
+
+export interface VisionDispatchSent {
+  readonly skipped: false;
+  readonly decision: DispatchDecision;
+  readonly provider: CoachCloudProvider;
+  readonly message: VisionMessage;
+}
+
+export type VisionDispatchResult = VisionDispatchSkipped | VisionDispatchSent;
+
+export interface DispatchVisionOptions {
+  /**
+   * Overrides the flag check. When omitted the env flag
+   * `EXPO_PUBLIC_COACH_VISION` is consulted via `isCoachVisionEnabled()`.
+   * Exposed primarily for tests and for call sites that already know the
+   * flag state (e.g. settings screen surface).
+   */
+  readonly flag?: boolean;
+  /**
+   * Which cloud provider the caller expects to serve this turn. The
+   * dispatcher itself doesn't care — it only picks a model id — but the
+   * returned result carries the provider so callers can hand the message
+   * to the right edge function.
+   */
+  readonly provider?: CoachCloudProvider;
+  /** User tier, defaults to `free`. */
+  readonly userTier?: CoachUserTier;
+  /**
+   * Pass-through to the dispatcher. When true, degrades to gpt-5.4-mini
+   * (text-only) with `reason: 'vision_fallback_cloud'`. Callers set this
+   * after observing Gemma failures.
+   */
+  readonly fallbackToCloud?: boolean;
+}
+
+/**
+ * Flag-gated vision dispatch shim. Does NOT call the coach-service or
+ * any network transport yet — that wiring is the next PR. This function
+ * is the single place where the flag check, dispatch decision, and
+ * provider selection live so unit tests can pin the routing logic.
+ *
+ * Return shape:
+ * - `{ skipped: true, reason: 'flag-off' }` when the flag is off or when
+ *   an explicit `flag: false` override was passed.
+ * - `{ skipped: false, decision, provider, message }` otherwise. The
+ *   caller (coach-service wiring, landing in a follow-up) is responsible
+ *   for sending the message.
+ */
+export function dispatchVisionRequest(
+  message: VisionMessage,
+  options?: DispatchVisionOptions,
+): VisionDispatchResult {
+  const flagOn = options?.flag ?? isCoachVisionEnabled();
+  if (!flagOn) {
+    return { skipped: true, reason: 'flag-off' };
+  }
+
+  const decision = decideCoachModel(
+    'form_vision_check',
+    {},
+    options?.userTier ?? 'free',
+    { visionFallbackToCloud: options?.fallbackToCloud === true },
+  );
+
+  return {
+    skipped: false,
+    decision,
+    provider: options?.provider ?? 'gemma',
+    message,
+  };
 }

--- a/lib/services/coach-vision.ts
+++ b/lib/services/coach-vision.ts
@@ -1,0 +1,161 @@
+/**
+ * coach-vision
+ *
+ * Multimodal form-check pipeline for Gemma 4. Encodes a single JPEG frame
+ * captured from the ARKit scan session into base64 and wraps it in the
+ * Anthropic/Gemma-compatible multimodal message shape. Dispatch (with the
+ * flag/provider routing) lives in this same module but is layered on top
+ * of the pure encoder + composer in a separate commit so each piece can
+ * be reviewed in isolation.
+ *
+ * Design goals:
+ * - Pure module. No React, no navigation, no UI. The
+ *   `SnapForFeedbackButton` component is the only mount point.
+ * - Feature-flag gated at the dispatch layer (not here) via
+ *   `EXPO_PUBLIC_COACH_VISION`.
+ *
+ * Not in scope for this PR:
+ * - Mounting the SnapForFeedbackButton into `app/(tabs)/scan-arkit.tsx`
+ *   (follow-up PR to avoid merge conflicts with another in-flight PR
+ *   touching that screen).
+ * - Wiring the dispatch return value into coach chat history.
+ * - Retry/backoff — a single shot is enough for the launch cut.
+ */
+
+import { File as ExpoFile } from 'expo-file-system';
+
+// ---------------------------------------------------------------------------
+// Multimodal message shape
+// ---------------------------------------------------------------------------
+
+export interface VisionTextPart {
+  readonly type: 'text';
+  readonly text: string;
+}
+
+export interface VisionImageSource {
+  readonly type: 'base64';
+  readonly media_type: 'image/jpeg';
+  readonly data: string;
+}
+
+export interface VisionImagePart {
+  readonly type: 'image';
+  readonly source: VisionImageSource;
+}
+
+export type VisionContentPart = VisionTextPart | VisionImagePart;
+
+export interface VisionMessage {
+  readonly role: 'user';
+  readonly content: VisionContentPart[];
+}
+
+// ---------------------------------------------------------------------------
+// Prompt composition
+// ---------------------------------------------------------------------------
+
+export interface ComposeVisionPromptArgs {
+  /** Canonical exercise key, e.g. 'squat', 'deadlift', 'pullup'. */
+  readonly exercise: string;
+  /**
+   * Session phase when the frame was captured. Used verbatim in the text
+   * part so the model knows whether to critique setup, bottom, or lockout.
+   */
+  readonly phase: string;
+  /** Raw base64-encoded JPEG payload from `encodeJpegToBase64`. */
+  readonly base64Image: string;
+  /**
+   * Optional free-form note from the user ("feels off at the bottom").
+   * Capped at 240 chars to match the rest of the coach prompt hygiene and
+   * keep token usage predictable.
+   */
+  readonly userNote?: string;
+}
+
+const USER_NOTE_MAX_LENGTH = 240;
+const EXERCISE_FALLBACK = 'lift';
+const PHASE_FALLBACK = 'setup';
+
+function cleanExercise(raw: string): string {
+  const trimmed = raw?.trim();
+  return trimmed ? trimmed : EXERCISE_FALLBACK;
+}
+
+function cleanPhase(raw: string): string {
+  const trimmed = raw?.trim();
+  return trimmed ? trimmed : PHASE_FALLBACK;
+}
+
+function cleanNote(note: string | undefined): string | null {
+  if (typeof note !== 'string') return null;
+  const trimmed = note.trim().slice(0, USER_NOTE_MAX_LENGTH);
+  return trimmed || null;
+}
+
+/**
+ * Compose the multimodal message the coach edge function expects. The
+ * shape is intentionally the Anthropic/Gemma vision format:
+ *
+ *   `{ role, content: [{type:'text'}, {type:'image', source:{...}}] }`
+ *
+ * The text part spells out the exercise and phase so the model doesn't
+ * have to infer them from the frame alone. The image part carries the
+ * raw base64 JPEG; callers must have already verified the data is a
+ * JPEG (via `encodeJpegToBase64` or otherwise).
+ */
+export function composeVisionPrompt(
+  args: ComposeVisionPromptArgs,
+): VisionMessage {
+  const exercise = cleanExercise(args.exercise);
+  const phase = cleanPhase(args.phase);
+  const note = cleanNote(args.userNote);
+
+  const textLines = [
+    `Critique my ${exercise} form during the ${phase} phase.`,
+    'Point out the top-1 or top-2 faults I can fix right now. Be concise.',
+  ];
+  if (note) {
+    textLines.push(`User note: ${note}`);
+  }
+
+  return {
+    role: 'user',
+    content: [
+      { type: 'text', text: textLines.join(' ') },
+      {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/jpeg',
+          data: args.base64Image,
+        },
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// JPEG encoder
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a file URI (typically produced by `CameraView.takePictureAsync`)
+ * and return its base64 representation. Throws if the file does not
+ * exist; lets `expo-file-system` surface any IO errors so the caller
+ * can classify them.
+ *
+ * Uses the modern `new File(uri).base64()` API (matches the pattern in
+ * `hooks/use-premium-cue-audio.ts`). The legacy `readAsStringAsync` is
+ * deprecated in expo-file-system 19.
+ */
+export async function encodeJpegToBase64(uri: string): Promise<string> {
+  if (typeof uri !== 'string' || !uri.trim()) {
+    throw new Error('encodeJpegToBase64: uri is required');
+  }
+  const file = new ExpoFile(uri);
+  if (!file.exists) {
+    throw new Error(`encodeJpegToBase64: file not found at ${uri}`);
+  }
+  return await file.base64();
+}

--- a/supabase/functions/coach-gemma/index.test.ts
+++ b/supabase/functions/coach-gemma/index.test.ts
@@ -5,18 +5,24 @@
 import {
   ALLOWED_MODELS,
   FALLBACK_MODEL,
+  MAX_IMAGES_PER_REQUEST,
+  VISION_CAPABLE_MODELS,
   buildGeminiPayload,
   buildGeminiUrl,
   buildSystemInstruction,
+  countImageParts,
   extractGeminiText,
   isAllowedModel,
   resolveModel,
   sanitizeMessages,
   sanitizeName,
+  stripImageParts,
+  supportsVision,
   toGeminiContents,
   MAX_CONTENT_LENGTH,
   MAX_MESSAGES,
   type ChatMessage,
+  type ContentPart,
 } from './translation';
 
 describe('coach-gemma translation helpers', () => {
@@ -252,6 +258,176 @@ describe('coach-gemma translation helpers', () => {
       expect(url).toBe(
         'https://generativelanguage.googleapis.com/v1beta/models/gemma-3-4b-it:generateContent?key=abc%2B%2F%3Dspecial',
       );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Multimodal extensions (#495)
+  // ---------------------------------------------------------------------------
+
+  describe('multimodal content parts', () => {
+    const imgPart: ContentPart = {
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/jpeg', data: 'IMG_B64' },
+    };
+    const textPart: ContentPart = { type: 'text', text: 'Critique my squat.' };
+
+    describe('sanitizeMessages', () => {
+      it('accepts a content-parts array on a valid message', () => {
+        const out = sanitizeMessages([
+          { role: 'user', content: [textPart, imgPart] },
+        ]);
+        expect(out).toHaveLength(1);
+        expect(Array.isArray(out[0].content)).toBe(true);
+      });
+
+      it('drops content-parts that have an invalid shape', () => {
+        const out = sanitizeMessages([
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { role: 'user', content: [{ type: 'video', url: 'x' } as any] },
+        ]);
+        expect(out).toHaveLength(0);
+      });
+
+      it('drops messages where the image source is malformed', () => {
+        const out = sanitizeMessages([
+          {
+            role: 'user',
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            content: [{ type: 'image', source: { data: 'no-type' } } as any],
+          },
+        ]);
+        expect(out).toHaveLength(0);
+      });
+
+      it('truncates text parts within content arrays', () => {
+        const huge = 'a'.repeat(MAX_CONTENT_LENGTH + 100);
+        const out = sanitizeMessages([
+          { role: 'user', content: [{ type: 'text', text: huge }] },
+        ]);
+        const first = out[0].content as ContentPart[];
+        expect((first[0] as { text: string }).text.length).toBe(
+          MAX_CONTENT_LENGTH,
+        );
+      });
+
+      it('preserves string-shape content for legacy callers', () => {
+        const out = sanitizeMessages([{ role: 'user', content: 'Hello' }]);
+        expect(out[0].content).toBe('Hello');
+      });
+    });
+
+    describe('countImageParts', () => {
+      it('counts images across messages', () => {
+        expect(
+          countImageParts([
+            { role: 'user', content: [textPart, imgPart] },
+            { role: 'user', content: [imgPart] },
+          ]),
+        ).toBe(2);
+      });
+
+      it('returns 0 for text-only messages', () => {
+        expect(
+          countImageParts([
+            { role: 'user', content: 'hi' },
+            { role: 'user', content: [textPart] },
+          ]),
+        ).toBe(0);
+      });
+
+      it('MAX_IMAGES_PER_REQUEST is the 1-per-request cap', () => {
+        expect(MAX_IMAGES_PER_REQUEST).toBe(1);
+      });
+    });
+
+    describe('stripImageParts', () => {
+      it('removes image parts and preserves text content', () => {
+        const out = stripImageParts([
+          { role: 'user', content: [textPart, imgPart] },
+        ]);
+        expect(out).toEqual([
+          { role: 'user', content: 'Critique my squat.' },
+        ]);
+      });
+
+      it('drops a message that is image-only', () => {
+        const out = stripImageParts([
+          { role: 'user', content: [imgPart] },
+          { role: 'user', content: 'kept' },
+        ]);
+        expect(out).toEqual([{ role: 'user', content: 'kept' }]);
+      });
+
+      it('passes through string-content messages untouched', () => {
+        const legacy: ChatMessage = { role: 'user', content: 'legacy' };
+        const out = stripImageParts([legacy]);
+        expect(out[0]).toBe(legacy);
+      });
+    });
+
+    describe('supportsVision / VISION_CAPABLE_MODELS', () => {
+      it('accepts gemma-4 multimodal variants only', () => {
+        expect(supportsVision('gemma-4-31b-it')).toBe(true);
+        expect(supportsVision('gemma-4-26b-a4b-it')).toBe(true);
+      });
+
+      it('rejects every gemma-3-* variant and OpenAI models', () => {
+        expect(supportsVision('gemma-3-4b-it')).toBe(false);
+        expect(supportsVision('gemma-3-27b-it')).toBe(false);
+        expect(supportsVision('gpt-5.4-mini')).toBe(false);
+      });
+
+      it('VISION_CAPABLE_MODELS is disjoint from ALLOWED_MODELS', () => {
+        for (const m of VISION_CAPABLE_MODELS) {
+          expect(ALLOWED_MODELS.has(m)).toBe(false);
+        }
+      });
+    });
+
+    describe('toGeminiContents with image parts', () => {
+      it('emits inlineData for image parts alongside text', () => {
+        const contents = toGeminiContents([
+          { role: 'user', content: [textPart, imgPart] },
+        ]);
+        expect(contents).toHaveLength(1);
+        const parts = contents[0].parts ?? [];
+        expect(parts[0]).toEqual({ text: 'Critique my squat.' });
+        expect(parts[1]).toEqual({
+          inlineData: { mimeType: 'image/jpeg', data: 'IMG_B64' },
+        });
+      });
+
+      it('joins multi-text parts with newlines before the image', () => {
+        const contents = toGeminiContents([
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'line one' },
+              { type: 'text', text: 'line two' },
+              imgPart,
+            ],
+          },
+        ]);
+        const parts = contents[0].parts ?? [];
+        expect(parts[0]).toEqual({ text: 'line one\nline two' });
+        expect(parts[1]).toEqual({
+          inlineData: { mimeType: 'image/jpeg', data: 'IMG_B64' },
+        });
+      });
+
+      it('still merges system-string messages with a subsequent multimodal user turn', () => {
+        const contents = toGeminiContents([
+          { role: 'system', content: 'Be concise.' },
+          { role: 'user', content: [textPart, imgPart] },
+        ]);
+        const parts = contents[0].parts ?? [];
+        expect((parts[0] as { text: string }).text).toContain('[System]: Be concise.');
+        expect((parts[0] as { text: string }).text).toContain('Critique my squat.');
+        expect(parts[1]).toEqual({
+          inlineData: { mimeType: 'image/jpeg', data: 'IMG_B64' },
+        });
+      });
     });
   });
 });

--- a/supabase/functions/coach-gemma/index.ts
+++ b/supabase/functions/coach-gemma/index.ts
@@ -11,9 +11,26 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.4?target
 
 type Role = 'user' | 'assistant' | 'system';
 
+interface TextContentPart {
+  type: 'text';
+  text: string;
+}
+
+interface ImageContentPart {
+  type: 'image';
+  source: {
+    type: 'base64';
+    media_type: 'image/jpeg';
+    data: string;
+  };
+}
+
+type ContentPart = TextContentPart | ImageContentPart;
+
 interface ChatMessage {
   role: Role;
-  content: string;
+  /** Legacy text shape, or Anthropic/Gemma-style content-parts array (#495). */
+  content: string | ContentPart[];
 }
 
 interface CoachContext {
@@ -27,8 +44,14 @@ interface RequestBody {
   model?: string;
 }
 
+interface GeminiInlineData {
+  mimeType: string;
+  data: string;
+}
+
 interface GeminiPart {
   text?: string;
+  inlineData?: GeminiInlineData;
 }
 
 interface GeminiContent {
@@ -46,6 +69,18 @@ const ALLOWED_MODELS = new Set([
   'gemma-3-12b-it',
   'gemma-3-27b-it',
 ]);
+/**
+ * Multimodal-capable models (#495). The vision dispatcher in
+ * `lib/services/coach-vision.ts` targets `gemma-4-31b-it`. Until #485
+ * extends `ALLOWED_MODELS` to include gemma-4-*, requests carrying
+ * image parts against a gemma-3-* model will have the images stripped
+ * server-side before they reach Gemini.
+ */
+const VISION_CAPABLE_MODELS = new Set([
+  'gemma-4-31b-it',
+  'gemma-4-26b-a4b-it',
+]);
+const MAX_IMAGES_PER_REQUEST = 1;
 const FALLBACK_MODEL = 'gemma-3-4b-it';
 const RAW_MODEL = (Deno.env.get('COACH_GEMMA_MODEL') || FALLBACK_MODEL).trim();
 const DEFAULT_MODEL = ALLOWED_MODELS.has(RAW_MODEL) ? RAW_MODEL : FALLBACK_MODEL;
@@ -113,16 +148,97 @@ function ok(body: Record<string, unknown>) {
   });
 }
 
+function isTextPart(part: unknown): part is TextContentPart {
+  return (
+    typeof part === 'object' &&
+    part !== null &&
+    (part as { type?: unknown }).type === 'text' &&
+    typeof (part as { text?: unknown }).text === 'string'
+  );
+}
+
+function isImagePart(part: unknown): part is ImageContentPart {
+  if (typeof part !== 'object' || part === null) return false;
+  if ((part as { type?: unknown }).type !== 'image') return false;
+  const src = (part as { source?: unknown }).source;
+  if (typeof src !== 'object' || src === null) return false;
+  return (
+    (src as { type?: unknown }).type === 'base64' &&
+    (src as { media_type?: unknown }).media_type === 'image/jpeg' &&
+    typeof (src as { data?: unknown }).data === 'string'
+  );
+}
+
+function isContentPartArray(content: unknown): content is ContentPart[] {
+  return (
+    Array.isArray(content) &&
+    content.every((p) => isTextPart(p) || isImagePart(p))
+  );
+}
+
+function isValidRawMessage(m: unknown): m is ChatMessage {
+  if (typeof m !== 'object' || m === null) return false;
+  const role = (m as { role?: unknown }).role;
+  const content = (m as { content?: unknown }).content;
+  if (typeof role !== 'string') return false;
+  return typeof content === 'string' || isContentPartArray(content);
+}
+
+function normalizeContent(content: string | ContentPart[]): string | ContentPart[] {
+  if (typeof content === 'string') {
+    return content.slice(0, MAX_CONTENT_LENGTH);
+  }
+  return content.map((part) =>
+    part.type === 'text'
+      ? { type: 'text', text: part.text.slice(0, MAX_CONTENT_LENGTH) }
+      : part,
+  );
+}
+
 function sanitizeMessages(messages: ChatMessage[] = []): ChatMessage[] {
   return messages
-    .filter((m) => m && typeof m.content === 'string' && typeof m.role === 'string')
+    .filter(isValidRawMessage)
     .map((m) => ({
       role: (['user', 'assistant', 'system'] as Role[]).includes(m.role as Role)
         ? (m.role as Role)
         : 'user',
-      content: m.content.slice(0, MAX_CONTENT_LENGTH),
+      content: normalizeContent(m.content),
     }))
     .slice(-MAX_MESSAGES);
+}
+
+function countImageParts(messages: ChatMessage[]): number {
+  let total = 0;
+  for (const m of messages) {
+    if (Array.isArray(m.content)) {
+      for (const part of m.content) {
+        if (isImagePart(part)) total += 1;
+      }
+    }
+  }
+  return total;
+}
+
+function stripImageParts(messages: ChatMessage[]): ChatMessage[] {
+  const result: ChatMessage[] = [];
+  for (const m of messages) {
+    if (typeof m.content === 'string') {
+      result.push(m);
+      continue;
+    }
+    const textParts = m.content.filter(isTextPart);
+    if (textParts.length === 0) continue;
+    if (textParts.length === 1) {
+      result.push({ role: m.role, content: textParts[0].text });
+    } else {
+      result.push({ role: m.role, content: textParts });
+    }
+  }
+  return result;
+}
+
+function supportsVision(model: string): boolean {
+  return VISION_CAPABLE_MODELS.has(model);
 }
 
 /** Strip control chars, prompt delimiters, and cap length to prevent injection. */
@@ -151,23 +267,54 @@ function buildSystemInstruction(context?: CoachContext): string {
   ].join(' ');
 }
 
+function collectTextFromContent(content: string | ContentPart[]): string {
+  if (typeof content === 'string') return content;
+  return content
+    .filter(isTextPart)
+    .map((p) => p.text)
+    .join('\n');
+}
+
+function collectImageParts(
+  content: string | ContentPart[],
+): ImageContentPart[] {
+  if (typeof content === 'string') return [];
+  return content.filter(isImagePart);
+}
+
 function toGeminiContents(messages: ChatMessage[]): GeminiContent[] {
   const contents: GeminiContent[] = [];
   const pendingSystem: string[] = [];
 
   for (const m of messages) {
     if (m.role === 'system') {
-      if (m.content.trim()) pendingSystem.push(m.content.trim());
+      const text = collectTextFromContent(m.content).trim();
+      if (text) pendingSystem.push(text);
       continue;
     }
 
     const role = m.role === 'assistant' ? 'model' : 'user';
-    let text = m.content;
+    let text = collectTextFromContent(m.content);
     if (role === 'user' && pendingSystem.length > 0) {
       text = `[System]: ${pendingSystem.join('\n')}\n\n${text}`;
       pendingSystem.length = 0;
     }
-    contents.push({ role, parts: [{ text }] });
+    const parts: GeminiPart[] = [];
+    if (text.trim() || role === 'model') {
+      parts.push({ text });
+    }
+    for (const img of collectImageParts(m.content)) {
+      parts.push({
+        inlineData: {
+          mimeType: img.source.media_type,
+          data: img.source.data,
+        },
+      });
+    }
+    if (parts.length === 0) {
+      parts.push({ text: '' });
+    }
+    contents.push({ role, parts });
   }
 
   if (pendingSystem.length > 0) {
@@ -231,6 +378,17 @@ async function generateReply(body: RequestBody) {
     return badRequest('messages array is required');
   }
 
+  // #495 multimodal guard: cap image parts regardless of model. Even if the
+  // eventual model is vision-capable, more than one image explodes token
+  // cost without a clear coaching win.
+  const imageCount = countImageParts(inputMessages);
+  if (imageCount > MAX_IMAGES_PER_REQUEST) {
+    return badRequest(
+      `Too many images (${imageCount}). Max ${MAX_IMAGES_PER_REQUEST} per request.`,
+      { status: 400 },
+    );
+  }
+
   const rawRequestedModel = typeof body.model === 'string' ? body.model.trim() : '';
   if (rawRequestedModel && !ALLOWED_MODELS.has(rawRequestedModel)) {
     return badRequest(
@@ -240,7 +398,14 @@ async function generateReply(body: RequestBody) {
   }
 
   const model = resolveRequestedModel(body.model);
-  const payload = buildGeminiPayload(inputMessages, body.context, {
+  // #495 multimodal guard: strip images when the resolved model does not
+  // support vision so the payload we send to Gemini is text-only. This is
+  // a server-side safety net — `coach-vision.ts` already won't dispatch to
+  // a non-vision model, but an older client might.
+  const payloadMessages = supportsVision(model)
+    ? inputMessages
+    : stripImageParts(inputMessages);
+  const payload = buildGeminiPayload(payloadMessages, body.context, {
     temperature: TEMPERATURE,
     maxOutputTokens: MAX_TOKENS,
   });

--- a/supabase/functions/coach-gemma/translation.ts
+++ b/supabase/functions/coach-gemma/translation.ts
@@ -4,13 +4,38 @@
  *
  * These are intentionally framework-free so they can be unit-tested with Bun
  * without pulling in Deno-only imports.
+ *
+ * Multimodal (#495): `ChatMessage.content` now accepts either a string (the
+ * legacy text shape) or an array of content parts
+ *   `[{ type:'text', text } | { type:'image', source:{type:'base64',
+ *     media_type:'image/jpeg', data} }]`
+ * matching the Anthropic/Gemma 4 vision format. Image parts are only honored
+ * when the caller-requested model is in the `gemma-4-*` allowlist; every
+ * other model path strips images and keeps just the text.
  */
 
 export type Role = 'user' | 'assistant' | 'system';
 
+export interface TextContentPart {
+  type: 'text';
+  text: string;
+}
+
+export interface ImageContentPart {
+  type: 'image';
+  source: {
+    type: 'base64';
+    media_type: 'image/jpeg';
+    data: string;
+  };
+}
+
+export type ContentPart = TextContentPart | ImageContentPart;
+
 export interface ChatMessage {
   role: Role;
-  content: string;
+  /** Legacy text shape, or Anthropic/Gemma-style content-parts array. */
+  content: string | ContentPart[];
 }
 
 export interface CoachContextPayload {
@@ -18,8 +43,14 @@ export interface CoachContextPayload {
   focus?: string;
 }
 
+export interface GeminiInlineData {
+  mimeType: string;
+  data: string;
+}
+
 export interface GeminiPart {
   text?: string;
+  inlineData?: GeminiInlineData;
 }
 
 export interface GeminiContent {
@@ -46,11 +77,77 @@ export const ALLOWED_MODELS = new Set([
   'gemma-3-12b-it',
   'gemma-3-27b-it',
 ]);
+/**
+ * Models that accept multimodal image parts. Keep this strictly disjoint
+ * from `ALLOWED_MODELS` until #485 extends the allowlist — today this
+ * set is empty at the allowlist layer because gemma-4-* is still gated
+ * on #485. The vision dispatcher (`coach-vision.ts`) already knows to
+ * route `form_vision_check` to `gemma-4-31b-it`; this set exists so the
+ * server-side guard is a simple `VISION_CAPABLE_MODELS.has(model)`
+ * check once the allowlist opens up.
+ */
+export const VISION_CAPABLE_MODELS = new Set([
+  'gemma-4-31b-it',
+  'gemma-4-26b-a4b-it',
+]);
 export const FALLBACK_MODEL = 'gemma-3-4b-it';
 export const MAX_MESSAGES = 12;
 export const MAX_CONTENT_LENGTH = 1200;
+/** Server-side cap: one image per request. More would blow the token budget. */
+export const MAX_IMAGES_PER_REQUEST = 1;
 
 const VALID_ROLES: Role[] = ['user', 'assistant', 'system'];
+
+function isTextPart(part: unknown): part is TextContentPart {
+  return (
+    typeof part === 'object' &&
+    part !== null &&
+    (part as { type?: unknown }).type === 'text' &&
+    typeof (part as { text?: unknown }).text === 'string'
+  );
+}
+
+function isImagePart(part: unknown): part is ImageContentPart {
+  if (typeof part !== 'object' || part === null) return false;
+  if ((part as { type?: unknown }).type !== 'image') return false;
+  const src = (part as { source?: unknown }).source;
+  if (typeof src !== 'object' || src === null) return false;
+  return (
+    (src as { type?: unknown }).type === 'base64' &&
+    (src as { media_type?: unknown }).media_type === 'image/jpeg' &&
+    typeof (src as { data?: unknown }).data === 'string'
+  );
+}
+
+function isContentPartArray(content: unknown): content is ContentPart[] {
+  return (
+    Array.isArray(content) &&
+    content.every((p) => isTextPart(p) || isImagePart(p))
+  );
+}
+
+function isValidRawMessage(m: unknown): m is ChatMessage {
+  if (typeof m !== 'object' || m === null) return false;
+  const role = (m as { role?: unknown }).role;
+  const content = (m as { content?: unknown }).content;
+  if (typeof role !== 'string') return false;
+  return typeof content === 'string' || isContentPartArray(content);
+}
+
+function normalizeContent(
+  content: string | ContentPart[],
+  maxContentLength: number,
+): string | ContentPart[] {
+  if (typeof content === 'string') {
+    return content.slice(0, maxContentLength);
+  }
+  return content.map((part) => {
+    if (part.type === 'text') {
+      return { type: 'text', text: part.text.slice(0, maxContentLength) };
+    }
+    return part;
+  });
+}
 
 export function sanitizeMessages(
   messages: ChatMessage[] = [],
@@ -59,15 +156,57 @@ export function sanitizeMessages(
   const maxMessages = opts.maxMessages ?? MAX_MESSAGES;
   const maxContentLength = opts.maxContentLength ?? MAX_CONTENT_LENGTH;
   return messages
-    .filter(
-      (m) =>
-        m && typeof m.content === 'string' && typeof m.role === 'string',
-    )
+    .filter(isValidRawMessage)
     .map((m) => ({
       role: VALID_ROLES.includes(m.role as Role) ? (m.role as Role) : 'user',
-      content: m.content.slice(0, maxContentLength),
+      content: normalizeContent(m.content, maxContentLength),
     }))
     .slice(-maxMessages);
+}
+
+/**
+ * Count the number of image parts across all messages. Used by the guard
+ * that rejects requests carrying more than `MAX_IMAGES_PER_REQUEST`.
+ */
+export function countImageParts(messages: ChatMessage[]): number {
+  let total = 0;
+  for (const m of messages) {
+    if (Array.isArray(m.content)) {
+      for (const part of m.content) {
+        if (isImagePart(part)) total += 1;
+      }
+    }
+  }
+  return total;
+}
+
+/**
+ * Strip image parts from every message, preserving their text content.
+ * Used when the target model is NOT in `VISION_CAPABLE_MODELS` so images
+ * never reach a text-only backend. If a message had only image parts
+ * it is dropped entirely.
+ */
+export function stripImageParts(messages: ChatMessage[]): ChatMessage[] {
+  const result: ChatMessage[] = [];
+  for (const m of messages) {
+    if (typeof m.content === 'string') {
+      result.push(m);
+      continue;
+    }
+    const textParts = m.content.filter(isTextPart);
+    if (textParts.length === 0) continue; // image-only message → drop
+    if (textParts.length === 1) {
+      result.push({ role: m.role, content: textParts[0].text });
+    } else {
+      result.push({ role: m.role, content: textParts });
+    }
+  }
+  return result;
+}
+
+/** True when the resolved model can receive image parts. */
+export function supportsVision(model: string): boolean {
+  return VISION_CAPABLE_MODELS.has(model);
 }
 
 /** Strip control chars, prompt delimiters, and cap length to prevent injection. */
@@ -105,23 +244,56 @@ export function buildSystemInstruction(context?: CoachContextPayload): string {
  * does accept `systemInstruction`, but inlining is a resilient fallback if a
  * particular model variant rejects it.
  */
+function collectTextFromContent(content: string | ContentPart[]): string {
+  if (typeof content === 'string') return content;
+  return content
+    .filter(isTextPart)
+    .map((p) => p.text)
+    .join('\n');
+}
+
+function collectImageParts(
+  content: string | ContentPart[],
+): ImageContentPart[] {
+  if (typeof content === 'string') return [];
+  return content.filter(isImagePart);
+}
+
 export function toGeminiContents(messages: ChatMessage[]): GeminiContent[] {
   const contents: GeminiContent[] = [];
   const pendingSystem: string[] = [];
 
   for (const m of messages) {
     if (m.role === 'system') {
-      if (m.content.trim()) pendingSystem.push(m.content.trim());
+      const text = collectTextFromContent(m.content).trim();
+      if (text) pendingSystem.push(text);
       continue;
     }
 
     const role = m.role === 'assistant' ? 'model' : 'user';
-    let text = m.content;
+    let text = collectTextFromContent(m.content);
     if (role === 'user' && pendingSystem.length > 0) {
       text = `[System]: ${pendingSystem.join('\n')}\n\n${text}`;
       pendingSystem.length = 0;
     }
-    contents.push({ role, parts: [{ text }] });
+    const parts: GeminiPart[] = [];
+    if (text.trim() || role === 'model') {
+      // Always emit a text part for user/model turns so Gemini doesn't
+      // reject a turn with only inlineData.
+      parts.push({ text });
+    }
+    for (const img of collectImageParts(m.content)) {
+      parts.push({
+        inlineData: {
+          mimeType: img.source.media_type,
+          data: img.source.data,
+        },
+      });
+    }
+    if (parts.length === 0) {
+      parts.push({ text: '' });
+    }
+    contents.push({ role, parts });
   }
 
   if (pendingSystem.length > 0) {

--- a/tests/unit/components/form-tracking/SnapForFeedbackButton.test.tsx
+++ b/tests/unit/components/form-tracking/SnapForFeedbackButton.test.tsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import type { CameraView } from 'expo-camera';
+
+import { SnapForFeedbackButton } from '@/components/form-tracking/SnapForFeedbackButton';
+
+type MinimalCamera = Pick<CameraView, 'takePictureAsync'>;
+
+function makeCameraRef(mockTake: jest.Mock): {
+  ref: React.RefObject<CameraView | null>;
+  camera: MinimalCamera;
+} {
+  const camera = { takePictureAsync: mockTake } as unknown as CameraView;
+  return {
+    ref: { current: camera } as React.RefObject<CameraView | null>,
+    camera,
+  };
+}
+
+describe('SnapForFeedbackButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('rendering + a11y', () => {
+    it('renders with the canonical label, role, and hint referencing exercise + phase', () => {
+      const mockTake = jest.fn();
+      const { ref } = makeCameraRef(mockTake);
+      const { getByTestId } = render(
+        <SnapForFeedbackButton
+          cameraRef={ref}
+          onSnap={jest.fn()}
+          exercise="squat"
+          phase="bottom"
+        />,
+      );
+
+      const btn = getByTestId('snap-for-feedback-button');
+      expect(btn.props.accessibilityRole).toBe('button');
+      expect(btn.props.accessibilityLabel).toBe('Snap for coach feedback');
+      expect(btn.props.accessibilityHint).toContain('squat');
+      expect(btn.props.accessibilityHint).toContain('bottom');
+    });
+
+    it('falls back to generic copy when exercise/phase are empty', () => {
+      const { ref } = makeCameraRef(jest.fn());
+      const { getByTestId } = render(
+        <SnapForFeedbackButton
+          cameraRef={ref}
+          onSnap={jest.fn()}
+          exercise=""
+          phase=""
+        />,
+      );
+
+      const btn = getByTestId('snap-for-feedback-button');
+      expect(btn.props.accessibilityHint).toContain('lift');
+      expect(btn.props.accessibilityHint).toContain('current');
+    });
+
+    it('respects a custom testID', () => {
+      const { ref } = makeCameraRef(jest.fn());
+      const { getByTestId } = render(
+        <SnapForFeedbackButton
+          cameraRef={ref}
+          onSnap={jest.fn()}
+          exercise="pullup"
+          phase="top"
+          testID="custom-snap"
+        />,
+      );
+      expect(getByTestId('custom-snap')).toBeTruthy();
+    });
+
+    it('renders disabled when the ref is not mounted', () => {
+      const emptyRef: React.RefObject<CameraView | null> = { current: null };
+      const { getByTestId } = render(
+        <SnapForFeedbackButton
+          cameraRef={emptyRef}
+          onSnap={jest.fn()}
+          exercise="squat"
+          phase="top"
+        />,
+      );
+      const btn = getByTestId('snap-for-feedback-button');
+      expect(btn.props.accessibilityState).toEqual(
+        expect.objectContaining({ disabled: true }),
+      );
+    });
+
+    it('renders disabled when the disabled prop is true', () => {
+      const { ref } = makeCameraRef(jest.fn());
+      const { getByTestId } = render(
+        <SnapForFeedbackButton
+          cameraRef={ref}
+          onSnap={jest.fn()}
+          exercise="squat"
+          phase="top"
+          disabled
+        />,
+      );
+      const btn = getByTestId('snap-for-feedback-button');
+      expect(btn.props.accessibilityState).toEqual(
+        expect.objectContaining({ disabled: true }),
+      );
+    });
+  });
+
+  describe('capture behavior', () => {
+    it('calls takePictureAsync and forwards the URI to onSnap', async () => {
+      const mockTake = jest
+        .fn()
+        .mockResolvedValue({ uri: 'file:///tmp/snap.jpg' });
+      const onSnap = jest.fn();
+      const { ref } = makeCameraRef(mockTake);
+      const { getByTestId } = render(
+        <SnapForFeedbackButton
+          cameraRef={ref}
+          onSnap={onSnap}
+          exercise="squat"
+          phase="bottom"
+        />,
+      );
+
+      fireEvent.press(getByTestId('snap-for-feedback-button'));
+      await waitFor(() => expect(onSnap).toHaveBeenCalledWith('file:///tmp/snap.jpg'));
+      expect(mockTake).toHaveBeenCalledWith(
+        expect.objectContaining({ base64: false, skipProcessing: false }),
+      );
+    });
+
+    it('honors the quality prop', async () => {
+      const mockTake = jest.fn().mockResolvedValue({ uri: 'file:///x.jpg' });
+      const { ref } = makeCameraRef(mockTake);
+      const { getByTestId } = render(
+        <SnapForFeedbackButton
+          cameraRef={ref}
+          onSnap={jest.fn()}
+          exercise="squat"
+          phase="top"
+          quality={0.9}
+        />,
+      );
+
+      fireEvent.press(getByTestId('snap-for-feedback-button'));
+      await waitFor(() => expect(mockTake).toHaveBeenCalled());
+      expect(mockTake).toHaveBeenCalledWith(
+        expect.objectContaining({ quality: 0.9 }),
+      );
+    });
+
+    it('does not call onSnap when takePictureAsync returns no uri', async () => {
+      const mockTake = jest.fn().mockResolvedValue({});
+      const onSnap = jest.fn();
+      const { ref } = makeCameraRef(mockTake);
+      const { getByTestId } = render(
+        <SnapForFeedbackButton
+          cameraRef={ref}
+          onSnap={onSnap}
+          exercise="squat"
+          phase="top"
+        />,
+      );
+
+      fireEvent.press(getByTestId('snap-for-feedback-button'));
+      await waitFor(() => expect(mockTake).toHaveBeenCalled());
+      expect(onSnap).not.toHaveBeenCalled();
+    });
+
+    it('invokes onError when takePictureAsync throws', async () => {
+      const err = new Error('boom');
+      const mockTake = jest.fn().mockRejectedValue(err);
+      const onError = jest.fn();
+      const { ref } = makeCameraRef(mockTake);
+      const { getByTestId } = render(
+        <SnapForFeedbackButton
+          cameraRef={ref}
+          onSnap={jest.fn()}
+          onError={onError}
+          exercise="squat"
+          phase="top"
+        />,
+      );
+
+      fireEvent.press(getByTestId('snap-for-feedback-button'));
+      await waitFor(() => expect(onError).toHaveBeenCalledWith(err));
+    });
+
+    it('swallows errors silently when no onError is supplied', async () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const mockTake = jest.fn().mockRejectedValue(new Error('boom'));
+      const { ref } = makeCameraRef(mockTake);
+      const { getByTestId } = render(
+        <SnapForFeedbackButton
+          cameraRef={ref}
+          onSnap={jest.fn()}
+          exercise="squat"
+          phase="top"
+        />,
+      );
+
+      fireEvent.press(getByTestId('snap-for-feedback-button'));
+      await waitFor(() => expect(mockTake).toHaveBeenCalled());
+      warn.mockRestore();
+    });
+
+    it('does nothing when pressed while the ref is not mounted', async () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const onSnap = jest.fn();
+      const emptyRef: React.RefObject<CameraView | null> = { current: null };
+      const { getByTestId } = render(
+        <SnapForFeedbackButton
+          cameraRef={emptyRef}
+          onSnap={onSnap}
+          exercise="squat"
+          phase="top"
+        />,
+      );
+
+      fireEvent.press(getByTestId('snap-for-feedback-button'));
+      // No takePictureAsync to call; onSnap must not fire.
+      expect(onSnap).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+  });
+});

--- a/tests/unit/services/coach-model-dispatch.test.ts
+++ b/tests/unit/services/coach-model-dispatch.test.ts
@@ -197,6 +197,87 @@ describe('decideCoachModel', () => {
     });
   });
 
+  describe('form_vision_check → multimodal Gemma', () => {
+    it.each<CoachUserTier>(['free', 'pro', 'premium'])(
+      'routes form_vision_check on tier=%s to gemma-4-31b-it by default',
+      (tier) => {
+        const decision = decideCoachModel('form_vision_check', NO_SIGNALS, tier);
+        expect(decision).toEqual({
+          model: 'gemma-4-31b-it',
+          reason: 'vision_gemma',
+          fellBackToCloud: false,
+        });
+      },
+    );
+
+    it('downgrades to gpt-5.4-mini when visionFallbackToCloud is set', () => {
+      const decision = decideCoachModel(
+        'form_vision_check',
+        NO_SIGNALS,
+        'pro',
+        { visionFallbackToCloud: true },
+      );
+      expect(decision).toEqual({
+        model: 'gpt-5.4-mini',
+        reason: 'vision_fallback_cloud',
+        fellBackToCloud: true,
+      });
+    });
+
+    it('dispatchDisabled still beats vision routing (ship-dark guarantee)', () => {
+      const decision = decideCoachModel(
+        'form_vision_check',
+        NO_SIGNALS,
+        'premium',
+        { dispatchDisabled: true },
+      );
+      expect(decision.reason).toBe('dispatch_disabled');
+      expect(decision.model).toBe('gpt-5.4-mini');
+    });
+
+    it('high-fault signal does NOT upgrade form_vision_check (multimodal required)', () => {
+      const decision = decideCoachModel(
+        'form_vision_check',
+        { faultCount: 99 },
+        'free',
+      );
+      expect(decision.model).toBe('gemma-4-31b-it');
+      expect(decision.reason).toBe('vision_gemma');
+    });
+
+    it('forceCloud does NOT downgrade form_vision_check (gpt-5.4-mini is text-only)', () => {
+      const decision = decideCoachModel(
+        'form_vision_check',
+        NO_SIGNALS,
+        'premium',
+        { forceCloud: true },
+      );
+      expect(decision.model).toBe('gemma-4-31b-it');
+      expect(decision.reason).toBe('vision_gemma');
+    });
+
+    it('visionFallbackToCloud on a non-vision task is a no-op', () => {
+      const decision = decideCoachModel(
+        'form_cue_lookup',
+        NO_SIGNALS,
+        'pro',
+        { visionFallbackToCloud: true },
+      );
+      expect(decision.model).toBe('gemma-4-31b-it');
+      expect(decision.reason).toBe('tactical_gemma');
+    });
+
+    it('visionFallbackToCloud stacks with dispatchDisabled (dispatchDisabled wins)', () => {
+      const decision = decideCoachModel(
+        'form_vision_check',
+        NO_SIGNALS,
+        'pro',
+        { visionFallbackToCloud: true, dispatchDisabled: true },
+      );
+      expect(decision.reason).toBe('dispatch_disabled');
+    });
+  });
+
   describe('signal/option shape handling', () => {
     it('treats missing faultCount as 0 (no upgrade)', () => {
       const decision = decideCoachModel('form_cue_lookup', {}, 'free');

--- a/tests/unit/services/coach-vision-flag.test.ts
+++ b/tests/unit/services/coach-vision-flag.test.ts
@@ -1,0 +1,42 @@
+import { isCoachVisionEnabled } from '@/lib/services/coach-vision-flag';
+
+const FLAG_ENV_VAR = 'EXPO_PUBLIC_COACH_VISION';
+
+describe('coach-vision-flag', () => {
+  const originalValue = process.env[FLAG_ENV_VAR];
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env[FLAG_ENV_VAR];
+    } else {
+      process.env[FLAG_ENV_VAR] = originalValue;
+    }
+  });
+
+  it('returns false when EXPO_PUBLIC_COACH_VISION is unset', () => {
+    delete process.env[FLAG_ENV_VAR];
+    expect(isCoachVisionEnabled()).toBe(false);
+  });
+
+  it('returns true when EXPO_PUBLIC_COACH_VISION is "on"', () => {
+    process.env[FLAG_ENV_VAR] = 'on';
+    expect(isCoachVisionEnabled()).toBe(true);
+  });
+
+  it('returns false when EXPO_PUBLIC_COACH_VISION is "off"', () => {
+    process.env[FLAG_ENV_VAR] = 'off';
+    expect(isCoachVisionEnabled()).toBe(false);
+  });
+
+  it('returns false for adjacent truthy-looking strings (strict parse)', () => {
+    for (const value of ['true', '1', 'yes', 'ON', 'On', 'enabled', '']) {
+      process.env[FLAG_ENV_VAR] = value;
+      expect(isCoachVisionEnabled()).toBe(false);
+    }
+  });
+
+  it('returns false for whitespace-padded "on"', () => {
+    process.env[FLAG_ENV_VAR] = ' on ';
+    expect(isCoachVisionEnabled()).toBe(false);
+  });
+});

--- a/tests/unit/services/coach-vision.test.ts
+++ b/tests/unit/services/coach-vision.test.ts
@@ -1,0 +1,299 @@
+/**
+ * coach-vision tests
+ *
+ * Covers:
+ * - encodeJpegToBase64: happy path + validation / missing-file errors
+ * - composeVisionPrompt: multimodal shape, fallbacks, user-note cap
+ * - dispatchVisionRequest: flag-off skip, flag-on delegate, provider
+ *   fallback pass-through
+ */
+
+// expo-file-system's runtime pulls in Expo native modules that aren't
+// loaded in jest-expo's default setup. Mock the File class directly so we
+// can control `exists` and `base64()` per test.
+const mockBase64 = jest.fn();
+const mockExistsGetter = jest.fn();
+
+jest.mock('expo-file-system', () => ({
+  File: jest.fn().mockImplementation((uri: string) => ({
+    uri,
+    get exists() {
+      return mockExistsGetter();
+    },
+    base64: mockBase64,
+  })),
+}));
+
+import {
+  composeVisionPrompt,
+  dispatchVisionRequest,
+  encodeJpegToBase64,
+  type VisionMessage,
+} from '@/lib/services/coach-vision';
+
+const FLAG_ENV_VAR = 'EXPO_PUBLIC_COACH_VISION';
+
+describe('coach-vision', () => {
+  const originalFlag = process.env[FLAG_ENV_VAR];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExistsGetter.mockReturnValue(true);
+    mockBase64.mockResolvedValue('BASE64_DATA');
+  });
+
+  afterEach(() => {
+    if (originalFlag === undefined) {
+      delete process.env[FLAG_ENV_VAR];
+    } else {
+      process.env[FLAG_ENV_VAR] = originalFlag;
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // encodeJpegToBase64
+  // ---------------------------------------------------------------------------
+
+  describe('encodeJpegToBase64', () => {
+    it('returns the base64 string from the File API', async () => {
+      mockBase64.mockResolvedValue('JPEG_B64');
+      const result = await encodeJpegToBase64('file:///tmp/snap.jpg');
+      expect(result).toBe('JPEG_B64');
+      expect(mockBase64).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws when uri is empty or whitespace', async () => {
+      await expect(encodeJpegToBase64('')).rejects.toThrow(/uri is required/);
+      await expect(encodeJpegToBase64('   ')).rejects.toThrow(/uri is required/);
+    });
+
+    it('throws when uri is not a string', async () => {
+      await expect(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        encodeJpegToBase64(undefined as unknown as string),
+      ).rejects.toThrow(/uri is required/);
+      await expect(
+        encodeJpegToBase64(null as unknown as string),
+      ).rejects.toThrow(/uri is required/);
+    });
+
+    it('throws a descriptive error when the file does not exist', async () => {
+      mockExistsGetter.mockReturnValue(false);
+      await expect(
+        encodeJpegToBase64('file:///tmp/missing.jpg'),
+      ).rejects.toThrow(/file not found at file:\/\/\/tmp\/missing\.jpg/);
+      expect(mockBase64).not.toHaveBeenCalled();
+    });
+
+    it('propagates IO errors from the File API', async () => {
+      mockBase64.mockRejectedValue(new Error('read failed'));
+      await expect(
+        encodeJpegToBase64('file:///tmp/broken.jpg'),
+      ).rejects.toThrow(/read failed/);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // composeVisionPrompt
+  // ---------------------------------------------------------------------------
+
+  describe('composeVisionPrompt', () => {
+    it('builds a user message with text + image parts in order', () => {
+      const msg = composeVisionPrompt({
+        exercise: 'squat',
+        phase: 'bottom',
+        base64Image: 'XYZ',
+      });
+      expect(msg.role).toBe('user');
+      expect(msg.content).toHaveLength(2);
+      expect(msg.content[0]).toEqual({
+        type: 'text',
+        text: expect.stringContaining('squat'),
+      });
+      expect(msg.content[0]).toEqual({
+        type: 'text',
+        text: expect.stringContaining('bottom'),
+      });
+      expect(msg.content[1]).toEqual({
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/jpeg',
+          data: 'XYZ',
+        },
+      });
+    });
+
+    it('preserves the exact exercise and phase strings (no mapping)', () => {
+      const msg = composeVisionPrompt({
+        exercise: 'romanian-deadlift',
+        phase: 'eccentric',
+        base64Image: '',
+      });
+      const text = (msg.content[0] as { text: string }).text;
+      expect(text).toContain('romanian-deadlift');
+      expect(text).toContain('eccentric');
+    });
+
+    it('falls back to "lift" / "setup" when exercise or phase are empty', () => {
+      const msg = composeVisionPrompt({
+        exercise: '',
+        phase: '',
+        base64Image: 'Q',
+      });
+      const text = (msg.content[0] as { text: string }).text;
+      expect(text).toContain('lift');
+      expect(text).toContain('setup');
+    });
+
+    it('appends the user note when provided', () => {
+      const msg = composeVisionPrompt({
+        exercise: 'pullup',
+        phase: 'top',
+        base64Image: 'IMG',
+        userNote: 'Feels like my elbows flare',
+      });
+      const text = (msg.content[0] as { text: string }).text;
+      expect(text).toContain('User note: Feels like my elbows flare');
+    });
+
+    it('omits the user-note clause when the note is blank', () => {
+      const msg = composeVisionPrompt({
+        exercise: 'pullup',
+        phase: 'top',
+        base64Image: 'IMG',
+        userNote: '   ',
+      });
+      const text = (msg.content[0] as { text: string }).text;
+      expect(text).not.toContain('User note');
+    });
+
+    it('caps the user note at 240 characters', () => {
+      const longNote = 'a'.repeat(400);
+      const msg = composeVisionPrompt({
+        exercise: 'squat',
+        phase: 'bottom',
+        base64Image: 'IMG',
+        userNote: longNote,
+      });
+      const text = (msg.content[0] as { text: string }).text;
+      const notePart = text.split('User note: ')[1] ?? '';
+      expect(notePart.length).toBe(240);
+    });
+
+    it('passes the raw base64 through verbatim (no re-encoding)', () => {
+      const msg = composeVisionPrompt({
+        exercise: 'squat',
+        phase: 'top',
+        base64Image: 'iVBORw0KGgoAAAANS',
+      });
+      expect(msg.content[1]).toMatchObject({
+        type: 'image',
+        source: { data: 'iVBORw0KGgoAAAANS' },
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // dispatchVisionRequest
+  // ---------------------------------------------------------------------------
+
+  describe('dispatchVisionRequest', () => {
+    const sampleMessage: VisionMessage = {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Critique my squat.' },
+        {
+          type: 'image',
+          source: { type: 'base64', media_type: 'image/jpeg', data: 'IMG' },
+        },
+      ],
+    };
+
+    it('skips with flag-off reason when env flag is unset', () => {
+      delete process.env[FLAG_ENV_VAR];
+      const result = dispatchVisionRequest(sampleMessage);
+      expect(result).toEqual({ skipped: true, reason: 'flag-off' });
+    });
+
+    it('skips with flag-off reason when env flag is off', () => {
+      process.env[FLAG_ENV_VAR] = 'off';
+      const result = dispatchVisionRequest(sampleMessage);
+      expect(result).toEqual({ skipped: true, reason: 'flag-off' });
+    });
+
+    it('explicit flag:false override still skips', () => {
+      process.env[FLAG_ENV_VAR] = 'on';
+      const result = dispatchVisionRequest(sampleMessage, { flag: false });
+      expect(result).toEqual({ skipped: true, reason: 'flag-off' });
+    });
+
+    it('flag:true override sends even when env is unset', () => {
+      delete process.env[FLAG_ENV_VAR];
+      const result = dispatchVisionRequest(sampleMessage, { flag: true });
+      expect(result.skipped).toBe(false);
+      if (result.skipped === false) {
+        expect(result.decision.model).toBe('gemma-4-31b-it');
+        expect(result.decision.reason).toBe('vision_gemma');
+      }
+    });
+
+    it('delegates to coach-model-dispatch for form_vision_check when flag is on', () => {
+      process.env[FLAG_ENV_VAR] = 'on';
+      const result = dispatchVisionRequest(sampleMessage);
+      expect(result.skipped).toBe(false);
+      if (result.skipped === false) {
+        expect(result.decision).toEqual({
+          model: 'gemma-4-31b-it',
+          reason: 'vision_gemma',
+          fellBackToCloud: false,
+        });
+        expect(result.provider).toBe('gemma');
+        expect(result.message).toBe(sampleMessage);
+      }
+    });
+
+    it('honors fallbackToCloud by downgrading to gpt-5.4-mini', () => {
+      process.env[FLAG_ENV_VAR] = 'on';
+      const result = dispatchVisionRequest(sampleMessage, {
+        fallbackToCloud: true,
+      });
+      expect(result.skipped).toBe(false);
+      if (result.skipped === false) {
+        expect(result.decision.model).toBe('gpt-5.4-mini');
+        expect(result.decision.reason).toBe('vision_fallback_cloud');
+        expect(result.decision.fellBackToCloud).toBe(true);
+      }
+    });
+
+    it('uses provided userTier (does not affect form_vision_check model choice)', () => {
+      process.env[FLAG_ENV_VAR] = 'on';
+      const free = dispatchVisionRequest(sampleMessage, { userTier: 'free' });
+      const premium = dispatchVisionRequest(sampleMessage, {
+        userTier: 'premium',
+      });
+      if (free.skipped === false && premium.skipped === false) {
+        expect(free.decision.model).toBe('gemma-4-31b-it');
+        expect(premium.decision.model).toBe('gemma-4-31b-it');
+      }
+    });
+
+    it('honors explicit provider option', () => {
+      process.env[FLAG_ENV_VAR] = 'on';
+      const result = dispatchVisionRequest(sampleMessage, {
+        provider: 'openai',
+      });
+      if (result.skipped === false) {
+        expect(result.provider).toBe('openai');
+      }
+    });
+
+    it('defaults provider to gemma when not supplied', () => {
+      process.env[FLAG_ENV_VAR] = 'on';
+      const result = dispatchVisionRequest(sampleMessage);
+      if (result.skipped === false) {
+        expect(result.provider).toBe('gemma');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `coach-vision.ts` with a JPEG→base64 encoder, multimodal prompt composer, and a flag-gated dispatch shim that delegates model selection to `coach-model-dispatch.ts` via the new `form_vision_check` task kind.
- Extends `coach-model-dispatch.ts` to route `form_vision_check` to `gemma-4-31b-it` by default with a `visionFallbackToCloud` escape hatch to `gpt-5.4-mini`.
- Extends the `coach-gemma` edge function (both `index.ts` and the Bun-testable `translation.ts`) to accept Anthropic/Gemma-style content-parts arrays, cap requests at 1 image, and strip image parts when the resolved model is not in `VISION_CAPABLE_MODELS`.
- Adds `SnapForFeedbackButton` (headless; not mounted into any screen yet).
- 55 new tests across 5 files; full test suite: 4622 passing, 0 failing.

## Why

Unlocks instant form feedback for:
- Users still calibrating (before internal joint-angle models have a baseline).
- Exercises that our per-exercise form models don't cover yet.

A single snapped frame → Gemma 4's multimodal path → a short coach reply, without needing a full session recording.

## Wiring

The `SnapForFeedbackButton` component is intentionally **not** mounted into `app/(tabs)/scan-arkit.tsx` in this PR — there's a parallel PR touching that file and we want to avoid a merge conflict. A follow-up PR will:

1. Import the button and render it in the scan overlay.
2. Wire its `onSnap` callback through `encodeJpegToBase64` → `composeVisionPrompt` → `dispatchVisionRequest`.
3. Thread the returned `decision` into `coach-service.sendCoachPrompt` so the message flows through the existing coach transport.

Everything here is gated behind `EXPO_PUBLIC_COACH_VISION` (default off) so it ships dark.

## Scope boundary vs #503

- Item 2 of #495 (cost-aware dispatch) was shipped in PR #503 — this PR does NOT re-implement it; it only **extends** the existing `CoachTaskKind` union with `form_vision_check`.

## Verification

```
bun run lint     # clean
bun run check:types   # clean
bun test --testPathPattern="coach-vision|coach-model-dispatch|SnapForFeedbackButton|coach-gemma"
# 7 suites, 157 tests, all pass
bun run test     # 375 suites, 4622 tests pass, 24 skipped, 0 failing
```

New files:
- `lib/services/coach-vision.ts`
- `lib/services/coach-vision-flag.ts`
- `components/form-tracking/SnapForFeedbackButton.tsx`
- `tests/unit/services/coach-vision.test.ts`
- `tests/unit/services/coach-vision-flag.test.ts`
- `tests/unit/components/form-tracking/SnapForFeedbackButton.test.tsx`

Touched files:
- `lib/services/coach-model-dispatch.ts` (new task kind + `visionFallbackToCloud` option)
- `tests/unit/services/coach-model-dispatch.test.ts` (+7 test cases covering the new kind)
- `supabase/functions/coach-gemma/index.ts` (multimodal types, guards)
- `supabase/functions/coach-gemma/translation.ts` (mirror of the same changes for Bun tests)
- `supabase/functions/coach-gemma/index.test.ts` (+17 test cases covering content-parts handling)

## Test plan

- [ ] Reviewer spot-checks `coach-vision.ts` dispatch return types.
- [ ] Reviewer confirms `VISION_CAPABLE_MODELS` stays disjoint from `ALLOWED_MODELS` until #485 extends the allowlist.
- [ ] Reviewer acknowledges follow-up PR will mount `SnapForFeedbackButton` in `scan-arkit.tsx`.

Partially closes #495 (item 1 only; item 2 was shipped in #503).