### PR TITLE
feat(watch): wire initWatchSessionBridge into app lifecycle

### DIFF
--- a/contexts/WatchSessionBridgeContext.tsx
+++ b/contexts/WatchSessionBridgeContext.tsx
@@ -1,0 +1,34 @@
+/**
+ * WatchSessionBridgeContext
+ *
+ * Mounts {@link initWatchSessionBridge} once per app lifecycle so the watch
+ * session event forwarder actually runs in production. The bridge itself is a
+ * pure service (see lib/services/watch-session-bridge.ts) — this provider's
+ * only job is to call it on mount and clean it up on unmount.
+ *
+ * There is intentionally no context value: consumers do not interact with the
+ * bridge directly. Keeping this as a provider-shaped component lets us slot it
+ * into the provider tree the same way every other app-lifecycle wiring is
+ * mounted, and gives tests a clean mount/unmount surface.
+ *
+ * Mount site: inside WorkoutsProvider (the session-aware scope). See
+ * contexts/WorkoutsContext.tsx for where children are wrapped.
+ *
+ * Closes #440 (the bridge service, its tests, and session-runner
+ * subscribeToEvents all landed previously; this is the last-mile wiring).
+ */
+
+import React, { ReactNode, useEffect } from 'react';
+import { initWatchSessionBridge } from '@/lib/services/watch-session-bridge';
+import { subscribeToEvents } from '@/lib/stores/session-runner';
+
+export const WatchSessionBridgeProvider = ({ children }: { children: ReactNode }) => {
+  useEffect(() => {
+    const teardown = initWatchSessionBridge({ subscribeToEvents });
+    return () => {
+      teardown();
+    };
+  }, []);
+
+  return <>{children}</>;
+};

--- a/contexts/WorkoutsContext.tsx
+++ b/contexts/WorkoutsContext.tsx
@@ -5,6 +5,7 @@ import { syncService } from '../lib/services/database/sync-service';
 import { useNetwork } from './NetworkContext';
 import { useAuth } from './AuthContext';
 import { useToast } from './ToastContext';
