### PR TITLE
feat(form-tracking): wave-25 fault-drills + pre-session warmup coach (Gemma)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,16 @@ EXPO_PUBLIC_COACH_MEMORY=true
 # finishSession triggers a coach-authored debrief via the auto-debrief hook.
 EXPO_PUBLIC_COACH_AUTO_DEBRIEF_ENABLED=true
 
+# Fault-heatmap Gemma drill CTA (wave 25 PR-β). When '1' or 'true', the
+# fault-heatmap modal renders an "Ask Gemma for drills" CTA that routes
+# persistent-fault context through `coach-drill-explainer`. Default off.
+EXPO_PUBLIC_FAULT_DRILL_GEMMA=
+
+# Pre-session warmup coach (wave 25 PR-β). When '1' or 'true', the
+# generate-session modal surfaces a "Warm up with coach" CTA that opens
+# the `session-warmup-coach` modal backed by `warmup-generator`. Default off.
+EXPO_PUBLIC_WARMUP_COACH=
+
 # ElevenLabs TTS (optional — voice coaching)
 ELEVENLABS_API_KEY=
 ELEVENLABS_VOICE_ID=

--- a/app/(modals)/_layout.tsx
+++ b/app/(modals)/_layout.tsx
@@ -102,6 +102,14 @@ export default function ModalsLayout() {
           contentStyle: { backgroundColor: '#050E1F' },
         }}
       />
+      <Stack.Screen
+        name="session-warmup-coach"
+        options={{
+          presentation: 'modal',
+          gestureEnabled: true,
+          contentStyle: { backgroundColor: '#050E1F' },
+        }}
+      />
     </Stack>
   );
 }

--- a/app/(modals)/fault-heatmap.tsx
+++ b/app/(modals)/fault-heatmap.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  ActivityIndicator,
   ScrollView,
   StyleSheet,
   Text,
@@ -10,32 +11,88 @@ import { Ionicons } from '@expo/vector-icons';
 import { Stack, useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { FaultHeatmapThumb, type FaultCell } from '@/components/form-home/FaultHeatmapThumb';
+import {
+  loadFaultHeatmapData,
+  type FaultHeatmapSnapshot,
+} from '@/lib/services/fault-heatmap-data-loader';
+
+interface HeatmapDataState {
+  cells: FaultCell[];
+  days: string[];
+  loading: boolean;
+  error: Error | null;
+  lastSessionId: string | null;
+}
+
+function fallbackDays(now: Date): string[] {
+  const days: string[] = [];
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(now);
+    d.setDate(now.getDate() - i);
+    days.push(`${d.getMonth() + 1}/${d.getDate()}`);
+  }
+  return days;
+}
+
+/**
+ * Internal hook that binds `loadFaultHeatmapData` to the modal. Kept
+ * module-local so the modal owns its lifecycle — if another surface
+ * later wants this data, it should pull from `use-persistent-fault-summary`
+ * instead, which layers aggregation + gating on top.
+ */
+function useHeatmapData(): HeatmapDataState & { refresh: () => void } {
+  const [state, setState] = useState<HeatmapDataState>(() => ({
+    cells: [],
+    days: fallbackDays(new Date()),
+    loading: true,
+    error: null,
+    lastSessionId: null,
+  }));
+
+  const run = useCallback(async () => {
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+    try {
+      const snapshot: FaultHeatmapSnapshot = await loadFaultHeatmapData();
+      setState({
+        cells: snapshot.cells,
+        days: snapshot.days,
+        loading: false,
+        error: null,
+        lastSessionId: snapshot.lastSessionId,
+      });
+    } catch (err) {
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        error: err instanceof Error ? err : new Error('Fault heatmap load failed'),
+      }));
+    }
+  }, []);
+
+  useEffect(() => {
+    void run();
+  }, [run]);
+
+  return { ...state, refresh: () => void run() };
+}
 
 /**
  * Full-screen fault heatmap modal (issue #470).
  *
- * Intentionally data-light: reads synthetic placeholder data locally so it
- * renders without coupling to the form-home data hook. Future PRs can wire
- * it to `useFormHomeData` via route params or context.
+ * Loads the real 7-day fault aggregation via `fault-heatmap-data-loader`.
+ * The loader returns an empty snapshot (not an error) when the user
+ * has no form-tracking reps in the horizon, so the empty-state copy
+ * from `FaultHeatmapThumb` stays the natural fallback.
  */
 export default function FaultHeatmapModal() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
+  const { cells, days, loading, error, refresh } = useHeatmapData();
 
