### PR TITLE
feat(workouts): wave-25 workouts-tab UX polish + Gemma retrospective chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,11 @@ EXPO_PUBLIC_COACH_MEMORY=true
 # finishSession triggers a coach-authored debrief via the auto-debrief hook.
 EXPO_PUBLIC_COACH_AUTO_DEBRIEF_ENABLED=true
 
+# Wave-25 workouts-tab × Gemma retrospective chat master flag.
+# When '1' or 'true', mounts AskCoachCTA on workout rows and enables the
+# workout-debrief-chat modal. Defaults off — strict string match.
+EXPO_PUBLIC_WORKOUT_COACH_RECALL=
+
 # ElevenLabs TTS (optional — voice coaching)
 ELEVENLABS_API_KEY=
 ELEVENLABS_VOICE_ID=

--- a/app/(modals)/_layout.tsx
+++ b/app/(modals)/_layout.tsx
@@ -102,6 +102,14 @@ export default function ModalsLayout() {
           contentStyle: { backgroundColor: '#050E1F' },
         }}
       />
+      <Stack.Screen
+        name="workout-debrief-chat"
+        options={{
+          presentation: 'modal',
+          gestureEnabled: true,
+          contentStyle: { backgroundColor: '#0B1626' },
+        }}
+      />
     </Stack>
   );
 }

--- a/app/(modals)/rep-insights.tsx
+++ b/app/(modals)/rep-insights.tsx
@@ -35,6 +35,10 @@ export default function RepInsightsModal() {
   const sessionId = typeof params.sessionId === 'string' ? params.sessionId : undefined;
 
   const [exporting, setExporting] = useState<'csv' | 'json' | null>(null);
+  // GAP-6: persist the last export error (plus its format) so the UI
+  // can render an inline retry banner instead of an Alert that users
+  // dismiss without context. `message` keeps the original error text.
+  const [exportError, setExportError] = useState<{ format: 'csv' | 'json'; message: string } | null>(null);
 
   const faultScope = useMemo<FaultHeatmapScope>(
     () => (sessionId ? { sessionId } : { exerciseId, days: 30 }),
@@ -49,6 +53,7 @@ export default function RepInsightsModal() {
       }
       try {
         setExporting(format);
+        setExportError(null);
         const result = await shareRepData(
           sessionId ? { sessionId } : { exerciseId, days: 30 },
           format,
@@ -62,13 +67,23 @@ export default function RepInsightsModal() {
           );
         }
       } catch (error) {
-        Alert.alert('Export failed', error instanceof Error ? error.message : 'Unknown error');
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        setExportError({ format, message });
       } finally {
         setExporting(null);
       }
     },
     [exerciseId, sessionId],
   );
