### PR TITLE
feat(gemma): EXPO_PUBLIC_GEMMA_SESSION_GEN flag gate for session generators (#468)

### DIFF
--- a/app/(modals)/generate-session.tsx
+++ b/app/(modals)/generate-session.tsx
@@ -34,6 +34,10 @@ import {
   getSessionFallback,
   withFallback,
 } from '@/lib/services/session-generator-fallback';
+import {
+  isGemmaSessionGenEnabled,
+  FLAG_DISABLED_ERROR_CODE,
+} from '@/lib/services/gemma-session-gen-flag';
 import { localDB } from '@/lib/services/database/local-db';
 import { genericLocalUpsert } from '@/lib/services/database/generic-sync';
 import type { Exercise, GoalProfile } from '@/lib/types/workout-session';
@@ -131,6 +135,7 @@ export default function GenerateSessionScreen() {
   const [durationMin, setDurationMin] = useState<number>(30);
 
   const userId = user?.id ?? 'local-user';
+  const aiEnabled = isGemmaSessionGenEnabled();
 
   const { loading, error, result, generate, reset } = useSessionGenerator({
     runtime: { userId, maxRetries: 1 },
@@ -143,10 +148,27 @@ export default function GenerateSessionScreen() {
     return rows.map((r) => r.name.toLowerCase().replace(/[^a-z0-9]/g, '_'));
   }, []);
 
+  const handleOfflineFallback = useCallback(async () => {
+    const hydrated = await withFallback(
+      async () => getSessionFallback({ goalProfile, durationMin }, { userId }),
+      () => getSessionFallback({}, { userId }),
+    );
+    await persistHydrated(hydrated);
+    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+    router.replace(`/(modals)/template-builder?templateId=${hydrated.template.id}` as never);
+  }, [goalProfile, durationMin, userId, router]);
+
   const handleGenerate = useCallback(async () => {
     const trimmed = intent.trim();
     if (trimmed.length === 0) {
       Alert.alert('Describe the session', 'Tell the AI what you want to train.');
+      return;
+    }
+    // Flag off: skip the dispatch entirely and use the offline library so the
+    // user still walks out with a template instead of hitting a disabled error.
+    if (!aiEnabled) {
+      await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      await handleOfflineFallback();
       return;
     }
     await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -162,17 +184,16 @@ export default function GenerateSessionScreen() {
       await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       router.replace(`/(modals)/template-builder?templateId=${hydrated.template.id}` as never);
     }
-  }, [intent, goalProfile, durationMin, availableSlugsPromise, generate, router]);
-
-  const handleOfflineFallback = useCallback(async () => {
-    const hydrated = await withFallback(
-      async () => getSessionFallback({ goalProfile, durationMin }, { userId }),
-      () => getSessionFallback({}, { userId }),
-    );
-    await persistHydrated(hydrated);
-    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
-    router.replace(`/(modals)/template-builder?templateId=${hydrated.template.id}` as never);
-  }, [goalProfile, durationMin, userId, router]);
+  }, [
+    intent,
+    aiEnabled,
+    goalProfile,
+    durationMin,
+    availableSlugsPromise,
+    generate,
+    handleOfflineFallback,
+    router,
+  ]);
 
   const handleClose = useCallback(() => {
     reset();
@@ -256,24 +277,37 @@ export default function GenerateSessionScreen() {
           onPress={handleGenerate}
           disabled={loading}
           accessibilityRole="button"
-          accessibilityLabel="Generate session"
+          accessibilityLabel={aiEnabled ? 'Generate session with AI' : 'Generate from offline library'}
         >
           {loading ? (
             <ActivityIndicator color="#fff" />
           ) : (
             <>
               <Ionicons name="sparkles-outline" size={18} color="#fff" />
-              <Text style={styles.primaryBtnText}>Generate</Text>
+              <Text style={styles.primaryBtnText}>
+                {aiEnabled ? 'Generate' : 'Use offline library'}
+              </Text>
             </>
           )}
         </TouchableOpacity>
+
+        {!aiEnabled && !loading && (
+          <View style={styles.infoCard} accessibilityRole="alert">
+            <Ionicons name="information-circle-outline" size={18} color={tabColors.accent} />
+            <Text style={styles.infoText}>
+              AI generation is disabled on this build. Tapping Generate will pull a handcrafted template from the offline library.
+            </Text>
+          </View>
+        )}
 
         {error && !loading && (
           <View style={styles.errorCard}>
             <Ionicons name="alert-circle-outline" size={18} color={tabColors.error} />
             <View style={{ flex: 1 }}>
               <Text style={styles.errorText}>
-                {(error as { message?: string }).message ?? 'Generation failed.'}
+                {(error as { code?: string }).code === FLAG_DISABLED_ERROR_CODE
+                  ? 'AI generation is disabled on this build. Use the offline library below.'
+                  : ((error as { message?: string }).message ?? 'Generation failed.')}
               </Text>
               <TouchableOpacity onPress={handleOfflineFallback}>
                 <Text style={styles.offlineLink}>Use offline suggestion</Text>
@@ -393,6 +427,24 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(255, 59, 48, 0.08)',
     borderWidth: 1,
     borderColor: 'rgba(255, 59, 48, 0.3)',
+  },
+  infoCard: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+    marginTop: 12,
+    padding: 12,
+    borderRadius: 10,
+    backgroundColor: 'rgba(10, 132, 255, 0.08)',
+    borderWidth: 1,
+    borderColor: 'rgba(10, 132, 255, 0.2)',
+  },
+  infoText: {
+    flex: 1,
+    fontSize: 12,
+    fontFamily: 'Lexend_400Regular',
+    color: tabColors.textSecondary,
+    lineHeight: 16,
   },
   errorText: {
     fontSize: 13,

--- a/docs/gemma-integration.md
+++ b/docs/gemma-integration.md
@@ -46,6 +46,36 @@ re-prompts the LLM with the validation issues.
 - `rest-advisor.ts` has its own inline `heuristicRestSeconds` fallback so it does
   not depend on the session-generator-fallback module.
 
+### Feature flag: `EXPO_PUBLIC_GEMMA_SESSION_GEN`
+
+All four generators are gated by `lib/services/gemma-session-gen-flag.ts` so
+production can ship the services dark while beta testers opt in via env.
+
+| Value | Behavior |
+|---|---|
+| `on`, `1`, `true` (case-insensitive, whitespace-trimmed) | Generators dispatch to the real coach-service |
+| unset, `off`, anything else | Generators reject with `GEMMA_SESSION_GEN_DISABLED` — except `rest-advisor`, which short-circuits to `heuristicRestSeconds` since it runs in-loop during a set |
+
+Guard behavior:
+
+- `generateSession` / `generateWarmup` / `generateCooldown` call
+  `assertGemmaSessionGenEnabled(surface)` before dispatch, throwing
+  `GemmaSessionGenDisabledError` (`code: 'GEMMA_SESSION_GEN_DISABLED'`).
+- `suggestRestSeconds` calls `isGemmaSessionGenEnabled()` and returns the
+  deterministic heuristic if false. This keeps rest recommendations flowing
+  during a live set even when the flag is off.
+- Every generator runtime has a `skipFlagCheck` escape hatch for integration
+  tests that want to exercise the real dispatcher without toggling env.
+- Custom `dispatch` overrides (all unit tests) bypass the gate automatically.
+
+UI behavior:
+
+- `app/(modals)/generate-session.tsx` calls `isGemmaSessionGenEnabled()` on
+  mount. When false, the primary button label flips to "Use offline library"
+  and a soft info banner explains the state. Tapping the button routes
+  directly to the offline-library path instead of kicking off a dispatch
+  that would reject.
+
 ### UI entry points
 
 - **Template Builder** (`app/(modals)/template-builder.tsx`) — "Generate from AI"

--- a/lib/services/cooldown-generator.ts
+++ b/lib/services/cooldown-generator.ts
@@ -5,6 +5,7 @@
  */
 import { sendCoachPrompt, type CoachContext, type CoachMessage } from './coach-service';
 import { parseGemmaJsonResponse, schema, type JsonSchema } from './gemma-json-parser';
+import { assertGemmaSessionGenEnabled } from './gemma-session-gen-flag';
 import {
   buildCooldownGeneratorMessages,
   type CooldownGeneratorInput,
@@ -52,12 +53,21 @@ export interface CooldownGeneratorRuntime {
   coachContext?: CoachContext;
   dispatch?: (messages: CoachMessage[], ctx?: CoachContext) => Promise<CoachMessage>;
   maxRetries?: number;
+  /**
+   * Bypass the EXPO_PUBLIC_GEMMA_SESSION_GEN gate. Intended for integration
+   * tests; unit tests that inject `dispatch` skip the gate automatically.
+   */
+  skipFlagCheck?: boolean;
 }
 
 export async function generateCooldown(
   input: CooldownGeneratorInput,
   runtime: CooldownGeneratorRuntime = {},
 ): Promise<CooldownPlan> {
+  if (!runtime.dispatch && !runtime.skipFlagCheck) {
+    assertGemmaSessionGenEnabled('cooldown-generator');
+  }
+
   const messages = buildCooldownGeneratorMessages(input);
   const dispatch = runtime.dispatch ?? sendCoachPrompt;
 

--- a/lib/services/gemma-session-gen-flag.ts
+++ b/lib/services/gemma-session-gen-flag.ts
@@ -1,0 +1,74 @@
+/**
+ * gemma-session-gen-flag
+ *
+ * Feature flag gate for the Gemma-powered session / warmup / cooldown /
+ * rest-advisor generators shipped under issue #468.
+ *
+ * All four generator services (`session-generator`, `warmup-generator`,
+ * `cooldown-generator`, `rest-advisor`) are safe to import and call at any
+ * time — they all accept a custom `dispatch` runtime override and they all
+ * have offline fallbacks. This flag lets callers short-circuit the dispatch
+ * entirely without mocking, so production can ship the generators dark and
+ * staff / beta users can opt in via env.
+ *
+ * Parsing:
+ * - `EXPO_PUBLIC_GEMMA_SESSION_GEN=on`  → generators active
+ * - `EXPO_PUBLIC_GEMMA_SESSION_GEN=1`   → generators active
+ * - `EXPO_PUBLIC_GEMMA_SESSION_GEN=true`→ generators active
+ * - unset / `off` / anything else       → generators inactive (fail safe)
+ *
+ * The parser is intentionally permissive on the enabled side (`on` | `1` |
+ * `true`, case-insensitive) because this is a user-facing rollout knob that
+ * docs commonly write three different ways. It is strictly disabled by
+ * default so a missing env var never lights up LLM traffic in production.
+ */
+
+const FLAG_ENV_VAR = 'EXPO_PUBLIC_GEMMA_SESSION_GEN';
+
+const ENABLED_VALUES = new Set(['on', '1', 'true']);
+
+/**
+ * Read the flag from `process.env` with a permissive parser. Returns `false`
+ * unless the env var matches one of the explicit enable tokens.
+ */
+export function isGemmaSessionGenEnabled(): boolean {
+  const raw = process.env[FLAG_ENV_VAR];
+  if (typeof raw !== 'string') return false;
+  return ENABLED_VALUES.has(raw.trim().toLowerCase());
+}
+
+/**
+ * Exported name of the env var so consumers can surface it in settings UIs,
+ * error messages, or telemetry without duplicating the string literal.
+ */
+export const GEMMA_SESSION_GEN_ENV_VAR = FLAG_ENV_VAR;
+
+/**
+ * Error thrown by generator services when the flag is disabled. Callers
+ * (hooks, UI) can match on `FLAG_DISABLED_ERROR_CODE` or on `instanceof
+ * GemmaSessionGenDisabledError` to route to offline fallbacks.
+ */
+export const FLAG_DISABLED_ERROR_CODE = 'GEMMA_SESSION_GEN_DISABLED';
+
+export class GemmaSessionGenDisabledError extends Error {
+  public readonly code = FLAG_DISABLED_ERROR_CODE;
+  public readonly envVar = FLAG_ENV_VAR;
+
+  constructor(surface: string) {
+    super(
+      `Gemma session generator is disabled (${FLAG_ENV_VAR} not set). ` +
+        `Caller: ${surface}. Set ${FLAG_ENV_VAR}=on to enable.`,
+    );
+    this.name = 'GemmaSessionGenDisabledError';
+  }
+}
+
+/**
+ * Assert the flag is on before dispatching. Throws a typed error so hooks
+ * can branch to their offline fallback deterministically.
+ */
+export function assertGemmaSessionGenEnabled(surface: string): void {
+  if (!isGemmaSessionGenEnabled()) {
+    throw new GemmaSessionGenDisabledError(surface);
+  }
+}

--- a/lib/services/rest-advisor.ts
+++ b/lib/services/rest-advisor.ts
@@ -11,6 +11,7 @@
  */
 import { sendCoachPrompt, type CoachContext, type CoachMessage } from './coach-service';
 import { parseGemmaJsonResponse, schema, type JsonSchema } from './gemma-json-parser';
+import { isGemmaSessionGenEnabled } from './gemma-session-gen-flag';
 import { getFewShots } from './template-generation-few-shots';
 
 export interface RestAdvisorInput {
@@ -53,6 +54,11 @@ export interface RestAdvisorRuntime {
   /** Timeout for the Gemma call before falling back to the heuristic. Default 2000ms. */
   timeoutMs?: number;
   maxRetries?: number;
+  /**
+   * Bypass the EXPO_PUBLIC_GEMMA_SESSION_GEN gate and always call the real
+   * dispatcher. Intended for integration tests.
+   */
+  skipFlagCheck?: boolean;
 }
 
 /**
@@ -123,6 +129,14 @@ export async function suggestRestSeconds(
   input: RestAdvisorInput,
   runtime: RestAdvisorRuntime = {},
 ): Promise<RestAdvice> {
+  // Flag gate: rest-advisor is called in-loop during an active set, so a
+  // disabled flag should short-circuit to the deterministic heuristic rather
+  // than throw. This keeps the workout UX smooth even when Gemma is off.
+  // Custom dispatch overrides (tests) and `skipFlagCheck` bypass the gate.
+  if (!runtime.dispatch && !runtime.skipFlagCheck && !isGemmaSessionGenEnabled()) {
+    return heuristicRestSeconds(input);
+  }
+
   const dispatch = runtime.dispatch ?? sendCoachPrompt;
   const timeoutMs = runtime.timeoutMs ?? 2000;
 

--- a/lib/services/session-generator.ts
+++ b/lib/services/session-generator.ts
@@ -15,6 +15,7 @@
 import * as Crypto from 'expo-crypto';
 import { sendCoachPrompt, type CoachContext, type CoachMessage } from './coach-service';
 import { parseGemmaJsonResponse, schema, type JsonSchema } from './gemma-json-parser';
+import { assertGemmaSessionGenEnabled } from './gemma-session-gen-flag';
 import {
   buildSessionGeneratorMessages,
   type SessionGeneratorInput,
@@ -98,6 +99,13 @@ export interface SessionGeneratorRuntime {
   uuid?: () => string;
   /** Retry count passed to gemma-json-parser. Default 1. */
   maxRetries?: number;
+  /**
+   * Bypass the `EXPO_PUBLIC_GEMMA_SESSION_GEN` feature flag gate. Intended for
+   * tests and for callers that inject their own `dispatch` stub — when
+   * `dispatch` is supplied we skip the assert automatically since no real
+   * Gemma traffic is generated.
+   */
+  skipFlagCheck?: boolean;
 }
 
 /**
@@ -111,6 +119,13 @@ export async function generateSession(
   input: SessionGeneratorInput,
   runtime: SessionGeneratorRuntime,
 ): Promise<HydratedTemplate> {
+  // Flag gate: only block the real production dispatcher. Tests and callers
+  // that provide their own `dispatch` are allowed through so pure unit tests
+  // don't need to toggle env vars.
+  if (!runtime.dispatch && !runtime.skipFlagCheck) {
+    assertGemmaSessionGenEnabled('session-generator');
+  }
+
   const messages = buildSessionGeneratorMessages(input);
   const dispatch = runtime.dispatch ?? sendCoachPrompt;
 

--- a/lib/services/warmup-generator.ts
+++ b/lib/services/warmup-generator.ts
@@ -7,6 +7,7 @@
  */
 import { sendCoachPrompt, type CoachContext, type CoachMessage } from './coach-service';
 import { parseGemmaJsonResponse, schema, type JsonSchema } from './gemma-json-parser';
+import { assertGemmaSessionGenEnabled } from './gemma-session-gen-flag';
 import {
   buildWarmupGeneratorMessages,
   type WarmupGeneratorInput,
@@ -60,12 +61,21 @@ export interface WarmupGeneratorRuntime {
   coachContext?: CoachContext;
   dispatch?: (messages: CoachMessage[], ctx?: CoachContext) => Promise<CoachMessage>;
   maxRetries?: number;
+  /**
+   * Bypass the EXPO_PUBLIC_GEMMA_SESSION_GEN gate. Intended for integration
+   * tests; unit tests that inject `dispatch` skip the gate automatically.
+   */
+  skipFlagCheck?: boolean;
 }
 
 export async function generateWarmup(
   input: WarmupGeneratorInput,
   runtime: WarmupGeneratorRuntime = {},
 ): Promise<WarmupPlan> {
+  if (!runtime.dispatch && !runtime.skipFlagCheck) {
+    assertGemmaSessionGenEnabled('warmup-generator');
+  }
+
   const messages = buildWarmupGeneratorMessages(input);
   const dispatch = runtime.dispatch ?? sendCoachPrompt;
 

--- a/tests/unit/services/cooldown-generator.test.ts
+++ b/tests/unit/services/cooldown-generator.test.ts
@@ -93,4 +93,37 @@ describe('generateCooldown', () => {
       generateCooldown({ completedExerciseSlugs: ['x'] }, { dispatch, maxRetries: 1 }),
     ).rejects.toMatchObject({ code: 'GEMMA_JSON_RETRY_EXHAUSTED' });
   });
+
+  describe('EXPO_PUBLIC_GEMMA_SESSION_GEN gate', () => {
+    const ENV_VAR = 'EXPO_PUBLIC_GEMMA_SESSION_GEN';
+    const originalValue = process.env[ENV_VAR];
+
+    afterEach(() => {
+      if (originalValue === undefined) {
+        delete process.env[ENV_VAR];
+      } else {
+        process.env[ENV_VAR] = originalValue;
+      }
+    });
+
+    it('rejects with GEMMA_SESSION_GEN_DISABLED when flag off and no dispatch override', async () => {
+      delete process.env[ENV_VAR];
+      await expect(
+        generateCooldown({ completedExerciseSlugs: ['squat'] }),
+      ).rejects.toMatchObject({ code: 'GEMMA_SESSION_GEN_DISABLED' });
+    });
+
+    it('runs normally when flag off but dispatch override is supplied', async () => {
+      delete process.env[ENV_VAR];
+      const dispatch = jest.fn<Promise<CoachMessage>, [CoachMessage[]]>().mockResolvedValue({
+        role: 'assistant',
+        content: JSON.stringify(VALID_PLAN),
+      });
+      const plan = await generateCooldown(
+        { completedExerciseSlugs: ['squat'] },
+        { dispatch },
+      );
+      expect(plan.name).toBe('Test Cooldown');
+    });
+  });
 });

--- a/tests/unit/services/gemma-session-gen-flag.test.ts
+++ b/tests/unit/services/gemma-session-gen-flag.test.ts
@@ -1,0 +1,105 @@
+import {
+  GEMMA_SESSION_GEN_ENV_VAR,
+  FLAG_DISABLED_ERROR_CODE,
+  GemmaSessionGenDisabledError,
+  assertGemmaSessionGenEnabled,
+  isGemmaSessionGenEnabled,
+} from '@/lib/services/gemma-session-gen-flag';
+
+const ENV_VAR = 'EXPO_PUBLIC_GEMMA_SESSION_GEN';
+
+describe('gemma-session-gen-flag', () => {
+  const originalValue = process.env[ENV_VAR];
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env[ENV_VAR];
+    } else {
+      process.env[ENV_VAR] = originalValue;
+    }
+  });
+
+  describe('isGemmaSessionGenEnabled', () => {
+    it('returns false when the env var is unset', () => {
+      delete process.env[ENV_VAR];
+      expect(isGemmaSessionGenEnabled()).toBe(false);
+    });
+
+    it('returns true for the literal "on" token', () => {
+      process.env[ENV_VAR] = 'on';
+      expect(isGemmaSessionGenEnabled()).toBe(true);
+    });
+
+    it('returns true for the literal "1" token', () => {
+      process.env[ENV_VAR] = '1';
+      expect(isGemmaSessionGenEnabled()).toBe(true);
+    });
+
+    it('returns true for the literal "true" token', () => {
+      process.env[ENV_VAR] = 'true';
+      expect(isGemmaSessionGenEnabled()).toBe(true);
+    });
+
+    it('is case-insensitive on the enabled side', () => {
+      for (const value of ['On', 'ON', 'TRUE', 'True']) {
+        process.env[ENV_VAR] = value;
+        expect(isGemmaSessionGenEnabled()).toBe(true);
+      }
+    });
+
+    it('trims whitespace before matching', () => {
+      process.env[ENV_VAR] = '  on  ';
+      expect(isGemmaSessionGenEnabled()).toBe(true);
+    });
+
+    it('returns false for "off"', () => {
+      process.env[ENV_VAR] = 'off';
+      expect(isGemmaSessionGenEnabled()).toBe(false);
+    });
+
+    it('returns false for empty and unknown tokens', () => {
+      for (const value of ['', '0', 'false', 'yes', 'no', 'enabled']) {
+        process.env[ENV_VAR] = value;
+        expect(isGemmaSessionGenEnabled()).toBe(false);
+      }
+    });
+  });
+
+  describe('exports', () => {
+    it('exposes the env var name as a string constant', () => {
+      expect(GEMMA_SESSION_GEN_ENV_VAR).toBe(ENV_VAR);
+    });
+
+    it('exposes a stable disabled error code', () => {
+      expect(FLAG_DISABLED_ERROR_CODE).toBe('GEMMA_SESSION_GEN_DISABLED');
+    });
+  });
+
+  describe('assertGemmaSessionGenEnabled', () => {
+    it('throws GemmaSessionGenDisabledError when flag is off', () => {
+      delete process.env[ENV_VAR];
+      expect(() => assertGemmaSessionGenEnabled('test-surface')).toThrow(
+        GemmaSessionGenDisabledError,
+      );
+    });
+
+    it('includes the surface label in the error message', () => {
+      delete process.env[ENV_VAR];
+      try {
+        assertGemmaSessionGenEnabled('session-generator');
+        fail('expected error');
+      } catch (err) {
+        expect((err as Error).message).toContain('session-generator');
+        expect((err as GemmaSessionGenDisabledError).code).toBe(
+          FLAG_DISABLED_ERROR_CODE,
+        );
+        expect((err as GemmaSessionGenDisabledError).envVar).toBe(ENV_VAR);
+      }
+    });
+
+    it('does not throw when flag is on', () => {
+      process.env[ENV_VAR] = 'on';
+      expect(() => assertGemmaSessionGenEnabled('session-generator')).not.toThrow();
+    });
+  });
+});

--- a/tests/unit/services/rest-advisor.test.ts
+++ b/tests/unit/services/rest-advisor.test.ts
@@ -123,4 +123,48 @@ describe('suggestRestSeconds', () => {
     );
     expect(advice.reasoning).toMatch(/Heuristic/);
   });
+
+  describe('EXPO_PUBLIC_GEMMA_SESSION_GEN gate', () => {
+    const ENV_VAR = 'EXPO_PUBLIC_GEMMA_SESSION_GEN';
+    const originalValue = process.env[ENV_VAR];
+
+    afterEach(() => {
+      if (originalValue === undefined) {
+        delete process.env[ENV_VAR];
+      } else {
+        process.env[ENV_VAR] = originalValue;
+      }
+    });
+
+    it('short-circuits to heuristic when flag is off and no dispatch override', async () => {
+      delete process.env[ENV_VAR];
+      const advice = await suggestRestSeconds({
+        lastRepTempoMs: 1200,
+        goalProfile: 'hypertrophy',
+      });
+      expect(advice.reasoning).toMatch(/Heuristic/);
+      expect(advice.seconds).toBe(75);
+    });
+
+    it('does NOT throw when flag is off — in-loop UX smoothness', async () => {
+      delete process.env[ENV_VAR];
+      await expect(
+        suggestRestSeconds({ lastRepTempoMs: 1200 }),
+      ).resolves.toMatchObject({ reasoning: expect.stringMatching(/Heuristic/) });
+    });
+
+    it('respects a custom dispatch override even when flag is off', async () => {
+      delete process.env[ENV_VAR];
+      const dispatch = jest.fn<Promise<CoachMessage>, [CoachMessage[]]>().mockResolvedValue({
+        role: 'assistant',
+        content: JSON.stringify({ seconds: 120, reasoning: 'override' }),
+      });
+      const advice = await suggestRestSeconds(
+        { lastRepTempoMs: 1200 },
+        { dispatch, timeoutMs: 500 },
+      );
+      expect(advice.seconds).toBe(120);
+      expect(advice.reasoning).toBe('override');
+    });
+  });
 });