-  const { cells, days } = useMemo(() => {
-    const today = new Date();
-    const d: string[] = [];
-    for (let i = 6; i >= 0; i--) {
-      const copy = new Date(today);
-      copy.setDate(today.getDate() - i);
-      d.push(`${copy.getMonth() + 1}/${copy.getDate()}`);
-    }
-    // Lightweight placeholder fault data — real data is injected by the
-    // form-home hook in a future PR; the route still needs to render
-    // deterministically when opened standalone.
-    const placeholder: FaultCell[] = [];
-    return { cells: placeholder, days: d };
-  }, []);
+  const displayDays = useMemo(
+    () => (days.length > 0 ? days : fallbackDays(new Date())),
+    [days],
+  );
 
   return (
     <View style={[styles.root, { paddingTop: insets.top + 8 }]}>
@@ -54,7 +111,27 @@ export default function FaultHeatmapModal() {
         <View style={styles.closeButton} />
       </View>
       <ScrollView contentContainerStyle={styles.scrollContent}>
-        <FaultHeatmapThumb cells={cells} days={days} />
+        {loading ? (
+          <View style={styles.centerBlock} testID="fault-heatmap-loading">
+            <ActivityIndicator color="#4C8CFF" />
+            <Text style={styles.loadingLabel}>Loading your faults…</Text>
+          </View>
+        ) : error ? (
+          <View style={styles.centerBlock} testID="fault-heatmap-error">
+            <Text style={styles.errorLabel}>Couldn’t load your faults.</Text>
+            <TouchableOpacity
+              accessibilityRole="button"
+              accessibilityLabel="Retry loading fault heatmap"
+              onPress={refresh}
+              style={styles.retryButton}
+              testID="fault-heatmap-retry"
+            >
+              <Text style={styles.retryText}>Retry</Text>
+            </TouchableOpacity>
+          </View>
+        ) : (
+          <FaultHeatmapThumb cells={cells} days={displayDays} />
+        )}
         <Text style={styles.legendTitle}>How to read this</Text>
         <Text style={styles.legendBody}>
           Each row is one of your top three detected faults over the last
@@ -92,6 +169,32 @@ const styles = StyleSheet.create({
   scrollContent: {
     gap: 16,
     paddingBottom: 40,
+  },
+  centerBlock: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    paddingVertical: 40,
+  },
+  loadingLabel: {
+    color: '#97A3C2',
+    fontSize: 13,
+  },
+  errorLabel: {
+    color: '#FF6B6B',
+    fontSize: 13,
+  },
+  retryButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#4C8CFF',
+  },
+  retryText: {
+    color: '#4C8CFF',
+    fontSize: 13,
+    fontWeight: '500',
   },
   legendTitle: {
     color: '#F5F7FF',

--- a/app/(modals)/fault-heatmap.tsx
+++ b/app/(modals)/fault-heatmap.tsx
@@ -15,6 +15,12 @@ import {
   loadFaultHeatmapData,
   type FaultHeatmapSnapshot,
 } from '@/lib/services/fault-heatmap-data-loader';
+import {
+  explainDrill,
+  type DrillFaultInput,
+  type ExplainDrillResult,
+} from '@/lib/services/coach-drill-explainer';
+import { usePersistentFaultSummary } from '@/hooks/use-persistent-fault-summary';
 
 interface HeatmapDataState {
   cells: FaultCell[];
@@ -24,6 +30,11 @@ interface HeatmapDataState {
   lastSessionId: string | null;
 }
 
+type DrillCardState =
+  | { status: 'loading' }
+  | { status: 'ready'; explanation: string; provider: string }
+  | { status: 'error'; message: string };
+
 function fallbackDays(now: Date): string[] {
   const days: string[] = [];
   for (let i = 6; i >= 0; i--) {
@@ -32,6 +43,23 @@ function fallbackDays(now: Date): string[] {
     days.push(`${d.getMonth() + 1}/${d.getDate()}`);
   }
   return days;
+}
+
+/**
+ * Build a minimal drill-request payload for a single persistent fault.
+ * The drill fields are generic placeholders — we don't have a concrete
+ * drill attached to the fault here; the model just needs something to
+ * anchor the explanation around the fault itself. Keeps the prompt
+ * well-formed without pretending we've selected a specific exercise.
+ */
+function buildDrillPayloadForFault(fault: DrillFaultInput) {
+  return {
+    drillTitle: 'Targeted form drill',
+    drillCategory: 'technique',
+    drillWhy: `Address persistent ${fault.displayName ?? fault.code} over the last 7 days.`,
+    exerciseId: 'form-tracking',
+    faults: [fault],
+  };
 }
 
 /**
@@ -83,16 +111,63 @@ function useHeatmapData(): HeatmapDataState & { refresh: () => void } {
  * The loader returns an empty snapshot (not an error) when the user
  * has no form-tracking reps in the horizon, so the empty-state copy
  * from `FaultHeatmapThumb` stays the natural fallback.
+ *
+ * When `EXPO_PUBLIC_FAULT_DRILL_GEMMA` is on AND the user has >=1
+ * persistent fault, an "Ask Gemma for drills" CTA renders below the
+ * heatmap. Tapping fans `coach-drill-explainer.explainDrill` out to
+ * each top fault and expands an inline section with the returned
+ * drill rationales.
  */
 export default function FaultHeatmapModal() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { cells, days, loading, error, refresh } = useHeatmapData();
+  const {
+    topFaults,
+    enabled: drillFlagEnabled,
+    loading: drillLoading,
+  } = usePersistentFaultSummary();
+
+  const [drillResults, setDrillResults] = useState<Record<string, DrillCardState>>({});
+  const [drillFetchInFlight, setDrillFetchInFlight] = useState(false);
 
   const displayDays = useMemo(
     () => (days.length > 0 ? days : fallbackDays(new Date())),
     [days],
   );
+
+  const handleAskGemma = useCallback(async () => {
+    if (!drillFlagEnabled || topFaults.length === 0 || drillFetchInFlight) return;
+    setDrillFetchInFlight(true);
+
+    const seeded: Record<string, DrillCardState> = {};
+    for (const fault of topFaults) seeded[fault.code] = { status: 'loading' };
+    setDrillResults(seeded);
+
+    const settled = await Promise.all(
+      topFaults.map(async (fault): Promise<[string, DrillCardState]> => {
+        try {
+          const result: ExplainDrillResult = await explainDrill(buildDrillPayloadForFault(fault));
+          if (result.error || !result.explanation) {
+            return [fault.code, { status: 'error', message: result.error ?? 'Empty response' }];
+          }
+          return [
+            fault.code,
+            { status: 'ready', explanation: result.explanation, provider: result.provider },
+          ];
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Unknown error';
+          return [fault.code, { status: 'error', message }];
+        }
+      }),
+    );
+
+    setDrillResults(Object.fromEntries(settled));
+    setDrillFetchInFlight(false);
+  }, [drillFlagEnabled, topFaults, drillFetchInFlight]);
+
+  const showDrillCta = drillFlagEnabled && !drillLoading && topFaults.length > 0;
+  const hasAnyDrillResult = Object.keys(drillResults).length > 0;
 
   return (
     <View style={[styles.root, { paddingTop: insets.top + 8 }]}>
@@ -132,6 +207,59 @@ export default function FaultHeatmapModal() {
         ) : (
           <FaultHeatmapThumb cells={cells} days={displayDays} />
         )}
+
+        {showDrillCta && (
+          <TouchableOpacity
+            accessibilityRole="button"
+            accessibilityLabel="Ask Gemma for drills targeting your top faults"
+            onPress={handleAskGemma}
+            disabled={drillFetchInFlight}
+            style={[styles.ctaButton, drillFetchInFlight && styles.ctaButtonBusy]}
+            testID="fault-heatmap-ask-gemma"
+          >
+            {drillFetchInFlight ? (
+              <ActivityIndicator color="#F5F7FF" />
+            ) : (
+              <>
+                <Ionicons name="sparkles" size={16} color="#F5F7FF" />
+                <Text style={styles.ctaText}>
+                  {hasAnyDrillResult ? 'Ask Gemma again' : 'Ask Gemma for drills'}
+                </Text>
+              </>
+            )}
+          </TouchableOpacity>
+        )}
+
+        {hasAnyDrillResult && (
+          <View style={styles.drillSheet} testID="fault-heatmap-drill-sheet">
+            <Text style={styles.drillSheetTitle}>Drill rationales</Text>
+            {topFaults.map((fault) => {
+              const card = drillResults[fault.code];
+              return (
+                <View
+                  key={fault.code}
+                  style={styles.drillCard}
+                  testID={`fault-heatmap-drill-${fault.code}`}
+                >
+                  <Text style={styles.drillCardTitle}>
+                    {fault.displayName ?? fault.code} · {fault.count}×
+                  </Text>
+                  {!card || card.status === 'loading' ? (
+                    <View style={styles.drillCardRow}>
+                      <ActivityIndicator color="#4C8CFF" size="small" />
+                      <Text style={styles.drillCardBody}>Finding a drill for you…</Text>
+                    </View>
+                  ) : card.status === 'error' ? (
+                    <Text style={styles.drillCardError}>{card.message}</Text>
+                  ) : (
+                    <Text style={styles.drillCardBody}>{card.explanation}</Text>
+                  )}
+                </View>
+              );
+            })}
+          </View>
+        )}
+
         <Text style={styles.legendTitle}>How to read this</Text>
         <Text style={styles.legendBody}>
           Each row is one of your top three detected faults over the last
@@ -195,6 +323,62 @@ const styles = StyleSheet.create({
     color: '#4C8CFF',
     fontSize: 13,
     fontWeight: '500',
+  },
+  ctaButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderRadius: 12,
+    backgroundColor: '#4C8CFF',
+  },
+  ctaButtonBusy: {
+    opacity: 0.7,
+  },
+  ctaText: {
+    color: '#F5F7FF',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  drillSheet: {
+    gap: 8,
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: 'rgba(15, 35, 57, 0.85)',
+    borderWidth: 1,
+    borderColor: 'rgba(27, 46, 74, 0.6)',
+  },
+  drillSheetTitle: {
+    color: '#F5F7FF',
+    fontSize: 13,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  drillCard: {
+    gap: 4,
+    paddingVertical: 6,
+  },
+  drillCardTitle: {
+    color: '#F5F7FF',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  drillCardBody: {
+    color: '#97A3C2',
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  drillCardRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  drillCardError: {
+    color: '#FF6B6B',
+    fontSize: 12,
   },
   legendTitle: {
     color: '#F5F7FF',

--- a/app/(modals)/generate-session.tsx
+++ b/app/(modals)/generate-session.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/lib/services/session-generator-fallback';
 import { localDB } from '@/lib/services/database/local-db';
 import { genericLocalUpsert } from '@/lib/services/database/generic-sync';
+import { isWarmupCoachFlowEnabled } from '@/lib/services/coach-warmup-provider';
 import type { Exercise, GoalProfile } from '@/lib/types/workout-session';
 import type { HydratedTemplate } from '@/lib/services/session-generator';
 
@@ -136,6 +137,12 @@ export default function GenerateSessionScreen() {
     runtime: { userId, maxRetries: 1 },
   });
 
+  // Capture the last successfully persisted template id so the warmup CTA
+  // survives after the user navigates to the builder and back. Separate
+  // from `result` because the generator hook may reset on subsequent calls.
+  const [lastTemplateId, setLastTemplateId] = useState<string | null>(null);
+  const warmupCoachEnabled = isWarmupCoachFlowEnabled();
+
   const availableSlugsPromise = useMemo(async () => {
     const db = localDB.db;
     if (!db) return [];
@@ -159,6 +166,7 @@ export default function GenerateSessionScreen() {
     });
     if (hydrated) {
       await persistHydrated(hydrated);
+      setLastTemplateId(hydrated.template.id);
       await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       router.replace(`/(modals)/template-builder?templateId=${hydrated.template.id}` as never);
     }
@@ -170,9 +178,17 @@ export default function GenerateSessionScreen() {
       () => getSessionFallback({}, { userId }),
     );
     await persistHydrated(hydrated);
+    setLastTemplateId(hydrated.template.id);
     await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
     router.replace(`/(modals)/template-builder?templateId=${hydrated.template.id}` as never);
   }, [goalProfile, durationMin, userId, router]);
+
+  const handleWarmupCoach = useCallback(() => {
+    if (!lastTemplateId) return;
+    router.push(
+      `/(modals)/session-warmup-coach?sessionId=${encodeURIComponent(lastTemplateId)}` as never,
+    );
+  }, [lastTemplateId, router]);
 
   const handleClose = useCallback(() => {
     reset();
@@ -292,6 +308,19 @@ export default function GenerateSessionScreen() {
               {result.raw.exercises.length} exercises · {result.raw.goal_profile}
             </Text>
           </View>
+        )}
+
+        {warmupCoachEnabled && lastTemplateId && !loading && (
+          <TouchableOpacity
+            onPress={handleWarmupCoach}
+            style={styles.warmupCta}
+            accessibilityRole="button"
+            accessibilityLabel="Warm up with coach for this session"
+            testID="generate-session-warmup-cta"
+          >
+            <Ionicons name="flame-outline" size={18} color={tabColors.accent} />
+            <Text style={styles.warmupCtaText}>Warm up with coach</Text>
+          </TouchableOpacity>
         )}
       </ScrollView>
     </SafeAreaView>
@@ -429,5 +458,22 @@ const styles = StyleSheet.create({
     fontFamily: 'Lexend_500Medium',
     color: tabColors.accent,
     marginTop: 8,
+  },
+  warmupCta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    marginTop: 12,
+    paddingVertical: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: tabColors.accent,
+    backgroundColor: 'rgba(76, 140, 255, 0.12)',
+  },
+  warmupCtaText: {
+    fontSize: 14,
+    fontFamily: 'Lexend_700Bold',
+    color: tabColors.accent,
   },
 });

--- a/app/(modals)/session-warmup-coach.tsx
+++ b/app/(modals)/session-warmup-coach.tsx
@@ -1,0 +1,460 @@
+/**
+ * SessionWarmupCoachScreen
+ *
+ * Pre-session warmup coach modal. Opens from `generate-session` when
+ * `EXPO_PUBLIC_WARMUP_COACH` is on. Takes a `sessionId` (the locally
+ * persisted `workout_templates.id` produced by the session generator)
+ * and builds a warmup plan via `usePreSessionCoach`.
+ *
+ * Intentionally lightweight: no local DB caching of the plan, no
+ * analytics. This is an exploratory surface — we want the user to be
+ * able to re-roll freely before committing.
+ */
+import { Ionicons } from '@expo/vector-icons';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { localDB } from '@/lib/services/database/local-db';
+import { usePreSessionCoach } from '@/hooks/use-pre-session-coach';
+import type { SessionTemplateLike, WarmupMovement } from '@/lib/services/coach-warmup-provider';
+import { tabColors } from '@/styles/tabs/_tab-theme';
+
+interface TemplateRow {
+  id: string;
+  name: string | null;
+}
+
+interface TemplateExerciseRow {
+  exercise_name: string | null;
+  sort_order: number | null;
+}
+
+interface ResolvedTemplate {
+  sessionId: string;
+  name: string;
+  exerciseNames: string[];
+}
+
+async function loadTemplate(sessionId: string): Promise<ResolvedTemplate | null> {
+  const db = localDB.db;
+  if (!db) return null;
+
+  const templateRows = await db.getAllAsync<TemplateRow>(
+    'SELECT id, name FROM workout_templates WHERE id = ? LIMIT 1',
+    sessionId,
+  );
+  if (templateRows.length === 0) return null;
+  const template = templateRows[0];
+
+  const exerciseRows = await db.getAllAsync<TemplateExerciseRow>(
+    `SELECT e.name AS exercise_name, wte.sort_order AS sort_order
+     FROM workout_template_exercises wte
+     JOIN exercises e ON e.id = wte.exercise_id
+     WHERE wte.template_id = ?
+     ORDER BY wte.sort_order ASC`,
+    sessionId,
+  );
+
+  const exerciseNames = exerciseRows
+    .map((r) => r.exercise_name)
+    .filter((n): n is string => typeof n === 'string' && n.length > 0);
+
+  return {
+    sessionId,
+    name: template.name ?? 'Session',
+    exerciseNames,
+  };
+}
+
+function formatMovementMeta(mv: WarmupMovement): string {
+  const parts: string[] = [];
+  if (typeof mv.reps === 'number') parts.push(`${mv.reps} reps`);
+  if (typeof mv.duration_seconds === 'number') parts.push(`${mv.duration_seconds}s`);
+  parts.push(mv.focus);
+  parts.push(mv.intensity);
+  return parts.join(' · ');
+}
+
+export default function SessionWarmupCoachScreen(): React.ReactElement {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ sessionId?: string | string[] }>();
+  const sessionId = useMemo(() => {
+    const raw = params.sessionId;
+    if (Array.isArray(raw)) return raw[0] ?? null;
+    return raw ?? null;
+  }, [params.sessionId]);
+
+  const [template, setTemplate] = useState<ResolvedTemplate | null>(null);
+  const [templateError, setTemplateError] = useState<Error | null>(null);
+  const [templateLoading, setTemplateLoading] = useState<boolean>(!!sessionId);
+
+  const { warmup, loading, error, generateWarmup, enabled } = usePreSessionCoach();
+
+  // Resolve the template from local SQLite on mount.
+  useEffect(() => {
+    if (!sessionId) {
+      setTemplate(null);
+      setTemplateLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setTemplateLoading(true);
+    setTemplateError(null);
+    void (async () => {
+      try {
+        const resolved = await loadTemplate(sessionId);
+        if (cancelled) return;
+        setTemplate(resolved);
+        setTemplateLoading(false);
+      } catch (err) {
+        if (cancelled) return;
+        setTemplateError(err instanceof Error ? err : new Error('Template load failed'));
+        setTemplateLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  const handleGenerate = useCallback(async () => {
+    if (!template) return;
+    const input: SessionTemplateLike = {
+      exerciseSlugs: template.exerciseNames,
+    };
+    await generateWarmup(input);
+  }, [template, generateWarmup]);
+
+  const handleClose = useCallback(() => {
+    router.back();
+  }, [router]);
+
+  // Auto-kick off the first generation when the template is ready and
+  // nothing is on screen yet — saves the user one tap and matches the
+  // "warm up with coach" intent.
+  useEffect(() => {
+    if (!enabled) return;
+    if (!template) return;
+    if (warmup || loading || error) return;
+    void handleGenerate();
+  }, [enabled, template, warmup, loading, error, handleGenerate]);
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']} testID="session-warmup-coach">
+      <Stack.Screen options={{ headerShown: false }} />
+
+      <View style={styles.header}>
+        <TouchableOpacity
+          onPress={handleClose}
+          accessibilityRole="button"
+          accessibilityLabel="Close warmup coach"
+          testID="session-warmup-close"
+        >
+          <Ionicons name="close" size={22} color={tabColors.textPrimary} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Warm up with coach</Text>
+        <View style={{ width: 22 }} />
+      </View>
+
+      <ScrollView contentContainerStyle={styles.content}>
+        {!enabled ? (
+          <View style={styles.banner} testID="session-warmup-flag-off">
+            <Text style={styles.bannerText}>
+              Warmup coach is currently disabled. Ask your admin to enable the
+              EXPO_PUBLIC_WARMUP_COACH feature flag.
+            </Text>
+          </View>
+        ) : !sessionId ? (
+          <View style={styles.banner} testID="session-warmup-missing-session">
+            <Text style={styles.bannerText}>
+              No session selected. Reopen the generator and tap “Warm up with
+              coach” after choosing a template.
+            </Text>
+          </View>
+        ) : templateLoading ? (
+          <View style={styles.centerBlock} testID="session-warmup-loading-template">
+            <ActivityIndicator color={tabColors.accent} />
+            <Text style={styles.loadingText}>Loading session…</Text>
+          </View>
+        ) : templateError || !template ? (
+          <View style={styles.centerBlock} testID="session-warmup-template-error">
+            <Text style={styles.errorText}>
+              {templateError?.message ?? 'Could not find that session.'}
+            </Text>
+            <TouchableOpacity
+              onPress={handleClose}
+              style={styles.secondaryButton}
+              accessibilityRole="button"
+              accessibilityLabel="Back to generate session"
+            >
+              <Text style={styles.secondaryButtonText}>Back</Text>
+            </TouchableOpacity>
+          </View>
+        ) : (
+          <>
+            <Text style={styles.label}>Session</Text>
+            <Text style={styles.sessionName} testID="session-warmup-session-name">
+              {template.name}
+            </Text>
+            {template.exerciseNames.length > 0 && (
+              <Text style={styles.sessionMeta}>
+                {template.exerciseNames.join(' · ')}
+              </Text>
+            )}
+
+            {loading ? (
+              <View style={styles.centerBlock} testID="session-warmup-generating">
+                <ActivityIndicator color={tabColors.accent} />
+                <Text style={styles.loadingText}>
+                  Coach is building your warmup…
+                </Text>
+                {/* Skeleton rows — 3 placeholder lines so the layout doesn't pop */}
+                {[0, 1, 2].map((i) => (
+                  <View key={i} style={styles.skeletonRow} />
+                ))}
+              </View>
+            ) : error ? (
+              <View style={styles.errorCard} testID="session-warmup-error">
+                <Text style={styles.errorText}>
+                  {error.message || 'Warmup generation failed.'}
+                </Text>
+                <TouchableOpacity
+                  onPress={handleGenerate}
+                  style={styles.primaryButton}
+                  accessibilityRole="button"
+                  accessibilityLabel="Retry warmup generation"
+                  testID="session-warmup-retry"
+                >
+                  <Text style={styles.primaryButtonText}>Retry</Text>
+                </TouchableOpacity>
+              </View>
+            ) : warmup ? (
+              <View style={styles.warmupBlock} testID="session-warmup-plan">
+                <Text style={styles.warmupName}>{warmup.name}</Text>
+                <Text style={styles.warmupMeta}>{warmup.duration_min} min warmup</Text>
+                {warmup.movements.map((mv, idx) => (
+                  <View
+                    key={`${mv.name}-${idx}`}
+                    style={styles.movementRow}
+                    testID={`session-warmup-movement-${idx}`}
+                  >
+                    <View style={styles.movementNumber}>
+                      <Text style={styles.movementNumberText}>{idx + 1}</Text>
+                    </View>
+                    <View style={styles.movementBody}>
+                      <Text style={styles.movementName}>{mv.name}</Text>
+                      <Text style={styles.movementMeta}>{formatMovementMeta(mv)}</Text>
+                      {mv.notes && <Text style={styles.movementNotes}>{mv.notes}</Text>}
+                    </View>
+                  </View>
+                ))}
+
+                <TouchableOpacity
+                  onPress={handleGenerate}
+                  style={styles.secondaryButton}
+                  accessibilityRole="button"
+                  accessibilityLabel="Regenerate warmup"
+                  testID="session-warmup-regenerate"
+                >
+                  <Text style={styles.secondaryButtonText}>Try another warmup</Text>
+                </TouchableOpacity>
+              </View>
+            ) : (
+              <View style={styles.centerBlock} testID="session-warmup-idle">
+                <Text style={styles.loadingText}>Tap “Generate” to build a warmup.</Text>
+                <TouchableOpacity
+                  onPress={handleGenerate}
+                  style={styles.primaryButton}
+                  accessibilityRole="button"
+                  accessibilityLabel="Generate warmup"
+                  testID="session-warmup-generate"
+                >
+                  <Text style={styles.primaryButtonText}>Generate</Text>
+                </TouchableOpacity>
+              </View>
+            )}
+          </>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: tabColors.background,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: tabColors.border,
+  },
+  headerTitle: {
+    fontSize: 17,
+    fontFamily: 'Lexend_700Bold',
+    color: tabColors.textPrimary,
+  },
+  content: {
+    padding: 16,
+    gap: 16,
+  },
+  label: {
+    fontSize: 13,
+    fontFamily: 'Lexend_500Medium',
+    color: tabColors.textSecondary,
+  },
+  sessionName: {
+    fontSize: 17,
+    fontFamily: 'Lexend_700Bold',
+    color: tabColors.textPrimary,
+  },
+  sessionMeta: {
+    fontSize: 13,
+    fontFamily: 'Lexend_400Regular',
+    color: tabColors.textSecondary,
+    marginTop: 2,
+  },
+  centerBlock: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    paddingVertical: 24,
+  },
+  loadingText: {
+    fontSize: 13,
+    fontFamily: 'Lexend_400Regular',
+    color: tabColors.textSecondary,
+  },
+  skeletonRow: {
+    height: 28,
+    width: '90%',
+    backgroundColor: 'rgba(15, 35, 57, 0.5)',
+    borderRadius: 8,
+    marginTop: 4,
+  },
+  banner: {
+    backgroundColor: 'rgba(255, 210, 85, 0.12)',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 210, 85, 0.35)',
+    borderRadius: 12,
+    padding: 14,
+  },
+  bannerText: {
+    color: tabColors.textPrimary,
+    fontSize: 13,
+    fontFamily: 'Lexend_400Regular',
+    lineHeight: 19,
+  },
+  errorCard: {
+    gap: 10,
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: 'rgba(255, 59, 48, 0.08)',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 59, 48, 0.3)',
+  },
+  errorText: {
+    color: tabColors.textPrimary,
+    fontSize: 13,
+    fontFamily: 'Lexend_400Regular',
+  },
+  warmupBlock: {
+    gap: 10,
+    padding: 14,
+    borderRadius: 14,
+    backgroundColor: 'rgba(15, 35, 57, 0.85)',
+    borderWidth: 1,
+    borderColor: 'rgba(27, 46, 74, 0.6)',
+  },
+  warmupName: {
+    color: tabColors.textPrimary,
+    fontSize: 16,
+    fontFamily: 'Lexend_700Bold',
+  },
+  warmupMeta: {
+    color: tabColors.accent,
+    fontSize: 12,
+    fontFamily: 'Lexend_500Medium',
+    marginBottom: 6,
+  },
+  movementRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+    paddingVertical: 6,
+  },
+  movementNumber: {
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(76, 140, 255, 0.22)',
+  },
+  movementNumberText: {
+    color: tabColors.accent,
+    fontSize: 12,
+    fontFamily: 'Lexend_700Bold',
+  },
+  movementBody: {
+    flex: 1,
+  },
+  movementName: {
+    color: tabColors.textPrimary,
+    fontSize: 14,
+    fontFamily: 'Lexend_500Medium',
+  },
+  movementMeta: {
+    color: tabColors.textSecondary,
+    fontSize: 12,
+    fontFamily: 'Lexend_400Regular',
+    marginTop: 2,
+  },
+  movementNotes: {
+    color: tabColors.textSecondary,
+    fontSize: 12,
+    fontFamily: 'Lexend_400Regular',
+    marginTop: 4,
+    fontStyle: 'italic',
+  },
+  primaryButton: {
+    alignSelf: 'center',
+    paddingHorizontal: 22,
+    paddingVertical: 10,
+    borderRadius: 12,
+    backgroundColor: tabColors.accent,
+  },
+  primaryButtonText: {
+    color: '#fff',
+    fontSize: 14,
+    fontFamily: 'Lexend_700Bold',
+  },
+  secondaryButton: {
+    alignSelf: 'center',
+    marginTop: 10,
+    paddingHorizontal: 18,
+    paddingVertical: 8,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: tabColors.accent,
+  },
+  secondaryButtonText: {
+    color: tabColors.accent,
+    fontSize: 13,
+    fontFamily: 'Lexend_500Medium',
+  },
+});

--- a/components/form-tracking/FormQualityRecoveryCard.tsx
+++ b/components/form-tracking/FormQualityRecoveryCard.tsx
@@ -20,6 +20,17 @@ interface FormQualityRecoveryCardProps {
   onRequestExplanation?: (drill: Drill) => void;
   onMarkDone?: (drillId: string) => void;
   isDone?: boolean;
+  /**
+   * When true, the card swaps the static reason copy for an inline
+   * spinner + "Finding a drill for you…" caption. Use this while a
+   * parent-controlled drill fetch (e.g. Gemma drill explainer, fault-
+   * drill aggregator round-trip) is in flight so the user sees the
+   * card is actively resolving instead of appearing frozen.
+   *
+   * Does NOT interact with the existing `explanation.isLoading` flag,
+   * which remains scoped to the "Ask coach why" button's state.
+   */
+  isFetchingDrill?: boolean;
   testID?: string;
 }
 
@@ -52,6 +63,7 @@ export function FormQualityRecoveryCard({
   onRequestExplanation,
   onMarkDone,
   isDone = false,
+  isFetchingDrill = false,
   testID,
 }: FormQualityRecoveryCardProps): React.ReactElement {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -95,9 +107,20 @@ export function FormQualityRecoveryCard({
         )}
       </View>
 
-      <Text style={cardStyles.reason} testID={`drill-reason-${drill.id}`}>
-        {reason}
-      </Text>
+      {isFetchingDrill ? (
+        <View
+          style={cardStyles.fetchingRow}
+          testID={`drill-fetching-${drill.id}`}
+          accessibilityLiveRegion="polite"
+        >
+          <ActivityIndicator color={tabColors.accent} size="small" />
+          <Text style={cardStyles.fetchingText}>Finding a drill for you…</Text>
+        </View>
+      ) : (
+        <Text style={cardStyles.reason} testID={`drill-reason-${drill.id}`}>
+          {reason}
+        </Text>
+      )}
 
       <TouchableOpacity
         style={cardStyles.whyRow}
@@ -236,6 +259,19 @@ const cardStyles = StyleSheet.create({
     color: tabColors.textSecondary,
     marginBottom: 10,
     lineHeight: 18,
+  },
+  fetchingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 10,
+  },
+  fetchingText: {
+    fontSize: 13,
+    fontFamily: 'Lexend_400Regular',
+    color: tabColors.textSecondary,
+    lineHeight: 18,
+    flexShrink: 1,
   },
   whyRow: {
     flexDirection: 'row',

--- a/hooks/use-persistent-fault-summary.ts
+++ b/hooks/use-persistent-fault-summary.ts
@@ -1,0 +1,128 @@
+/**
+ * usePersistentFaultSummary
+ *
+ * Combines `fault-heatmap-data-loader` with `fault-drill-aggregator`
+ * to expose the top-N persistent faults across the last 7 days as a
+ * React hook.
+ *
+ * Flag-gated by `EXPO_PUBLIC_FAULT_DRILL_GEMMA`: when disabled the
+ * hook immediately resolves to an empty summary and never touches the
+ * network. This is the primary fail-closed gate for the fault-drill
+ * pipeline — the CTA, the drill dispatch, and any downstream surfaces
+ * all bail when `topFaults.length === 0`.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { DrillFaultInput } from '@/lib/services/coach-drill-explainer';
+import {
+  aggregatePersistentFaults,
+  type AggregatePersistentFaultsOptions,
+} from '@/lib/services/fault-drill-aggregator';
+import { isFaultDrillGemmaEnabled } from '@/lib/services/fault-drill-gemma-flag';
+import {
+  loadFaultHeatmapData,
+  type FaultHeatmapSnapshot,
+} from '@/lib/services/fault-heatmap-data-loader';
+
+export interface UsePersistentFaultSummaryOptions extends AggregatePersistentFaultsOptions {
+  /**
+   * Override the loader — used by tests so we don't have to jest.mock
+   * the supabase client just to exercise the hook shape.
+   */
+  loader?: () => Promise<FaultHeatmapSnapshot>;
+  /**
+   * When true, skip the flag check and always run. Only used by tests;
+   * production call sites should honour the flag.
+   */
+  bypassFlag?: boolean;
+}
+
+export interface UsePersistentFaultSummaryResult {
+  /** Top-N persistent faults (may be empty when flag off or no data). */
+  topFaults: DrillFaultInput[];
+  /** Full snapshot — useful for the heatmap modal CTA gating. */
+  snapshot: FaultHeatmapSnapshot | null;
+  loading: boolean;
+  error: Error | null;
+  /** Re-runs the loader. No-op when the flag is off. */
+  refresh: () => void;
+  /** True when the master flag is on — exposed for CTA visibility checks. */
+  enabled: boolean;
+}
+
+const EMPTY_SNAPSHOT: FaultHeatmapSnapshot = {
+  cells: [],
+  days: [],
+  totals: [],
+  lastSessionId: null,
+};
+
+export function usePersistentFaultSummary(
+  options: UsePersistentFaultSummaryOptions = {},
+): UsePersistentFaultSummaryResult {
+  const { loader, bypassFlag, topN, minCount, displayNames } = options;
+
+  const enabled = bypassFlag === true ? true : isFaultDrillGemmaEnabled();
+
+  const [snapshot, setSnapshot] = useState<FaultHeatmapSnapshot | null>(null);
+  const [topFaults, setTopFaults] = useState<DrillFaultInput[]>([]);
+  const [loading, setLoading] = useState<boolean>(() => enabled);
+  const [error, setError] = useState<Error | null>(null);
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // Latest options land in a ref so `runLoader`'s identity only depends
+  // on `enabled` + `loader` — callers can pass inline-constructed
+  // `displayNames` objects without triggering a refetch loop.
+  const aggregatorOptsRef = useRef<AggregatePersistentFaultsOptions>({
+    topN,
+    minCount,
+    displayNames,
+  });
+  aggregatorOptsRef.current = { topN, minCount, displayNames };
+
+  const runLoader = useCallback(async () => {
+    if (!enabled) {
+      setSnapshot(EMPTY_SNAPSHOT);
+      setTopFaults([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const source = loader ?? loadFaultHeatmapData;
+      const next = await source();
+      if (!mountedRef.current) return;
+      setSnapshot(next);
+      setTopFaults(aggregatePersistentFaults(next.totals, aggregatorOptsRef.current));
+      setLoading(false);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setLoading(false);
+      setError(err instanceof Error ? err : new Error('persistent fault summary load failed'));
+    }
+  }, [enabled, loader]);
+
+  useEffect(() => {
+    void runLoader();
+  }, [runLoader]);
+
+  return {
+    topFaults,
+    snapshot,
+    loading,
+    error,
+    enabled,
+    refresh: () => void runLoader(),
+  };
+}

--- a/hooks/use-pre-session-coach.ts
+++ b/hooks/use-pre-session-coach.ts
@@ -1,0 +1,107 @@
+/**
+ * usePreSessionCoach
+ *
+ * React hook around `coach-warmup-provider.buildWarmupForSession`.
+ * Callers invoke `generateWarmup(template)` from a button press and
+ * observe `warmup`, `loading`, `error` state.
+ *
+ * Flag-gated by `EXPO_PUBLIC_WARMUP_COACH` (through the underlying
+ * provider). When the flag is off, `enabled` is false and
+ * `generateWarmup` resolves to `null` immediately — no Gemma request,
+ * no state churn.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  buildWarmupForSession,
+  isWarmupCoachFlowEnabled,
+  type BuildWarmupOptions,
+  type SessionTemplateLike,
+  type WarmupPlan,
+} from '@/lib/services/coach-warmup-provider';
+
+export interface UsePreSessionCoachOptions {
+  /** Test-only: override the provider so tests don't mock the full chain. */
+  providerOverride?: (
+    template: SessionTemplateLike,
+    options?: BuildWarmupOptions,
+  ) => Promise<WarmupPlan | null>;
+  /** Test-only: pretend the flag is on. */
+  bypassFlag?: boolean;
+}
+
+export interface UsePreSessionCoachResult {
+  warmup: WarmupPlan | null;
+  loading: boolean;
+  error: Error | null;
+  /**
+   * Triggers a warmup build. Resolves to the built `WarmupPlan` (or
+   * `null` when the flag is off / template is empty / provider threw —
+   * in the error case the hook's `error` state also gets set).
+   */
+  generateWarmup: (template: SessionTemplateLike) => Promise<WarmupPlan | null>;
+  /** Clear any stored plan / error without re-running. */
+  reset: () => void;
+  /** True when the master flag is on. */
+  enabled: boolean;
+}
+
+export function usePreSessionCoach(
+  options: UsePreSessionCoachOptions = {},
+): UsePreSessionCoachResult {
+  const { providerOverride, bypassFlag } = options;
+
+  const [warmup, setWarmup] = useState<WarmupPlan | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const enabled = bypassFlag === true ? true : isWarmupCoachFlowEnabled();
+
+  const generateWarmup = useCallback(
+    async (template: SessionTemplateLike): Promise<WarmupPlan | null> => {
+      if (!enabled) {
+        setWarmup(null);
+        setError(null);
+        setLoading(false);
+        return null;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const impl = providerOverride ?? buildWarmupForSession;
+        const plan = await impl(template, { bypassFlag: bypassFlag === true });
+        if (!mountedRef.current) return plan;
+        setWarmup(plan);
+        setLoading(false);
+        return plan;
+      } catch (err) {
+        const wrapped =
+          err instanceof Error ? err : new Error('Warmup generation failed');
+        if (mountedRef.current) {
+          setError(wrapped);
+          setLoading(false);
+        }
+        return null;
+      }
+    },
+    [enabled, providerOverride, bypassFlag],
+  );
+
+  const reset = useCallback(() => {
+    setWarmup(null);
+    setError(null);
+    setLoading(false);
+  }, []);
+
+  return { warmup, loading, error, generateWarmup, reset, enabled };
+}

--- a/lib/services/coach-warmup-provider.ts
+++ b/lib/services/coach-warmup-provider.ts
@@ -1,0 +1,124 @@
+/**
+ * coach-warmup-provider
+ *
+ * Thin wrapper around `warmup-generator.generateWarmup` that layers:
+ *   - flag-gating via `EXPO_PUBLIC_WARMUP_COACH` (fail-closed)
+ *   - session-template → `WarmupGeneratorInput` normalization
+ *   - consistent `WarmupPlan` re-export
+ *
+ * The underlying generator lives in `lib/services/warmup-generator.ts`
+ * and is imported read-only. All Gemma / coach transport concerns
+ * (JSON schema, retries, coach context) are delegated to it.
+ *
+ * When the master flag is off, `buildWarmupForSession` returns `null`
+ * immediately without touching the generator — no Gemma request fires,
+ * no tokens burned, no side effects.
+ */
+
+import {
+  generateWarmup as generateWarmupImpl,
+  type WarmupGeneratorRuntime,
+  type WarmupPlan as GeneratorWarmupPlan,
+} from '@/lib/services/warmup-generator';
+import type { WarmupGeneratorInput } from '@/lib/services/warmup-generator-prompt';
+import { isWarmupCoachEnabled } from '@/lib/services/warmup-coach-flag';
+
+// Re-export the generator's WarmupPlan shape so callers only import
+// from this provider. If the generator surface ever changes, this file
+// is the single adaption point.
+export type WarmupPlan = GeneratorWarmupPlan;
+export type { WarmupMovement } from '@/lib/services/warmup-generator';
+
+export interface SessionTemplateLike {
+  /**
+   * Slugs (or human-readable names — we lower/slugify internally) of
+   * the main-session exercises this warmup precedes.
+   */
+  exerciseSlugs?: readonly string[];
+  /** Alternate: flat list of exercises with a `name` / `slug` property. */
+  exercises?: ReadonlyArray<{ slug?: string; name?: string }>;
+  /** Target warmup duration in minutes. */
+  durationMin?: number;
+  /** User-supplied free-text hint (e.g. "left shoulder stiff today"). */
+  userContext?: string;
+}
+
+export interface BuildWarmupOptions {
+  runtime?: WarmupGeneratorRuntime;
+  /**
+   * Test-only injection seam. Production callers should never pass this —
+   * the generator import is the one source of truth.
+   */
+  generatorOverride?: (
+    input: WarmupGeneratorInput,
+    runtime?: WarmupGeneratorRuntime,
+  ) => Promise<WarmupPlan>;
+  /** Bypass the flag for tests. Production code must not use this. */
+  bypassFlag?: boolean;
+}
+
+function slugify(raw: string): string {
+  return raw.toLowerCase().replace(/\s+/g, '_').replace(/[^a-z0-9_]/g, '');
+}
+
+function normalizeExerciseSlugs(template: SessionTemplateLike): string[] {
+  if (Array.isArray(template.exerciseSlugs) && template.exerciseSlugs.length > 0) {
+    return template.exerciseSlugs
+      .filter((s): s is string => typeof s === 'string' && s.length > 0)
+      .map(slugify);
+  }
+  if (Array.isArray(template.exercises) && template.exercises.length > 0) {
+    return template.exercises
+      .map((e) => (typeof e.slug === 'string' ? e.slug : typeof e.name === 'string' ? e.name : ''))
+      .filter((s) => s.length > 0)
+      .map(slugify);
+  }
+  return [];
+}
+
+export function buildGeneratorInput(template: SessionTemplateLike): WarmupGeneratorInput {
+  const exerciseSlugs = normalizeExerciseSlugs(template);
+  return {
+    exerciseSlugs,
+    durationMin: typeof template.durationMin === 'number' ? template.durationMin : undefined,
+    userContext:
+      typeof template.userContext === 'string' && template.userContext.trim().length > 0
+        ? template.userContext
+        : undefined,
+  };
+}
+
+/**
+ * Build a warmup plan for the supplied session template.
+ *
+ * Returns:
+ *   - `null` when `EXPO_PUBLIC_WARMUP_COACH` is off (fail-closed).
+ *   - `null` when the template contains no resolvable exercises — the
+ *     generator rejects empty inputs anyway; we bail early to avoid
+ *     burning a coach request.
+ *   - A validated `WarmupPlan` on success.
+ *
+ * Errors from the generator (network, schema validation, retry
+ * exhaustion) propagate — callers layer their own UI fallback.
+ */
+export async function buildWarmupForSession(
+  template: SessionTemplateLike,
+  options: BuildWarmupOptions = {},
+): Promise<WarmupPlan | null> {
+  const enabled = options.bypassFlag === true ? true : isWarmupCoachEnabled();
+  if (!enabled) return null;
+
+  const input = buildGeneratorInput(template);
+  if (input.exerciseSlugs.length === 0) return null;
+
+  const generator = options.generatorOverride ?? generateWarmupImpl;
+  return generator(input, options.runtime);
+}
+
+/**
+ * Exposes whether the warmup coach flow is currently live. Useful for
+ * CTA visibility checks that don't need to call the generator.
+ */
+export function isWarmupCoachFlowEnabled(): boolean {
+  return isWarmupCoachEnabled();
+}

--- a/lib/services/fault-drill-aggregator.ts
+++ b/lib/services/fault-drill-aggregator.ts
@@ -1,0 +1,108 @@
+/**
+ * fault-drill-aggregator
+ *
+ * Takes a `FaultHeatmapSnapshot` and produces the top-N persistent
+ * faults, each with a `DrillFaultInput` payload ready to ship into
+ * `coach-drill-explainer.explainDrill(faults[…])`.
+ *
+ * Pure — zero IO. Aggregator shape is intentionally small so a caller
+ * can compose it after any aggregator (`loadFaultHeatmapData`, a
+ * session-scoped loader, a manual fixture) that yields `FaultTotal[]`.
+ *
+ * Severity mapping: the heatmap / rep-analytics code buckets faults on
+ * a 0-2 scale keyed by regex, but the drill-explainer expects 1-3.
+ * We promote by +1 so a regex-minor fault becomes drill-severity 1
+ * and a regex-major becomes 3 — matching the "minor/moderate/major"
+ * copy in `coach-drill-explainer.summarizeFaults`.
+ */
+
+import type { DrillFaultInput } from '@/lib/services/coach-drill-explainer';
+import type { FaultTotal } from '@/lib/services/fault-heatmap-data-loader';
+
+/** Default top-N persistent faults to surface. */
+export const DEFAULT_TOP_N = 3;
+
+/** Minimum total occurrence count for a fault to be considered persistent. */
+export const DEFAULT_MIN_COUNT = 2;
+
+export interface AggregatePersistentFaultsOptions {
+  /** Maximum number of faults to return. Defaults to 3. */
+  topN?: number;
+  /**
+   * Minimum total count a fault must have to be considered persistent.
+   * Defaults to 2 — one-off detections are noisy and rarely worth a
+   * round-trip to the drill explainer.
+   */
+  minCount?: number;
+  /**
+   * Optional display-name lookup so the drill explainer prompt can
+   * reference a human-readable label. When missing the explainer falls
+   * back to prettifying the code (`knees_in` → `knees in`).
+   */
+  displayNames?: Record<string, string>;
+}
+
+const MAJOR_RE = /collapse|valgus|lumbar|extreme|severe|hyper/i;
+const MODERATE_RE = /shallow|forward|shift|asymmetry/i;
+
+/**
+ * Map a fault code to drill-explainer severity (1..3).
+ */
+export function severityForFault(code: string): 1 | 2 | 3 {
+  if (MAJOR_RE.test(code)) return 3;
+  if (MODERATE_RE.test(code)) return 2;
+  return 1;
+}
+
+/**
+ * Titleize a fault code for the `displayName` field when no explicit
+ * label was supplied. Matches the thumbnail component's formatter so
+ * the CTA label stays consistent.
+ */
+export function prettifyFaultCode(code: string): string {
+  const parts = code.replace(/_/g, ' ').trim().split(/\s+/);
+  return parts
+    .map((p) => (p.length === 0 ? p : p[0].toUpperCase() + p.slice(1)))
+    .join(' ');
+}
+
+/**
+ * Reduce a list of per-fault totals (as emitted by
+ * `fault-heatmap-data-loader.aggregateFaultHeatmap`) into a top-N list
+ * of drill-ready payloads.
+ *
+ * - Drops faults below `minCount`.
+ * - Drops faults with a missing / non-string code or non-positive count.
+ * - Sorts by count desc, then by code asc (stable).
+ */
+export function aggregatePersistentFaults(
+  totals: readonly FaultTotal[],
+  options: AggregatePersistentFaultsOptions = {},
+): DrillFaultInput[] {
+  const topN = Math.max(0, Math.floor(options.topN ?? DEFAULT_TOP_N));
+  const minCount = Math.max(1, Math.floor(options.minCount ?? DEFAULT_MIN_COUNT));
+  const displayNames = options.displayNames ?? {};
+
+  const filtered = totals
+    .filter((t): t is FaultTotal =>
+      t != null
+      && typeof t.faultId === 'string'
+      && t.faultId.length > 0
+      && typeof t.count === 'number'
+      && Number.isFinite(t.count)
+      && t.count >= minCount,
+    )
+    .slice()
+    .sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;
+      return a.faultId.localeCompare(b.faultId);
+    })
+    .slice(0, topN);
+
+  return filtered.map(({ faultId, count }) => ({
+    code: faultId,
+    displayName: displayNames[faultId] ?? prettifyFaultCode(faultId),
+    count,
+    severity: severityForFault(faultId),
+  }));
+}

--- a/lib/services/fault-drill-gemma-flag.ts
+++ b/lib/services/fault-drill-gemma-flag.ts
@@ -1,0 +1,26 @@
+/**
+ * fault-drill-gemma-flag
+ *
+ * Feature flag gate for the fault-heatmap "Ask Gemma for drills" CTA
+ * and the underlying persistent-fault → drill-explainer pipeline.
+ *
+ * Parsing (strict):
+ *   - `EXPO_PUBLIC_FAULT_DRILL_GEMMA=1`    → enabled
+ *   - `EXPO_PUBLIC_FAULT_DRILL_GEMMA=true` → enabled
+ *   - unset / anything else                → disabled (fail-closed)
+ *
+ * Intentionally strict: only literal `'1'` or `'true'` flip on. No
+ * `'yes'` / `'on'` / `'TRUE'` / whitespace-padded variants. Keeps the
+ * production default unambiguous — no CTA surfaces unless an operator
+ * has explicitly opted in.
+ */
+
+const FLAG_ENV_VAR = 'EXPO_PUBLIC_FAULT_DRILL_GEMMA';
+
+export function isFaultDrillGemmaEnabled(): boolean {
+  const raw = process.env[FLAG_ENV_VAR];
+  if (typeof raw !== 'string') return false;
+  return raw === '1' || raw === 'true';
+}
+
+export const FAULT_DRILL_GEMMA_FLAG_ENV_VAR = FLAG_ENV_VAR;

--- a/lib/services/fault-heatmap-data-loader.ts
+++ b/lib/services/fault-heatmap-data-loader.ts
@@ -1,0 +1,200 @@
+/**
+ * fault-heatmap-data-loader
+ *
+ * Pulls recent form-tracking fault data and reshapes it into the
+ * `FaultCell[]` + `days[]` tuple the fault-heatmap modal renders.
+ *
+ * Data source note: fault telemetry lives on the Supabase `reps` table
+ * (see `lib/services/rep-analytics.ts` — the on-device
+ * `lib/services/database/local-db.ts` deliberately does NOT mirror reps
+ * because per-rep payloads would balloon the SQLite file and the reps
+ * table is heavily RLS'd on Supabase anyway). We reuse the same
+ * `session_metrics → reps` pattern `useFormHomeData` uses so the
+ * heatmap, the form-home thumb, and this loader all agree on shape.
+ *
+ * The aggregation math is deliberately split from the IO so tests can
+ * drive it with fixture rows (no supabase mocking required for the
+ * hot path).
+ */
+import { supabase } from '@/lib/supabase';
+import { errorWithTs } from '@/lib/logger';
+import type { FaultCell } from '@/components/form-home/FaultHeatmapThumb';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const SESSION_HORIZON_DAYS = 120;
+const HEATMAP_WINDOW_DAYS = 7;
+
+export interface FaultHeatmapSnapshot {
+  /** Cells in the same shape `FaultHeatmapThumb` consumes. */
+  cells: FaultCell[];
+  /** 7 day labels, earliest -> today, same format as the thumb. */
+  days: string[];
+  /**
+   * Flat list of per-fault totals across the 7-day window. Convenience
+   * for downstream aggregators that only care about "most-frequent
+   * fault", not per-day breakdown.
+   */
+  totals: FaultTotal[];
+  /** Most recent session id touched by this aggregation, or null. */
+  lastSessionId: string | null;
+}
+
+export interface FaultTotal {
+  faultId: string;
+  count: number;
+}
+
+export interface SessionMetricsRow {
+  session_id: string;
+  start_at: string | null;
+  created_at?: string | null;
+}
+
+export interface RepsRow {
+  session_id: string;
+  faults_detected: string[] | null;
+  start_ts: string | null;
+}
+
+export interface AggregateFaultsInput {
+  sessions: SessionMetricsRow[];
+  reps: RepsRow[];
+  /** Defaults to Date.now(). Overridable for deterministic tests. */
+  now?: Date;
+}
+
+function isoDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function shortDayLabel(date: Date): string {
+  return `${date.getMonth() + 1}/${date.getDate()}`;
+}
+
+/**
+ * Pure aggregator — takes raw session + rep rows and produces the
+ * day × fault matrix the heatmap renders. Kept side-effect-free so
+ * tests drive it without touching Supabase.
+ */
+export function aggregateFaultHeatmap(input: AggregateFaultsInput): FaultHeatmapSnapshot {
+  const now = input.now ?? new Date();
+
+  // Build 7-day day axis earliest -> today.
+  const days: string[] = [];
+  const dayIsoByIdx: string[] = [];
+  for (let i = HEATMAP_WINDOW_DAYS - 1; i >= 0; i--) {
+    const d = new Date(now.getTime() - i * DAY_MS);
+    days.push(shortDayLabel(d));
+    dayIsoByIdx.push(isoDay(d));
+  }
+
+  // Session timestamp lookup — rep rows sometimes lack start_ts.
+  const sessionStart = new Map<string, string>();
+  for (const s of input.sessions) {
+    const t = s.start_at ?? s.created_at ?? null;
+    if (t) sessionStart.set(s.session_id, t);
+  }
+
+  // Per-day fault counts.
+  const faultCountByDay = new Map<string, Map<string, number>>();
+  for (const iso of dayIsoByIdx) faultCountByDay.set(iso, new Map());
+  const totalByFault = new Map<string, number>();
+
+  let lastSessionTs = 0;
+  let lastSessionId: string | null = null;
+
+  for (const rep of input.reps) {
+    const isoFromRep = rep.start_ts ? rep.start_ts.slice(0, 10) : null;
+    const isoFromSession = sessionStart.get(rep.session_id)?.slice(0, 10) ?? null;
+    const iso = isoFromRep ?? isoFromSession;
+    if (!iso) continue;
+    const dayMap = faultCountByDay.get(iso);
+    if (!dayMap) continue;
+    if (!Array.isArray(rep.faults_detected)) continue;
+
+    for (const f of rep.faults_detected) {
+      if (typeof f !== 'string' || f.length === 0) continue;
+      dayMap.set(f, (dayMap.get(f) ?? 0) + 1);
+      totalByFault.set(f, (totalByFault.get(f) ?? 0) + 1);
+    }
+  }
+
+  for (const s of input.sessions) {
+    const ts = s.start_at ?? s.created_at ?? null;
+    if (!ts) continue;
+    const epoch = Date.parse(ts);
+    if (!Number.isFinite(epoch)) continue;
+    if (epoch > lastSessionTs) {
+      lastSessionTs = epoch;
+      lastSessionId = s.session_id;
+    }
+  }
+
+  // Flatten day×fault map into cells, labelled with the rendered day string.
+  const cells: FaultCell[] = [];
+  for (let i = 0; i < dayIsoByIdx.length; i++) {
+    const iso = dayIsoByIdx[i];
+    const label = days[i];
+    const dayMap = faultCountByDay.get(iso);
+    if (!dayMap) continue;
+    for (const [faultId, count] of dayMap) {
+      cells.push({ dayLabel: label, faultId, count });
+    }
+  }
+
+  const totals: FaultTotal[] = [...totalByFault.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([faultId, count]) => ({ faultId, count }));
+
+  return { cells, days, totals, lastSessionId };
+}
+
+/**
+ * IO-backed loader. Fetches recent sessions + reps from Supabase and
+ * routes them through `aggregateFaultHeatmap`. Returns an empty
+ * snapshot on any network / RLS / parse failure so the heatmap can
+ * render its empty-state copy instead of crashing.
+ */
+export async function loadFaultHeatmapData(now?: Date): Promise<FaultHeatmapSnapshot> {
+  const anchor = now ?? new Date();
+  const emptyDays: string[] = [];
+  for (let i = HEATMAP_WINDOW_DAYS - 1; i >= 0; i--) {
+    const d = new Date(anchor.getTime() - i * DAY_MS);
+    emptyDays.push(shortDayLabel(d));
+  }
+  const empty: FaultHeatmapSnapshot = {
+    cells: [],
+    days: emptyDays,
+    totals: [],
+    lastSessionId: null,
+  };
+
+  try {
+    const allTimeHorizon = new Date(anchor.getTime() - SESSION_HORIZON_DAYS * DAY_MS);
+    const horizonIso = isoDay(allTimeHorizon);
+
+    const { data: sessionsRaw, error: sessionsError } = await supabase
+      .from('session_metrics')
+      .select('session_id,start_at,created_at')
+      .gte('start_at', `${horizonIso}T00:00:00.000Z`)
+      .order('created_at', { ascending: false })
+      .limit(120);
+    if (sessionsError) throw sessionsError;
+    const sessions = (sessionsRaw ?? []) as SessionMetricsRow[];
+    if (sessions.length === 0) return empty;
+
+    const sessionIds = sessions.map((s) => s.session_id);
+    const { data: repsRaw, error: repsError } = await supabase
+      .from('reps')
+      .select('session_id,faults_detected,start_ts')
+      .in('session_id', sessionIds)
+      .limit(5000);
+    if (repsError) throw repsError;
+    const reps = (repsRaw ?? []) as RepsRow[];
+
+    return aggregateFaultHeatmap({ sessions, reps, now: anchor });
+  } catch (err) {
+    errorWithTs('[fault-heatmap-data-loader] loadFaultHeatmapData failed', err);
+    return empty;
+  }
+}

--- a/lib/services/warmup-coach-flag.ts
+++ b/lib/services/warmup-coach-flag.ts
@@ -1,0 +1,26 @@
+/**
+ * warmup-coach-flag
+ *
+ * Feature flag gate for the pre-session warmup coach flow —
+ * `coach-warmup-provider`, `use-pre-session-coach`, and the
+ * `session-warmup-coach` modal.
+ *
+ * Parsing (strict):
+ *   - `EXPO_PUBLIC_WARMUP_COACH=1`    → enabled
+ *   - `EXPO_PUBLIC_WARMUP_COACH=true` → enabled
+ *   - unset / anything else           → disabled (fail-closed)
+ *
+ * Intentionally strict: only literal `'1'` or `'true'` flip on. The
+ * production default must behave identically to pre-PR — no new CTA
+ * surfaces, no generator calls, nothing.
+ */
+
+const FLAG_ENV_VAR = 'EXPO_PUBLIC_WARMUP_COACH';
+
+export function isWarmupCoachEnabled(): boolean {
+  const raw = process.env[FLAG_ENV_VAR];
+  if (typeof raw !== 'string') return false;
+  return raw === '1' || raw === 'true';
+}
+
+export const WARMUP_COACH_FLAG_ENV_VAR = FLAG_ENV_VAR;

--- a/tests/integration/fault-heatmap-drill-cta.integration.test.tsx
+++ b/tests/integration/fault-heatmap-drill-cta.integration.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * Integration test: fault-heatmap drill CTA → coach-drill-explainer.
+ *
+ * Verifies the full wiring from the heatmap modal down to the drill
+ * explainer service: mocks supabase so `loadFaultHeatmapData` returns
+ * a realistic fault distribution, mocks `explainDrill` so we can
+ * assert on the call payload, then drives the CTA tap and checks
+ * that the top-N persistent faults all reach the explainer with the
+ * drill-input shape the service expects.
+ */
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+const mockBack = jest.fn();
+const mockSupabaseFrom = jest.fn();
+const mockExplainDrill = jest.fn();
+
+jest.mock('expo-router', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    useRouter: () => ({ back: mockBack, push: jest.fn() }),
+    Stack: { Screen: (props: { children?: React.ReactNode }) => <View>{props.children ?? null}</View> },
+  };
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const { Text } = jest.requireActual('react-native');
+  return {
+    Ionicons: (props: { name: string }) => <Text>{props.name}</Text>,
+  };
+});
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockSupabaseFrom(...args),
+    auth: {
+      onAuthStateChange: jest.fn(() => ({
+        data: { subscription: { unsubscribe: jest.fn() } },
+      })),
+    },
+  },
+}));
+
+jest.mock('@/lib/services/coach-drill-explainer', () => ({
+  explainDrill: (...args: unknown[]) => mockExplainDrill(...args),
+}));
+
+import { FAULT_DRILL_GEMMA_FLAG_ENV_VAR } from '@/lib/services/fault-drill-gemma-flag';
+
+function mkBuilder(data: unknown, error: unknown = null) {
+  const builder: Record<string, unknown> = {};
+  const chain = () => builder;
+  builder.select = chain;
+  builder.order = chain;
+  builder.gte = chain;
+  builder.in = chain;
+  builder.limit = jest.fn(() => Promise.resolve({ data, error }));
+  return builder;
+}
+
+const TODAY = '2026-04-20';
+const YESTERDAY = '2026-04-19';
+const THREE_DAYS_AGO = '2026-04-17';
+
+const FLAG_ORIGINAL = process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR];
+
+describe('fault-heatmap drill CTA → drill-explainer', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(`${TODAY}T12:00:00.000Z`));
+    mockBack.mockReset();
+    mockSupabaseFrom.mockReset();
+    mockExplainDrill.mockReset();
+
+    mockSupabaseFrom.mockImplementation((table: string) => {
+      if (table === 'session_metrics') {
+        return mkBuilder(
+          [
+            { session_id: 's-today', start_at: `${TODAY}T09:00:00.000Z` },
+            { session_id: 's-yesterday', start_at: `${YESTERDAY}T09:00:00.000Z` },
+            { session_id: 's-three', start_at: `${THREE_DAYS_AGO}T09:00:00.000Z` },
+          ],
+          null,
+        );
+      }
+      if (table === 'reps') {
+        return mkBuilder(
+          [
+            // Most frequent: knees_in × 5
+            {
+              session_id: 's-today',
+              faults_detected: ['knees_in', 'knees_in'],
+              start_ts: `${TODAY}T09:01:00.000Z`,
+            },
+            {
+              session_id: 's-yesterday',
+              faults_detected: ['knees_in', 'knees_in', 'knees_in'],
+              start_ts: `${YESTERDAY}T09:01:00.000Z`,
+            },
+            // Second: shallow_depth × 3
+            {
+              session_id: 's-today',
+              faults_detected: ['shallow_depth'],
+              start_ts: `${TODAY}T09:02:00.000Z`,
+            },
+            {
+              session_id: 's-yesterday',
+              faults_detected: ['shallow_depth'],
+              start_ts: `${YESTERDAY}T09:02:00.000Z`,
+            },
+            {
+              session_id: 's-three',
+              faults_detected: ['shallow_depth'],
+              start_ts: `${THREE_DAYS_AGO}T09:01:00.000Z`,
+            },
+            // Third: forward_lean × 2
+            {
+              session_id: 's-today',
+              faults_detected: ['forward_lean'],
+              start_ts: `${TODAY}T09:03:00.000Z`,
+            },
+            {
+              session_id: 's-yesterday',
+              faults_detected: ['forward_lean'],
+              start_ts: `${YESTERDAY}T09:03:00.000Z`,
+            },
+            // Below minCount — should be filtered out
+            {
+              session_id: 's-today',
+              faults_detected: ['noise'],
+              start_ts: `${TODAY}T09:04:00.000Z`,
+            },
+          ],
+          null,
+        );
+      }
+      return mkBuilder([], null);
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+    if (FLAG_ORIGINAL === undefined) {
+      delete process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR];
+    } else {
+      process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR] = FLAG_ORIGINAL;
+    }
+  });
+
+  it('does not render the CTA when the flag is off', async () => {
+    delete process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR];
+    const FaultHeatmapModal = require('@/app/(modals)/fault-heatmap').default;
+
+    const { queryByTestId, findByText } = render(<FaultHeatmapModal />);
+    await findByText('Fault heatmap');
+    expect(queryByTestId('fault-heatmap-ask-gemma')).toBeNull();
+    expect(mockExplainDrill).not.toHaveBeenCalled();
+  });
+
+  it('fires explainDrill for each top-N fault when CTA tapped', async () => {
+    process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR] = '1';
+    mockExplainDrill.mockImplementation(async () => ({
+      explanation: 'Fix it like this',
+      provider: 'cloud',
+    }));
+
+    jest.isolateModules(() => {});
+    const FaultHeatmapModal = require('@/app/(modals)/fault-heatmap').default;
+
+    const { findByTestId, getByTestId } = render(<FaultHeatmapModal />);
+
+    // Wait for the CTA to appear (snapshot loads via supabase mock).
+    const cta = await findByTestId('fault-heatmap-ask-gemma');
+    expect(cta).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.press(cta);
+    });
+
+    await waitFor(() => expect(mockExplainDrill).toHaveBeenCalledTimes(3));
+
+    const faultCodesInCalls = mockExplainDrill.mock.calls.map(
+      ([input]) => input.faults[0].code,
+    );
+    expect(new Set(faultCodesInCalls)).toEqual(
+      new Set(['knees_in', 'shallow_depth', 'forward_lean']),
+    );
+
+    // Every call carries one DrillFaultInput with the expected shape.
+    for (const [input] of mockExplainDrill.mock.calls) {
+      expect(input.faults).toHaveLength(1);
+      expect(input.faults[0]).toEqual(
+        expect.objectContaining({
+          code: expect.any(String),
+          displayName: expect.any(String),
+          count: expect.any(Number),
+          severity: expect.any(Number),
+        }),
+      );
+      expect(input.drillTitle).toBe('Targeted form drill');
+      expect(input.drillCategory).toBe('technique');
+      expect(typeof input.drillWhy).toBe('string');
+      expect(input.exerciseId).toBe('form-tracking');
+    }
+
+    // 'noise' (count=1) is below the default minCount=2 and should NOT
+    // have been sent to the explainer.
+    expect(faultCodesInCalls).not.toContain('noise');
+
+    // Drill sheet renders each result inline.
+    await waitFor(() => getByTestId('fault-heatmap-drill-sheet'));
+    for (const code of ['knees_in', 'shallow_depth', 'forward_lean']) {
+      expect(getByTestId(`fault-heatmap-drill-${code}`)).toBeTruthy();
+    }
+  });
+});

