### PR TITLE
feat: form-tracking a11y + haptics + audio polish (#428)

### DIFF
--- a/hooks/use-low-gesture-trigger.ts
+++ b/hooks/use-low-gesture-trigger.ts
@@ -1,0 +1,156 @@
+/**
+ * useLowGestureTrigger
+ *
+ * Alternate hand-gesture recording trigger for exercises where the user's
+ * arms spend most of the set extended overhead or straight out — making the
+ * existing "both hands above shoulders" gesture ambiguous or impossible
+ * (e.g. overhead press, jumping jacks, Y/T/W). This hook watches the live
+ * 2D joint stream for both hands held *below the hips* for a hold window,
+ * then fires a single trigger callback. Re-entrant fires are rate-limited.
+ *
+ * Designed to slot in next to the existing arms-above-shoulders detector in
+ * scan-arkit.tsx rather than replace it. Accessibility benefit (issue #428
+ * Gap 5): users holding a barbell overhead can still start/stop recording
+ * one-handed by briefly lowering their hands past the hip line.
+ */
+import { useCallback, useRef } from 'react';
+
+/**
+ * Minimal 2D joint shape — mirrors the ARKit skeleton payload used in
+ * scan-arkit.tsx and `lib/tracking-quality/human-validation.ts`. Kept as a
+ * local interface so this hook has zero downstream dependencies.
+ */
+export interface LowGestureJoint {
+  /** Lowercase-or-mixed-case joint name; we match by substring. */
+  name: string;
+  /** Normalised (0..1) image-space Y — 0 = top of frame, 1 = bottom. */
+  y: number;
+  /** Whether ARKit trusts this joint for the current frame. */
+  isTracked: boolean;
+}
+
+export interface UseLowGestureTriggerOptions {
+  /** Master on/off switch (e.g. user setting, or disable while recording). */
+  enabled: boolean;
+  /** Joint stream refreshed per frame by the caller. */
+  joints: readonly LowGestureJoint[] | null | undefined;
+  /** Fired once per confirmed gesture. */
+  onTrigger: () => void;
+  /**
+   * How long (ms) both hands must stay below the hip line before we fire.
+   * Default 500 ms — mirrors the existing arms-above-shoulders detector.
+   */
+  holdMs?: number;
+  /**
+   * Minimum normalised Y delta between each hand and the corresponding hip
+   * before we consider the hand "below" the hip. Default 0.04 (≈4 % of
+   * frame height) to filter out idle arm swing noise.
+   */
+  marginY?: number;
+  /**
+   * Minimum gap (ms) between consecutive trigger fires. Default 2000 ms —
+   * prevents the gesture from re-firing while the user is still lowering /
+   * raising their hands after a completed gesture.
+   */
+  cooldownMs?: number;
+  /** Optional clock override for deterministic tests. */
+  now?: () => number;
+}
+
+const DEFAULT_HOLD_MS = 500;
+const DEFAULT_MARGIN_Y = 0.04;
+const DEFAULT_COOLDOWN_MS = 2000;
+
+type JointFinder = (needle: string) => LowGestureJoint | undefined;
+
+function makeFinder(joints: readonly LowGestureJoint[]): JointFinder {
+  return (needle) =>
+    joints.find((joint) => joint.isTracked && joint.name.toLowerCase().includes(needle));
+}
+
+/**
+ * Determine whether both hands are currently held below the hip line.
+ * Exported for unit-test coverage; not part of the public hook surface.
+ */
+export function handsBelowHips(
+  joints: readonly LowGestureJoint[] | null | undefined,
+  marginY: number = DEFAULT_MARGIN_Y,
+): boolean {
+  if (!joints || joints.length === 0) return false;
+  const find = makeFinder(joints);
+  const leftHand = find('left_hand');
+  const rightHand = find('right_hand');
+  const leftHip = find('left_hip');
+  const rightHip = find('right_hip');
+  if (!leftHand || !rightHand || !leftHip || !rightHip) return false;
+  // Y grows downward, so "below" means the hand's y is greater than hip + margin.
+  return leftHand.y > leftHip.y + marginY && rightHand.y > rightHip.y + marginY;
+}
+
+/**
+ * Result object exposing a deterministic pure-function check plus a reset
+ * in case the caller wants to cancel a pending hold (e.g. after the user
+ * taps the manual record button).
+ */
+export interface UseLowGestureTriggerResult {
+  /** Reset any in-progress hold so the next frame starts the window fresh. */
+  reset: () => void;
+}
+
+export function useLowGestureTrigger(
+  options: UseLowGestureTriggerOptions,
+): UseLowGestureTriggerResult {
+  const {
+    enabled,
+    joints,
+    onTrigger,
+    holdMs = DEFAULT_HOLD_MS,
+    marginY = DEFAULT_MARGIN_Y,
+    cooldownMs = DEFAULT_COOLDOWN_MS,
+    now,
+  } = options;
+
+  const holdStartRef = useRef<number | null>(null);
+  const lastTriggerRef = useRef<number>(0);
+  const onTriggerRef = useRef(onTrigger);
+  const nowRef = useRef(now);
+
+  onTriggerRef.current = onTrigger;
+  nowRef.current = now;
+
+  // Run detection inline on every render so callers can drive re-evaluation
+  // by re-rendering with a fresh frame reference — the caller already re-
+  // renders per ARKit pose tick and we can ride that cadence without needing
+  // to thread a separate ref-count prop through the hook.
+  if (!enabled) {
+    holdStartRef.current = null;
+  } else if (!handsBelowHips(joints, marginY)) {
+    holdStartRef.current = null;
+  } else {
+    const clock = nowRef.current ?? Date.now;
+    const t = clock();
+    if (holdStartRef.current === null) {
+      holdStartRef.current = t;
+    } else {
+      const heldFor = t - holdStartRef.current;
+      const sinceLast = t - lastTriggerRef.current;
+      if (heldFor >= holdMs && sinceLast > cooldownMs) {
+        lastTriggerRef.current = t;
+        holdStartRef.current = null;
+        try {
+          onTriggerRef.current();
+        } catch {
+          /* swallow listener failures — trigger is best-effort */
+        }
+      }
+    }
+  }
+
+  const reset = useCallback(() => {
+    holdStartRef.current = null;
+  }, []);
+
+  return { reset };
+}
+
+export default useLowGestureTrigger;

--- a/lib/a11y/HitTargets.ts
+++ b/lib/a11y/HitTargets.ts
@@ -4,6 +4,13 @@
  * Apple HIG and WCAG 2.5.5 both call for a minimum 44x44pt touch target.
  * Components that render smaller should still grow their effective hit
  * region via `hitSlop` to meet the spec.
+ *
+ * TODO(#428): the scan-arkit record-button a11y wiring
+ * (accessibilityRole/Label/State/Hint for start/stop/finalising) is deferred
+ * until PR #505 (`feat/445-form-resilience-ar-overlays`) merges and releases
+ * ownership of `app/(tabs)/scan-arkit.tsx`. The record button currently has
+ * no a11y props so VoiceOver announces only the generic 'button' role.
+ * Re-wire once #505 lands.
  */
 
 import type { Insets } from 'react-native';

--- a/tests/unit/hooks/use-low-gesture-trigger.test.ts
+++ b/tests/unit/hooks/use-low-gesture-trigger.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Unit tests for useLowGestureTrigger — hand-below-hip alternate recording
+ * gesture (issue #428 Gap 5).
+ */
+import { renderHook } from '@testing-library/react-native';
+import {
+  handsBelowHips,
+  useLowGestureTrigger,
+  type LowGestureJoint,
+} from '@/hooks/use-low-gesture-trigger';
+
+function joint(name: string, y: number, isTracked = true): LowGestureJoint {
+  return { name, y, isTracked };
+}
+
+function skeleton(opts: {
+  leftHandY: number;
+  rightHandY: number;
+  leftHipY: number;
+  rightHipY: number;
+  tracked?: boolean;
+}): LowGestureJoint[] {
+  const tracked = opts.tracked ?? true;
+  return [
+    joint('left_hand', opts.leftHandY, tracked),
+    joint('right_hand', opts.rightHandY, tracked),
+    joint('left_hip', opts.leftHipY, tracked),
+    joint('right_hip', opts.rightHipY, tracked),
+  ];
+}
+
+describe('handsBelowHips', () => {
+  it('returns false when joint array is missing/empty', () => {
+    expect(handsBelowHips(null)).toBe(false);
+    expect(handsBelowHips(undefined)).toBe(false);
+    expect(handsBelowHips([])).toBe(false);
+  });
+
+  it('returns false when required joints are not tracked', () => {
+    const joints = skeleton({
+      leftHandY: 0.9,
+      rightHandY: 0.9,
+      leftHipY: 0.5,
+      rightHipY: 0.5,
+      tracked: false,
+    });
+    expect(handsBelowHips(joints)).toBe(false);
+  });
+
+  it('returns true when both hands are clearly below both hips', () => {
+    const joints = skeleton({
+      leftHandY: 0.9,
+      rightHandY: 0.88,
+      leftHipY: 0.55,
+      rightHipY: 0.5,
+    });
+    expect(handsBelowHips(joints)).toBe(true);
+  });
+
+  it('returns false when only one hand is below', () => {
+    const joints = skeleton({
+      leftHandY: 0.9,
+      rightHandY: 0.4,
+      leftHipY: 0.5,
+      rightHipY: 0.5,
+    });
+    expect(handsBelowHips(joints)).toBe(false);
+  });
+
+  it('respects the marginY threshold', () => {
+    // Hands barely below hips — smaller than default 0.04 margin.
+    const joints = skeleton({
+      leftHandY: 0.52,
+      rightHandY: 0.52,
+      leftHipY: 0.5,
+      rightHipY: 0.5,
+    });
+    expect(handsBelowHips(joints)).toBe(false);
+    expect(handsBelowHips(joints, 0.01)).toBe(true);
+  });
+});
+
+describe('useLowGestureTrigger', () => {
+  it('does not fire immediately when the gesture is first seen', () => {
+    const onTrigger = jest.fn();
+    const joints = skeleton({
+      leftHandY: 0.9,
+      rightHandY: 0.9,
+      leftHipY: 0.5,
+      rightHipY: 0.5,
+    });
+    let t = 1_000;
+    renderHook(() =>
+      useLowGestureTrigger({
+        enabled: true,
+        joints,
+        onTrigger,
+        now: () => t,
+      }),
+    );
+    expect(onTrigger).not.toHaveBeenCalled();
+  });
+
+  it('fires once the hold window is satisfied across frames', () => {
+    const onTrigger = jest.fn();
+    const joints = skeleton({
+      leftHandY: 0.9,
+      rightHandY: 0.9,
+      leftHipY: 0.5,
+      rightHipY: 0.5,
+    });
+    let t = 10_000;
+    const { rerender } = renderHook(
+      ({ frame }: { frame: number }) =>
+        useLowGestureTrigger({
+          enabled: true,
+          joints,
+          onTrigger,
+          now: () => t,
+          holdMs: 500,
+          cooldownMs: 2000,
+        }),
+      { initialProps: { frame: 0 } },
+    );
+    // Advance the clock and re-render with a new joint reference to simulate
+    // a fresh frame from the ARKit stream.
+    t = 10_600; // 600 ms later — past 500 ms hold
+    rerender({ frame: 1 });
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  it('enforces the cooldown between successive triggers', () => {
+    const onTrigger = jest.fn();
+    const joints = skeleton({
+      leftHandY: 0.9,
+      rightHandY: 0.9,
+      leftHipY: 0.5,
+      rightHipY: 0.5,
+    });
+    let t = 10_000;
+    const { rerender } = renderHook(
+      ({ frame }: { frame: number }) =>
+        useLowGestureTrigger({
+          enabled: true,
+          joints,
+          onTrigger,
+          now: () => t,
+          holdMs: 300,
+          cooldownMs: 2_000,
+        }),
+      { initialProps: { frame: 0 } },
+    );
+    t = 10_400;
+    rerender({ frame: 1 });
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+
+    // Another frame well past the hold window but inside the cooldown —
+    // should not re-trigger.
+    t = 11_500; // 1.1s after first trigger
+    rerender({ frame: 2 });
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+
+    // And one past the cooldown — allowed, but only if we've reset the hold
+    // and then accumulated a fresh hold window.
+    t = 12_600; // > cooldown
+    rerender({ frame: 3 });
+    t = 13_100; // fresh hold satisfied
+    rerender({ frame: 4 });
+    expect(onTrigger).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancels the in-progress hold when the gesture breaks', () => {
+    const onTrigger = jest.fn();
+    const hold: LowGestureJoint[] = skeleton({
+      leftHandY: 0.9,
+      rightHandY: 0.9,
+      leftHipY: 0.5,
+      rightHipY: 0.5,
+    });
+    const released: LowGestureJoint[] = skeleton({
+      leftHandY: 0.3,
+      rightHandY: 0.3,
+      leftHipY: 0.5,
+      rightHipY: 0.5,
+    });
+    let t = 10_000;
+    const { rerender } = renderHook(
+      ({ joints }: { joints: LowGestureJoint[] }) =>
+        useLowGestureTrigger({
+          enabled: true,
+          joints,
+          onTrigger,
+          now: () => t,
+          holdMs: 500,
+        }),
+      { initialProps: { joints: hold } },
+    );
+    // Breaks gesture before hold completes.
+    t = 10_200;
+    rerender({ joints: released });
+    // Come back to gesture but only briefly — should not fire (hold resets).
+    t = 10_300;
+    rerender({ joints: hold });
+    t = 10_600; // only 300 ms since the new hold started
+    rerender({ joints: hold });
+    expect(onTrigger).not.toHaveBeenCalled();
+  });
+
+  it('never fires when enabled is false', () => {
+    const onTrigger = jest.fn();
+    const joints = skeleton({
+      leftHandY: 0.9,
+      rightHandY: 0.9,
+      leftHipY: 0.5,
+      rightHipY: 0.5,
+    });
+    let t = 1_000;
+    const { rerender } = renderHook(
+      ({ frame }: { frame: number }) =>
+        useLowGestureTrigger({
+          enabled: false,
+          joints,
+          onTrigger,
+          now: () => t,
+        }),
+      { initialProps: { frame: 0 } },
+    );
+    t = 10_000;
+    rerender({ frame: 1 });
+    expect(onTrigger).not.toHaveBeenCalled();
+  });
+
+  it('exposes a reset() that clears any pending hold', () => {
+    const onTrigger = jest.fn();
+    const joints = skeleton({
+      leftHandY: 0.9,
+      rightHandY: 0.9,
+      leftHipY: 0.5,
+      rightHipY: 0.5,
+    });
+    let t = 10_000;
+    const { result, rerender } = renderHook(
+      ({ frame }: { frame: number }) =>
+        useLowGestureTrigger({
+          enabled: true,
+          joints,
+          onTrigger,
+          now: () => t,
+          holdMs: 500,
+        }),
+      { initialProps: { frame: 0 } },
+    );
+    t = 10_200;
+    rerender({ frame: 1 });
+    // Caller hits the manual record button — reset any pending hold.
+    result.current.reset();
+    t = 10_400;
+    rerender({ frame: 2 });
+    expect(onTrigger).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Ship the one piece of issue #428 that was never consolidated into main by the Stack D bundle (PR #499): an alternate hand-below-hip recording gesture for users whose hands stay overhead or extended during a set (Gap 5).

The other 6 gaps from the issue are already on main — this PR also audits each one and confirms the wiring, documents the deferred record-button a11y edit, and adds no regressions to the existing 270-test hook surface.

### Per-gap status audit

- Gap 1 — Cross-platform haptic bus + `useHapticBus` → DONE on main (`lib/haptics/haptic-bus.ts`, `useHapticBus.ts`, wired into `rest-timer`, `rep-logger`, `calibration`, `use-workout-controller`, `use-haptic-wiring`). `HapticPreferencesContext` mirrors prefs into the bus.
- Gap 2 — Non-voice audio cue tones + BT route handling → DONE on main (`lib/audio/cue-tones.ts` with 3 MP3 tone assets, `audio-session-manager` route-change plumbing, `useAudioRouteToast`).
- Gap 3 — Reduce-motion support → DONE on main (`lib/a11y/useReducedMotion.ts`, `motion-presets.ts`).
- Gap 4 — Dynamic Type / font scaling → DONE on main (`lib/a11y/typography.ts::scaled`, `AccessibleText.tsx`, `_scan-arkit.styles.ts` `scaledMin` floor).
- Gap 5 — 44x44 hit targets + record-button a11y → PARTIAL. 44x44 top-bar + `AccessiblePressable` + `RestTimerSheet` a11y are on main. **This PR adds** `hooks/use-low-gesture-trigger.ts`, the last missing piece of this gap (hand-below-hip trigger for arms-extended scenarios). Record-button a11y wiring on `scan-arkit.tsx` is **deferred** — see below.
- Gap 6 — Color-blind FqiGauge + CueCard → DONE on main (`color-blind-palette.ts`, `useColorBlindMode.ts`, `FqiGaugeShapeOverlay.tsx`, `CueShapeBadge.tsx`).
- Gap 7 — Smart keep-awake → DONE on main (`useKeepAwakeSmart.ts`, wired into `RestTimerSheet`).

### New this PR

**`hooks/use-low-gesture-trigger.ts`** — alternate recording-gesture trigger for exercises where hands stay overhead. Exports `handsBelowHips()` pure helper plus `useLowGestureTrigger({ enabled, joints, onTrigger, holdMs?, marginY?, cooldownMs?, now? })`. 500 ms hold + 2 s cooldown defaults mirror the existing arms-above-shoulders detector in `scan-arkit.tsx`.

**`tests/unit/hooks/use-low-gesture-trigger.test.ts`** — 11 tests covering joint-availability gating, tracking flag, marginY threshold, hold-window integration across frames, cooldown enforcement, pending-hold cancellation, disabled pass-through, and manual `reset()`.

**`lib/a11y/HitTargets.ts`** — header note pointing to the deferred record-button a11y wiring so the next contributor sees why it's missing.

## Verification

- `bun run lint` — clean
- `bun run check:types` — clean
- `bun run test -- tests/unit/a11y tests/unit/haptics tests/unit/audio tests/unit/hooks/use-low-gesture-trigger.test.ts` → **74 passed / 74 total** (63 prior + 11 new)
- `bun run test -- tests/unit/hooks` → **270 passed / 270 total**
- `bun run test -- tests/unit/contexts/HapticPreferencesContext.test.tsx` → **3 passed / 3 total**

## Deferred

- **Record-button a11y wiring on `app/(tabs)/scan-arkit.tsx`**. The prior commit `4e81d79d feat(a11y): add record-button accessibilityRole/Label/State` was reverted somewhere in the Stack A form-tracking consolidation merge. Re-landing it requires editing `scan-arkit.tsx`, which is the edit region of open PR #505 (`feat/445-form-resilience-ar-overlays`). A TODO reference in `lib/a11y/HitTargets.ts` header flags this so it can be re-wired once #505 merges.

## Scope boundaries honoured

- No edits to `app/(tabs)/scan-arkit.tsx`, `lib/fusion/engine.ts`, `lib/services/ar-overlays-v2-flag.ts` (PR #505).
- No edits to `lib/services/coach-service.ts` / `coach-model-dispatch*.ts` / `supabase/functions/coach-gemma/*` (PR #506).
- No edits to `supabase/migrations/`, `ios/`, `android/`, `.env*`, `package.json`, `bun.lock`.
- No new dependencies.

Closes #428 (modulo the deferred record-button item above).