### PR TITLE
feat: progression flag gates + modal disabled-state (#475 follow-up)

### DIFF
--- a/app/(modals)/progression-plan.tsx
+++ b/app/(modals)/progression-plan.tsx
@@ -29,6 +29,7 @@ import {
   getExerciseHistorySummary,
   type ExerciseHistorySummary,
 } from '@/lib/services/exercise-history-service';
+import { isProgressionPlanEnabled } from '@/lib/services/progression-flags';
 import {
   generateProgressionPlan,
   type ProgressionPlan,
@@ -79,6 +80,11 @@ export default function ProgressionPlanModal() {
   const [error, setError] = useState<string | null>(null);
   const [acceptedWeight, setAcceptedWeight] = useState<number | null>(null);
 
+  // EXPO_PUBLIC_PROGRESSION_PLAN gate (#475). When off, the modal renders a
+  // lightweight disabled-state — keeps deep links from crashing the bundler
+  // and doesn't touch the coach-service / local-db while the feature is dark.
+  const planEnabled = isProgressionPlanEnabled();
+
   const loadSummary = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -124,14 +130,19 @@ export default function ProgressionPlanModal() {
   );
 
   useEffect(() => {
+    if (!planEnabled) {
+      setLoading(false);
+      return;
+    }
     loadSummary();
-  }, [loadSummary]);
+  }, [loadSummary, planEnabled]);
 
   useEffect(() => {
+    if (!planEnabled) return;
     if (summary && summary.sets.length > 0) {
       loadPlan(summary);
     }
-  }, [summary, loadPlan]);
+  }, [summary, loadPlan, planEnabled]);
 
   const triggeredPrs = useMemo(
     () => (summary?.prData ?? []).filter((p) => p.isPr),
@@ -164,7 +175,19 @@ export default function ProgressionPlanModal() {
         <View style={{ width: 32 }} />
       </View>
 
-      {loading ? (
+      {!planEnabled ? (
+        <View
+          style={styles.loadingPanel}
+          accessibilityRole="summary"
+          testID="progression-plan-disabled"
+        >
+          <Ionicons name="construct" size={40} color={TEXT_SECONDARY} />
+          <Text style={styles.loadingText}>
+            Progression planner is turned off. Enable it with
+            EXPO_PUBLIC_PROGRESSION_PLAN=on to preview.
+          </Text>
+        </View>
+      ) : loading ? (
         <View style={styles.loadingPanel}>
           <ActivityIndicator size="large" color={ACCENT} />
           <Text style={styles.loadingText}>Building your overload plan…</Text>

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -9,6 +9,10 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useUnits } from '@/contexts/UnitsContext';
 import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
 import { getMostRecentAvgFqi } from '@/lib/services/form-session-history-lookup';
+import {
+  isOverloadCardEnabled,
+  isProgressionPlanEnabled,
+} from '@/lib/services/progression-flags';
 import { exportSession } from '@/lib/services/session-export-service';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -74,6 +78,10 @@ export default function WorkoutsScreen() {
 
   const openProgressionPlan = useCallback(() => {
     if (!featuredExercise) return;
+    // Gated on EXPO_PUBLIC_PROGRESSION_PLAN — no-op when flag is off so the
+    // analytics card can still render (in "view only" mode) without opening
+    // the modal. Issue #475.
+    if (!isProgressionPlanEnabled()) return;
     Haptics.selectionAsync().catch(() => {});
     router.push(
       `/(modals)/progression-plan?exercise=${encodeURIComponent(featuredExercise)}`,
@@ -463,7 +471,7 @@ export default function WorkoutsScreen() {
               {lastUpdatedLabel ? (
                 <Text style={{ color: '#8E8E93', fontSize: 12, marginBottom: 12, textAlign: 'center' }}>{lastUpdatedLabel}</Text>
               ) : null}
-              {featuredExercise ? (
+              {featuredExercise && isOverloadCardEnabled() ? (
                 <OverloadAnalyticsCard
                   userId={user?.id ?? 'local-user'}
                   exercise={featuredExercise}

--- a/lib/services/progression-flags.ts
+++ b/lib/services/progression-flags.ts
@@ -1,0 +1,52 @@
+/**
+ * progression-flags
+ *
+ * Feature flag gates for the progressive-overload intelligence engine.
+ * The underlying services (`rep-max-calculator`, `weight-suggester`,
+ * `exercise-history-service`, `progression-planner`, `pr-detector-overload`)
+ * are pure and safe to call any time; these flags decide whether the
+ * user-facing surfaces — the overload analytics card on the workouts tab
+ * and the post-session progression-plan modal — are mounted.
+ *
+ * Parsing:
+ * - `EXPO_PUBLIC_OVERLOAD_CARD=on`     → analytics card rendered on workouts tab
+ * - `EXPO_PUBLIC_PROGRESSION_PLAN=on`  → "Plan" CTA opens progression-plan modal
+ * - any other value (including unset)  → surface hidden (fail safe)
+ *
+ * Intentionally strict string matching: only the literal `'on'` flips a
+ * flag. Mirrors `coach-model-dispatch-flag` so both knobs behave the same.
+ *
+ * Issue #475 — progressive overload engine. The services themselves landed
+ * via #477 (squash-merged); these flags gate the consumer surfaces so the
+ * engine can ship quietly until we are ready to promote it.
+ */
+
+const OVERLOAD_CARD_ENV_VAR = 'EXPO_PUBLIC_OVERLOAD_CARD';
+const PROGRESSION_PLAN_ENV_VAR = 'EXPO_PUBLIC_PROGRESSION_PLAN';
+
+function parseOnFlag(envVar: string): boolean {
+  const raw = process.env[envVar];
+  if (typeof raw !== 'string') return false;
+  return raw === 'on';
+}
+
+/**
+ * Whether the `OverloadAnalyticsCard` should mount on the workouts tab.
+ * Default: off.
+ */
+export function isOverloadCardEnabled(): boolean {
+  return parseOnFlag(OVERLOAD_CARD_ENV_VAR);
+}
+
+/**
+ * Whether the progression-plan modal (and any call site that routes to it)
+ * is reachable from the UI. Default: off.
+ */
+export function isProgressionPlanEnabled(): boolean {
+  return parseOnFlag(PROGRESSION_PLAN_ENV_VAR);
+}
+
+export const PROGRESSION_FLAG_ENV_VARS = {
+  overloadCard: OVERLOAD_CARD_ENV_VAR,
+  progressionPlan: PROGRESSION_PLAN_ENV_VAR,
+} as const;

--- a/tests/unit/screens/progression-plan-modal.test.tsx
+++ b/tests/unit/screens/progression-plan-modal.test.tsx
@@ -73,8 +73,13 @@ function sampleSummary() {
 }
 
 describe('ProgressionPlanModal', () => {
+  const originalPlanFlag = process.env.EXPO_PUBLIC_PROGRESSION_PLAN;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    // Engaged-behavior tests assume the progression plan flag is on (#475).
+    // A dedicated disabled-state test below asserts the off-by-default path.
+    process.env.EXPO_PUBLIC_PROGRESSION_PLAN = 'on';
     mockGetExerciseHistorySummary.mockResolvedValue(sampleSummary());
     mockGenerateProgressionPlan.mockResolvedValue({
       text: 'Week 1: 5x5 @ 230.',
@@ -83,6 +88,14 @@ describe('ProgressionPlanModal', () => {
       horizonWeeks: 3,
       cacheKey: 'cache-key',
     });
+  });
+
+  afterAll(() => {
+    if (originalPlanFlag === undefined) {
+      delete process.env.EXPO_PUBLIC_PROGRESSION_PLAN;
+    } else {
+      process.env.EXPO_PUBLIC_PROGRESSION_PLAN = originalPlanFlag;
+    }
   });
 
   it('renders a loading state before data resolves', () => {
@@ -127,6 +140,17 @@ describe('ProgressionPlanModal', () => {
       expect(getByText(/No sets logged yet for this exercise/)).toBeTruthy(),
     );
     // Planner should not be invoked when there is no history.
+    expect(mockGenerateProgressionPlan).not.toHaveBeenCalled();
+  });
+
+  it('renders disabled-state and skips services when flag is off', async () => {
+    // Override the engaged-behavior flag set in beforeEach.
+    delete process.env.EXPO_PUBLIC_PROGRESSION_PLAN;
+    const { getByTestId } = render(<ProgressionPlanModal />);
+    expect(getByTestId('progression-plan-disabled')).toBeTruthy();
+    // Wait a tick to confirm no async service calls leaked through.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(mockGetExerciseHistorySummary).not.toHaveBeenCalled();
     expect(mockGenerateProgressionPlan).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/services/progression-flags.test.ts
+++ b/tests/unit/services/progression-flags.test.ts
@@ -1,0 +1,93 @@
+import {
+  PROGRESSION_FLAG_ENV_VARS,
+  isOverloadCardEnabled,
+  isProgressionPlanEnabled,
+} from '@/lib/services/progression-flags';
+
+const OVERLOAD_CARD = PROGRESSION_FLAG_ENV_VARS.overloadCard;
+const PROGRESSION_PLAN = PROGRESSION_FLAG_ENV_VARS.progressionPlan;
+
+describe('progression-flags', () => {
+  const originalOverload = process.env[OVERLOAD_CARD];
+  const originalPlan = process.env[PROGRESSION_PLAN];
+
+  afterEach(() => {
+    if (originalOverload === undefined) {
+      delete process.env[OVERLOAD_CARD];
+    } else {
+      process.env[OVERLOAD_CARD] = originalOverload;
+    }
+    if (originalPlan === undefined) {
+      delete process.env[PROGRESSION_PLAN];
+    } else {
+      process.env[PROGRESSION_PLAN] = originalPlan;
+    }
+  });
+
+  describe('isOverloadCardEnabled', () => {
+    it('returns false when EXPO_PUBLIC_OVERLOAD_CARD is unset', () => {
+      delete process.env[OVERLOAD_CARD];
+      expect(isOverloadCardEnabled()).toBe(false);
+    });
+
+    it('returns true when EXPO_PUBLIC_OVERLOAD_CARD is "on"', () => {
+      process.env[OVERLOAD_CARD] = 'on';
+      expect(isOverloadCardEnabled()).toBe(true);
+    });
+
+    it('returns false when EXPO_PUBLIC_OVERLOAD_CARD is "off"', () => {
+      process.env[OVERLOAD_CARD] = 'off';
+      expect(isOverloadCardEnabled()).toBe(false);
+    });
+
+    it('returns false for adjacent truthy-looking strings (strict parse)', () => {
+      for (const value of ['true', '1', 'yes', 'ON', 'On', 'enabled', '']) {
+        process.env[OVERLOAD_CARD] = value;
+        expect(isOverloadCardEnabled()).toBe(false);
+      }
+    });
+
+    it('returns false for whitespace-padded "on"', () => {
+      process.env[OVERLOAD_CARD] = ' on ';
+      expect(isOverloadCardEnabled()).toBe(false);
+    });
+  });
+
+  describe('isProgressionPlanEnabled', () => {
+    it('returns false when EXPO_PUBLIC_PROGRESSION_PLAN is unset', () => {
+      delete process.env[PROGRESSION_PLAN];
+      expect(isProgressionPlanEnabled()).toBe(false);
+    });
+
+    it('returns true when EXPO_PUBLIC_PROGRESSION_PLAN is "on"', () => {
+      process.env[PROGRESSION_PLAN] = 'on';
+      expect(isProgressionPlanEnabled()).toBe(true);
+    });
+
+    it('returns false when EXPO_PUBLIC_PROGRESSION_PLAN is "off"', () => {
+      process.env[PROGRESSION_PLAN] = 'off';
+      expect(isProgressionPlanEnabled()).toBe(false);
+    });
+
+    it('returns false for adjacent truthy-looking strings (strict parse)', () => {
+      for (const value of ['true', '1', 'yes', 'ON', 'On', 'enabled', '']) {
+        process.env[PROGRESSION_PLAN] = value;
+        expect(isProgressionPlanEnabled()).toBe(false);
+      }
+    });
+  });
+
+  describe('independence', () => {
+    it('toggling one flag does not affect the other', () => {
+      process.env[OVERLOAD_CARD] = 'on';
+      delete process.env[PROGRESSION_PLAN];
+      expect(isOverloadCardEnabled()).toBe(true);
+      expect(isProgressionPlanEnabled()).toBe(false);
+
+      delete process.env[OVERLOAD_CARD];
+      process.env[PROGRESSION_PLAN] = 'on';
+      expect(isOverloadCardEnabled()).toBe(false);
+      expect(isProgressionPlanEnabled()).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up to the closed PR #477 (which shipped the progressive-overload engine as squash-merged commit `595661ea`). Adds the two feature-flag gates the current spec for issue #475 requires so the user-facing surfaces are off by default while the underlying services ship dark.

- New `lib/services/progression-flags.ts` — strict-parse `EXPO_PUBLIC_OVERLOAD_CARD` and `EXPO_PUBLIC_PROGRESSION_PLAN` toggles, mirroring the `coach-model-dispatch-flag` pattern (`'on'` literal only; anything else = off).
- `app/(tabs)/workouts.tsx` — `OverloadAnalyticsCard` only mounts when `EXPO_PUBLIC_OVERLOAD_CARD=on`, and the "Plan" CTA only routes when `EXPO_PUBLIC_PROGRESSION_PLAN=on`.
- `app/(modals)/progression-plan.tsx` — gains a disabled-state branch keyed by `progression-plan-disabled` testID; short-circuits all side-effect loaders (local-db, coach-service, weight-suggester) when the flag is off so deep links no longer trigger hidden service calls.
- New `tests/unit/services/progression-flags.test.ts` (10 cases) + extended `tests/unit/screens/progression-plan-modal.test.tsx` with a 6th test covering the off-state no-op.

## Scope note
Closes #475. The original scope of #475 (Exercise history query, 1RM estimator, weight suggester, category-aware PR detector, exercise-history aggregator, Gemma progression planner, progression-plan modal, OverloadAnalyticsCard) **already landed via squash commit 595661ea from PR #477**. That squash also closed the child issues #306/#307/#308/#309 implicitly — this follow-up just adds the flag gates the current issue acceptance requires. Marking #306/#307/#308/#309 as `closes` here as well so GitHub links them back to #475 on merge.

## Grep-first findings
- `rg -n 'rep-max-calculator|weightSuggester|progressionPlanner|exerciseHistoryService' lib/ components/ app/` on `origin/main` returns hits in all expected locations — engine is fully landed.
- `lib/services/progression-flags.ts` did **not** exist on `origin/main` — only new file created here.
- `app/(tabs)/workouts.tsx` mounts the card unconditionally on `origin/main` (no flag gate). This PR is the first to gate it.

## TODO markers
- `TODO(#447)` — pre-existing in `lib/services/pr-detector-overload.ts` (landed via squash of #477); not touched by this PR.
- `TODO(#466)` — pre-existing in `lib/services/progression-planner.ts` (streaming dispatch opts); not touched by this PR.

## Non-overlap guardrails honored
- No edits to `app/(tabs)/scan-arkit.tsx`, `lib/fusion/engine.ts`, `lib/services/ar-overlays-v2-flag.ts` (PR #505 surface).
- No edits to `lib/services/coach-service.ts`, `lib/services/coach-model-dispatch.ts`, `lib/services/coach-vision*.ts`, `supabase/functions/coach-gemma/*` (PR #506 surface).
- No edits to `lib/stores/session-runner.ts`, `lib/services/rest-timer.ts`, `lib/services/audio-session-manager.ts`.
- No edits to `supabase/migrations/`, `ios/`, `android/`, `.env*`, `package.json`, `bun.lock`. No new dependencies.
- Checked `app/(tabs)/workouts.tsx` against `origin/feat/445-form-resilience-ar-overlays`; #505 does not edit this file in the conflicting section.

## Verification
- `bun run lint` clean.
- `bun run check:types` clean.
- `bun run test -- --testPathPattern="(progression|overload|pr-detector-categories|rep-max|weight-suggester|exercise-history)"` → **11 suites, 120 tests passing**.
- Dedicated `progression-flags` suite: 10 tests (strict-parse + independence).
- `progression-plan-modal` suite: 6 tests (was 5 — added disabled-state coverage).

## Feature flags
| Flag | Default | Effect when `on` |
|---|---|---|
| `EXPO_PUBLIC_OVERLOAD_CARD` | `off` | `OverloadAnalyticsCard` renders on the workouts tab header |
| `EXPO_PUBLIC_PROGRESSION_PLAN` | `off` | "Plan" CTA opens the modal; modal loads services; deep links work |

Both flags use strict `'on'` matching — `"true"`, `"1"`, `"ON"`, padded whitespace, etc. all resolve to off. Fail-safe by design.

Closes #475, closes #306, closes #307, closes #308, closes #309.