--- a/tests/integration/session-warmup-coach.integration.test.tsx
+++ b/tests/integration/session-warmup-coach.integration.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Integration test: session-warmup-coach modal generates a plan.
+ *
+ * Mocks `warmup-generator.generateWarmup` (so no coach network
+ * touches), mocks the local-db template lookup, renders the modal,
+ * and verifies:
+ *
+ * - Flag off → "disabled" banner, generator never called.
+ * - Flag on + valid sessionId → generator called with normalized input,
+ *   plan renders with movement rows.
+ * - Generator rejection → error card + Retry button.
+ */
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+const mockBack = jest.fn();
+const mockGenerateWarmup = jest.fn();
+
+jest.mock('expo-router', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    useRouter: () => ({ back: mockBack, push: jest.fn() }),
+    useLocalSearchParams: () => ({ sessionId: 'tmpl-123' }),
+    Stack: { Screen: (props: { children?: React.ReactNode }) => <View>{props.children ?? null}</View> },
+  };
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const { Text } = jest.requireActual('react-native');
+  return {
+    Ionicons: (props: { name: string }) => <Text>{props.name}</Text>,
+  };
+});
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => {
+    const { View } = jest.requireActual('react-native');
+    return <View>{children}</View>;
+  },
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('@/lib/services/warmup-generator', () => ({
+  generateWarmup: (...args: unknown[]) => mockGenerateWarmup(...args),
+}));
+
+const mockDbGetAllAsync = jest.fn();
+jest.mock('@/lib/services/database/local-db', () => ({
+  localDB: {
+    get db() {
+      return {
+        getAllAsync: (...args: unknown[]) => mockDbGetAllAsync(...args),
+      };
+    },
+  },
+}));
+
+import { WARMUP_COACH_FLAG_ENV_VAR } from '@/lib/services/warmup-coach-flag';
+
+const FLAG_ORIGINAL = process.env[WARMUP_COACH_FLAG_ENV_VAR];
+
+const FAKE_PLAN = {
+  name: 'Squat day warmup',
+  duration_min: 6,
+  movements: [
+    { name: 'Hip flow', focus: 'mobility', intensity: 'low', duration_seconds: 60 },
+    { name: 'Goblet squat', focus: 'activation', intensity: 'medium', reps: 10 },
+  ],
+};
+
+describe('session-warmup-coach modal generates plan', () => {
+  beforeEach(() => {
+    mockBack.mockReset();
+    mockGenerateWarmup.mockReset();
+    mockDbGetAllAsync.mockReset();
+
+    mockDbGetAllAsync.mockImplementation((sql: string) => {
+      if (sql.startsWith('SELECT id, name FROM workout_templates')) {
+        return Promise.resolve([{ id: 'tmpl-123', name: 'Push day' }]);
+      }
+      if (sql.includes('FROM workout_template_exercises')) {
+        return Promise.resolve([
+          { exercise_name: 'Bench Press', sort_order: 0 },
+          { exercise_name: 'Overhead Press', sort_order: 1 },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+  });
+
+  afterEach(() => {
+    if (FLAG_ORIGINAL === undefined) {
+      delete process.env[WARMUP_COACH_FLAG_ENV_VAR];
+    } else {
+      process.env[WARMUP_COACH_FLAG_ENV_VAR] = FLAG_ORIGINAL;
+    }
+  });
+
+  it('shows the "disabled" banner and does NOT call the generator when the flag is off', async () => {
+    delete process.env[WARMUP_COACH_FLAG_ENV_VAR];
+    const SessionWarmupCoachScreen =
+      require('@/app/(modals)/session-warmup-coach').default;
+
+    const { getByTestId, queryByTestId } = render(<SessionWarmupCoachScreen />);
+
+    await waitFor(() => getByTestId('session-warmup-flag-off'));
+    expect(queryByTestId('session-warmup-plan')).toBeNull();
+    expect(mockGenerateWarmup).not.toHaveBeenCalled();
+  });
+
+  it('renders the plan after generating when the flag is on', async () => {
+    process.env[WARMUP_COACH_FLAG_ENV_VAR] = '1';
+    mockGenerateWarmup.mockResolvedValue(FAKE_PLAN);
+
+    const SessionWarmupCoachScreen =
+      require('@/app/(modals)/session-warmup-coach').default;
+
+    const { findByTestId, getByText, getByTestId } = render(<SessionWarmupCoachScreen />);
+
+    // Session name resolves from the mocked local-db lookup.
+    await findByTestId('session-warmup-session-name');
+    expect(getByText('Push day')).toBeTruthy();
+
+    // Generator auto-fires — wait for the plan block.
+    await findByTestId('session-warmup-plan');
+    expect(getByText('Squat day warmup')).toBeTruthy();
+    expect(getByText('6 min warmup')).toBeTruthy();
+    expect(getByTestId('session-warmup-movement-0')).toBeTruthy();
+    expect(getByTestId('session-warmup-movement-1')).toBeTruthy();
+
+    expect(mockGenerateWarmup).toHaveBeenCalledTimes(1);
+    const [input] = mockGenerateWarmup.mock.calls[0];
+    expect(input.exerciseSlugs).toEqual(['bench_press', 'overhead_press']);
+  });
+
+  it('surfaces an error card + retry when the generator rejects', async () => {
+    process.env[WARMUP_COACH_FLAG_ENV_VAR] = 'true';
+    mockGenerateWarmup.mockRejectedValueOnce(new Error('coach offline'));
+
+    const SessionWarmupCoachScreen =
+      require('@/app/(modals)/session-warmup-coach').default;
+
+    const { findByTestId, getByText, getByTestId } = render(<SessionWarmupCoachScreen />);
+
+    await findByTestId('session-warmup-error');
+    expect(getByText('coach offline')).toBeTruthy();
+
+    // Retry resolves this time — plan should render.
+    mockGenerateWarmup.mockResolvedValueOnce(FAKE_PLAN);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('session-warmup-retry'));
+    });
+    await findByTestId('session-warmup-plan');
+    expect(mockGenerateWarmup).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/components/form-tracking/FormQualityRecoveryCard.test.tsx
+++ b/tests/unit/components/form-tracking/FormQualityRecoveryCard.test.tsx
@@ -137,4 +137,23 @@ describe('FormQualityRecoveryCard', () => {
     );
     expect(getByTestId('custom-id')).toBeTruthy();
   });
+
+  it('shows "Finding a drill for you…" caption when isFetchingDrill is true', () => {
+    const { getByTestId, queryByText, getByText } = render(
+      <FormQualityRecoveryCard prescription={PRESCRIPTION} isFetchingDrill />,
+    );
+    expect(getByTestId('drill-fetching-tempo-squat-320')).toBeTruthy();
+    expect(getByText('Finding a drill for you…')).toBeTruthy();
+    // Static reason copy is swapped out while the fetch is in flight.
+    expect(queryByText(PRESCRIPTION.reason)).toBeNull();
+  });
+
+  it('restores the reason copy when isFetchingDrill flips back to false', () => {
+    const { getByText, rerender, queryByTestId } = render(
+      <FormQualityRecoveryCard prescription={PRESCRIPTION} isFetchingDrill />,
+    );
+    rerender(<FormQualityRecoveryCard prescription={PRESCRIPTION} isFetchingDrill={false} />);
+    expect(queryByTestId('drill-fetching-tempo-squat-320')).toBeNull();
+    expect(getByText(PRESCRIPTION.reason)).toBeTruthy();
+  });
 });

--- a/tests/unit/hooks/use-persistent-fault-summary.test.tsx
+++ b/tests/unit/hooks/use-persistent-fault-summary.test.tsx
@@ -1,0 +1,96 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import { usePersistentFaultSummary } from '@/hooks/use-persistent-fault-summary';
+import { FAULT_DRILL_GEMMA_FLAG_ENV_VAR } from '@/lib/services/fault-drill-gemma-flag';
+import type { FaultHeatmapSnapshot } from '@/lib/services/fault-heatmap-data-loader';
+
+const flagOriginal = process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR];
+
+function makeSnapshot(totals: { faultId: string; count: number }[]): FaultHeatmapSnapshot {
+  return { cells: [], days: [], totals, lastSessionId: 's-1' };
+}
+
+describe('usePersistentFaultSummary', () => {
+  afterEach(() => {
+    if (flagOriginal === undefined) {
+      delete process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR];
+    } else {
+      process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR] = flagOriginal;
+    }
+  });
+
+  it('stays empty + not loading when flag is off', async () => {
+    delete process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR];
+    const loader = jest.fn(() => Promise.resolve(makeSnapshot([{ faultId: 'knees_in', count: 5 }])));
+    const { result } = renderHook(() => usePersistentFaultSummary({ loader }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.topFaults).toEqual([]);
+    // Flag-gated loaders never fire — fail-closed.
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  it('runs the loader + aggregates when flag is on', async () => {
+    process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR] = '1';
+    const loader = jest.fn(() =>
+      Promise.resolve(
+        makeSnapshot([
+          { faultId: 'knees_in', count: 5 },
+          { faultId: 'shallow_depth', count: 3 },
+          { faultId: 'forward_lean', count: 2 },
+          { faultId: 'noise', count: 1 },
+        ]),
+      ),
+    );
+
+    const { result } = renderHook(() => usePersistentFaultSummary({ loader }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.enabled).toBe(true);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(result.current.topFaults.map((f) => f.code)).toEqual([
+      'knees_in',
+      'shallow_depth',
+      'forward_lean',
+    ]);
+    expect(result.current.snapshot?.lastSessionId).toBe('s-1');
+  });
+
+  it('surfaces loader errors', async () => {
+    process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR] = 'true';
+    const loader = jest.fn(() => Promise.reject(new Error('net down')));
+    const { result } = renderHook(() => usePersistentFaultSummary({ loader }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error?.message).toBe('net down');
+    expect(result.current.topFaults).toEqual([]);
+  });
+
+  it('exposes refresh() which reruns the loader when enabled', async () => {
+    process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR] = '1';
+    const loader = jest.fn(() => Promise.resolve(makeSnapshot([{ faultId: 'knees_in', count: 5 }])));
+    const { result } = renderHook(() => usePersistentFaultSummary({ loader }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      result.current.refresh();
+      await Promise.resolve();
+    });
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('bypassFlag lets tests exercise the loader path regardless of env', async () => {
+    delete process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR];
+    const loader = jest.fn(() => Promise.resolve(makeSnapshot([{ faultId: 'knees_in', count: 3 }])));
+    const { result } = renderHook(() =>
+      usePersistentFaultSummary({ loader, bypassFlag: true }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.enabled).toBe(true);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(result.current.topFaults.map((f) => f.code)).toEqual(['knees_in']);
+  });
+});

--- a/tests/unit/hooks/use-pre-session-coach.test.tsx
+++ b/tests/unit/hooks/use-pre-session-coach.test.tsx
@@ -1,0 +1,122 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import { usePreSessionCoach } from '@/hooks/use-pre-session-coach';
+import { WARMUP_COACH_FLAG_ENV_VAR } from '@/lib/services/warmup-coach-flag';
+import type { WarmupPlan } from '@/lib/services/coach-warmup-provider';
+
+const flagOriginal = process.env[WARMUP_COACH_FLAG_ENV_VAR];
+
+const SAMPLE_PLAN: WarmupPlan = {
+  name: 'Squat day warmup',
+  duration_min: 6,
+  movements: [
+    { name: 'Hip flow', focus: 'mobility', intensity: 'low', duration_seconds: 60 },
+    { name: 'Goblet squat', focus: 'activation', intensity: 'medium', reps: 10 },
+  ],
+};
+
+describe('usePreSessionCoach', () => {
+  afterEach(() => {
+    if (flagOriginal === undefined) {
+      delete process.env[WARMUP_COACH_FLAG_ENV_VAR];
+    } else {
+      process.env[WARMUP_COACH_FLAG_ENV_VAR] = flagOriginal;
+    }
+  });
+
+  it('returns enabled=false when flag is off', () => {
+    delete process.env[WARMUP_COACH_FLAG_ENV_VAR];
+    const { result } = renderHook(() => usePreSessionCoach());
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.warmup).toBeNull();
+  });
+
+  it('generateWarmup is a no-op when flag is off', async () => {
+    delete process.env[WARMUP_COACH_FLAG_ENV_VAR];
+    const providerOverride = jest.fn(() => Promise.resolve(SAMPLE_PLAN));
+    const { result } = renderHook(() =>
+      usePreSessionCoach({ providerOverride }),
+    );
+
+    let returned: WarmupPlan | null | undefined;
+    await act(async () => {
+      returned = await result.current.generateWarmup({ exerciseSlugs: ['squat'] });
+    });
+
+    expect(returned).toBeNull();
+    expect(providerOverride).not.toHaveBeenCalled();
+  });
+
+  it('generateWarmup resolves with the provider plan when flag on', async () => {
+    process.env[WARMUP_COACH_FLAG_ENV_VAR] = '1';
+    const providerOverride = jest.fn(() => Promise.resolve(SAMPLE_PLAN));
+    const { result } = renderHook(() =>
+      usePreSessionCoach({ providerOverride }),
+    );
+
+    let returned: WarmupPlan | null | undefined;
+    await act(async () => {
+      returned = await result.current.generateWarmup({ exerciseSlugs: ['squat'] });
+    });
+
+    expect(returned).toEqual(SAMPLE_PLAN);
+    expect(providerOverride).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.warmup).toEqual(SAMPLE_PLAN);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('exposes provider rejections via error state', async () => {
+    process.env[WARMUP_COACH_FLAG_ENV_VAR] = 'true';
+    const providerOverride = jest.fn(() => Promise.reject(new Error('schema bad')));
+    const { result } = renderHook(() =>
+      usePreSessionCoach({ providerOverride }),
+    );
+
+    await act(async () => {
+      const r = await result.current.generateWarmup({ exerciseSlugs: ['squat'] });
+      expect(r).toBeNull();
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error?.message).toBe('schema bad');
+    expect(result.current.warmup).toBeNull();
+  });
+
+  it('bypassFlag lets tests exercise the generator regardless of env', async () => {
+    delete process.env[WARMUP_COACH_FLAG_ENV_VAR];
+    const providerOverride = jest.fn(() => Promise.resolve(SAMPLE_PLAN));
+    const { result } = renderHook(() =>
+      usePreSessionCoach({ providerOverride, bypassFlag: true }),
+    );
+
+    await act(async () => {
+      await result.current.generateWarmup({ exerciseSlugs: ['squat'] });
+    });
+
+    expect(providerOverride).toHaveBeenCalledTimes(1);
+    expect(result.current.warmup).toEqual(SAMPLE_PLAN);
+    expect(result.current.enabled).toBe(true);
+  });
+
+  it('reset clears state without a new generator call', async () => {
+    process.env[WARMUP_COACH_FLAG_ENV_VAR] = '1';
+    const providerOverride = jest.fn(() => Promise.resolve(SAMPLE_PLAN));
+    const { result } = renderHook(() =>
+      usePreSessionCoach({ providerOverride }),
+    );
+
+    await act(async () => {
+      await result.current.generateWarmup({ exerciseSlugs: ['squat'] });
+    });
+    await waitFor(() => expect(result.current.warmup).toEqual(SAMPLE_PLAN));
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.warmup).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/tests/unit/services/coach-warmup-provider.test.ts
+++ b/tests/unit/services/coach-warmup-provider.test.ts
@@ -1,0 +1,158 @@
+jest.mock('@/lib/services/warmup-generator', () => ({
+  generateWarmup: jest.fn(),
+}));
+
+import { generateWarmup as generateWarmupMock } from '@/lib/services/warmup-generator';
+import {
+  buildGeneratorInput,
+  buildWarmupForSession,
+  isWarmupCoachFlowEnabled,
+} from '@/lib/services/coach-warmup-provider';
+import { WARMUP_COACH_FLAG_ENV_VAR } from '@/lib/services/warmup-coach-flag';
+import type { WarmupPlan } from '@/lib/services/coach-warmup-provider';
+
+const generateWarmupSpy = generateWarmupMock as jest.MockedFunction<typeof generateWarmupMock>;
+
+const FAKE_PLAN: WarmupPlan = {
+  name: 'Squat day warmup',
+  duration_min: 6,
+  movements: [
+    { name: 'Hip flow', focus: 'mobility', intensity: 'low', duration_seconds: 60 },
+    { name: 'Goblet squat', focus: 'activation', intensity: 'medium', reps: 10 },
+  ],
+};
+
+describe('buildGeneratorInput', () => {
+  it('prefers explicit exerciseSlugs', () => {
+    const result = buildGeneratorInput({
+      exerciseSlugs: ['back_squat', 'Dead Lift'],
+      durationMin: 7,
+    });
+    expect(result.exerciseSlugs).toEqual(['back_squat', 'dead_lift']);
+    expect(result.durationMin).toBe(7);
+  });
+
+  it('falls back to exercises.name + exercises.slug', () => {
+    const result = buildGeneratorInput({
+      exercises: [{ name: 'Bench Press' }, { slug: 'overhead_press' }],
+    });
+    expect(result.exerciseSlugs).toEqual(['bench_press', 'overhead_press']);
+  });
+
+  it('drops empty / non-string entries', () => {
+    const result = buildGeneratorInput({
+      exerciseSlugs: ['good', '', undefined as unknown as string],
+    });
+    expect(result.exerciseSlugs).toEqual(['good']);
+  });
+
+  it('trims whitespace-only userContext to undefined', () => {
+    const result = buildGeneratorInput({ exerciseSlugs: ['a'], userContext: '   ' });
+    expect(result.userContext).toBeUndefined();
+  });
+
+  it('preserves non-empty userContext', () => {
+    const result = buildGeneratorInput({
+      exerciseSlugs: ['a'],
+      userContext: 'left shoulder stiff',
+    });
+    expect(result.userContext).toBe('left shoulder stiff');
+  });
+});
+
+describe('buildWarmupForSession', () => {
+  const originalFlag = process.env[WARMUP_COACH_FLAG_ENV_VAR];
+
+  beforeEach(() => {
+    generateWarmupSpy.mockReset();
+    generateWarmupSpy.mockResolvedValue(FAKE_PLAN);
+  });
+
+  afterEach(() => {
+    if (originalFlag === undefined) {
+      delete process.env[WARMUP_COACH_FLAG_ENV_VAR];
+    } else {
+      process.env[WARMUP_COACH_FLAG_ENV_VAR] = originalFlag;
+    }
+  });
+
+  it('returns null when the flag is off — never calls the generator', async () => {
+    delete process.env[WARMUP_COACH_FLAG_ENV_VAR];
+    const result = await buildWarmupForSession({ exerciseSlugs: ['squat'] });
+    expect(result).toBeNull();
+    expect(generateWarmupSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no exercises resolve — never calls the generator', async () => {
+    process.env[WARMUP_COACH_FLAG_ENV_VAR] = '1';
+    const result = await buildWarmupForSession({ exerciseSlugs: [] });
+    expect(result).toBeNull();
+    expect(generateWarmupSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls the generator with normalized input when flag on', async () => {
+    process.env[WARMUP_COACH_FLAG_ENV_VAR] = 'true';
+    const result = await buildWarmupForSession({
+      exerciseSlugs: ['Back Squat', 'Dead Lift'],
+      durationMin: 5,
+      userContext: 'tight hips',
+    });
+    expect(result).toEqual(FAKE_PLAN);
+    expect(generateWarmupSpy).toHaveBeenCalledTimes(1);
+    const [input] = generateWarmupSpy.mock.calls[0];
+    expect(input).toEqual({
+      exerciseSlugs: ['back_squat', 'dead_lift'],
+      durationMin: 5,
+      userContext: 'tight hips',
+    });
+  });
+
+  it('uses generatorOverride when provided (test seam)', async () => {
+    process.env[WARMUP_COACH_FLAG_ENV_VAR] = '1';
+    const override = jest.fn(() => Promise.resolve(FAKE_PLAN));
+    const result = await buildWarmupForSession(
+      { exerciseSlugs: ['squat'] },
+      { generatorOverride: override },
+    );
+    expect(result).toEqual(FAKE_PLAN);
+    expect(override).toHaveBeenCalledTimes(1);
+    expect(generateWarmupSpy).not.toHaveBeenCalled();
+  });
+
+  it('bypassFlag lets tests run without setting env', async () => {
+    delete process.env[WARMUP_COACH_FLAG_ENV_VAR];
+    const result = await buildWarmupForSession(
+      { exerciseSlugs: ['squat'] },
+      { bypassFlag: true },
+    );
+    expect(result).toEqual(FAKE_PLAN);
+    expect(generateWarmupSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates generator errors', async () => {
+    process.env[WARMUP_COACH_FLAG_ENV_VAR] = '1';
+    generateWarmupSpy.mockRejectedValueOnce(new Error('schema mismatch'));
+    await expect(
+      buildWarmupForSession({ exerciseSlugs: ['squat'] }),
+    ).rejects.toThrow('schema mismatch');
+  });
+});
+
+describe('isWarmupCoachFlowEnabled', () => {
+  const originalFlag = process.env[WARMUP_COACH_FLAG_ENV_VAR];
+
+  afterEach(() => {
+    if (originalFlag === undefined) {
+      delete process.env[WARMUP_COACH_FLAG_ENV_VAR];
+    } else {
+      process.env[WARMUP_COACH_FLAG_ENV_VAR] = originalFlag;
+    }
+  });
+
+  it('mirrors the flag', () => {
+    delete process.env[WARMUP_COACH_FLAG_ENV_VAR];
+    expect(isWarmupCoachFlowEnabled()).toBe(false);
+    process.env[WARMUP_COACH_FLAG_ENV_VAR] = '1';
+    expect(isWarmupCoachFlowEnabled()).toBe(true);
+  });
+});

--- a/tests/unit/services/fault-drill-aggregator.test.ts
+++ b/tests/unit/services/fault-drill-aggregator.test.ts
@@ -1,0 +1,135 @@
+import {
+  aggregatePersistentFaults,
+  severityForFault,
+  prettifyFaultCode,
+  DEFAULT_TOP_N,
+  DEFAULT_MIN_COUNT,
+} from '@/lib/services/fault-drill-aggregator';
+
+describe('severityForFault', () => {
+  it('flags major-regex faults as severity 3', () => {
+    expect(severityForFault('knee_valgus_collapse')).toBe(3);
+    expect(severityForFault('severe_lumbar_flexion')).toBe(3);
+    expect(severityForFault('hyper_extension')).toBe(3);
+  });
+
+  it('flags moderate-regex faults as severity 2', () => {
+    expect(severityForFault('shallow_depth')).toBe(2);
+    expect(severityForFault('forward_lean')).toBe(2);
+    expect(severityForFault('lateral_shift')).toBe(2);
+    expect(severityForFault('rep_asymmetry')).toBe(2);
+  });
+
+  it('defaults unknown faults to severity 1', () => {
+    expect(severityForFault('knees_in')).toBe(1);
+    expect(severityForFault('butt_wink')).toBe(1);
+    expect(severityForFault('random_thing')).toBe(1);
+  });
+});
+
+describe('prettifyFaultCode', () => {
+  it('replaces underscores and title-cases words', () => {
+    expect(prettifyFaultCode('knees_in')).toBe('Knees In');
+    expect(prettifyFaultCode('butt_wink')).toBe('Butt Wink');
+  });
+
+  it('trims excess whitespace', () => {
+    expect(prettifyFaultCode('  knees_in  ')).toBe('Knees In');
+  });
+
+  it('preserves single-word codes', () => {
+    expect(prettifyFaultCode('asymmetry')).toBe('Asymmetry');
+  });
+});
+
+describe('aggregatePersistentFaults', () => {
+  it('returns empty when no totals', () => {
+    expect(aggregatePersistentFaults([])).toEqual([]);
+  });
+
+  it('applies default top-N and minCount', () => {
+    const totals = [
+      { faultId: 'a', count: 1 },
+      { faultId: 'b', count: 4 },
+      { faultId: 'c', count: 3 },
+      { faultId: 'd', count: 2 },
+      { faultId: 'e', count: 5 },
+    ];
+    const result = aggregatePersistentFaults(totals);
+    // min=2 drops 'a'. top 3 by count: e=5, b=4, c=3.
+    expect(result.map((r) => r.code)).toEqual(['e', 'b', 'c']);
+    expect(result).toHaveLength(DEFAULT_TOP_N);
+  });
+
+  it('honours override topN', () => {
+    const totals = [
+      { faultId: 'a', count: 5 },
+      { faultId: 'b', count: 5 },
+    ];
+    const result = aggregatePersistentFaults(totals, { topN: 1 });
+    expect(result).toHaveLength(1);
+  });
+
+  it('honours override minCount', () => {
+    const totals = [
+      { faultId: 'a', count: 1 },
+      { faultId: 'b', count: 2 },
+    ];
+    const result = aggregatePersistentFaults(totals, { minCount: 1 });
+    expect(result).toHaveLength(2);
+  });
+
+  it('tie-breaks on faultId asc for stable ordering', () => {
+    const totals = [
+      { faultId: 'zz', count: 3 },
+      { faultId: 'aa', count: 3 },
+    ];
+    const result = aggregatePersistentFaults(totals);
+    expect(result.map((r) => r.code)).toEqual(['aa', 'zz']);
+  });
+
+  it('populates displayName from lookup when provided', () => {
+    const totals = [{ faultId: 'knees_in', count: 5 }];
+    const result = aggregatePersistentFaults(totals, {
+      displayNames: { knees_in: 'Knees caving in' },
+    });
+    expect(result[0].displayName).toBe('Knees caving in');
+  });
+
+  it('falls back to prettifyFaultCode when no display name supplied', () => {
+    const totals = [{ faultId: 'butt_wink', count: 5 }];
+    const result = aggregatePersistentFaults(totals);
+    expect(result[0].displayName).toBe('Butt Wink');
+  });
+
+  it('assigns severity consistently with severityForFault', () => {
+    const totals = [
+      { faultId: 'knees_in', count: 5 },
+      { faultId: 'shallow_depth', count: 4 },
+      { faultId: 'lumbar_collapse', count: 3 },
+    ];
+    const result = aggregatePersistentFaults(totals);
+    const byCode = Object.fromEntries(result.map((r) => [r.code, r.severity]));
+    expect(byCode).toEqual({
+      knees_in: 1,
+      shallow_depth: 2,
+      lumbar_collapse: 3,
+    });
+  });
+
+  it('defends against malformed entries', () => {
+    const totals = [
+      { faultId: 'good', count: 5 },
+      { faultId: '', count: 10 },
+      { faultId: 'nan', count: Number.NaN },
+      { faultId: 'inf', count: Number.POSITIVE_INFINITY },
+      { faultId: 'neg', count: -3 },
+    ] as unknown as { faultId: string; count: number }[];
+    const result = aggregatePersistentFaults(totals);
+    expect(result.map((r) => r.code)).toEqual(['good']);
+  });
+
+  it('matches the default min count constant', () => {
+    expect(DEFAULT_MIN_COUNT).toBe(2);
+  });
+});

--- a/tests/unit/services/fault-drill-gemma-flag.test.ts
+++ b/tests/unit/services/fault-drill-gemma-flag.test.ts
@@ -1,0 +1,45 @@
+import {
+  isFaultDrillGemmaEnabled,
+  FAULT_DRILL_GEMMA_FLAG_ENV_VAR,
+} from '@/lib/services/fault-drill-gemma-flag';
+
+describe('fault-drill-gemma-flag', () => {
+  const originalValue = process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR];
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR];
+    } else {
+      process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR] = originalValue;
+    }
+  });
+
+  it('returns false when unset', () => {
+    delete process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR];
+    expect(isFaultDrillGemmaEnabled()).toBe(false);
+  });
+
+  it('returns true for "1"', () => {
+    process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR] = '1';
+    expect(isFaultDrillGemmaEnabled()).toBe(true);
+  });
+
+  it('returns true for "true"', () => {
+    process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR] = 'true';
+    expect(isFaultDrillGemmaEnabled()).toBe(true);
+  });
+
+  it('returns false for adjacent truthy-looking strings', () => {
+    for (const value of ['yes', 'on', 'TRUE', 'True', 'ON', '0', 'false', 'enabled', '']) {
+      process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR] = value;
+      expect(isFaultDrillGemmaEnabled()).toBe(false);
+    }
+  });
+
+  it('returns false for whitespace-padded values', () => {
+    process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR] = ' 1 ';
+    expect(isFaultDrillGemmaEnabled()).toBe(false);
+    process.env[FAULT_DRILL_GEMMA_FLAG_ENV_VAR] = ' true ';
+    expect(isFaultDrillGemmaEnabled()).toBe(false);
+  });
+});