--- a/tests/unit/services/session-generator.test.ts
+++ b/tests/unit/services/session-generator.test.ts
@@ -174,4 +174,52 @@ describe('generateSession', () => {
       generateSession({ intent: 'x' }, { userId: 'u1', dispatch }),
     ).rejects.toThrow('network down');
   });
+
+  describe('EXPO_PUBLIC_GEMMA_SESSION_GEN gate', () => {
+    const ENV_VAR = 'EXPO_PUBLIC_GEMMA_SESSION_GEN';
+    const originalValue = process.env[ENV_VAR];
+
+    afterEach(() => {
+      if (originalValue === undefined) {
+        delete process.env[ENV_VAR];
+      } else {
+        process.env[ENV_VAR] = originalValue;
+      }
+    });
+
+    it('rejects with GEMMA_SESSION_GEN_DISABLED when flag is off and no dispatch override supplied', async () => {
+      delete process.env[ENV_VAR];
+      await expect(
+        generateSession({ intent: 'x' }, { userId: 'u1' }),
+      ).rejects.toMatchObject({ code: 'GEMMA_SESSION_GEN_DISABLED' });
+    });
+
+    it('allows custom dispatch stubs even when flag is off (test ergonomics)', async () => {
+      delete process.env[ENV_VAR];
+      const dispatch = jest.fn<Promise<CoachMessage>, [CoachMessage[]]>().mockResolvedValue({
+        role: 'assistant',
+        content: JSON.stringify(validResponse),
+      });
+      const result = await generateSession(
+        { intent: 'x' },
+        { userId: 'u1', dispatch },
+      );
+      expect(result.template.name).toBe('Quick');
+    });
+
+    it('skipFlagCheck bypasses the gate when no dispatch is supplied (for integration tests)', async () => {
+      delete process.env[ENV_VAR];
+      // Without dispatch AND without skipFlagCheck this would throw; with
+      // skipFlagCheck we expect the error to come from the real coach-service
+      // instead (network / auth), not from the flag gate.
+      try {
+        await generateSession(
+          { intent: 'x' },
+          { userId: 'u1', skipFlagCheck: true },
+        );
+      } catch (err) {
+        expect((err as { code?: string }).code).not.toBe('GEMMA_SESSION_GEN_DISABLED');
+      }
+    });
+  });
 });

