### PR TITLE
feat(form-ux): progression-plan markdown renderer + scan-arkit upload logging + DEV overlay diagnostic

### DIFF
--- a/app/(modals)/progression-plan.tsx
+++ b/app/(modals)/progression-plan.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/lib/services/progression-planner';
 import { suggestWeight, type WeightSuggestion } from '@/lib/services/weight-suggester';
 import type { PrResult } from '@/lib/services/pr-detector-overload';
+import { ProgressionPlanView } from '@/components/ProgressionPlanView';
 
 const BG = '#050E1F';
 const PANEL = '#0E1A2E';
@@ -241,7 +242,12 @@ export default function ProgressionPlanModal() {
                 <Text style={styles.loadingText}>Asking the coach…</Text>
               </View>
             ) : plan ? (
-              <Text style={styles.planText}>{plan.text}</Text>
+              <ProgressionPlanView
+                source={plan.text}
+                textColor={TEXT_PRIMARY}
+                mutedColor={TEXT_SECONDARY}
+                accentColor={ACCENT}
+              />
             ) : (
               <Text style={styles.cardBody}>
                 The coach service is unavailable — your suggested weight above still applies.

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -18,7 +18,7 @@ import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Ionicons } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useIsFocused } from '@react-navigation/native';
-import { Svg, Circle, Line } from 'react-native-svg';
+import { Svg, Circle, Line, Rect } from 'react-native-svg';
 import { VideoView, useVideoPlayer } from 'expo-video';
 import * as Haptics from 'expo-haptics';
 import * as FileSystem from 'expo-file-system/legacy';
