### PR TITLE
feat(form-ux): first-60s + live-session polish wave — 7 fixes

### DIFF
--- a/app/(modals)/calibration-failure-recovery.tsx
+++ b/app/(modals)/calibration-failure-recovery.tsx
@@ -14,7 +14,7 @@
  * calling screen decides what each CTA does.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import {
   ScrollView,
   StyleSheet,
@@ -25,6 +25,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
+import * as Haptics from 'expo-haptics';
 
 const REASON_LABELS: Record<string, string> = {
   low_stability: 'Low stability',
@@ -98,6 +99,13 @@ export default function CalibrationFailureRecoveryModal(): React.ReactElement {
   const handleClose = useCallback(() => {
     router.back();
   }, [router]);
+
+  // Fire a warning haptic on mount so users get tactile feedback that
+  // calibration failed — parity with the native iOS recovery pattern and
+  // makes the modal feel less silent when it slides in.
+  useEffect(() => {
+    void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+  }, []);
 
   return (
     <SafeAreaView style={styles.container} edges={['top', 'bottom']}>

--- a/app/(modals)/form-tracking-setup.tsx
+++ b/app/(modals)/form-tracking-setup.tsx
@@ -250,19 +250,36 @@ function PermissionStep({
         <View style={styles.permissionActions} testID="form-tracking-setup-permission-denied">
           <View style={[styles.statusCard, styles.statusDenied]}>
             <Ionicons name="close-circle" size={22} color="#FF4B4B" />
-            <Text style={[styles.statusText, { color: '#FF8A8A' }]}>
-              Camera access was denied. Open Settings to enable it.
-            </Text>
+            <View style={styles.statusTextColumn}>
+              <Text style={[styles.statusText, styles.statusTextDenied]}>
+                Camera access is blocked
+              </Text>
+              <Text style={styles.statusSubtext}>
+                Form tracking needs camera access. You can grant it in
+                Settings, then come back to finish setup.
+              </Text>
+            </View>
           </View>
           <Pressable
             onPress={onOpenSettings}
             accessibilityRole="button"
-            accessibilityLabel="Open Settings"
+            accessibilityLabel="Open Settings to grant camera access"
+            accessibilityHint="Opens the iOS Settings app for this app so you can enable the camera permission"
             style={styles.primaryButton}
             testID="form-tracking-setup-open-settings"
           >
             <Ionicons name="settings-outline" size={18} color="#FFFFFF" />
             <Text style={styles.primaryButtonText}>Open Settings</Text>
+          </Pressable>
+          <Pressable
+            onPress={onRequest}
+            accessibilityRole="button"
+            accessibilityLabel="Try requesting camera access again"
+            style={styles.secondaryInlineButton}
+            testID="form-tracking-setup-retry-permission"
+          >
+            <Ionicons name="refresh-outline" size={16} color="#C9D7F4" />
+            <Text style={styles.secondaryInlineButtonText}>Try again</Text>
           </Pressable>
         </View>
       ) : (
@@ -481,6 +498,35 @@ const styles = StyleSheet.create({
     color: '#C9D7F4',
     fontSize: 14,
     lineHeight: 20,
+  },
+  statusTextColumn: {
+    flex: 1,
+    gap: 4,
+  },
+  statusTextDenied: {
+    color: '#FF8A8A',
+    fontWeight: '700',
+    fontSize: 14,
+  },
+  statusSubtext: {
+    color: '#C9D7F4',
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  secondaryInlineButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 12,
+    alignSelf: 'center',
+  },
+  secondaryInlineButtonText: {
+    color: '#C9D7F4',
+    fontSize: 14,
+    fontWeight: '600',
   },
   permissionActions: {
     alignSelf: 'stretch',

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -440,6 +440,13 @@ export default function ScanARKitScreen() {
   }, [activeFormTargets, detectionMode, deepLinkTemplateId]);
   const [activePhase, setActivePhase] = useState<string>(getWorkoutByMode(DEFAULT_DETECTION_MODE).initialPhase);
   const [audioFeedbackEnabled, setAudioFeedbackEnabled] = useState(true);
+  // Mirror for callback-stable access inside memoized workout callbacks.
+  // Updating a ref keeps `workoutControllerCallbacks` from churning every
+  // time the user flips the audio-cue switch.
+  const audioFeedbackEnabledRef = React.useRef<boolean>(true);
+  useEffect(() => {
+    audioFeedbackEnabledRef.current = audioFeedbackEnabled;
+  }, [audioFeedbackEnabled]);
   const activePhaseRef = React.useRef<string>(getWorkoutByMode(DEFAULT_DETECTION_MODE).initialPhase);
   // Tracks the current workout's resting/initial phase so timer callbacks can
   // cheaply skip heavy work while the user is between reps.
@@ -1023,6 +1030,18 @@ export default function ScanARKitScreen() {
       }
       if (recordingActiveRef.current && Date.now() >= recordingStartEpochMsRef.current) {
         recordingFqiScoresRef.current.push(fqi);
+      }
+      // Additive rep-complete haptic: the workout controller already fires
+      // a Light impact through the shared haptic bus, but testers reported
+      // that in noisy gym environments the light tap is easy to miss. When
+      // the user has audio/cue feedback enabled we also fire a Heavy impact
+      // here so successful reps register unambiguously. Gated by
+      // audioFeedbackEnabledRef.current (mirrors the cue-audio toggle) so
+      // users who explicitly silenced cues don't get a phantom extra buzz.
+      if (audioFeedbackEnabledRef.current) {
+        void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy).catch(() => {
+          /* native bridge unavailable — silent */
+        });
       }
     },
     onPullupScoring: (

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -42,6 +42,7 @@ import { BodyTracker, useBodyTracking, type JointAngles, type Joint2D, type Medi
 import { usePremiumCueAudio } from '@/hooks/use-premium-cue-audio';
 import { audioSessionManager } from '@/lib/services/audio-session-manager';
 import { CrashBoundary } from '@/components/CrashBoundary';
+import { ARKitUnsupportedPlaceholder } from '@/components/form-tracking/ARKitUnsupportedPlaceholder';
 import { ExitMidSessionSheet } from '@/components/form-tracking/ExitMidSessionSheet';
 import { PreSetPreviewCard } from '@/components/form-tracking/PreSetPreviewCard';
 import { usePreSetPreview } from '@/hooks/use-pre-set-preview';
@@ -2706,7 +2707,7 @@ export default function ScanARKitScreen() {
   }
 
   if (supportStatus === 'unsupported') {
-    // Debug info: Check what BodyTracker reports
+    // Debug info: Check what BodyTracker reports (only surfaced in __DEV__).
     const nativeDiagnostics = BodyTracker.getSupportDiagnostics();
     const debugInfo = {
       platform: Platform.OS,
@@ -2717,19 +2718,7 @@ export default function ScanARKitScreen() {
       isSupportedResult: nativeDiagnostics?.finalSupported ?? nativeSupported,
     };
 
-    return (
-      <SafeAreaView style={styles.container}>
-        <View style={styles.errorContainer}>
-          <Ionicons name="warning-outline" size={60} color="#FF6B6B" />
-          <Text style={styles.errorText}>Device not supported</Text>
-          {__DEV__ ? (
-            <Text style={{ color: '#666', fontSize: 10, marginTop: 20, textAlign: 'center' }}>
-              Debug: {JSON.stringify(debugInfo, null, 2)}
-            </Text>
-          ) : null}
-        </View>
-      </SafeAreaView>
-    );
+    return <ARKitUnsupportedPlaceholder debugInfo={debugInfo} />;
   }
 
   const telemetryReps = repCount;

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -41,6 +41,7 @@ import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
 import { BodyTracker, useBodyTracking, type JointAngles, type Joint2D, type MediaPipePose2D } from '@/lib/arkit/ARKitBodyTracker';
 import { usePremiumCueAudio } from '@/hooks/use-premium-cue-audio';
 import { audioSessionManager } from '@/lib/services/audio-session-manager';
+import { useToast } from '@/contexts/ToastContext';
 import { CrashBoundary } from '@/components/CrashBoundary';
 import { ARKitUnsupportedPlaceholder } from '@/components/form-tracking/ARKitUnsupportedPlaceholder';
 import { ExitMidSessionSheet } from '@/components/form-tracking/ExitMidSessionSheet';
@@ -345,6 +346,7 @@ const PreviewPlayer = ({ uri }: { uri: string }) => {
 export default function ScanARKitScreen() {
   const DEV = __DEV__;
   const router = useRouter();
+  const { show: showToast } = useToast();
   const params = useLocalSearchParams<{ fixturePlayback?: string; fixture?: string; trackingDebug?: string; templateId?: string }>();
   const fixturePlaybackRequested = params.fixturePlayback === '1';
   // Issue #447 — deep-link / scheduled-workout template binding.
@@ -749,6 +751,10 @@ export default function ScanARKitScreen() {
         if (DEV) {
           warnWithTs('[ScanARKit] MediaPipe shadow unavailable, falling back to proxy provider');
         }
+        // Surface the fallback to the user. Previously this was DEV-only,
+        // so prod users would silently drop onto the proxy provider with
+        // no explanation for the accuracy regression.
+        showToast('Pose tracking degraded — using fallback.', { type: 'info' });
       }
     };
 
@@ -758,13 +764,14 @@ export default function ScanARKitScreen() {
       }
       if (!cancelled) {
         setShadowProviderRuntime('mediapipe_proxy');
+        showToast('Pose tracking degraded — using fallback.', { type: 'info' });
       }
     });
 
     return () => {
       cancelled = true;
     };
-  }, [DEV, isTracking, mediaPipeModelPath, shadowModeEnabled]);
+  }, [DEV, isTracking, mediaPipeModelPath, shadowModeEnabled, showToast]);
 
   useEffect(() => {
     const shouldPollMediaPipe =

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -939,6 +939,13 @@ export default function ScanARKitScreen() {
       if (__DEV__) {
         warnWithTs('[ScanARKit] Failed to initialize session context', error);
       }
+      // Surface the failure to the user — when the telemetry context
+      // can't initialize, the rep-count pipeline may fail to persist
+      // session metrics, so we owe them an honest warning rather than a
+      // silent session that produces no history entry.
+      showToast('Telemetry unavailable — reps may not be counted.', {
+        type: 'error',
+      });
     });
     resetFrameCounter();
     shadowStatsRef.current = createShadowStatsAccumulator();
@@ -948,7 +955,7 @@ export default function ScanARKitScreen() {
     realtimeFormEngineRef.current = createRealtimeEngineState();
     lastShadowMeanAbsDeltaRef.current = null;
     resetBaselineDebugMetrics();
-  }, [createRealtimeEngineState, resetBaselineDebugMetrics]);
+  }, [createRealtimeEngineState, resetBaselineDebugMetrics, showToast]);
 
   useEffect(() => {
     const countersRef = cueCountersRef;

--- a/components/form-tracking/ARKitUnsupportedPlaceholder.tsx
+++ b/components/form-tracking/ARKitUnsupportedPlaceholder.tsx
@@ -1,0 +1,148 @@
+/**
+ * ARKitUnsupportedPlaceholder
+ *
+ * Full-screen empty-state shown by `app/(tabs)/scan-arkit.tsx` when the
+ * device does not support ARKit body tracking (pre-iPhone 13 or non-iOS).
+ *
+ * Previously the screen rendered a bare warning icon + "Device not
+ * supported" string, which read as an error skeleton. This component
+ * replaces that with a proper empty state: icon + title + helpful
+ * subtitle + secondary CTA that routes users to the Workouts tab so
+ * they can still log sessions manually.
+ *
+ * Pure presentational — no native calls, no side effects. The caller
+ * decides when to render it via `supportStatus === 'unsupported'`.
+ */
+import React, { useCallback } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+
+export interface ARKitUnsupportedPlaceholderProps {
+  /** Optional override for the CTA tap handler (tests / storybook). */
+  onGoToWorkouts?: () => void;
+  /** Optional diagnostic JSON shown only in __DEV__ builds. */
+  debugInfo?: unknown;
+  /** Optional testID — defaults to `arkit-unsupported-placeholder`. */
+  testID?: string;
+}
+
+export function ARKitUnsupportedPlaceholder({
+  onGoToWorkouts,
+  debugInfo,
+  testID = 'arkit-unsupported-placeholder',
+}: ARKitUnsupportedPlaceholderProps) {
+  const router = useRouter();
+
+  const handlePress = useCallback(() => {
+    if (onGoToWorkouts) {
+      onGoToWorkouts();
+      return;
+    }
+    router.replace('/(tabs)/workouts');
+  }, [onGoToWorkouts, router]);
+
+  return (
+    <SafeAreaView style={styles.safeArea} edges={['top', 'bottom']} testID={testID}>
+      <View style={styles.container}>
+        <View style={styles.iconCircle}>
+          <Ionicons name="body-outline" size={56} color="#9AACD1" />
+        </View>
+        <Text style={styles.title}>Body tracking unavailable</Text>
+        <Text style={styles.subtitle}>
+          This device doesn&apos;t support ARKit body tracking. Please upgrade
+          to iPhone 13 or newer to use live form analysis.
+        </Text>
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Go to Workouts instead"
+          onPress={handlePress}
+          style={({ pressed }) => [styles.cta, pressed && styles.ctaPressed]}
+          testID={`${testID}-cta`}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Ionicons name="barbell-outline" size={18} color="#FFFFFF" />
+          <Text style={styles.ctaText}>Go to Workouts instead</Text>
+        </Pressable>
+
+        {__DEV__ && debugInfo ? (
+          <Text style={styles.debugText} testID={`${testID}-debug`}>
+            Debug: {JSON.stringify(debugInfo, null, 2)}
+          </Text>
+        ) : null}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#050E1F',
+  },
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+    paddingVertical: 24,
+    gap: 14,
+  },
+  iconCircle: {
+    width: 112,
+    height: 112,
+    borderRadius: 56,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(154, 172, 209, 0.10)',
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.28)',
+  },
+  title: {
+    color: '#F5F7FF',
+    fontSize: 22,
+    fontWeight: '700',
+    marginTop: 8,
+    textAlign: 'center',
+  },
+  subtitle: {
+    color: '#9AACD1',
+    fontSize: 15,
+    lineHeight: 22,
+    textAlign: 'center',
+    maxWidth: 320,
+  },
+  cta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    marginTop: 16,
+    paddingVertical: 14,
+    paddingHorizontal: 22,
+    minHeight: 44,
+    minWidth: 220,
+    borderRadius: 22,
+    backgroundColor: '#4C8CFF',
+  },
+  ctaPressed: {
+    backgroundColor: '#3B76E0',
+  },
+  ctaText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '700',
+    letterSpacing: 0.2,
+  },
+  debugText: {
+    marginTop: 24,
+    color: '#5D6B83',
+    fontSize: 10,
+    textAlign: 'center',
+    fontFamily: undefined,
+  },
+});
+
+export default ARKitUnsupportedPlaceholder;