--- a/tests/unit/services/warmup-generator.test.ts
+++ b/tests/unit/services/warmup-generator.test.ts
@@ -93,4 +93,34 @@ describe('generateWarmup', () => {
       generateWarmup({ exerciseSlugs: ['x'] }, { dispatch, maxRetries: 1 }),
     ).rejects.toMatchObject({ code: 'GEMMA_JSON_RETRY_EXHAUSTED' });
   });
+
+  describe('EXPO_PUBLIC_GEMMA_SESSION_GEN gate', () => {
+    const ENV_VAR = 'EXPO_PUBLIC_GEMMA_SESSION_GEN';
+    const originalValue = process.env[ENV_VAR];
+
+    afterEach(() => {
+      if (originalValue === undefined) {
+        delete process.env[ENV_VAR];
+      } else {
+        process.env[ENV_VAR] = originalValue;
+      }
+    });
+
+    it('rejects with GEMMA_SESSION_GEN_DISABLED when flag off and no dispatch override', async () => {
+      delete process.env[ENV_VAR];
+      await expect(
+        generateWarmup({ exerciseSlugs: ['squat'] }),
+      ).rejects.toMatchObject({ code: 'GEMMA_SESSION_GEN_DISABLED' });
+    });
+
+    it('runs normally when flag off but dispatch override is supplied', async () => {
+      delete process.env[ENV_VAR];
+      const dispatch = jest.fn<Promise<CoachMessage>, [CoachMessage[]]>().mockResolvedValue({
+        role: 'assistant',
+        content: JSON.stringify(VALID_PLAN),
+      });
+      const plan = await generateWarmup({ exerciseSlugs: ['squat'] }, { dispatch });
+      expect(plan.name).toBe('Test Warmup');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Completes issue #468 by adding the missing `EXPO_PUBLIC_GEMMA_SESSION_GEN` feature-flag gate on top of the seven-service session-generator bundle that already shipped via the Stack B consolidation in #502.

The bundle itself (NL session generator, warmup generator, cooldown generator, rest advisor, JSON parser wrapper, few-shots library, offline fallback, minimal UI in `template-builder.tsx` + `templates.tsx`, `generate-session.tsx` modal) is already on `main` as of #502. This PR fills the lone remaining spec delta: a feature flag helper plus dispatch guards across all four generator services, plus a flag-aware info banner in the generate-session modal.

### What this PR adds

- `lib/services/gemma-session-gen-flag.ts` — permissive parser (`on` / `1` / `true`, case-insensitive, whitespace-trimmed), strictly disabled by default.
- `assertGemmaSessionGenEnabled(surface)` guard and `GemmaSessionGenDisabledError` (stable `code: 'GEMMA_SESSION_GEN_DISABLED'`).
- Dispatch guard calls in `session-generator.ts`, `warmup-generator.ts`, `cooldown-generator.ts`, `rest-advisor.ts`.
- `skipFlagCheck` escape hatch on every generator runtime for integration tests; custom `dispatch` overrides bypass the gate automatically (keeps ~40 existing unit tests green).
- Flag-aware UI in `app/(modals)/generate-session.tsx` — button label, info banner, and error-code → friendly copy.

### Why this is non-trivial

The four generators have three distinct behaviors under flag-off:

| Service | Flag off + no dispatch override | Flag off + dispatch override (tests) | Flag on |
|---|---|---|---|
| `session-generator` | Throws `GEMMA_SESSION_GEN_DISABLED` | Runs normally | Runs normally |
| `warmup-generator` | Throws `GEMMA_SESSION_GEN_DISABLED` | Runs normally | Runs normally |
| `cooldown-generator` | Throws `GEMMA_SESSION_GEN_DISABLED` | Runs normally | Runs normally |
| `rest-advisor` | Short-circuits to `heuristicRestSeconds` (no throw) | Runs normally | Runs normally |

Rest-advisor is special because it runs in-loop during an active set — throwing would break UX smoothness. The other three are pre/post-session, so a hard error that routes to the offline library is acceptable.

## JSON shape (no changes — documenting what the generators already produce)

### session-generator

```json
{
  "name": "string",
  "description": "string",
  "goal_profile": "hypertrophy|strength|power|endurance|mixed",
  "exercises": [
    {
      "exercise_slug": "string",
      "sets": [
        {
          "target_reps?": "int 1-1000",
          "target_seconds?": "int 1-3600",
          "target_weight?": "number 0-2000",
          "target_rpe?": "number 1-10",
          "set_type?": "normal|warmup|dropset|amrap|failure|timed"
        }
      ],
      "default_rest_seconds?": "int 0-600",
      "notes?": "string"
    }
  ]
}
```

### warmup-generator

```json
{
  "name": "string",
  "duration_min": "number 1-60",
  "movements": [
    {
      "name": "string",
      "duration_seconds?": "int 1-1800",
      "reps?": "int 1-200",
      "focus": "mobility|activation|cardio|breathing",
      "intensity": "low|medium|high",
      "notes?": "string"
    }
  ]
}
```

### cooldown-generator

Same shape as warmup but `focus` is `stretch|breathing|cardio|activation` plus optional `reflection_prompt: string`.

### rest-advisor

```json
{ "seconds": "int 10-900", "reasoning": "string" }
```

## Feature flag

`EXPO_PUBLIC_GEMMA_SESSION_GEN` — default **off**.

| Value | Behavior |
|---|---|
| unset, `off`, or anything else | Generators inactive (fail safe) |
| `on`, `1`, `true` (case-insensitive, whitespace-trimmed) | Generators active |

Flip to any enabled token to dispatch to the real coach-service. See `docs/gemma-integration.md` for the full behavior matrix and test-ergonomics escape hatches.

## Verification

- `bun run lint` — clean
- `bun run check:types` — clean
- `bunx jest tests/unit/services/{session-generator,warmup-generator,cooldown-generator,rest-advisor,gemma-json-parser,session-generator-fallback,template-generation-few-shots,gemma-session-gen-flag}.test.ts` — **8 suites, 118 tests passing**

### Non-overlap check

Zero edits to:
- `app/(tabs)/scan-arkit.tsx`, `lib/fusion/engine.ts`, `lib/services/ar-overlays-v2-flag.ts` (PR #505 territory)
- `lib/services/coach-service.ts`, `lib/services/coach-model-dispatch*`, `lib/services/coach-vision*`, `supabase/functions/coach-gemma/*` (PR #506 territory)
- `lib/stores/session-runner.ts`, `lib/services/rest-timer.ts`, `lib/services/audio-session-manager.ts` (parallel-PR territory)
- `supabase/migrations/`, `ios/`, `android/`, `.env*`, `package.json`, `bun.lock`

No new dependencies.

## Deviation from runsheet spec

The runsheet requested a fresh `feat/468-gemma-session-generator` branch with ~14-18 atomic commits scaffolding all seven services from scratch. In practice, every service, hook, prompt, fallback library, few-shots module, and UI entry point called for was already merged to `main` via #502 (the Stack B consolidation of #471). Rather than re-author identical code on a new branch, this PR ships the one real delta the consolidation missed — the `EXPO_PUBLIC_GEMMA_SESSION_GEN` flag — on a narrower branch (`feat/468-gemma-session-gen-flag`) with 7 atomic commits. See the commit log for the per-service breakdown.

Closes #468.