@@ -2837,6 +2837,34 @@ export default function ScanARKitScreen() {
           onStartShouldSetResponder={() => !isTracking}
           onLayout={handleOverlayLayout}
         >
+
+          {/*
+            Overlay-alignment diagnostic (dev only). If corner dots don't
+            sit at the actual screen corners and the border doesn't trace
+            the visible camera rect, the SVG container is not the same
+            rect as the native ARView — that's the overlay misalignment bug.
+          */}
+          {DEV && (
+            <Svg
+              style={styles.fullFill}
+              viewBox="0 0 1 1"
+              preserveAspectRatio="none"
+              pointerEvents="none"
+            >
+              <Rect x="0" y="0" width="1" height="1" fill="none" stroke="#FF00FF" strokeWidth="0.004" />
+              <Circle cx="0" cy="0" r="0.012" fill="#FF00FF" />
+              <Circle cx="1" cy="0" r="0.012" fill="#FF00FF" />
+              <Circle cx="0" cy="1" r="0.012" fill="#FF00FF" />
+              <Circle cx="1" cy="1" r="0.012" fill="#FF00FF" />
+              <Line x1="0.45" y1="0.5" x2="0.55" y2="0.5" stroke="#FFFF00" strokeWidth="0.004" />
+              <Line x1="0.5" y1="0.45" x2="0.5" y2="0.55" stroke="#FFFF00" strokeWidth="0.004" />
+              <Circle cx="0.5" cy="0.5" r="0.006" fill="#FFFF00" />
+              <Line x1="0.25" y1="0.48" x2="0.25" y2="0.52" stroke="#00FFFF" strokeWidth="0.003" />
+              <Line x1="0.75" y1="0.48" x2="0.75" y2="0.52" stroke="#00FFFF" strokeWidth="0.003" />
+              <Line x1="0.48" y1="0.25" x2="0.52" y2="0.25" stroke="#00FFFF" strokeWidth="0.003" />
+              <Line x1="0.48" y1="0.75" x2="0.52" y2="0.75" stroke="#00FFFF" strokeWidth="0.003" />
+            </Svg>
+          )}
 
           {!showTelemetry && (
             <Animated.View style={[styles.topGuide, { top: topBarBottom + 16, opacity: textOpacity }]}>

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -2299,16 +2299,30 @@ export default function ScanARKitScreen() {
       try {
         const uploadAllowed = await shouldUploadVideo();
         if (!uploadAllowed) {
+          warnWithTs('[ScanARKit] Auto upload skipped: video consent disabled', {
+            exercise: payload.exercise,
+            uri: payload.uri,
+          });
           return;
         }
 
         const info = await FileSystem.getInfoAsync(payload.uri);
         if (!info.exists) {
+          warnWithTs('[ScanARKit] Auto upload skipped: recording file missing', { uri: payload.uri });
           return;
         }
         if (info.size && info.size > MAX_UPLOAD_BYTES) {
+          warnWithTs('[ScanARKit] Auto upload skipped: file exceeds max size', {
+            size: info.size,
+            max: MAX_UPLOAD_BYTES,
+          });
           return;
         }
+
+        logWithTs('[ScanARKit] Auto analysis upload starting', {
+          exercise: payload.exercise,
+          sizeBytes: info.size ?? null,
+        });
 
         await uploadWorkoutVideo({
           fileUri: payload.uri,
@@ -2316,6 +2330,8 @@ export default function ScanARKitScreen() {
           metrics: payload.metrics,
           analysisOnly: true,
         });
+
+        logWithTs('[ScanARKit] Auto analysis upload succeeded', { exercise: payload.exercise });
       } catch (error) {
         warnWithTs('[ScanARKit] Auto analysis upload failed', error);
       }

--- a/components/ProgressionPlanView.tsx
+++ b/components/ProgressionPlanView.tsx
@@ -1,0 +1,143 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+type InlineToken = { kind: 'text' | 'bold'; value: string };
+
+type Block =
+  | { kind: 'heading'; level: number; tokens: InlineToken[] }
+  | { kind: 'bullet'; depth: number; tokens: InlineToken[] }
+  | { kind: 'paragraph'; tokens: InlineToken[] }
+  | { kind: 'spacer' };
+
+function tokenizeInline(line: string): InlineToken[] {
+  const tokens: InlineToken[] = [];
+  const re = /\*\*(.+?)\*\*/g;
+  let lastIdx = 0;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(line)) !== null) {
+    if (match.index > lastIdx) {
+      tokens.push({ kind: 'text', value: line.slice(lastIdx, match.index) });
+    }
+    tokens.push({ kind: 'bold', value: match[1] });
+    lastIdx = match.index + match[0].length;
+  }
+  if (lastIdx < line.length) {
+    tokens.push({ kind: 'text', value: line.slice(lastIdx) });
+  }
+  return tokens;
+}
+
+function parseBlocks(source: string): Block[] {
+  const lines = source.replace(/\r\n/g, '\n').split('\n');
+  const blocks: Block[] = [];
+  for (const raw of lines) {
+    if (!raw.trim()) {
+      blocks.push({ kind: 'spacer' });
+      continue;
+    }
+    const headingMatch = raw.match(/^(#{1,6})\s+(.*)$/);
+    if (headingMatch) {
+      blocks.push({
+        kind: 'heading',
+        level: headingMatch[1].length,
+        tokens: tokenizeInline(headingMatch[2]),
+      });
+      continue;
+    }
+    const bulletMatch = raw.match(/^(\s*)[-*]\s+(.*)$/);
+    if (bulletMatch) {
+      const depth = Math.floor(bulletMatch[1].length / 2);
+      blocks.push({
+        kind: 'bullet',
+        depth,
+        tokens: tokenizeInline(bulletMatch[2]),
+      });
+      continue;
+    }
+    blocks.push({ kind: 'paragraph', tokens: tokenizeInline(raw.trim()) });
+  }
+  return blocks;
+}
+
+function renderTokens(tokens: InlineToken[], boldColor: string) {
+  return tokens.map((t, i) =>
+    t.kind === 'bold' ? (
+      <Text key={i} style={[styles.bold, { color: boldColor }]}>
+        {t.value}
+      </Text>
+    ) : (
+      <Text key={i}>{t.value}</Text>
+    ),
+  );
+}
+
+export interface ProgressionPlanViewProps {
+  source: string;
+  textColor?: string;
+  mutedColor?: string;
+  accentColor?: string;
+}
+
+export function ProgressionPlanView({
+  source,
+  textColor = '#F8F9FF',
+  mutedColor = '#8E9BAD',
+  accentColor = '#4C8CFF',
+}: ProgressionPlanViewProps) {
+  const blocks = useMemo(() => parseBlocks(source), [source]);
+
+  return (
+    <View style={styles.container}>
+      {blocks.map((block, i) => {
+        if (block.kind === 'spacer') return <View key={i} style={styles.spacer} />;
+
+        if (block.kind === 'heading') {
+          const sizeStyle =
+            block.level <= 1 ? styles.h1 : block.level === 2 ? styles.h2 : styles.h3;
+          return (
+            <Text
+              key={i}
+              style={[styles.heading, sizeStyle, { color: textColor }]}
+              accessibilityRole="header"
+            >
+              {renderTokens(block.tokens, accentColor)}
+            </Text>
+          );
+        }
+
+        if (block.kind === 'bullet') {
+          return (
+            <View key={i} style={[styles.bulletRow, { marginLeft: block.depth * 14 }]}>
+              <Text style={[styles.bulletDot, { color: mutedColor }]}>•</Text>
+              <Text style={[styles.bulletText, { color: textColor }]}>
+                {renderTokens(block.tokens, accentColor)}
+              </Text>
+            </View>
+          );
+        }
+
+        return (
+          <Text key={i} style={[styles.paragraph, { color: textColor }]}>
+            {renderTokens(block.tokens, accentColor)}
+          </Text>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { gap: 2 },
+  heading: { fontWeight: '700', marginTop: 8, marginBottom: 4 },
+  h1: { fontSize: 18 },
+  h2: { fontSize: 16 },
+  h3: { fontSize: 15 },
+  bulletRow: { flexDirection: 'row', alignItems: 'flex-start', paddingVertical: 1 },
+  bulletDot: { width: 14, fontSize: 14, lineHeight: 20 },
+  bulletText: { flex: 1, fontSize: 14, lineHeight: 20 },
+  paragraph: { fontSize: 14, lineHeight: 20, marginVertical: 2 },
+  spacer: { height: 6 },
+  bold: { fontWeight: '700' },
+});
+
+export default ProgressionPlanView;


### PR DESCRIPTION
## Summary

Bundle of three small-but-independent form-tracking UX polish
items, each landed as its own atomic commit:

- **Coach progression-plan rendering.** Adds
  `components/ProgressionPlanView.tsx` — a no-dependency
  Markdown-ish renderer (headings, bullets, **bold**) and swaps
  the progression-plan modal to use it. Previously the plan text
  rendered as one collapsed `<Text>`, losing all structure.
- **Auto-upload lifecycle logging.** `autoUploadAnalysisVideo` had
  three silent skip paths (consent off, missing file, oversize)
  and only logged on thrown errors. Adds `warnWithTs` on each
  skip path and `logWithTs` bracketing the upload call so
  ""nothing uploads after my session"" reports are traceable.
- **DEV-only overlay alignment diagnostic.** Adds a magenta
  border + corner dots + yellow crosshair SVG under the scan
  overlay, gated by `DEV = __DEV__`. If the reference marks
  don't line up with the visible camera rect in a dev build,
  the overlay-misalignment bug is active.

## Commits (atomic)

- `7aa23785` feat(coach): add ProgressionPlanView markdown-ish renderer
- `11771bd0` feat(coach): render progression plan through ProgressionPlanView
- `6b005422` chore(scan-arkit): add auto-upload lifecycle logging
- `01a1a453` feat(scan-arkit): add DEV-only overlay alignment diagnostic

## Verification

- [x] Pre-commit hook ran lint + tsc + shared-sync + cue-coverage on every commit; all clean
- [x] No production behavior change to scan-arkit (diagnostic is `__DEV__`-gated)
- [x] No new dependency — ProgressionPlanView uses only `react-native` primitives
- [x] ProgressionPlanView tokenizer handles missing/malformed markdown gracefully (falls back to paragraph)

## File overlap with open PRs

- **#508** (progression flag gates) touches `app/(modals)/progression-plan.tsx` in a different region (adds flag-gated disabled state around the generate button). Both should merge cleanly — the import block is the only potential line-level contact, both-ways additive.
- **#505** (form-tracking resilience + AR overlays) touches `app/(tabs)/scan-arkit.tsx` heavily. Both this PR's additions are in separate regions (`autoUploadAnalysisVideo` body ~L2298 and the overlay SVG block ~L2838) — but rebase-on-#505 is safer. If merge conflicts, prefer landing #505 first.
- No overlap with #506, #509, #510, #511, #512, #513, #514, #515, #516.

## Non-goals

- This PR does NOT change `lib/services/consent-service.ts`. A user-staged change flipping `allowVideoUpload` default from `false` → `true` is held for explicit privacy review in a separate PR.