+
+  const handleDismissExportError = useCallback(() => {
+    setExportError(null);
+  }, []);
+
+  const handleRetryExport = useCallback(() => {
+    if (!exportError) return;
+    void handleExport(exportError.format);
+  }, [exportError, handleExport]);
 
   if (!exerciseId && !sessionId) {
     return (
@@ -126,6 +141,45 @@ export default function RepInsightsModal() {
           <Text style={styles.exportSubtitle}>
             Share your rep telemetry with a coach or import into a spreadsheet.
           </Text>
+          {exportError ? (
+            <View style={styles.exportErrorBanner} testID="rep-export-error-banner">
+              <View style={styles.exportErrorHeader}>
+                <Ionicons name="alert-circle" size={18} color="#EF4444" />
+                <Text style={styles.exportErrorTitle}>
+                  {exportError.format.toUpperCase()} export failed
+                </Text>
+              </View>
+              <Text
+                style={styles.exportErrorMessage}
+                numberOfLines={3}
+                accessibilityLabel={`Export error: ${exportError.message}`}
+                testID="rep-export-error-message"
+              >
+                {exportError.message}
+              </Text>
+              <View style={styles.exportErrorRow}>
+                <TouchableOpacity
+                  style={styles.exportRetryButton}
+                  onPress={handleRetryExport}
+                  accessibilityRole="button"
+                  accessibilityLabel="Retry export"
+                  testID="rep-export-retry-button"
+                >
+                  <Ionicons name="refresh" size={14} color="#F5F7FF" />
+                  <Text style={styles.exportRetryText}>Retry</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={styles.exportDismissButton}
+                  onPress={handleDismissExportError}
+                  accessibilityRole="button"
+                  accessibilityLabel="Dismiss export error"
+                  testID="rep-export-dismiss-button"
+                >
+                  <Text style={styles.exportDismissText}>Dismiss</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          ) : null}
           <View style={styles.exportRow}>
             <TouchableOpacity
               style={[styles.exportButton, exporting !== null && styles.exportButtonDisabled]}
@@ -292,5 +346,64 @@ const styles = StyleSheet.create({
   },
   exportButtonDisabled: {
     opacity: 0.5,
+  },
+  exportErrorBanner: {
+    marginBottom: 12,
+    padding: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(239, 68, 68, 0.4)',
+    backgroundColor: 'rgba(239, 68, 68, 0.1)',
+  },
+  exportErrorHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  exportErrorTitle: {
+    color: '#F5F7FF',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  exportErrorMessage: {
+    color: '#DCE5F5',
+    fontSize: 12,
+    lineHeight: 17,
+    marginTop: 6,
+  },
+  exportErrorRow: {
+    marginTop: 10,
+    flexDirection: 'row',
+    gap: 8,
+  },
+  exportRetryButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    minHeight: 36,
+    paddingHorizontal: 14,
+    borderRadius: 10,
+    backgroundColor: '#4C8CFF',
+  },
+  exportRetryText: {
+    color: '#F5F7FF',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  exportDismissButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 36,
+    paddingHorizontal: 14,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.3)',
+    backgroundColor: 'transparent',
+  },
+  exportDismissText: {
+    color: '#9AACD1',
+    fontSize: 12,
+    fontWeight: '600',
   },
 });

--- a/app/(modals)/session-history.tsx
+++ b/app/(modals)/session-history.tsx
@@ -19,6 +19,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { localDB } from '@/lib/services/database/local-db';
 import { tabColors } from '@/styles/tabs/_tab-theme';
+import { EmptySessionState } from '@/components/form-tracking/EmptySessionState';
 
 interface SessionSummary {
   id: string;
@@ -162,13 +163,7 @@ export default function SessionHistoryScreen() {
           </TouchableOpacity>
         </View>
       ) : sessions.length === 0 ? (
-        <View style={historyStyles.stateContainer}>
-          <Ionicons name="barbell-outline" size={48} color={tabColors.textSecondary} />
-          <Text style={historyStyles.emptyText}>No completed sessions yet</Text>
-          <Text style={historyStyles.emptySubtext}>
-            Start a workout session to see your history here
-          </Text>
-        </View>
+        <EmptySessionState />
       ) : (
         <FlatList
           data={sessions}
@@ -280,18 +275,5 @@ const historyStyles = StyleSheet.create({
   retryButtonText: {
     color: '#fff',
     fontFamily: 'Lexend_700Bold',
-  },
-  emptyText: {
-    fontSize: 16,
-    fontFamily: 'Lexend_500Medium',
-    color: tabColors.textPrimary,
-    marginTop: 16,
-  },
-  emptySubtext: {
-    fontSize: 14,
-    fontFamily: 'Lexend_400Regular',
-    color: tabColors.textSecondary,
-    textAlign: 'center',
-    marginTop: 8,
   },
 });

--- a/app/(modals)/workout-debrief-chat.tsx
+++ b/app/(modals)/workout-debrief-chat.tsx
@@ -66,6 +66,14 @@ export default function WorkoutDebriefChatModal() {
     };
   }, []);
 
+  // Keep the latest askAboutWorkout in a ref so the first-message
+  // effect does not re-fire when the hook returns a fresh closure each
+  // render (matters when consumers don't memoize the hook return).
+  const askRef = useRef(askAboutWorkout);
+  useEffect(() => {
+    askRef.current = askAboutWorkout;
+  }, [askAboutWorkout]);
+
   // First-message stream — triggered once on mount when flag is on.
   useEffect(() => {
     if (!enabled || !workoutId) return;
@@ -74,7 +82,7 @@ export default function WorkoutDebriefChatModal() {
       setFirstLoading(true);
       setError(null);
       try {
-        const reply = await askAboutWorkout(workoutId, '');
+        const reply = await askRef.current(workoutId, '');
         if (cancelled || !mountedRef.current) return;
         if (reply) {
           setBubbles((prev) => [
@@ -94,7 +102,7 @@ export default function WorkoutDebriefChatModal() {
     return () => {
       cancelled = true;
     };
-  }, [enabled, workoutId, askAboutWorkout]);
+  }, [enabled, workoutId]);
 
   const handleSend = useCallback(async () => {
     const trimmed = input.trim();
@@ -109,7 +117,7 @@ export default function WorkoutDebriefChatModal() {
     setSending(true);
     setError(null);
     try {
-      const reply: CoachMessage | null = await askAboutWorkout(workoutId, trimmed);
+      const reply: CoachMessage | null = await askRef.current(workoutId, trimmed);
       if (!mountedRef.current) return;
       if (reply) {
         setBubbles((prev) => [
@@ -125,7 +133,7 @@ export default function WorkoutDebriefChatModal() {
         setSending(false);
       }
     }
-  }, [input, enabled, workoutId, askAboutWorkout]);
+  }, [input, enabled, workoutId]);
 
   const header = useMemo(
     () => (

--- a/app/(modals)/workout-debrief-chat.tsx
+++ b/app/(modals)/workout-debrief-chat.tsx
@@ -1,0 +1,404 @@
+/**
+ * WorkoutDebriefChatModal
+ *
+ * Gemma-powered retrospective chat for a past workout (GEMMA-5 /
+ * INT-1). The modal route accepts a `workoutId` query param; the
+ * first assistant message is generated from the recall context, after
+ * which the user can ask follow-up questions.
+ *
+ * Flag gating: when EXPO_PUBLIC_WORKOUT_COACH_RECALL is off, the
+ * modal renders a disabled fallback card instead of the chat UI so the
+ * screen is always mountable (a deep-link into this route with the
+ * flag off simply shows "feature disabled").
+ */
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { TextInput } from 'react-native-paper';
+
+import { useWorkoutCoachContext } from '@/hooks/use-workout-coach-context';
+import type { CoachMessage } from '@/lib/services/coach-service';
+
+interface ChatBubble {
+  id: string;
+  role: 'assistant' | 'user';
+  content: string;
+}
+
+let bubbleSeq = 0;
+function nextBubbleId(prefix: string): string {
+  bubbleSeq += 1;
+  return `${prefix}-${bubbleSeq}`;
+}
+
+export default function WorkoutDebriefChatModal() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ workoutId?: string }>();
+  const workoutId = typeof params.workoutId === 'string' ? params.workoutId : '';
+
+  const { enabled, askAboutWorkout } = useWorkoutCoachContext();
+
+  const [bubbles, setBubbles] = useState<ChatBubble[]>([]);
+  const [input, setInput] = useState('');
+  const [firstLoading, setFirstLoading] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+
+  const handleClose = useCallback(() => {
+    router.back();
+  }, [router]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // First-message stream — triggered once on mount when flag is on.
+  useEffect(() => {
+    if (!enabled || !workoutId) return;
+    let cancelled = false;
+    (async () => {
+      setFirstLoading(true);
+      setError(null);
+      try {
+        const reply = await askAboutWorkout(workoutId, '');
+        if (cancelled || !mountedRef.current) return;
+        if (reply) {
+          setBubbles((prev) => [
+            ...prev,
+            { id: nextBubbleId('a'), role: 'assistant', content: reply.content },
+          ]);
+        }
+      } catch (err) {
+        if (cancelled || !mountedRef.current) return;
+        setError(err instanceof Error ? err.message : 'Could not load the retrospective.');
+      } finally {
+        if (!cancelled && mountedRef.current) {
+          setFirstLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, workoutId, askAboutWorkout]);
+
+  const handleSend = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed || !enabled || !workoutId) return;
+    const userBubble: ChatBubble = {
+      id: nextBubbleId('u'),
+      role: 'user',
+      content: trimmed,
+    };
+    setBubbles((prev) => [...prev, userBubble]);
+    setInput('');
+    setSending(true);
+    setError(null);
+    try {
+      const reply: CoachMessage | null = await askAboutWorkout(workoutId, trimmed);
+      if (!mountedRef.current) return;
+      if (reply) {
+        setBubbles((prev) => [
+          ...prev,
+          { id: nextBubbleId('a'), role: 'assistant', content: reply.content },
+        ]);
+      }
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError(err instanceof Error ? err.message : 'Message failed to send.');
+    } finally {
+      if (mountedRef.current) {
+        setSending(false);
+      }
+    }
+  }, [input, enabled, workoutId, askAboutWorkout]);
+
+  const header = useMemo(
+    () => (
+      <View style={styles.header}>
+        <TouchableOpacity
+          onPress={handleClose}
+          style={styles.backButton}
+          accessibilityRole="button"
+          accessibilityLabel="Close retrospective chat"
+          testID="workout-debrief-chat-close"
+        >
+          <Ionicons name="close" size={22} color="#F5F7FF" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Workout retrospective</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+    ),
+    [handleClose],
+  );
+
+  if (!enabled) {
+    return (
+      <View style={styles.container}>
+        {header}
+        <View style={styles.centerState}>
+          <View style={styles.disabledCard} testID="workout-debrief-chat-disabled">
+            <Ionicons name="lock-closed-outline" size={28} color="#9AACD1" />
+            <Text style={styles.disabledTitle}>Feature disabled</Text>
+            <Text style={styles.disabledText}>
+              Ask-coach retrospective chat is behind a feature flag. Set
+              {' '}EXPO_PUBLIC_WORKOUT_COACH_RECALL=1 to enable it.
+            </Text>
+          </View>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container} testID="workout-debrief-chat-root">
+      {header}
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          style={styles.flex}
+          contentContainerStyle={styles.bubbleList}
+          showsVerticalScrollIndicator={false}
+        >
+          {firstLoading && bubbles.length === 0 ? (
+            <View style={styles.skeletonBubble} testID="workout-debrief-chat-skeleton">
+              <ActivityIndicator color="#4C8CFF" />
+              <Text style={styles.skeletonText}>Building retrospective…</Text>
+            </View>
+          ) : null}
+          {bubbles.map((b) => (
+            <View
+              key={b.id}
+              style={[
+                styles.bubble,
+                b.role === 'user' ? styles.bubbleUser : styles.bubbleAssistant,
+              ]}
+              testID={`workout-debrief-chat-bubble-${b.role}`}
+            >
+              <Text
+                style={[
+                  styles.bubbleText,
+                  b.role === 'user' ? styles.bubbleTextUser : styles.bubbleTextAssistant,
+                ]}
+              >
+                {b.content}
+              </Text>
+            </View>
+          ))}
+          {error ? (
+            <View style={styles.errorBanner} testID="workout-debrief-chat-error">
+              <Ionicons name="alert-circle" size={16} color="#EF4444" />
+              <Text style={styles.errorText}>{error}</Text>
+            </View>
+          ) : null}
+        </ScrollView>
+        <View style={styles.inputRow}>
+          <TextInput
+            mode="outlined"
+            value={input}
+            onChangeText={setInput}
+            placeholder="Ask Gemma about this workout…"
+            style={styles.input}
+            outlineColor="rgba(154, 172, 209, 0.2)"
+            activeOutlineColor="#4C8CFF"
+            textColor="#F5F7FF"
+            theme={{
+              colors: {
+                onSurfaceVariant: '#9AACD1',
+                background: '#12243A',
+                primary: '#4C8CFF',
+              },
+            }}
+            editable={!sending}
+            multiline
+            testID="workout-debrief-chat-input"
+          />
+          <TouchableOpacity
+            onPress={handleSend}
+            disabled={sending || input.trim().length === 0}
+            style={[
+              styles.sendButton,
+              (sending || input.trim().length === 0) && styles.sendButtonDisabled,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Send follow-up"
+            testID="workout-debrief-chat-send"
+          >
+            {sending ? (
+              <ActivityIndicator color="#F5F7FF" size="small" />
+            ) : (
+              <Ionicons name="send" size={18} color="#F5F7FF" />
+            )}
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0B1626',
+  },
+  flex: { flex: 1 },
+  header: {
+    paddingTop: 58,
+    paddingHorizontal: 16,
+    paddingBottom: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(154, 172, 209, 0.18)',
+  },
+  backButton: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(76, 140, 255, 0.2)',
+  },
+  headerTitle: {
+    flex: 1,
+    textAlign: 'center',
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#F5F7FF',
+    marginRight: 34,
+  },
+  headerSpacer: { width: 0 },
+  centerState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  disabledCard: {
+    backgroundColor: '#12243A',
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.2)',
+    padding: 20,
+    alignItems: 'center',
+    gap: 8,
+    maxWidth: 360,
+  },
+  disabledTitle: {
+    color: '#F5F7FF',
+    fontSize: 16,
+    fontWeight: '700',
+    marginTop: 4,
+  },
+  disabledText: {
+    color: '#9AACD1',
+    textAlign: 'center',
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  bubbleList: {
+    padding: 16,
+    gap: 8,
+    paddingBottom: 24,
+  },
+  bubble: {
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 14,
+    maxWidth: '86%',
+  },
+  bubbleUser: {
+    alignSelf: 'flex-end',
+    backgroundColor: '#4C8CFF',
+  },
+  bubbleAssistant: {
+    alignSelf: 'flex-start',
+    backgroundColor: '#12243A',
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.14)',
+  },
+  bubbleText: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  bubbleTextUser: {
+    color: '#F5F7FF',
+  },
+  bubbleTextAssistant: {
+    color: '#DCE5F5',
+  },
+  skeletonBubble: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 14,
+    backgroundColor: '#12243A',
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.14)',
+  },
+  skeletonText: {
+    color: '#9AACD1',
+    fontSize: 13,
+  },
+  errorBanner: {
+    marginTop: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    alignSelf: 'flex-start',
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: 'rgba(239, 68, 68, 0.4)',
+    backgroundColor: 'rgba(239, 68, 68, 0.1)',
+  },
+  errorText: {
+    color: '#F5F7FF',
+    fontSize: 12,
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 8,
+    padding: 12,
+    borderTopWidth: 1,
+    borderTopColor: 'rgba(154, 172, 209, 0.18)',
+    backgroundColor: '#0B1626',
+  },
+  input: {
+    flex: 1,
+    backgroundColor: '#12243A',
+    maxHeight: 120,
+  },
+  sendButton: {
+    width: 46,
+    height: 46,
+    borderRadius: 23,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#4C8CFF',
+  },
+  sendButtonDisabled: {
+    backgroundColor: 'rgba(76, 140, 255, 0.4)',
+  },
+});

--- a/app/(modals)/workout-insights.tsx
+++ b/app/(modals)/workout-insights.tsx
@@ -19,6 +19,7 @@ import {
   type DriverCard,
   type WorkoutInsightsSnapshot,
 } from '@/lib/services/workout-insights';
+import { getFqiBand } from '@/lib/services/workout-insights-fqi-bands';
 
 const { width: screenWidth } = Dimensions.get('window');
 const chartWidth = screenWidth - 40;
@@ -292,6 +293,17 @@ export default function WorkoutInsightsModal() {
             <View style={styles.summaryCard}>
               <Text style={styles.summaryLabel}>Avg FQI</Text>
               <Text style={styles.summaryValue}>{snapshot.avgFqi ?? '--'}</Text>
+              {(() => {
+                const info = getFqiBand(snapshot.avgFqi);
+                return (
+                  <Text
+                    style={[styles.summaryBand, { color: info.color }]}
+                    testID="fqi-band-label"
+                  >
+                    {info.label}
+                  </Text>
+                );
+              })()}
             </View>
             <View style={styles.summaryCard}>
               <Text style={styles.summaryLabel}>Balance</Text>
@@ -699,6 +711,13 @@ const styles = StyleSheet.create({
     fontSize: 22,
     fontWeight: '700',
     marginTop: 4,
+  },
+  summaryBand: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 0.4,
+    marginTop: 2,
+    textTransform: 'uppercase',
   },
   card: {
     backgroundColor: '#12243A',

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -3,6 +3,7 @@ import * as Haptics from 'expo-haptics';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
 import { DeleteAction } from '@/components';
+import { AskCoachCTA } from '@/components/form-tracking/AskCoachCTA';
 import { FormQualityBadgeRow } from '@/components/workouts/FormQualityBadgeRow';
 import { OverloadAnalyticsCard } from '@/components/workouts/OverloadAnalyticsCard';
 import { useAuth } from '@/contexts/AuthContext';
@@ -10,6 +11,7 @@ import { useUnits } from '@/contexts/UnitsContext';
 import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
 import { getMostRecentAvgFqi } from '@/lib/services/form-session-history-lookup';
 import { exportSession } from '@/lib/services/session-export-service';
+import { isWorkoutCoachRecallEnabled } from '@/lib/services/workout-coach-recall-flag';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
     ActivityIndicator,
@@ -58,6 +60,19 @@ export default function WorkoutsScreen() {
   const [formQualityByExercise, setFormQualityByExercise] = useState<
     Record<string, number | null>
   >({});
+  // Wave-25 master flag — when off, the per-row AskCoachCTA is not
+  // rendered. Read once on mount to match other flag consumers.
+  const coachRecallEnabled = useMemo(() => isWorkoutCoachRecallEnabled(), []);
+
+  const handleAskCoachAboutWorkout = useCallback(
+    (workoutId: string) => {
+      Haptics.selectionAsync().catch(() => {});
+      router.push(
+        `/(modals)/workout-debrief-chat?workoutId=${encodeURIComponent(workoutId)}`,
+      );
+    },
+    [router],
+  );
 
   // Pick the most recently logged exercise for the overload card. We fall
   // back to the first row when dates are missing; if the list is empty, the
@@ -391,6 +406,18 @@ export default function WorkoutsScreen() {
                 style={styles.deleteAction}
               />
             </View>
+            {coachRecallEnabled ? (
+              <View style={workoutCardStyles.askCoachRow} testID={`ask-coach-row-${item.id}`}>
+                <AskCoachCTA
+                  exerciseName={item.exercise}
+                  repCount={typeof item.reps === 'number' ? item.reps : 0}
+                  averageFqi={formQualityByExercise[item.exercise] ?? null}
+                  onPress={() => handleAskCoachAboutWorkout(item.id)}
+                  label="Ask Gemma about this workout"
+                  testID={`ask-coach-cta-${item.id}`}
+                />
+              </View>
+            ) : null}
           </LinearGradient>
           </TouchableOpacity>
         </View>
@@ -501,6 +528,13 @@ const workoutCardStyles = StyleSheet.create({
   badgeRow: {
     marginTop: 6,
     marginBottom: 2,
+  },
+  // Wave-25: pulled-in padding on the embedded AskCoachCTA so it does
+  // not break out of the card gradient. The CTA wraps itself in its
+  // own padding; this container just tightens the vertical margin.
+  askCoachRow: {
+    marginTop: 4,
+    marginBottom: -4,
   },
 });
 

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -3,7 +3,7 @@ import * as Haptics from 'expo-haptics';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
 import { DeleteAction } from '@/components';
-import { FormQualityBadge } from '@/components/form-tracking/FormQualityBadge';
+import { FormQualityBadgeRow } from '@/components/workouts/FormQualityBadgeRow';
 import { OverloadAnalyticsCard } from '@/components/workouts/OverloadAnalyticsCard';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUnits } from '@/contexts/UnitsContext';
@@ -314,11 +314,12 @@ export default function WorkoutsScreen() {
               </View>
             </View>
 
-            {formQualityByExercise[item.exercise] != null ? (
-              <View style={workoutCardStyles.badgeRow}>
-                <FormQualityBadge score={formQualityByExercise[item.exercise]} />
-              </View>
-            ) : null}
+            <FormQualityBadgeRow
+              exerciseName={item.exercise}
+              score={formQualityByExercise[item.exercise]}
+              style={workoutCardStyles.badgeRow}
+            />
+
 
             <View style={styles.cardDetails}>
               <View style={styles.detailItem}>

--- a/components/form-tracking/AskCoachCTA.tsx
+++ b/components/form-tracking/AskCoachCTA.tsx
@@ -18,6 +18,20 @@ export interface AskCoachCTAProps {
   averageFqi: number | null;
   topFault?: string | null;
   testID?: string;
+  /**
+   * Optional tap handler override. When provided, the CTA calls this
+   * instead of navigating to the coach tab with a prefill. Used by
+   * the workouts-tab rows to route into the retrospective chat modal
+   * under EXPO_PUBLIC_WORKOUT_COACH_RECALL. Defaults to the original
+   * coach-tab navigation so existing consumers keep working.
+   */
+  onPress?: () => void;
+  /**
+   * Optional label override; defaults to
+   * "Ask coach about this session". The workouts-tab row uses a
+   * shorter label to fit inside the card footer.
+   */
+  label?: string;
 }
 
 export function buildCoachPrefill({
@@ -42,28 +56,36 @@ export function AskCoachCTA({
   averageFqi,
   topFault,
   testID = 'ask-coach-cta',
+  onPress,
+  label,
 }: AskCoachCTAProps) {
   const router = useRouter();
 
   const handlePress = useCallback(() => {
+    if (onPress) {
+      onPress();
+      return;
+    }
     const prefill = buildCoachPrefill({ exerciseName, repCount, averageFqi, topFault });
     router.push({
       pathname: '/(tabs)/coach',
       params: { prefill },
     } as never);
-  }, [router, exerciseName, repCount, averageFqi, topFault]);
+  }, [onPress, router, exerciseName, repCount, averageFqi, topFault]);
+
+  const buttonLabel = label ?? 'Ask coach about this session';
 
   return (
     <View style={styles.container}>
       <Pressable
         accessibilityRole="button"
-        accessibilityLabel="Ask coach about this session"
+        accessibilityLabel={buttonLabel}
         onPress={handlePress}
         style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
         testID={testID}
       >
         <Ionicons name="sparkles" size={18} color="#FFFFFF" />
-        <Text style={styles.buttonText}>Ask coach about this session</Text>
+        <Text style={styles.buttonText}>{buttonLabel}</Text>
         <Ionicons name="arrow-forward" size={18} color="#FFFFFF" />
       </Pressable>
     </View>

--- a/components/form-tracking/EmptySessionState.tsx
+++ b/components/form-tracking/EmptySessionState.tsx
@@ -1,0 +1,114 @@
+/**
+ * EmptySessionState
+ *
+ * Friendly empty-state card shown when a user has never completed a
+ * form-tracking session yet. Rendered by `app/(modals)/session-history.tsx`
+ * when `sessions.length === 0 && !isLoading`.
+ *
+ * The CTA routes into `/(tabs)/scan-arkit` to begin their first session.
+ * Pure presentational — does not fetch data or call services itself.
+ */
+import React, { useCallback } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+
+export interface EmptySessionStateProps {
+  /** Optional override for the CTA tap handler (useful in tests / storybook). */
+  onStartPress?: () => void;
+  /** Optional testID — defaults to `empty-session-state`. */
+  testID?: string;
+}
+
+export function EmptySessionState({ onStartPress, testID = 'empty-session-state' }: EmptySessionStateProps) {
+  const router = useRouter();
+
+  const handlePress = useCallback(() => {
+    if (onStartPress) {
+      onStartPress();
+      return;
+    }
+    router.push('/(tabs)/scan-arkit');
+  }, [onStartPress, router]);
+
+  return (
+    <View style={styles.container} testID={testID}>
+      <View style={styles.iconCircle}>
+        <Ionicons name="barbell-outline" size={40} color="#4C8CFF" />
+      </View>
+      <Text style={styles.title}>No sessions yet</Text>
+      <Text style={styles.subtitle}>
+        Start your first form-tracking session to see analytics here.
+      </Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Start your first form-tracking session"
+        onPress={handlePress}
+        style={({ pressed }) => [styles.cta, pressed && styles.ctaPressed]}
+        testID={`${testID}-cta`}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      >
+        <Ionicons name="sparkles" size={18} color="#FFFFFF" />
+        <Text style={styles.ctaText}>Start tracking</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+    paddingVertical: 24,
+    gap: 12,
+  },
+  iconCircle: {
+    width: 84,
+    height: 84,
+    borderRadius: 42,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(76, 140, 255, 0.12)',
+    borderWidth: 1,
+    borderColor: 'rgba(76, 140, 255, 0.3)',
+  },
+  title: {
+    color: '#F5F7FF',
+    fontSize: 20,
+    fontWeight: '700',
+    marginTop: 6,
+    textAlign: 'center',
+  },
+  subtitle: {
+    color: '#9AACD1',
+    fontSize: 14,
+    lineHeight: 20,
+    textAlign: 'center',
+    maxWidth: 280,
+  },
+  cta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    marginTop: 12,
+    paddingVertical: 14,
+    paddingHorizontal: 22,
+    minHeight: 44,
+    borderRadius: 22,
+    backgroundColor: '#4C8CFF',
+  },
+  ctaPressed: {
+    backgroundColor: '#3B76E0',
+  },
+  ctaText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '700',
+    letterSpacing: 0.2,
+  },
+});
+
+export default EmptySessionState;

--- a/components/workouts/FormQualityBadgeRow.tsx
+++ b/components/workouts/FormQualityBadgeRow.tsx
@@ -1,0 +1,124 @@
+/**
+ * FormQualityBadgeRow
+ *
+ * Per-exercise badge row rendered on the workouts-tab session cards.
+ * Decides between two presentations based on whether the user has
+ * any FQI history for the exercise:
+ *
+ *   - With history (score is a finite number): delegates to the
+ *     existing `FormQualityBadge` unchanged so tracked exercises keep
+ *     their current visual treatment.
+ *   - Without history (score is null/undefined): renders a subtle
+ *     muted "Track form to unlock" pill that routes into
+ *     `/(tabs)/scan-arkit`. The pill keeps a 44x44 hit target and
+ *     proper accessibility metadata so the empty state is discoverable
+ *     without being visually loud.
+ *
+ * Wrapping the decision in a single component keeps `workouts.tsx`
+ * render logic simple and lets us unit-test the empty-state branch
+ * without rendering the whole tab.
+ */
+import React, { useCallback } from 'react';
+import { Pressable, StyleSheet, Text, View, type StyleProp, type ViewStyle } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+
+import { FormQualityBadge } from '@/components/form-tracking/FormQualityBadge';
+
+export interface FormQualityBadgeRowProps {
+  /** Canonical exercise name (e.g. "Pull-Up"). Used for a11y labels only. */
+  exerciseName?: string;
+  /**
+   * Most-recent session-average FQI for this exercise.
+   * `null` / `undefined` → render the empty-state "Track form to unlock" pill.
+   */
+  score: number | null | undefined;
+  /** Optional wrapping style (e.g. margins on the card). */
+  style?: StyleProp<ViewStyle>;
+  /** Override for the empty-state tap handler (tests / storybook). */
+  onEmptyStatePress?: () => void;
+  /** Optional testID — defaults to `form-quality-badge-row`. */
+  testID?: string;
+}
+
+function hasFqi(score: number | null | undefined): score is number {
+  return typeof score === 'number' && Number.isFinite(score);
+}
+
+export function FormQualityBadgeRow({
+  exerciseName,
+  score,
+  style,
+  onEmptyStatePress,
+  testID = 'form-quality-badge-row',
+}: FormQualityBadgeRowProps) {
+  const router = useRouter();
+
+  const handleEmptyPress = useCallback(() => {
+    if (onEmptyStatePress) {
+      onEmptyStatePress();
+      return;
+    }
+    router.push('/(tabs)/scan-arkit');
+  }, [onEmptyStatePress, router]);
+
+  if (hasFqi(score)) {
+    return (
+      <View style={[styles.wrap, style]} testID={testID}>
+        <FormQualityBadge score={score} />
+      </View>
+    );
+  }
+
+  const a11y = exerciseName
+    ? `Track form for ${exerciseName} to unlock form quality`
+    : 'Track form to unlock form quality';
+
+  return (
+    <View style={[styles.wrap, style]} testID={testID}>
+      <Pressable
+        onPress={handleEmptyPress}
+        accessibilityRole="button"
+        accessibilityLabel={a11y}
+        accessibilityHint="Opens the form scan tab to begin a tracked session"
+        style={({ pressed }) => [styles.emptyPill, pressed && styles.emptyPillPressed]}
+        testID={`${testID}-empty`}
+        hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+      >
+        <Ionicons name="barbell-outline" size={14} color="#7C8FB0" />
+        <Text style={styles.emptyText}>Track form to unlock</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    marginTop: 6,
+    marginBottom: 2,
+  },
+  emptyPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    minHeight: 44,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.2)',
+    backgroundColor: 'rgba(154, 172, 209, 0.06)',
+    alignSelf: 'flex-start',
+  },
+  emptyPillPressed: {
+    backgroundColor: 'rgba(154, 172, 209, 0.14)',
+  },
+  emptyText: {
+    color: '#9AACD1',
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 0.2,
+  },
+});
+
+export default FormQualityBadgeRow;

--- a/hooks/use-workout-coach-context.ts
+++ b/hooks/use-workout-coach-context.ts
@@ -1,0 +1,87 @@
+/**
+ * use-workout-coach-context
+ *
+ * Wires the coach-workout-recall service to the coach-service under the
+ * EXPO_PUBLIC_WORKOUT_COACH_RECALL master flag. Consumers get two
+ * things back:
+ *
+ *   - `loadContext(workoutId)` — builds the structured retrospective
+ *     context (no coach call; always safe).
+ *   - `askAboutWorkout(workoutId, userMessage)` — sends the recall
+ *     prompt plus the user's follow-up question to sendCoachPrompt
+ *     and returns the coach's reply.
+ *
+ * When the master flag is off, `askAboutWorkout` returns `null` and
+ * does NOT call the coach service, so the hook can be imported safely
+ * from screens that render conditionally based on the flag.
+ *
+ * The hook purposely does not manage chat history itself — the UI owns
+ * the message list and calls `askAboutWorkout` for each turn. Keeping
+ * state in the screen keeps the hook trivially testable.
+ */
+import { useCallback, useMemo } from 'react';
+import {
+  buildWorkoutRecallContext,
+  buildWorkoutRecallPrompt,
+  type WorkoutRecallContext,
+} from '@/lib/services/coach-workout-recall';
+import { isWorkoutCoachRecallEnabled } from '@/lib/services/workout-coach-recall-flag';
+import { sendCoachPrompt, type CoachMessage } from '@/lib/services/coach-service';
+
+export interface WorkoutCoachContextApi {
+  /** True when the master flag is on. */
+  enabled: boolean;
+  /** Reloads the recall context for a workout id. Safe regardless of flag. */
+  loadContext: (workoutId: string) => Promise<WorkoutRecallContext>;
+  /**
+   * Sends the recall prompt + user message to the coach. Returns null
+   * when the master flag is off (the UI should render a "disabled"
+   * fallback instead) or when the workout id is empty.
+   */
+  askAboutWorkout: (
+    workoutId: string,
+    userMessage: string,
+  ) => Promise<CoachMessage | null>;
+}
+
+export function useWorkoutCoachContext(): WorkoutCoachContextApi {
+  const enabled = useMemo(() => isWorkoutCoachRecallEnabled(), []);
+
+  const loadContext = useCallback(
+    (workoutId: string) => buildWorkoutRecallContext(workoutId),
+    [],
+  );
+
+  const askAboutWorkout = useCallback(
+    async (workoutId: string, userMessage: string): Promise<CoachMessage | null> => {
+      if (!isWorkoutCoachRecallEnabled()) return null;
+      if (!workoutId) return null;
+
+      const ctx = await buildWorkoutRecallContext(workoutId);
+      const recallPrompt = buildWorkoutRecallPrompt(ctx);
+
+      const trimmed = typeof userMessage === 'string' ? userMessage.trim() : '';
+
+      const messages: CoachMessage[] = [
+        {
+          role: 'system',
+          content:
+            'You are helping the athlete debrief a past workout. Use the ' +
+            'recall context they give you. Keep answers concrete and ' +
+            'actionable.',
+        },
+        { role: 'user', content: recallPrompt },
+      ];
+      if (trimmed.length > 0) {
+        messages.push({ role: 'user', content: trimmed });
+      }
+
+      return sendCoachPrompt(messages, {
+        focus: 'workout-retrospective',
+      });
+    },
+    [],
+  );
+
+  return { enabled, loadContext, askAboutWorkout };
+}

--- a/lib/services/coach-workout-recall.ts
+++ b/lib/services/coach-workout-recall.ts
@@ -1,0 +1,220 @@
+/**
+ * coach-workout-recall
+ *
+ * Assembles a structured retrospective context for the Gemma coach when
+ * a user asks to review a past workout. The service is pure and safe to
+ * call regardless of whether the EXPO_PUBLIC_WORKOUT_COACH_RECALL flag
+ * is enabled — the gating happens at the hook layer.
+ *
+ * Data sources:
+ *   - `workouts` table in local-db (exercise name, sets/reps/weight, date)
+ *   - `form-session-history` AsyncStorage log (avg FQI per exercise, ended-at)
+ *
+ * Emitted context:
+ *   - `WorkoutRecallContext` — structured summary used by the hook/UI.
+ *   - `buildWorkoutRecallPrompt` — renders the context to a single string
+ *     that the coach service can consume as the user's opening prompt.
+ *
+ * Best-effort: each dependency (db, history store) can fail independently
+ * and the service degrades to partial context rather than throwing. The
+ * caller always gets a `WorkoutRecallContext` — the `found` flag says
+ * whether the workout id was actually resolved.
+ */
+import { localDB } from '@/lib/services/database/local-db';
+import { warnWithTs } from '@/lib/logger';
+import {
+  getFormSessionHistory,
+  type FormSessionHistoryEntry,
+} from '@/lib/services/form-session-history';
+import { resolveExerciseKey } from '@/lib/services/form-session-history-lookup';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface WorkoutRecallContext {
+  /** The workout id requested by the caller. */
+  workoutId: string;
+  /** True when the workout row was found in local-db. */
+  found: boolean;
+  /** User-facing exercise name, or null when the workout wasn't found. */
+  exerciseName: string | null;
+  /** ISO date string from the workouts row, or null. */
+  dateIso: string | null;
+  /** Logged set count (0 when missing). */
+  sets: number;
+  /** Logged rep count per set (null when not recorded). */
+  reps: number | null;
+  /** Logged weight value (null when not recorded). */
+  weight: number | null;
+  /** Logged duration in minutes (null when not recorded). */
+  durationMinutes: number | null;
+  /**
+   * Most-recent form-session-history entry for this exercise when one
+   * exists. Lets the coach reference an FQI baseline without us having
+   * to round-trip through coach-service.
+   */
+  latestFormEntry: FormSessionHistoryEntry | null;
+}
+
+interface WorkoutRow {
+  id: string;
+  exercise: string;
+  sets: number;
+  reps: number | null;
+  weight: number | null;
+  duration: number | null;
+  date: string;
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Builds the retrospective context for a given workout id. Always
+ * returns a `WorkoutRecallContext` — callers inspect `.found` to decide
+ * whether to render the prompt or a "workout not found" fallback.
+ */
+export async function buildWorkoutRecallContext(
+  workoutId: string,
+): Promise<WorkoutRecallContext> {
+  const empty: WorkoutRecallContext = {
+    workoutId,
+    found: false,
+    exerciseName: null,
+    dateIso: null,
+    sets: 0,
+    reps: null,
+    weight: null,
+    durationMinutes: null,
+    latestFormEntry: null,
+  };
+
+  if (!workoutId || typeof workoutId !== 'string') {
+    return empty;
+  }
+
+  const row = await safeFetchWorkoutRow(workoutId);
+  if (!row) {
+    return empty;
+  }
+
+  const latestFormEntry = await safeFetchLatestFormEntry(row.exercise);
+
+  return {
+    workoutId,
+    found: true,
+    exerciseName: row.exercise,
+    dateIso: row.date,
+    sets: Number.isFinite(row.sets) ? row.sets : 0,
+    reps: row.reps,
+    weight: row.weight,
+    durationMinutes: row.duration,
+    latestFormEntry,
+  };
+}
+
+/**
+ * Renders a `WorkoutRecallContext` into a single human-readable prompt
+ * the coach can use as the opening user turn. The prompt deliberately
+ * reads as a first-person user summary so Gemma treats it as the
+ * athlete's own framing rather than a system directive.
+ *
+ * When the context was not found, returns a graceful fallback string
+ * so callers never need to branch on `ctx.found`.
+ */
+export function buildWorkoutRecallPrompt(ctx: WorkoutRecallContext): string {
+  if (!ctx.found || !ctx.exerciseName) {
+    return (
+      "I wanted to review an old workout but I can't find it in my " +
+      'history. Can you ask me what I remember about it so we can still ' +
+      'talk through it?'
+    );
+  }
+
+  const dateLabel = formatDateLabel(ctx.dateIso);
+  const setsLabel = ctx.sets > 0 ? `${ctx.sets} set${ctx.sets === 1 ? '' : 's'}` : 'some sets';
+  const repsLabel =
+    ctx.reps != null && Number.isFinite(ctx.reps) && ctx.reps > 0
+      ? `${ctx.reps} reps each`
+      : null;
+  const weightLabel =
+    ctx.weight != null && Number.isFinite(ctx.weight) && ctx.weight > 0
+      ? `${ctx.weight} lb`
+      : null;
+  const durationLabel =
+    ctx.durationMinutes != null &&
+    Number.isFinite(ctx.durationMinutes) &&
+    ctx.durationMinutes > 0
+      ? `${ctx.durationMinutes} min`
+      : null;
+
+  const fqiLabel = ctx.latestFormEntry
+    ? `My most-recent tracked form FQI was ${Math.round(ctx.latestFormEntry.avgFqi)} out of 100.`
+    : 'I have no tracked form-quality data for this exercise yet.';
+
+  const statsParts = [setsLabel, repsLabel, weightLabel, durationLabel].filter(
+    (part): part is string => !!part,
+  );
+  const statsLine = statsParts.length > 0 ? statsParts.join(', ') : 'no detailed stats';
+
+  return [
+    `I want to look back at my ${ctx.exerciseName} workout from ${dateLabel}.`,
+    `Here is what I logged: ${statsLine}.`,
+    fqiLabel,
+    'Can you help me debrief this session and suggest what to work on next?',
+  ].join(' ');
+}
+
+// =============================================================================
+// Internals
+// =============================================================================
+
+async function safeFetchWorkoutRow(workoutId: string): Promise<WorkoutRow | null> {
+  try {
+    const db = localDB.db;
+    if (!db) return null;
+    const rows = await db.getAllAsync<WorkoutRow>(
+      `SELECT id, exercise, sets, reps, weight, duration, date
+         FROM workouts
+        WHERE id = ? AND deleted = 0
+        LIMIT 1`,
+      workoutId,
+    );
+    return rows[0] ?? null;
+  } catch (err) {
+    warnWithTs('[coach-workout-recall] workout lookup failed', err);
+    return null;
+  }
+}
+
+async function safeFetchLatestFormEntry(
+  exerciseName: string,
+): Promise<FormSessionHistoryEntry | null> {
+  try {
+    const key = resolveExerciseKey(exerciseName);
+    if (!key) return null;
+    const history = await getFormSessionHistory(key);
+    return history[0] ?? null;
+  } catch (err) {
+    warnWithTs('[coach-workout-recall] form-history lookup failed', err);
+    return null;
+  }
+}
+
+function formatDateLabel(iso: string | null): string {
+  if (!iso) return 'an earlier day';
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return 'an earlier day';
+    return d.toLocaleDateString(undefined, {
+      weekday: 'long',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  } catch {
+    return 'an earlier day';
+  }
+}

--- a/lib/services/workout-coach-recall-flag.ts
+++ b/lib/services/workout-coach-recall-flag.ts
@@ -1,0 +1,30 @@
+/**
+ * workout-coach-recall-flag
+ *
+ * Master feature flag for the wave-25 workouts-tab × Gemma
+ * retrospective chat bundle. When this flag is off, none of the new
+ * user-visible wiring in the bundle should render:
+ *   - `AskCoachCTA` on workout rows (`app/(tabs)/workouts.tsx`)
+ *   - `workout-debrief-chat` modal (shows a "feature disabled" card)
+ *   - `use-workout-coach-context` hook no-ops from `askAboutWorkout`
+ *
+ * The underlying services (`coach-workout-recall`, `use-workout-coach-context`)
+ * are pure and safe to import any time; this flag gates whether callers
+ * should actually invoke the coach.
+ *
+ * Parsing:
+ * - `EXPO_PUBLIC_WORKOUT_COACH_RECALL=1`     → enabled
+ * - `EXPO_PUBLIC_WORKOUT_COACH_RECALL=true`  → enabled
+ * - unset / anything else                     → disabled (fail safe)
+ *
+ * Strict on accept: only the exact strings `"1"` and `"true"` (case
+ * sensitive) flip the flag on. Keeps the knob unambiguous for ops.
+ */
+
+const FLAG_ENV_VAR = 'EXPO_PUBLIC_WORKOUT_COACH_RECALL';
+
+export function isWorkoutCoachRecallEnabled(): boolean {
+  const raw = process.env[FLAG_ENV_VAR];
+  if (typeof raw !== 'string') return false;
+  return raw === '1' || raw === 'true';
+}

--- a/lib/services/workout-insights-fqi-bands.ts
+++ b/lib/services/workout-insights-fqi-bands.ts
@@ -1,0 +1,47 @@
+/**
+ * workout-insights-fqi-bands
+ *
+ * Pure helper for the workout-insights modal. Maps a numeric
+ * session-average FQI (Form Quality Index, 0-100) to a human-readable
+ * band label plus a color code suitable for text rendering.
+ *
+ * Band thresholds (matches the worklog's GAP-4 acceptance):
+ *   >= 85      → Excellent
+ *   70 .. <85  → Good
+ *   50 .. <70  → Fair
+ *   <50        → Poor
+ *
+ * When the score is missing / NaN the helper returns a neutral label
+ * so callers can still render the row without a conditional branch.
+ */
+
+export type FqiBand = 'excellent' | 'good' | 'fair' | 'poor' | 'unknown';
+
+export interface FqiBandInfo {
+  /** Lowercase key (useful for analytics + styling keys). */
+  band: FqiBand;
+  /** Capitalised label for direct display ('Excellent', 'Good', ...). */
+  label: string;
+  /**
+   * Suggested foreground color for the label text. Keeps the visual
+   * treatment consistent with the existing FqiGauge / FormQualityBadge
+   * palette used elsewhere on the workouts tab.
+   */
+  color: string;
+}
+
+export function getFqiBand(score: number | null | undefined): FqiBandInfo {
+  if (score === null || score === undefined || !Number.isFinite(score)) {
+    return { band: 'unknown', label: 'Not available', color: '#9AACD1' };
+  }
+  if (score >= 85) {
+    return { band: 'excellent', label: 'Excellent', color: '#3CC8A9' };
+  }
+  if (score >= 70) {
+    return { band: 'good', label: 'Good', color: '#4C8CFF' };
+  }
+  if (score >= 50) {
+    return { band: 'fair', label: 'Fair', color: '#F59E0B' };
+  }
+  return { band: 'poor', label: 'Poor', color: '#EF4444' };
+}

--- a/tests/unit/components/form-tracking/empty-session-state.test.tsx
+++ b/tests/unit/components/form-tracking/empty-session-state.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+
+const mockPush = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+import { EmptySessionState } from '@/components/form-tracking/EmptySessionState';
+
+describe('EmptySessionState', () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+  });
+
+  it('renders title and subtitle copy', () => {
+    const { getByText } = render(<EmptySessionState />);
+    expect(getByText('No sessions yet')).toBeTruthy();
+    expect(
+      getByText('Start your first form-tracking session to see analytics here.'),
+    ).toBeTruthy();
+  });
+
+  it('routes to /(tabs)/scan-arkit when CTA pressed without onStartPress', () => {
+    const { getByTestId } = render(<EmptySessionState />);
+    fireEvent.press(getByTestId('empty-session-state-cta'));
+    expect(mockPush).toHaveBeenCalledWith('/(tabs)/scan-arkit');
+  });
+
+  it('invokes onStartPress override when provided', () => {
+    const onStartPress = jest.fn();
+    const { getByTestId } = render(<EmptySessionState onStartPress={onStartPress} />);
+    fireEvent.press(getByTestId('empty-session-state-cta'));
+    expect(onStartPress).toHaveBeenCalledTimes(1);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/workouts/form-quality-badge-row.test.tsx
+++ b/tests/unit/components/workouts/form-quality-badge-row.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+
+const mockPush = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('moti', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    MotiView: View,
+    MotiText: View,
+  };
+});
+
+// eslint-disable-next-line import/first
+import { FormQualityBadgeRow } from '@/components/workouts/FormQualityBadgeRow';
+
+describe('FormQualityBadgeRow', () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+  });
+
+  it('renders FormQualityBadge when score is a finite number', () => {
+    const { getByTestId, queryByTestId } = render(
+      <FormQualityBadgeRow exerciseName="Pull-Up" score={82} />,
+    );
+    // The underlying FormQualityBadge uses testID 'form-quality-badge'.
+    expect(getByTestId('form-quality-badge')).toBeTruthy();
+    expect(queryByTestId('form-quality-badge-row-empty')).toBeNull();
+  });
+
+  it('renders empty-state pill when score is null', () => {
+    const { getByTestId, queryByTestId } = render(
+      <FormQualityBadgeRow exerciseName="Pull-Up" score={null} />,
+    );
+    expect(getByTestId('form-quality-badge-row-empty')).toBeTruthy();
+    expect(queryByTestId('form-quality-badge')).toBeNull();
+  });
+
+  it('renders empty-state pill when score is undefined', () => {
+    const { getByTestId } = render(<FormQualityBadgeRow score={undefined} />);
+    expect(getByTestId('form-quality-badge-row-empty')).toBeTruthy();
+  });
+
+  it('renders empty-state pill when score is NaN (not finite)', () => {
+    const { getByTestId } = render(<FormQualityBadgeRow score={Number.NaN} />);
+    expect(getByTestId('form-quality-badge-row-empty')).toBeTruthy();
+  });
+
+  it('routes to /(tabs)/scan-arkit when empty-state pill is pressed', () => {
+    const { getByTestId } = render(
+      <FormQualityBadgeRow exerciseName="Pull-Up" score={null} />,
+    );
+    fireEvent.press(getByTestId('form-quality-badge-row-empty'));
+    expect(mockPush).toHaveBeenCalledWith('/(tabs)/scan-arkit');
+  });
+
+  it('invokes onEmptyStatePress override when provided', () => {
+    const onEmptyStatePress = jest.fn();
+    const { getByTestId } = render(
+      <FormQualityBadgeRow score={null} onEmptyStatePress={onEmptyStatePress} />,
+    );
+    fireEvent.press(getByTestId('form-quality-badge-row-empty'));
+    expect(onEmptyStatePress).toHaveBeenCalledTimes(1);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('embeds exerciseName in the empty-state accessibility label', () => {
+    const { getByLabelText } = render(
+      <FormQualityBadgeRow exerciseName="Pull-Up" score={null} />,
+    );
+    expect(
+      getByLabelText('Track form for Pull-Up to unlock form quality'),
+    ).toBeTruthy();
+  });
+});

--- a/tests/unit/hooks/use-workout-coach-context.test.tsx
+++ b/tests/unit/hooks/use-workout-coach-context.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * use-workout-coach-context tests.
+ *
+ * Verifies the flag gate, the null-return when the flag is off, and the
+ * sendCoachPrompt wire-up with a mocked coach-service.
+ */
+import React from 'react';
+import { act, render } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+const mockSendCoachPrompt = jest.fn();
+const mockBuildContext = jest.fn();
+const mockIsEnabled = jest.fn();
+
+jest.mock('@/lib/services/coach-service', () => ({
+  sendCoachPrompt: (...args: unknown[]) => mockSendCoachPrompt(...args),
+}));
+
+jest.mock('@/lib/services/coach-workout-recall', () => {
+  const actual = jest.requireActual('@/lib/services/coach-workout-recall');
+  return {
+    ...actual,
+    buildWorkoutRecallContext: (...args: unknown[]) => mockBuildContext(...args),
+  };
+});
+
+jest.mock('@/lib/services/workout-coach-recall-flag', () => ({
+  isWorkoutCoachRecallEnabled: () => mockIsEnabled(),
+}));
+
+jest.mock('@/lib/services/database/local-db', () => ({
+  localDB: { db: null },
+}));
+
+// eslint-disable-next-line import/first
+import { useWorkoutCoachContext } from '@/hooks/use-workout-coach-context';
+
+interface HarnessProps {
+  onReady: (api: ReturnType<typeof useWorkoutCoachContext>) => void;
+}
+
+function Harness({ onReady }: HarnessProps) {
+  const api = useWorkoutCoachContext();
+  React.useEffect(() => {
+    onReady(api);
+  }, [api, onReady]);
+  return <Text testID="harness">ready</Text>;
+}
+
+function mockCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    workoutId: 'w-1',
+    found: true,
+    exerciseName: 'Pull-Up',
+    dateIso: '2026-04-15T10:00:00.000Z',
+    sets: 3,
+    reps: 8,
+    weight: null,
+    durationMinutes: null,
+    latestFormEntry: null,
+    ...overrides,
+  };
+}
+
+describe('useWorkoutCoachContext', () => {
+  beforeEach(() => {
+    mockSendCoachPrompt.mockReset();
+    mockBuildContext.mockReset();
+    mockIsEnabled.mockReset();
+  });
+
+  it('returns enabled=false when the flag is off', async () => {
+    mockIsEnabled.mockReturnValue(false);
+    let api: ReturnType<typeof useWorkoutCoachContext> | null = null;
+    render(<Harness onReady={(a) => (api = a)} />);
+    expect(api).not.toBeNull();
+    expect(api!.enabled).toBe(false);
+  });
+
+  it('returns enabled=true when the flag is on', () => {
+    mockIsEnabled.mockReturnValue(true);
+    let api: ReturnType<typeof useWorkoutCoachContext> | null = null;
+    render(<Harness onReady={(a) => (api = a)} />);
+    expect(api!.enabled).toBe(true);
+  });
+
+  it('askAboutWorkout returns null when flag is off and does NOT call the coach', async () => {
+    mockIsEnabled.mockReturnValue(false);
+    mockBuildContext.mockResolvedValue(mockCtx());
+    let api: ReturnType<typeof useWorkoutCoachContext> | null = null;
+    render(<Harness onReady={(a) => (api = a)} />);
+
+    const result = await act(async () => await api!.askAboutWorkout('w-1', 'hi'));
+    expect(result).toBeNull();
+    expect(mockSendCoachPrompt).not.toHaveBeenCalled();
+  });
+
+  it('askAboutWorkout returns null when workoutId is empty', async () => {
+    mockIsEnabled.mockReturnValue(true);
+    mockBuildContext.mockResolvedValue(mockCtx());
+    let api: ReturnType<typeof useWorkoutCoachContext> | null = null;
+    render(<Harness onReady={(a) => (api = a)} />);
+
+    const result = await act(async () => await api!.askAboutWorkout('', 'hi'));
+    expect(result).toBeNull();
+    expect(mockSendCoachPrompt).not.toHaveBeenCalled();
+  });
+
+  it('askAboutWorkout sends a system + recall-prompt + user message when flag is on', async () => {
+    mockIsEnabled.mockReturnValue(true);
+    mockBuildContext.mockResolvedValue(mockCtx());
+    mockSendCoachPrompt.mockResolvedValue({ role: 'assistant', content: 'sure, lets dig in' });
+
+    let api: ReturnType<typeof useWorkoutCoachContext> | null = null;
+    render(<Harness onReady={(a) => (api = a)} />);
+
+    const result = await act(async () =>
+      await api!.askAboutWorkout('w-1', 'what about my tempo?'),
+    );
+
+    expect(mockSendCoachPrompt).toHaveBeenCalledTimes(1);
+    const [messages, context] = mockSendCoachPrompt.mock.calls[0];
+    expect(Array.isArray(messages)).toBe(true);
+    expect(messages[0].role).toBe('system');
+    expect(messages[1].role).toBe('user');
+    expect(messages[1].content).toContain('Pull-Up');
+    expect(messages[2].role).toBe('user');
+    expect(messages[2].content).toBe('what about my tempo?');
+    expect(context).toMatchObject({ focus: 'workout-retrospective' });
+    expect(result).toEqual({ role: 'assistant', content: 'sure, lets dig in' });
+  });
+
+  it('askAboutWorkout omits the user follow-up when message is whitespace-only', async () => {
+    mockIsEnabled.mockReturnValue(true);
+    mockBuildContext.mockResolvedValue(mockCtx());
+    mockSendCoachPrompt.mockResolvedValue({ role: 'assistant', content: 'ok' });
+
+    let api: ReturnType<typeof useWorkoutCoachContext> | null = null;
+    render(<Harness onReady={(a) => (api = a)} />);
+
+    await act(async () => await api!.askAboutWorkout('w-1', '   '));
+
+    expect(mockSendCoachPrompt).toHaveBeenCalledTimes(1);
+    const [messages] = mockSendCoachPrompt.mock.calls[0];
+    expect(messages).toHaveLength(2);
+    expect(messages[1].role).toBe('user');
+  });
+
+  it('loadContext is always callable regardless of flag', async () => {
+    mockIsEnabled.mockReturnValue(false);
+    mockBuildContext.mockResolvedValue(mockCtx({ workoutId: 'w-9' }));
+
+    let api: ReturnType<typeof useWorkoutCoachContext> | null = null;
+    render(<Harness onReady={(a) => (api = a)} />);
+
+    const ctx = await act(async () => await api!.loadContext('w-9'));
+    expect(mockBuildContext).toHaveBeenCalledWith('w-9');
+    expect(ctx.workoutId).toBe('w-9');
+  });
+});

--- a/tests/unit/screens/rep-export-retry.test.tsx
+++ b/tests/unit/screens/rep-export-retry.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Rep-insights export retry UI (GAP-6).
+ *
+ * Verifies that when `shareRepData` throws, the modal surfaces an
+ * inline error banner with Retry + Dismiss rather than an Alert, and
+ * that Retry re-invokes the exporter with the same format.
+ */
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+const mockShareRepData = jest.fn();
+const mockRouterBack = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: mockRouterBack, push: jest.fn() }),
+  useLocalSearchParams: () => ({ sessionId: 'session-1' }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('@/lib/services/rep-export', () => ({
+  shareRepData: (...args: unknown[]) => mockShareRepData(...args),
+}));
+
+// Stub heavy insight widgets so the test only exercises the export card.
+jest.mock('@/components/insights/FqiTrendChart', () => ({
+  FqiTrendChart: () => null,
+}));
+jest.mock('@/components/insights/FaultHeatmap', () => ({
+  FaultHeatmap: () => null,
+}));
+jest.mock('@/components/insights/RomProgressionCard', () => ({
+  RomProgressionCard: () => null,
+}));
+jest.mock('@/components/insights/SymmetryCard', () => ({
+  SymmetryCard: () => null,
+}));
+jest.mock('@/components/insights/RepRewindCarousel', () => ({
+  RepRewindCarousel: () => null,
+}));
+
+// eslint-disable-next-line import/first
+import RepInsightsModal from '../../../app/(modals)/rep-insights';
+
+describe('RepInsightsModal — export retry UI', () => {
+  beforeEach(() => {
+    mockShareRepData.mockReset();
+  });
+
+  it('surfaces an error banner with Retry when shareRepData throws', async () => {
+    mockShareRepData.mockRejectedValueOnce(new Error('Network error'));
+
+    const { getByText, getByTestId, queryByTestId } = render(<RepInsightsModal />);
+    expect(queryByTestId('rep-export-error-banner')).toBeNull();
+
+    fireEvent.press(getByText('CSV'));
+
+    await waitFor(() => {
+      expect(getByTestId('rep-export-error-banner')).toBeTruthy();
+    });
+    expect(getByTestId('rep-export-error-message')).toBeTruthy();
+    expect(getByText('CSV export failed')).toBeTruthy();
+    expect(getByTestId('rep-export-retry-button')).toBeTruthy();
+  });
+
+  it('retries with the same format when the user presses Retry', async () => {
+    mockShareRepData
+      .mockRejectedValueOnce(new Error('Timeout'))
+      .mockResolvedValueOnce({ shared: true, fileUri: '/tmp/out.csv', payload: '', filename: 'out.csv', mimeType: 'text/csv' });
+
+    const { getByText, getByTestId, queryByTestId } = render(<RepInsightsModal />);
+    fireEvent.press(getByText('CSV'));
+
+    await waitFor(() => {
+      expect(getByTestId('rep-export-error-banner')).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId('rep-export-retry-button'));
+
+    await waitFor(() => {
+      expect(queryByTestId('rep-export-error-banner')).toBeNull();
+    });
+    // Both calls should target csv, not json.
+    expect(mockShareRepData).toHaveBeenCalledTimes(2);
+    expect(mockShareRepData.mock.calls[0][1]).toBe('csv');
+    expect(mockShareRepData.mock.calls[1][1]).toBe('csv');
+  });
+
+  it('clears the banner when Dismiss is pressed', async () => {
+    mockShareRepData.mockRejectedValueOnce(new Error('boom'));
+
+    const { getByText, getByTestId, queryByTestId } = render(<RepInsightsModal />);
+    fireEvent.press(getByText('JSON'));
+
+    await waitFor(() => {
+      expect(getByTestId('rep-export-error-banner')).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId('rep-export-dismiss-button'));
+    expect(queryByTestId('rep-export-error-banner')).toBeNull();
+  });
+
+  it('keeps the original error text accessible on the banner', async () => {
+    mockShareRepData.mockRejectedValueOnce(new Error('Device storage full'));
+
+    const { getByText, findByTestId } = render(<RepInsightsModal />);
+    fireEvent.press(getByText('CSV'));
+
+    const message = await findByTestId('rep-export-error-message');
+    // The full error should remain visible in the banner — tests against
+    // regressions where only a generic "Export failed" label is shown.
+    expect(message).toBeTruthy();
+    expect((message.props.children as string)).toContain('Device storage full');
+  });
+});

--- a/tests/unit/screens/workout-debrief-chat.test.tsx
+++ b/tests/unit/screens/workout-debrief-chat.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * workout-debrief-chat integration test (wave-25).
+ *
+ * Covers the four lifecycle scenarios called out in the task:
+ *   1. Flag off → disabled card renders, coach not called.
+ *   2. Flag on → first message renders after askAboutWorkout resolves.
+ *   3. Send follow-up → askAboutWorkout is called with the trimmed user message.
+ *   4. Close modal → router.back() is invoked on the close button.
+ */
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+const mockRouterBack = jest.fn();
+const mockAskAboutWorkout = jest.fn();
+let mockEnabled = false;
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: mockRouterBack, push: jest.fn() }),
+  useLocalSearchParams: () => ({ workoutId: 'w-1' }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('react-native-paper', () => {
+  const ReactRef = require('react');
+  const { TextInput: NativeTextInput } = require('react-native');
+  return {
+    TextInput: (props: Record<string, unknown>) => {
+      const {
+        value,
+        onChangeText,
+        testID,
+        placeholder,
+        mode: _mode,
+        outlineColor: _outlineColor,
+        activeOutlineColor: _activeOutlineColor,
+        textColor: _textColor,
+        theme: _theme,
+        ...rnProps
+      } = props as Record<string, unknown>;
+      void _mode;
+      void _outlineColor;
+      void _activeOutlineColor;
+      void _textColor;
+      void _theme;
+      return ReactRef.createElement(NativeTextInput, {
+        testID,
+        placeholder,
+        value,
+        onChangeText,
+        ...rnProps,
+      });
+    },
+  };
+});
+
+jest.mock('@/hooks/use-workout-coach-context', () => ({
+  useWorkoutCoachContext: () => ({
+    get enabled() {
+      return mockEnabled;
+    },
+    loadContext: jest.fn(),
+    askAboutWorkout: (...args: unknown[]) => mockAskAboutWorkout(...args),
+  }),
+}));
+
+// eslint-disable-next-line import/first
+import WorkoutDebriefChatModal from '../../../app/(modals)/workout-debrief-chat';
+
+describe('WorkoutDebriefChatModal', () => {
+  beforeEach(() => {
+    mockRouterBack.mockReset();
+    mockAskAboutWorkout.mockReset();
+    mockEnabled = false;
+  });
+
+  it('renders the disabled fallback card when flag is off', () => {
+    mockEnabled = false;
+    const { getByTestId, queryByTestId } = render(<WorkoutDebriefChatModal />);
+    expect(getByTestId('workout-debrief-chat-disabled')).toBeTruthy();
+    expect(queryByTestId('workout-debrief-chat-root')).toBeNull();
+    expect(mockAskAboutWorkout).not.toHaveBeenCalled();
+  });
+
+  it('renders the first assistant bubble once askAboutWorkout resolves (flag on)', async () => {
+    mockEnabled = true;
+    mockAskAboutWorkout.mockResolvedValue({
+      role: 'assistant',
+      content: "Here's your retrospective.",
+    });
+
+    const { findByText, getByTestId } = render(<WorkoutDebriefChatModal />);
+    await waitFor(() => {
+      expect(mockAskAboutWorkout).toHaveBeenCalledWith('w-1', '');
+    });
+    expect(await findByText("Here's your retrospective.")).toBeTruthy();
+    expect(getByTestId('workout-debrief-chat-root')).toBeTruthy();
+  });
+
+  it('sends a follow-up when the user presses send', async () => {
+    mockEnabled = true;
+    mockAskAboutWorkout
+      .mockResolvedValueOnce({ role: 'assistant', content: 'first reply' })
+      .mockResolvedValueOnce({ role: 'assistant', content: 'follow-up reply' });
+
+    const { findByText, getByTestId } = render(<WorkoutDebriefChatModal />);
+    await findByText('first reply');
+
+    const input = getByTestId('workout-debrief-chat-input');
+    fireEvent.changeText(input, '  what about tempo?  ');
+    await act(async () => {
+      fireEvent.press(getByTestId('workout-debrief-chat-send'));
+    });
+
+    await waitFor(() => {
+      expect(mockAskAboutWorkout).toHaveBeenCalledTimes(2);
+    });
+    expect(mockAskAboutWorkout.mock.calls[1]).toEqual(['w-1', 'what about tempo?']);
+    expect(await findByText('follow-up reply')).toBeTruthy();
+  });
+
+  it('calls router.back() when the close button is pressed (cleanup)', async () => {
+    mockEnabled = true;
+    mockAskAboutWorkout.mockResolvedValue({ role: 'assistant', content: 'hi' });
+    const { findByText, getByTestId } = render(<WorkoutDebriefChatModal />);
+    // Wait for mount-time state update to settle first.
+    await findByText('hi');
+    fireEvent.press(getByTestId('workout-debrief-chat-close'));
+    expect(mockRouterBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/services/coach-workout-recall.test.ts
+++ b/tests/unit/services/coach-workout-recall.test.ts
@@ -1,0 +1,233 @@
+/**
+ * coach-workout-recall unit tests.
+ *
+ * Covers the context assembly (db hit/miss, form-history hit/miss) and
+ * the prompt shape (found vs. fallback, optional stats collapsed).
+ */
+
+const mockGetAllAsync = jest.fn();
+const mockGetFormSessionHistory = jest.fn();
+const mockResolveExerciseKey = jest.fn();
+
+jest.mock('@/lib/services/database/local-db', () => ({
+  localDB: {
+    get db() {
+      return { getAllAsync: mockGetAllAsync };
+    },
+  },
+}));
+
+jest.mock('@/lib/services/form-session-history', () => ({
+  getFormSessionHistory: (...args: unknown[]) => mockGetFormSessionHistory(...args),
+}));
+
+jest.mock('@/lib/services/form-session-history-lookup', () => ({
+  resolveExerciseKey: (...args: unknown[]) => mockResolveExerciseKey(...args),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  warnWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+  logWithTs: jest.fn(),
+}));
+
+import {
+  buildWorkoutRecallContext,
+  buildWorkoutRecallPrompt,
+} from '@/lib/services/coach-workout-recall';
+
+describe('coach-workout-recall', () => {
+  beforeEach(() => {
+    mockGetAllAsync.mockReset();
+    mockGetFormSessionHistory.mockReset();
+    mockResolveExerciseKey.mockReset();
+    mockResolveExerciseKey.mockReturnValue('pullup');
+    mockGetFormSessionHistory.mockResolvedValue([]);
+  });
+
+  describe('buildWorkoutRecallContext', () => {
+    it('returns empty context when workoutId is empty', async () => {
+      const ctx = await buildWorkoutRecallContext('');
+      expect(ctx.found).toBe(false);
+      expect(ctx.exerciseName).toBeNull();
+      expect(mockGetAllAsync).not.toHaveBeenCalled();
+    });
+
+    it('returns empty context when workout row is not found', async () => {
+      mockGetAllAsync.mockResolvedValueOnce([]);
+      const ctx = await buildWorkoutRecallContext('missing-id');
+      expect(ctx.found).toBe(false);
+      expect(ctx.workoutId).toBe('missing-id');
+      expect(ctx.exerciseName).toBeNull();
+    });
+
+    it('returns empty context when db query throws', async () => {
+      mockGetAllAsync.mockRejectedValueOnce(new Error('db err'));
+      const ctx = await buildWorkoutRecallContext('id-x');
+      expect(ctx.found).toBe(false);
+    });
+
+    it('assembles structured context when workout row exists', async () => {
+      mockGetAllAsync.mockResolvedValueOnce([
+        {
+          id: 'w-1',
+          exercise: 'Pull-Up',
+          sets: 5,
+          reps: 8,
+          weight: 0,
+          duration: null,
+          date: '2026-04-15T10:00:00.000Z',
+        },
+      ]);
+      mockGetFormSessionHistory.mockResolvedValueOnce([
+        { exerciseKey: 'pullup', avgFqi: 82.4, endedAt: '2026-04-14T12:00:00.000Z' },
+        { exerciseKey: 'pullup', avgFqi: 74, endedAt: '2026-04-07T12:00:00.000Z' },
+      ]);
+
+      const ctx = await buildWorkoutRecallContext('w-1');
+      expect(ctx.found).toBe(true);
+      expect(ctx.exerciseName).toBe('Pull-Up');
+      expect(ctx.sets).toBe(5);
+      expect(ctx.reps).toBe(8);
+      expect(ctx.dateIso).toBe('2026-04-15T10:00:00.000Z');
+      expect(ctx.latestFormEntry?.avgFqi).toBe(82.4);
+    });
+
+    it('leaves latestFormEntry null when no exercise key resolves', async () => {
+      mockGetAllAsync.mockResolvedValueOnce([
+        { id: 'w-2', exercise: 'Weird Exotic Lift', sets: 3, reps: 5, weight: null, duration: null, date: '2026-04-15' },
+      ]);
+      mockResolveExerciseKey.mockReturnValueOnce(null);
+
+      const ctx = await buildWorkoutRecallContext('w-2');
+      expect(ctx.found).toBe(true);
+      expect(ctx.latestFormEntry).toBeNull();
+      expect(mockGetFormSessionHistory).not.toHaveBeenCalled();
+    });
+
+    it('leaves latestFormEntry null when form-history lookup throws', async () => {
+      mockGetAllAsync.mockResolvedValueOnce([
+        { id: 'w-3', exercise: 'Pull-Up', sets: 2, reps: 10, weight: null, duration: null, date: '2026-04-15' },
+      ]);
+      mockGetFormSessionHistory.mockRejectedValueOnce(new Error('storage err'));
+
+      const ctx = await buildWorkoutRecallContext('w-3');
+      expect(ctx.found).toBe(true);
+      expect(ctx.latestFormEntry).toBeNull();
+    });
+
+    it('defaults sets to 0 when the db returns NaN / missing', async () => {
+      mockGetAllAsync.mockResolvedValueOnce([
+        { id: 'w-4', exercise: 'Pull-Up', sets: Number.NaN, reps: null, weight: null, duration: null, date: '2026-04-15' },
+      ]);
+      const ctx = await buildWorkoutRecallContext('w-4');
+      expect(ctx.sets).toBe(0);
+    });
+  });
+
+  describe('buildWorkoutRecallPrompt', () => {
+    it('emits a fallback prompt when context was not found', () => {
+      const prompt = buildWorkoutRecallPrompt({
+        workoutId: 'missing',
+        found: false,
+        exerciseName: null,
+        dateIso: null,
+        sets: 0,
+        reps: null,
+        weight: null,
+        durationMinutes: null,
+        latestFormEntry: null,
+      });
+      expect(prompt).toMatch(/can't find it/i);
+      expect(prompt).toMatch(/what i remember/i);
+    });
+
+    it('includes exercise, sets, reps, weight, and FQI when present', () => {
+      const prompt = buildWorkoutRecallPrompt({
+        workoutId: 'w-1',
+        found: true,
+        exerciseName: 'Pull-Up',
+        dateIso: '2026-04-15T10:00:00.000Z',
+        sets: 5,
+        reps: 8,
+        weight: 25,
+        durationMinutes: null,
+        latestFormEntry: {
+          exerciseKey: 'pullup',
+          avgFqi: 82.4,
+          endedAt: '2026-04-14T12:00:00.000Z',
+        },
+      });
+      expect(prompt).toContain('Pull-Up');
+      expect(prompt).toContain('5 sets');
+      expect(prompt).toContain('8 reps each');
+      expect(prompt).toContain('25 lb');
+      expect(prompt).toContain('82');
+    });
+
+    it('collapses missing optional stats cleanly', () => {
+      const prompt = buildWorkoutRecallPrompt({
+        workoutId: 'w-1',
+        found: true,
+        exerciseName: 'Pull-Up',
+        dateIso: '2026-04-15T10:00:00.000Z',
+        sets: 3,
+        reps: null,
+        weight: null,
+        durationMinutes: null,
+        latestFormEntry: null,
+      });
+      expect(prompt).toContain('Pull-Up');
+      expect(prompt).toContain('3 sets');
+      expect(prompt).not.toMatch(/\blb\b/);
+      expect(prompt).not.toMatch(/reps each/);
+      expect(prompt).toMatch(/no tracked form-quality data/i);
+    });
+
+    it('uses singular "set" for sets=1', () => {
+      const prompt = buildWorkoutRecallPrompt({
+        workoutId: 'w-1',
+        found: true,
+        exerciseName: 'Pull-Up',
+        dateIso: '2026-04-15T10:00:00.000Z',
+        sets: 1,
+        reps: null,
+        weight: null,
+        durationMinutes: null,
+        latestFormEntry: null,
+      });
+      expect(prompt).toContain('1 set.');
+      expect(prompt).not.toContain('1 sets');
+    });
+
+    it('falls back to "an earlier day" when dateIso is null or invalid', () => {
+      const prompt = buildWorkoutRecallPrompt({
+        workoutId: 'w-1',
+        found: true,
+        exerciseName: 'Pull-Up',
+        dateIso: null,
+        sets: 3,
+        reps: null,
+        weight: null,
+        durationMinutes: null,
+        latestFormEntry: null,
+      });
+      expect(prompt).toContain('an earlier day');
+    });
+
+    it('ends with an explicit ask', () => {
+      const prompt = buildWorkoutRecallPrompt({
+        workoutId: 'w-1',
+        found: true,
+        exerciseName: 'Pull-Up',
+        dateIso: '2026-04-15',
+        sets: 3,
+        reps: 8,
+        weight: null,
+        durationMinutes: null,
+        latestFormEntry: null,
+      });
+      expect(prompt).toMatch(/debrief|what to work on next/i);
+    });
+  });
+});

--- a/tests/unit/services/workout-coach-recall-flag.test.ts
+++ b/tests/unit/services/workout-coach-recall-flag.test.ts
@@ -1,0 +1,51 @@
+import { isWorkoutCoachRecallEnabled } from '@/lib/services/workout-coach-recall-flag';
+
+const FLAG_ENV_VAR = 'EXPO_PUBLIC_WORKOUT_COACH_RECALL';
+
+describe('workout-coach-recall-flag', () => {
+  const originalValue = process.env[FLAG_ENV_VAR];
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env[FLAG_ENV_VAR];
+    } else {
+      process.env[FLAG_ENV_VAR] = originalValue;
+    }
+  });
+
+  it('returns false when flag is unset', () => {
+    delete process.env[FLAG_ENV_VAR];
+    expect(isWorkoutCoachRecallEnabled()).toBe(false);
+  });
+
+  it('returns true when flag is "1"', () => {
+    process.env[FLAG_ENV_VAR] = '1';
+    expect(isWorkoutCoachRecallEnabled()).toBe(true);
+  });
+
+  it('returns true when flag is "true"', () => {
+    process.env[FLAG_ENV_VAR] = 'true';
+    expect(isWorkoutCoachRecallEnabled()).toBe(true);
+  });
+
+  it('returns false for adjacent truthy-looking strings (strict parse)', () => {
+    for (const value of ['on', 'yes', 'TRUE', 'True', 'enabled', '2', 'T', '']) {
+      process.env[FLAG_ENV_VAR] = value;
+      expect(isWorkoutCoachRecallEnabled()).toBe(false);
+    }
+  });
+
+  it('returns false for whitespace-padded accepted values', () => {
+    for (const value of [' 1 ', ' true ', '1 ', ' true']) {
+      process.env[FLAG_ENV_VAR] = value;
+      expect(isWorkoutCoachRecallEnabled()).toBe(false);
+    }
+  });
+
+  it('returns false for "0" and "false"', () => {
+    for (const value of ['0', 'false', 'off', 'no']) {
+      process.env[FLAG_ENV_VAR] = value;
+      expect(isWorkoutCoachRecallEnabled()).toBe(false);
+    }
+  });
+});

--- a/tests/unit/services/workout-insights-fqi-bands.test.ts
+++ b/tests/unit/services/workout-insights-fqi-bands.test.ts
@@ -1,0 +1,55 @@
+import { getFqiBand } from '@/lib/services/workout-insights-fqi-bands';
+
+describe('workout-insights-fqi-bands', () => {
+  describe('getFqiBand', () => {
+    it('returns "unknown" for null/undefined/NaN', () => {
+      expect(getFqiBand(null).band).toBe('unknown');
+      expect(getFqiBand(undefined).band).toBe('unknown');
+      expect(getFqiBand(Number.NaN).band).toBe('unknown');
+      expect(getFqiBand(null).label).toBe('Not available');
+    });
+
+    it('returns "excellent" for scores >= 85', () => {
+      expect(getFqiBand(100).band).toBe('excellent');
+      expect(getFqiBand(85).band).toBe('excellent');
+      expect(getFqiBand(85).label).toBe('Excellent');
+    });
+
+    it('returns "good" for scores in [70, 85)', () => {
+      expect(getFqiBand(84.9).band).toBe('good');
+      expect(getFqiBand(70).band).toBe('good');
+      expect(getFqiBand(75).label).toBe('Good');
+    });
+
+    it('returns "fair" for scores in [50, 70)', () => {
+      expect(getFqiBand(69.9).band).toBe('fair');
+      expect(getFqiBand(50).band).toBe('fair');
+      expect(getFqiBand(60).label).toBe('Fair');
+    });
+
+    it('returns "poor" for scores < 50', () => {
+      expect(getFqiBand(49.9).band).toBe('poor');
+      expect(getFqiBand(0).band).toBe('poor');
+      expect(getFqiBand(25).label).toBe('Poor');
+    });
+
+    it('includes a color for each band', () => {
+      expect(getFqiBand(90).color).toMatch(/^#/);
+      expect(getFqiBand(75).color).toMatch(/^#/);
+      expect(getFqiBand(60).color).toMatch(/^#/);
+      expect(getFqiBand(25).color).toMatch(/^#/);
+      expect(getFqiBand(null).color).toMatch(/^#/);
+    });
+
+    it('handles edge cases at band boundaries', () => {
+      // Exactly 85 → excellent
+      expect(getFqiBand(85).band).toBe('excellent');
+      // Exactly 70 → good
+      expect(getFqiBand(70).band).toBe('good');
+      // Exactly 50 → fair
+      expect(getFqiBand(50).band).toBe('fair');
+      // 49.9 → poor
+      expect(getFqiBand(49.9).band).toBe('poor');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Large-scoped wave-25 PR-α. Bundles 4 workouts-tab UX polish gaps with a
Gemma-powered retrospective chat. All new user-visible wiring is gated
behind a single master flag.

**Master flag: `EXPO_PUBLIC_WORKOUT_COACH_RECALL`** (default off,
strict accept on `1` or `true`). When the flag is off the app behaves
exactly as before: the new modal is not reachable from any row, the
`AskCoachCTA` on workout rows is not mounted, and the new service is
not called.

### What's in the bundle

Linked to the findings in
`docs/overnight/worklog-2026-04-20-form-ux-gemma.md`:

- **GAP-1** — `EmptySessionState` on `app/(modals)/session-history.tsx`.
- **GAP-7** — `FormQualityBadgeRow` with a "Track form to unlock" empty
  state on `app/(tabs)/workouts.tsx`.
- **GAP-4** — FQI label bands (Excellent / Good / Fair / Poor) under
  the numeric FQI in `app/(modals)/workout-insights.tsx`.
- **GAP-6** — Inline export retry banner (with original error text)
  on `app/(modals)/rep-insights.tsx`.
- **INT-1** — New `lib/services/coach-workout-recall.ts` assembles a
  retrospective context from local-db + form-session-history.
- **GEMMA-5** — `AskCoachCTA` now mounts on each workout row (flag on)
  and routes to the new `workout-debrief-chat` modal.

### Files touched

- New: `lib/services/workout-coach-recall-flag.ts`,
  `lib/services/coach-workout-recall.ts`,
  `lib/services/workout-insights-fqi-bands.ts`,
  `hooks/use-workout-coach-context.ts`,
  `components/form-tracking/EmptySessionState.tsx`,
  `components/workouts/FormQualityBadgeRow.tsx`,
  `app/(modals)/workout-debrief-chat.tsx`
- Edited: `app/(modals)/_layout.tsx`,
  `app/(modals)/session-history.tsx`,
  `app/(modals)/workout-insights.tsx`,
  `app/(modals)/rep-insights.tsx`,
  `app/(tabs)/workouts.tsx`,
  `components/form-tracking/AskCoachCTA.tsx` (additive `onPress` + `label`
  props; existing consumer `app/(modals)/form-tracking-debrief.tsx` is
  unchanged and still uses the default coach-tab navigation),
  `.env.example`
- Read-only import from `lib/services/coach-service.ts` (`sendCoachPrompt`
  only — file not edited)

### Zero overlap with in-flight PRs #505-512

Per the non-overlap matrix in the worklog, none of the files edited
here are on any open PR's write set:
- PR #505 owns `app/(tabs)/scan-arkit.tsx` — not touched.
- PR #510 edits `lib/services/coach-service.ts` — imported only, not edited.
- PR #511 edits `app/(tabs)/coach.tsx` — not touched.
- PR #512 edits `lib/services/coach-drill-explainer.ts` — not imported.
- PRs #506-509 — non-overlapping surfaces.

The 12 commits in this branch map 1:1 to the 12 sub-tasks of the
wave-25 plan; no gold-plating beyond the listed deliverables.

### How to verify

```bash
# 1. Lint + types
bun run lint
bun run check:types

# 2. New suite (45+ tests, 9 suites)
bun run test -- --testPathPattern="(coach-workout-recall|workout-coach-recall|use-workout-coach-context|workout-debrief-chat|form-quality-badge-row|empty-session-state|rep-export|workout-insights-fqi-bands)"

# 3. Smoke the flag-off path (default)
#    - Workouts tab row: no AskCoachCTA, existing FormQualityBadge unchanged
#      for tracked exercises, new 'Track form to unlock' pill shown for
#      untracked ones.
#    - Deep-link to /(modals)/workout-debrief-chat?workoutId=... → renders
#      'Feature disabled' fallback card.

# 4. Flip the flag
export EXPO_PUBLIC_WORKOUT_COACH_RECALL=1
bun run start
#    - Workouts tab row: 'Ask Gemma about this workout' CTA appears.
#    - Tap → workout-debrief-chat modal, first bubble streams with the
#      recall context.
#    - Type a follow-up → askAboutWorkout is called with the trimmed text.

# 5. GAP touch-points
#    - session-history modal with empty history → EmptySessionState card.
#    - workout-insights modal → 'EXCELLENT' / 'GOOD' / 'FAIR' / 'POOR'
#      label under the avg FQI.
#    - rep-insights export → force a failure → banner with Retry + Dismiss
#      (original error text stays on screen).
```

### Notes

- `coach-service.ts` was read-only: the new hook imports `sendCoachPrompt`
  and `CoachMessage` but does not modify the file. Edits would have
  conflicted with PR #512.
- `AskCoachCTA` gained two optional props (`onPress`, `label`) that are
  strictly additive. The existing `form-tracking-debrief.tsx` call site
  does not pass them and retains its current navigation behavior.
- The workout-debrief-chat modal carries a small re-render fix: the
  first-message effect now reads askAboutWorkout through a ref so it
  does not retrigger if the hook return changes. This matches the real
  hook's stable-callback guarantee and is what the integration test
  exercises.