--- a/tests/unit/services/fault-heatmap-data-loader.test.ts
+++ b/tests/unit/services/fault-heatmap-data-loader.test.ts
@@ -1,0 +1,202 @@
+const mockSupabaseFrom = jest.fn();
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockSupabaseFrom(...args),
+  },
+}));
+
+import {
+  aggregateFaultHeatmap,
+  loadFaultHeatmapData,
+  type SessionMetricsRow,
+  type RepsRow,
+} from '@/lib/services/fault-heatmap-data-loader';
+
+function mkBuilder(data: unknown, error: unknown = null) {
+  const builder: Record<string, unknown> = {};
+  const chain = () => builder;
+  builder.select = chain;
+  builder.order = chain;
+  builder.gte = chain;
+  builder.in = chain;
+  builder.limit = jest.fn(() => Promise.resolve({ data, error }));
+  return builder;
+}
+
+const NOW = new Date('2026-04-20T12:00:00.000Z');
+
+function isoDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+describe('aggregateFaultHeatmap', () => {
+  it('produces 7 day labels earliest -> today', () => {
+    const result = aggregateFaultHeatmap({ sessions: [], reps: [], now: NOW });
+    expect(result.days).toHaveLength(7);
+    // Day labels are M/D — last one is today.
+    expect(result.days[6]).toBe(`${NOW.getMonth() + 1}/${NOW.getDate()}`);
+    expect(result.cells).toEqual([]);
+    expect(result.totals).toEqual([]);
+    expect(result.lastSessionId).toBeNull();
+  });
+
+  it('aggregates rep faults by day + fault id', () => {
+    const today = isoDay(NOW);
+    const yesterday = isoDay(new Date(NOW.getTime() - 24 * 60 * 60 * 1000));
+
+    const sessions: SessionMetricsRow[] = [
+      { session_id: 's-today', start_at: `${today}T09:00:00.000Z` },
+      { session_id: 's-yesterday', start_at: `${yesterday}T09:00:00.000Z` },
+    ];
+    const reps: RepsRow[] = [
+      {
+        session_id: 's-today',
+        faults_detected: ['knees_in'],
+        start_ts: `${today}T09:01:00.000Z`,
+      },
+      {
+        session_id: 's-today',
+        faults_detected: ['knees_in', 'butt_wink'],
+        start_ts: `${today}T09:02:00.000Z`,
+      },
+      {
+        session_id: 's-yesterday',
+        faults_detected: ['butt_wink'],
+        start_ts: `${yesterday}T09:01:00.000Z`,
+      },
+    ];
+
+    const result = aggregateFaultHeatmap({ sessions, reps, now: NOW });
+
+    const today6 = result.days[6];
+    const yesterday5 = result.days[5];
+
+    const kneesToday = result.cells.find((c) => c.dayLabel === today6 && c.faultId === 'knees_in');
+    const buttToday = result.cells.find((c) => c.dayLabel === today6 && c.faultId === 'butt_wink');
+    const buttYesterday = result.cells.find(
+      (c) => c.dayLabel === yesterday5 && c.faultId === 'butt_wink',
+    );
+
+    expect(kneesToday?.count).toBe(2);
+    expect(buttToday?.count).toBe(1);
+    expect(buttYesterday?.count).toBe(1);
+
+    expect(result.totals).toEqual([
+      { faultId: 'knees_in', count: 2 },
+      { faultId: 'butt_wink', count: 2 },
+    ]);
+  });
+
+  it('uses session start_at to bucket reps with missing start_ts', () => {
+    const today = isoDay(NOW);
+    const sessions: SessionMetricsRow[] = [
+      { session_id: 's-today', start_at: `${today}T09:00:00.000Z` },
+    ];
+    const reps: RepsRow[] = [
+      { session_id: 's-today', faults_detected: ['knees_in'], start_ts: null },
+    ];
+
+    const result = aggregateFaultHeatmap({ sessions, reps, now: NOW });
+    const todayLabel = result.days[6];
+    expect(result.cells).toContainEqual({ dayLabel: todayLabel, faultId: 'knees_in', count: 1 });
+  });
+
+  it('drops reps outside the 7-day window', () => {
+    const old = isoDay(new Date(NOW.getTime() - 30 * 24 * 60 * 60 * 1000));
+    const sessions: SessionMetricsRow[] = [
+      { session_id: 's-old', start_at: `${old}T09:00:00.000Z` },
+    ];
+    const reps: RepsRow[] = [
+      { session_id: 's-old', faults_detected: ['knees_in'], start_ts: `${old}T09:00:00.000Z` },
+    ];
+    const result = aggregateFaultHeatmap({ sessions, reps, now: NOW });
+    expect(result.cells).toEqual([]);
+    expect(result.totals).toEqual([]);
+    // lastSessionId still captures the most recent session even if its
+    // reps are out of window — heatmap consumers use totals anyway.
+    expect(result.lastSessionId).toBe('s-old');
+  });
+
+  it('defends against malformed fault rows', () => {
+    const today = isoDay(NOW);
+    const sessions: SessionMetricsRow[] = [
+      { session_id: 's', start_at: `${today}T09:00:00.000Z` },
+    ];
+    const reps: RepsRow[] = [
+      { session_id: 's', faults_detected: null, start_ts: `${today}T09:00:00.000Z` },
+      {
+        session_id: 's',
+        faults_detected: ['knees_in', '', null as unknown as string, undefined as unknown as string],
+        start_ts: `${today}T09:01:00.000Z`,
+      },
+    ];
+    const result = aggregateFaultHeatmap({ sessions, reps, now: NOW });
+    expect(result.totals).toEqual([{ faultId: 'knees_in', count: 1 }]);
+  });
+
+  it('picks the most recent session as lastSessionId', () => {
+    const today = isoDay(NOW);
+    const earlier = new Date(NOW.getTime() - 2 * 24 * 60 * 60 * 1000);
+    const sessions: SessionMetricsRow[] = [
+      { session_id: 's-earlier', start_at: earlier.toISOString() },
+      { session_id: 's-today', start_at: `${today}T11:00:00.000Z` },
+    ];
+    const result = aggregateFaultHeatmap({ sessions, reps: [], now: NOW });
+    expect(result.lastSessionId).toBe('s-today');
+  });
+});
+
+describe('loadFaultHeatmapData', () => {
+  beforeEach(() => {
+    mockSupabaseFrom.mockReset();
+  });
+
+  it('returns the empty snapshot when the sessions query errors', async () => {
+    mockSupabaseFrom.mockImplementation(() =>
+      mkBuilder(null, { message: 'boom' }),
+    );
+    const result = await loadFaultHeatmapData(NOW);
+    expect(result.cells).toEqual([]);
+    expect(result.totals).toEqual([]);
+    expect(result.days).toHaveLength(7);
+    expect(result.lastSessionId).toBeNull();
+  });
+
+  it('returns the empty snapshot when there are no sessions', async () => {
+    mockSupabaseFrom.mockImplementation(() => mkBuilder([], null));
+    const result = await loadFaultHeatmapData(NOW);
+    expect(result.cells).toEqual([]);
+    expect(result.totals).toEqual([]);
+    expect(result.lastSessionId).toBeNull();
+  });
+
+  it('pipes supabase rows through the aggregator', async () => {
+    const today = isoDay(NOW);
+    mockSupabaseFrom.mockImplementation((table: string) => {
+      if (table === 'session_metrics') {
+        return mkBuilder(
+          [{ session_id: 's-today', start_at: `${today}T09:00:00.000Z` }],
+          null,
+        );
+      }
+      if (table === 'reps') {
+        return mkBuilder(
+          [
+            {
+              session_id: 's-today',
+              faults_detected: ['knees_in', 'knees_in'],
+              start_ts: `${today}T09:01:00.000Z`,
+            },
+          ],
+          null,
+        );
+      }
+      return mkBuilder([], null);
+    });
+
+    const result = await loadFaultHeatmapData(NOW);
+    expect(result.totals).toEqual([{ faultId: 'knees_in', count: 2 }]);
+    expect(result.lastSessionId).toBe('s-today');
+  });
+});