+import { WatchSessionBridgeProvider } from './WatchSessionBridgeContext';
 
 export interface Workout {
   id: string;
@@ -223,7 +224,7 @@ export const WorkoutsProvider = ({ children }: { children: ReactNode }) => {
 
   return (
     <WorkoutsContext.Provider value={value}>
-      {children}
+      <WatchSessionBridgeProvider>{children}</WatchSessionBridgeProvider>
     </WorkoutsContext.Provider>
   );
 };

--- a/lib/services/watch-session-bridge.ts
+++ b/lib/services/watch-session-bridge.ts
@@ -14,6 +14,10 @@
  *   const teardown = initWatchSessionBridge({ subscribeToEvents });
  *   // ... later
  *   teardown();
+ *
+ * Production mount site: contexts/WatchSessionBridgeContext.tsx, which is
+ * nested inside WorkoutsProvider (see contexts/WorkoutsContext.tsx). The
+ * provider owns the lifecycle so the bridge starts/stops with the app.
  */
 import { sendMessage } from '@/lib/watch-connectivity';
 import type {

--- a/tests/unit/contexts/WatchSessionBridgeContext.test.tsx
+++ b/tests/unit/contexts/WatchSessionBridgeContext.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Integration test for contexts/WatchSessionBridgeContext.tsx.
+ *
+ * Last-mile wiring test for #440. Proves the provider:
+ *   1. Renders children pass-through.
+ *   2. On mount, subscribes the bridge to session-runner's event registry.
+ *   3. Forwards a routed event end-to-end: emitted event → sendMessage call
+ *      with the session_event payload shape.
+ *   4. Filters non-routed events so the watch channel stays quiet.
+ *   5. On unmount, the bridge's teardown runs (unsubscribe invoked).
+ *
+ * Boundaries mocked: `sendMessage` from `@/lib/watch-connectivity` and
+ * `subscribeToEvents` from `@/lib/stores/session-runner`. The
+ * WatchSessionBridgeProvider + initWatchSessionBridge wiring under test is
+ * real — this test exists specifically to prove the provider binds them
+ * together and cleans up on unmount.
+ */
+
+const mockSendMessage = jest.fn();
+const mockSubscribeToEvents = jest.fn();
+const mockUnsubscribe = jest.fn();
+
+jest.mock('@/lib/watch-connectivity', () => ({
+  sendMessage: (...args: unknown[]) => mockSendMessage(...args),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  warnWithTs: jest.fn(),
+  logWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+}));
+
+jest.mock('@/lib/stores/session-runner', () => ({
+  subscribeToEvents: (...args: unknown[]) => mockSubscribeToEvents(...args),
+}));
+
+import React from 'react';
+import { Text } from 'react-native';
+import { render } from '@testing-library/react-native';
+import type { WorkoutSessionEvent } from '@/lib/types/workout-session';
+import { WatchSessionBridgeProvider } from '@/contexts/WatchSessionBridgeContext';
+
+type Listener = (event: WorkoutSessionEvent) => void;
+
+function buildEvent(overrides: Partial<WorkoutSessionEvent> = {}): WorkoutSessionEvent {
+  return {
+    id: 'evt-int-1',
+    session_id: 'sess-int-1',
+    created_at: new Date('2026-04-20T12:00:00.000Z').toISOString(),
+    type: 'set_completed',
+    session_exercise_id: 'sex-int-1',
+    session_set_id: 'set-int-1',
+    payload: { actual_reps: 5 },
+    ...overrides,
+  };
+}
+
+describe('WatchSessionBridgeProvider (integration)', () => {
+  let capturedListener: Listener | null;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedListener = null;
+    mockSubscribeToEvents.mockImplementation((listener: Listener) => {
+      capturedListener = listener;
+      return mockUnsubscribe;
+    });
+  });
+
+  it('renders children untouched', () => {
+    const { queryByText } = render(
+      <WatchSessionBridgeProvider>
+        <Text>child-content</Text>
+      </WatchSessionBridgeProvider>,
+    );
+    expect(queryByText('child-content')).not.toBeNull();
+  });
+
+  it('subscribes to session-runner exactly once on mount', () => {
+    render(
+      <WatchSessionBridgeProvider>
+        <Text>x</Text>
+      </WatchSessionBridgeProvider>,
+    );
+    expect(mockSubscribeToEvents).toHaveBeenCalledTimes(1);
+    expect(typeof mockSubscribeToEvents.mock.calls[0][0]).toBe('function');
+  });
+
+  it('forwards a routed session event end-to-end through the mounted bridge', () => {
+    render(
+      <WatchSessionBridgeProvider>
+        <Text>x</Text>
+      </WatchSessionBridgeProvider>,
+    );
+
+    expect(capturedListener).not.toBeNull();
+    capturedListener!(buildEvent({ type: 'set_completed' }));
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    const [msg] = mockSendMessage.mock.calls[0];
+    expect(msg).toMatchObject({
+      v: 1,
+      type: 'session_event',
+      event: 'set_completed',
+      sessionId: 'sess-int-1',
+      sessionSetId: 'set-int-1',
+      sessionExerciseId: 'sex-int-1',
+    });
+  });
+
+  it('filters non-routed events so the watch channel stays quiet', () => {
+    render(
+      <WatchSessionBridgeProvider>
+        <Text>x</Text>
+      </WatchSessionBridgeProvider>,
+    );
+
+    capturedListener!(buildEvent({ type: 'set_started' }));
+    capturedListener!(buildEvent({ type: 'session_started', session_set_id: null }));
+
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('tears down the bridge subscription on unmount', () => {
+    const { unmount } = render(
+      <WatchSessionBridgeProvider>
+        <Text>x</Text>
+      </WatchSessionBridgeProvider>,
+    );
+
+    expect(mockUnsubscribe).not.toHaveBeenCalled();
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Mounts `initWatchSessionBridge` so the already-shipped watch session-event forwarding actually runs in production.
- The service (`lib/services/watch-session-bridge.ts`), tests, and `session-runner.subscribeToEvents` API were landed via a prior squash that didn't carry `Closes #440`; this PR is the last-mile wiring.
- Forwards `set_completed`, `rest_started`, `rest_completed`, `rest_skipped`, `session_completed`, `pr_detected` to the paired Apple Watch via `sendMessage`. Dedup window and payload shape unchanged from the service spec.

## Implementation

- New `contexts/WatchSessionBridgeContext.tsx` — small provider that calls `initWatchSessionBridge({ subscribeToEvents })` in a `useEffect` on mount and invokes the returned teardown on unmount.
- Mounted inside `WorkoutsProvider` (`contexts/WorkoutsContext.tsx`) rather than `app/_layout.tsx` to keep the wiring in the session-aware scope and avoid conflicting with the concurrent voice-pipeline changes that reindent the top-level provider tree in PR #511.
- Atomic commits: provider → mount → integration test → doc note.

## Verification

- [x] `bun run lint` passes
- [x] `bun run check:types` passes
- [x] Watch-bridge unit tests pass (9/9, pre-existing)
- [x] New integration test for provider mount/teardown passes (5/5)
- [x] Full test suite: baseline 4559 → 4564 passed (+5 new, 0 regressions), 24 skipped unchanged, 0 failures
- [x] No file overlap with open PRs #505-#514 (confirmed via `gh pr view <n> --json files`); `app/_layout.tsx` intentionally not touched so PR #511 can merge without conflict

## Non-overlap

- `lib/services/watch-session-bridge.ts` — read-only import (plus a 3-line header comment documenting the mount site).
- `lib/stores/session-runner.ts` — read-only import (uses existing `subscribeToEvents`).
- `app/(tabs)/scan-arkit.tsx` — untouched (respects #505 boundary).
- `app/_layout.tsx` — untouched (respects #511 boundary).

Closes #440