--- a/components/form-tracking/TrackingLossBanner.tsx
+++ b/components/form-tracking/TrackingLossBanner.tsx
@@ -7,6 +7,12 @@
  *
  * Pure presentational component — it does NOT subscribe to tracking
  * state. Callers use `useTrackingLoss` and pass `visible` down.
+ *
+ * Actions (all optional; ordered by priority):
+ *   1. `onRecalibrate`    — primary recovery. Shows "Recalibrate" pill.
+ *   2. `onCheckLighting`  — secondary guidance. Shows "Check lighting" pill.
+ *   3. `onDismiss`        — legacy close affordance (kept for back-compat
+ *                            with existing callers that only want a dismiss).
  */
 
 import React from 'react';
@@ -26,8 +32,22 @@ export interface TrackingLossBannerProps {
   visible: boolean;
   /** Optional number of milliseconds the tracking has been lost. Rendered as "Nxs". */
   lostForMs?: number | null;
-  /** Optional action label + handler ("Recalibrate", "Dismiss"). */
+  /**
+   * Optional legacy close handler. Still supported for callers that only
+   * want a soft dismiss; newer callers should prefer `onRecalibrate`.
+   */
   onDismiss?: () => void;
+  /**
+   * Optional primary recovery handler. When provided, a "Recalibrate" pill
+   * renders next to the banner copy. Hooked up to the subject-identity
+   * recalibration flow in scan-arkit.tsx.
+   */
+  onRecalibrate?: () => void;
+  /**
+   * Optional secondary guidance handler. When provided, a "Check lighting"
+   * pill renders below the main row.
+   */
+  onCheckLighting?: () => void;
   /** Optional extra style (e.g., top offset below the top bar). */
   style?: StyleProp<ViewStyle>;
   /** Optional testID for component tests. */
@@ -45,6 +65,8 @@ export default function TrackingLossBanner({
   visible,
   lostForMs,
   onDismiss,
+  onRecalibrate,
+  onCheckLighting,
   style,
   testID,
 }: TrackingLossBannerProps) {
@@ -70,28 +92,56 @@ export default function TrackingLossBanner({
           }
           testID={testID ?? 'tracking-loss-banner'}
         >
-          <View style={styles.iconBubble}>
-            <Ionicons name="warning-outline" size={18} color="#FFFFFF" />
+          <View style={styles.row}>
+            <View style={styles.iconBubble}>
+              <Ionicons name="warning-outline" size={18} color="#FFFFFF" />
+            </View>
+            <View style={styles.body}>
+              <Text style={styles.title} accessibilityElementsHidden>
+                Tracking signal lost
+                {duration ? `  \u00B7  ${duration}` : ''}
+              </Text>
+              <Text style={styles.subtitle} accessibilityElementsHidden>
+                Step fully into frame and check lighting.
+              </Text>
+            </View>
+            {onRecalibrate ? (
+              <TouchableOpacity
+                onPress={onRecalibrate}
+                accessibilityRole="button"
+                accessibilityLabel="Recalibrate tracking"
+                style={styles.primaryAction}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                testID="tracking-loss-banner-recalibrate"
+              >
+                <Ionicons name="refresh" size={14} color="#B41E1E" />
+                <Text style={styles.primaryActionText}>Recalibrate</Text>
+              </TouchableOpacity>
+            ) : null}
+            {onDismiss ? (
+              <TouchableOpacity
+                onPress={onDismiss}
+                accessibilityRole="button"
+                accessibilityLabel="Dismiss tracking loss banner"
+                style={styles.closeButton}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                testID="tracking-loss-banner-dismiss"
+              >
+                <Ionicons name="close" size={16} color="#FFFFFF" />
+              </TouchableOpacity>
+            ) : null}
           </View>
-          <View style={styles.body}>
-            <Text style={styles.title} accessibilityElementsHidden>
-              Tracking signal lost
-              {duration ? `  \u00B7  ${duration}` : ''}
-            </Text>
-            <Text style={styles.subtitle} accessibilityElementsHidden>
-              Step fully into frame and check lighting.
-            </Text>
-          </View>
-          {onDismiss ? (
+          {onCheckLighting ? (
             <TouchableOpacity
-              onPress={onDismiss}
+              onPress={onCheckLighting}
               accessibilityRole="button"
-              accessibilityLabel="Dismiss tracking loss banner"
-              style={styles.closeButton}
+              accessibilityLabel="Show lighting tips"
+              style={styles.secondaryAction}
               hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              testID="tracking-loss-banner-dismiss"
+              testID="tracking-loss-banner-check-lighting"
             >
-              <Ionicons name="close" size={16} color="#FFFFFF" />
+              <Ionicons name="sunny-outline" size={14} color="#FFE0DC" />
+              <Text style={styles.secondaryActionText}>Check lighting</Text>
             </TouchableOpacity>
           ) : null}
         </MotiView>
@@ -102,9 +152,6 @@ export default function TrackingLossBanner({
 
 const styles = StyleSheet.create({
   banner: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
     paddingHorizontal: 12,
     paddingVertical: 10,
     backgroundColor: 'rgba(180, 30, 30, 0.94)',
@@ -116,6 +163,12 @@ const styles = StyleSheet.create({
     shadowRadius: 10,
     shadowOffset: { width: 0, height: 4 },
     elevation: 6,
+    gap: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
   },
   iconBubble: {
     width: 30,
@@ -139,6 +192,37 @@ const styles = StyleSheet.create({
     fontSize: 12,
     marginTop: 2,
     fontWeight: '600',
+  },
+  primaryAction: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+    backgroundColor: '#FFFFFF',
+  },
+  primaryActionText: {
+    color: '#B41E1E',
+    fontSize: 12,
+    fontWeight: '800',
+    letterSpacing: 0.2,
+  },
+  secondaryAction: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+    backgroundColor: 'rgba(255, 255, 255, 0.12)',
+  },
+  secondaryActionText: {
+    color: '#FFE0DC',
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 0.2,
   },
   closeButton: {
     width: 26,


### PR DESCRIPTION
## Summary

PR A of a 3-PR wave closing the form-UX audit in
`docs/overnight/worklog-2026-04-21-form-ux-gemma-wave-close.md`.
Polishes the first 60 seconds of a form-tracking session plus
live-session feedback. Seven concrete gaps, seven atomic commits.

## Fixes

1. **ARKit unsupported → graceful full-screen fallback**
   `app/(tabs)/scan-arkit.tsx` + new `components/form-tracking/ARKitUnsupportedPlaceholder.tsx`.
   Replaces the bare warning-icon skeleton with a proper empty state:
   icon + "Body tracking unavailable" + hardware-requirement copy +
   "Go to Workouts instead" CTA that routes to the workouts tab.
   __DEV__ diagnostics preserved.

2. **Permission-denial → Settings CTA**
   `app/(modals)/form-tracking-setup.tsx`. The denied state now shows
   a two-line banner (bold title + supporting copy), the existing
   Open Settings CTA (with explicit accessibilityHint), and an
   inline "Try again" retry that re-invokes `requestPermission()`.
   Back button remains available.

3. **Calibration failure modal → warning haptic on mount**
   `app/(modals)/calibration-failure-recovery.tsx`. Adds a
   mount-time `useEffect` firing
   `Haptics.notificationAsync(NotificationFeedbackType.Warning)` so
   users feel the failure the moment the modal slides in.

4. **Rep confirmation → heavy haptic gated by cue preference**
   `app/(tabs)/scan-arkit.tsx` `onRepComplete`. Adds an additive
   `Haptics.impactAsync(Heavy)` on each completed rep, gated by the
   existing `audioFeedbackEnabled` preference (mirrored via
   `audioFeedbackEnabledRef` to keep the memoized callback bundle
   stable). The controller's existing Light tap stays in place.

5. **TrackingLossBanner → real recovery action**
   `components/form-tracking/TrackingLossBanner.tsx`. Adds optional
   `onRecalibrate` (primary white pill) and `onCheckLighting`
   (secondary pill) props. Legacy `onDismiss` remains untouched so
   the existing unit tests pass. Callers can wire
   `onRecalibrate` to the existing `subjectIdentity.recalibrate()`
   exposed by `hooks/use-subject-identity.ts`; the live wiring will
   ride with the banner-render integration PR.

6. **MediaPipe fallback → surface via Toast**
   `app/(tabs)/scan-arkit.tsx` MediaPipe shadow `configure()` block.
   Wires `useToast()` and emits "Pose tracking degraded — using
   fallback." on both soft fallback (`configured === false`) and hard
   error (`configure().catch`). DEV warnings preserved.

7. **Telemetry init failure → surface via Toast**
   `app/(tabs)/scan-arkit.tsx` `initSessionContext()` catch. Emits
   an error-styled toast "Telemetry unavailable — reps may not be
   counted." so users understand a session may not be persisted
   rather than silently losing rep history.

## Constraints honored

- No new dependencies
- No edits to `supabase/migrations/`, `ios/`, `android/`, or `.env` files
- No existing tests modified; all 13 relevant unit tests pass
  (TrackingLossBanner ×5, form-tracking-setup ×8)
- Each fix is an independent atomic commit with `feat(form-ux): ...`
- Lint and type-check clean before every commit

## Test plan

- [ ] Run on an older iOS device (pre-iPhone 13) and verify the
      new `ARKitUnsupportedPlaceholder` shows instead of the bare
      skeleton; tap "Go to Workouts instead" and verify it routes.
- [ ] In Settings, revoke camera access, re-open the setup wizard,
      and verify the new denied banner + Open Settings + Try again
      all render correctly. Confirm Back still navigates.
- [ ] Trigger a calibration failure (e.g. leave frame) and verify
      a Warning haptic fires on modal mount.
- [ ] Complete a rep with audio cues ON and verify a Heavy haptic
      fires in addition to the existing Light tap. Toggle audio
      cues OFF and verify only the Light tap remains.
- [ ] Render `TrackingLossBanner` in a sandbox with `onRecalibrate`
      wired to `subjectIdentity.recalibrate`; confirm the white
      "Recalibrate" pill fires the callback.
- [ ] Simulate MediaPipe `configure()` returning false and confirm
      the neutral toast appears.
- [ ] Simulate `initSessionContext()` rejecting and confirm the
      error toast appears.