--- a/tests/unit/services/warmup-coach-flag.test.ts
+++ b/tests/unit/services/warmup-coach-flag.test.ts
@@ -1,0 +1,45 @@
+import {
+  isWarmupCoachEnabled,
+  WARMUP_COACH_FLAG_ENV_VAR,
+} from '@/lib/services/warmup-coach-flag';
+
+describe('warmup-coach-flag', () => {
+  const originalValue = process.env[WARMUP_COACH_FLAG_ENV_VAR];
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env[WARMUP_COACH_FLAG_ENV_VAR];
+    } else {
+      process.env[WARMUP_COACH_FLAG_ENV_VAR] = originalValue;
+    }
+  });
+
+  it('returns false when unset', () => {
+    delete process.env[WARMUP_COACH_FLAG_ENV_VAR];
+    expect(isWarmupCoachEnabled()).toBe(false);
+  });
+
+  it('returns true for "1"', () => {
+    process.env[WARMUP_COACH_FLAG_ENV_VAR] = '1';
+    expect(isWarmupCoachEnabled()).toBe(true);
+  });
+
+  it('returns true for "true"', () => {
+    process.env[WARMUP_COACH_FLAG_ENV_VAR] = 'true';
+    expect(isWarmupCoachEnabled()).toBe(true);
+  });
+
+  it('returns false for adjacent truthy-looking strings', () => {
+    for (const value of ['yes', 'on', 'TRUE', 'True', 'ON', '0', 'false', 'enabled', '']) {
+      process.env[WARMUP_COACH_FLAG_ENV_VAR] = value;
+      expect(isWarmupCoachEnabled()).toBe(false);
+    }
+  });
+
+  it('returns false for whitespace-padded values', () => {
+    process.env[WARMUP_COACH_FLAG_ENV_VAR] = ' 1 ';
+    expect(isWarmupCoachEnabled()).toBe(false);
+    process.env[WARMUP_COACH_FLAG_ENV_VAR] = ' true ';
+    expect(isWarmupCoachEnabled()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Wave 25 PR-β — the "pre-session + in-session form-tracking UX arc" bundle. Two top-level flows behind independent feature flags, both default off.

- **Fault-heatmap → Gemma drill CTA**: the heatmap modal now pulls real 7-day fault data from Supabase (replacing the synthetic placeholder grid) and, when `EXPO_PUBLIC_FAULT_DRILL_GEMMA` is on with at least one persistent fault, surfaces an "Ask Gemma for drills" CTA. Tapping fans `coach-drill-explainer.explainDrill` across the top-N persistent faults and expands an inline sheet with per-fault rationales.
- **Pre-session warmup coach**: new `session-warmup-coach` modal that wraps `warmup-generator.generateWarmup` behind `EXPO_PUBLIC_WARMUP_COACH`. The generate-session modal now shows a "Warm up with coach" CTA after a template is persisted; tapping opens the warmup modal which auto-kicks a generation.

## Flags (both default OFF, fail-closed)

- `EXPO_PUBLIC_FAULT_DRILL_GEMMA` — strict `'1'` / `'true'` parse. Gates the heatmap drill CTA + drill-explainer dispatch. `use-persistent-fault-summary` is the primary fail-closed gate; when off, `topFaults.length === 0` and the CTA never renders.
- `EXPO_PUBLIC_WARMUP_COACH` — strict `'1'` / `'true'` parse. Gates the warmup provider + hook + modal + CTA. Generator never called when off.

Both added to `.env.example`.

## Non-overlap with in-flight PRs (#505–#512)

Zero writes to any AVOIDED file. Only read-only imports of:

- `lib/services/coach-drill-explainer.ts` (#512 edits) — imported, zero diff.
- `lib/services/warmup-generator.ts` (#510 edits) — imported via `coach-warmup-provider`, zero diff.
- `lib/services/coach-service.ts` — imported transitively, zero diff.

Edit surface is confined to:
- `app/(modals)/fault-heatmap.tsx` (wave-25 exclusive)
- `app/(modals)/generate-session.tsx` (wave-25 exclusive)
- `app/(modals)/_layout.tsx` (append-only stack entry)
- `components/form-tracking/FormQualityRecoveryCard.tsx` (additive prop, non-breaking)
- `.env.example` (append-only)

## 13 atomic commits

1. `feat(flags): add EXPO_PUBLIC_FAULT_DRILL_GEMMA + EXPO_PUBLIC_WARMUP_COACH flags`
2. `feat(services): add fault-heatmap-data-loader service`
3. `feat(fault-heatmap): wire real data from loader (replacing synthetic grid)`
4. `feat(services): add fault-drill-aggregator`
5. `feat(hooks): add use-persistent-fault-summary hook`
6. `feat(fault-heatmap): "Ask Gemma for drills" CTA (flag-gated)`
7. `feat(recovery-card): add loading state during drill fetch`
8. `feat(services): add coach-warmup-provider service`
9. `feat(hooks): add use-pre-session-coach hook`
10. `feat(modals): add session-warmup-coach modal`
11. `feat(generate-session): "Warm up with coach" CTA`
12. `test(integration): fault-heatmap CTA → drill-explainer call`
13. `test(integration): warmup-coach modal generates plan`

## Deviations from spec

1. **Loader source**: the spec said "Pulls recent form-tracking session data from local-db". The on-device `local-db.ts` does NOT mirror the `reps` table (per-rep payloads are heavily RLS'd on Supabase and would balloon the SQLite file). The loader instead uses the same `session_metrics` + `reps` Supabase pattern that `hooks/use-form-home-data.ts` already ships — same data source the existing heatmap thumb reads from. Documented in the loader header. No new local-db surface created.

## Verification

- `bun run lint` clean.
- `bun run check:types` clean.
- Target-suite: `bun run test --testPathPattern="(fault-heatmap-data-loader|fault-drill-aggregator|fault-drill-gemma-flag|use-persistent-fault-summary|coach-warmup-provider|use-pre-session-coach|warmup-coach-flag|fault-heatmap-drill-cta|session-warmup-coach)"` → 9 suites, 63 tests, all passing.
- `git diff f77d980c..HEAD --name-only` — 23 files: 11 source, 9 tests, 1 env-template, 2 modal routes. Zero AVOIDED-list files touched.

## Linked worklog

`docs/overnight/worklog-2026-04-20-form-ux-gemma.md` (wave 25 PR-β section).

## Test plan

- [ ] Pull + `bun install`.
- [ ] `bun run lint` + `bun run check:types` — both clean.
- [ ] Run target-suite above — 63/63 pass.
- [ ] With both flags unset, smoke-test the app: fault-heatmap modal renders without CTA; generate-session flow has no warmup CTA.
- [ ] Set `EXPO_PUBLIC_FAULT_DRILL_GEMMA=1`, open fault-heatmap with >=1 persistent fault → CTA visible, tap → drill sheet populates.
- [ ] Set `EXPO_PUBLIC_WARMUP_COACH=1`, generate a session → CTA visible after persist, tap → warmup modal auto-generates plan.