### PR TITLE
feat(coach-ux): debrief + coach-modal resilience wave — 9 fixes

### DIFF
--- a/app/(modals)/form-tracking-debrief.tsx
+++ b/app/(modals)/form-tracking-debrief.tsx
@@ -182,9 +182,9 @@ export default function FormTrackingDebriefScreen() {
           ) : (
             <View style={styles.emptyState} testID="form-tracking-debrief-empty">
               <Ionicons name="information-circle-outline" size={28} color="#9AACD1" />
-              <Text style={styles.emptyTitle}>No reps recorded</Text>
+              <Text style={styles.emptyTitle}>No reps recorded yet</Text>
               <Text style={styles.emptyBody}>
-                Finish a live tracking set to see your rep-by-rep breakdown here.
+                Start a live tracking set to see your breakdown.
               </Text>
             </View>
           )}
@@ -198,6 +198,11 @@ export default function FormTrackingDebriefScreen() {
               error={autoDebrief.error}
               data={autoDebrief.data}
               onRetry={autoDebrief.retry}
+              // Reps in the URL params indicate the user just finished a
+              // session (recap route), so we want the friendly "preparing
+              // your feedback…" copy in the empty grace window — NOT the
+              // cold "No debrief yet" history placeholder.
+              awaitingResult={hasReps}
             />
           </View>
         ) : null}

--- a/app/(modals)/generate-session.tsx
+++ b/app/(modals)/generate-session.tsx
@@ -19,7 +19,6 @@ import {
   StyleSheet,
   ScrollView,
   ActivityIndicator,
-  Alert,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -29,6 +28,8 @@ import * as Haptics from 'expo-haptics';
 import { tabColors } from '@/styles/tabs/_tab-theme';
 import { sessionStyles } from '@/styles/workout-session.styles';
 import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/contexts/ToastContext';
+import { CrashBoundary } from '@/components/CrashBoundary';
 import { useSessionGenerator } from '@/hooks/use-session-generator';
 import {
   getSessionFallback,
@@ -41,6 +42,7 @@ import {
 import { localDB } from '@/lib/services/database/local-db';
 import { genericLocalUpsert } from '@/lib/services/database/generic-sync';
 import { isWarmupCoachFlowEnabled } from '@/lib/services/coach-warmup-provider';
+import { createError, logError } from '@/lib/services/ErrorHandler';
 import type { Exercise, GoalProfile } from '@/lib/types/workout-session';
 import type { HydratedTemplate } from '@/lib/services/session-generator';
 
@@ -129,8 +131,20 @@ async function persistHydrated(hydrated: HydratedTemplate): Promise<void> {
 }
 
 export default function GenerateSessionScreen() {
+  return (
+    <CrashBoundary
+      fallbackTitle="Generator crashed"
+      fallbackMessage="The session generator hit an unexpected error. Close this modal and try again, or pick from the Templates tab."
+    >
+      <GenerateSessionScreenBody />
+    </CrashBoundary>
+  );
+}
+
+function GenerateSessionScreenBody() {
   const router = useRouter();
   const { user } = useAuth();
+  const { show: showToast } = useToast();
   const [intent, setIntent] = useState('');
   const [goalProfile, setGoalProfile] = useState<GoalProfile>('hypertrophy');
   const [durationMin, setDurationMin] = useState<number>(30);
@@ -148,11 +162,24 @@ export default function GenerateSessionScreen() {
   const [lastTemplateId, setLastTemplateId] = useState<string | null>(null);
   const warmupCoachEnabled = isWarmupCoachFlowEnabled();
 
+  // Resolve exercise slugs from the local DB; if that throws (missing table
+  // during migration, SQLite closed on web, etc.) we return an empty list so
+  // the AI can still attempt a generation using its built-in catalogue.
   const availableSlugsPromise = useMemo(async () => {
-    const db = localDB.db;
-    if (!db) return [];
-    const rows = await db.getAllAsync<Exercise>('SELECT name FROM exercises LIMIT 64');
-    return rows.map((r) => r.name.toLowerCase().replace(/[^a-z0-9]/g, '_'));
+    try {
+      const db = localDB.db;
+      if (!db) return [] as string[];
+      const rows = await db.getAllAsync<Exercise>('SELECT name FROM exercises LIMIT 64');
+      return rows.map((r) => r.name.toLowerCase().replace(/[^a-z0-9]/g, '_'));
+    } catch (err) {
+      logError(
+        createError('storage', 'EXERCISE_SLUGS_QUERY_FAILED',
+          err instanceof Error ? err.message : 'Failed to read exercise slugs.',
+          { details: err, severity: 'warning' }),
+        { feature: 'workouts', location: 'generate-session.availableSlugsPromise' },
+      );
+      return [] as string[];
+    }
   }, []);
 
   const handleOfflineFallback = useCallback(async () => {
@@ -169,7 +196,7 @@ export default function GenerateSessionScreen() {
   const handleGenerate = useCallback(async () => {
     const trimmed = intent.trim();
     if (trimmed.length === 0) {
-      Alert.alert('Describe the session', 'Tell the AI what you want to train.');
+      showToast('Tell the AI what you want to train.', { type: 'info' });
       return;
     }
     // Flag off: skip the dispatch entirely and use the offline library so the
@@ -202,6 +229,7 @@ export default function GenerateSessionScreen() {
     generate,
     handleOfflineFallback,
     router,
+    showToast,
   ]);
 
   const handleWarmupCoach = useCallback(() => {

--- a/app/(modals)/progression-plan.tsx
+++ b/app/(modals)/progression-plan.tsx
@@ -189,9 +189,14 @@ export default function ProgressionPlanModal() {
           </Text>
         </View>
       ) : loading ? (
-        <View style={styles.loadingPanel}>
+        <View
+          style={styles.loadingPanel}
+          accessibilityRole="alert"
+          accessibilityLabel="Analyzing your history"
+          testID="progression-plan-loading"
+        >
           <ActivityIndicator size="large" color={ACCENT} />
-          <Text style={styles.loadingText}>Building your overload plan…</Text>
+          <Text style={styles.loadingText}>Analyzing your history…</Text>
         </View>
       ) : error ? (
         <View style={styles.errorPanel}>

--- a/app/(modals)/rep-insights.tsx
+++ b/app/(modals)/rep-insights.tsx
@@ -10,7 +10,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
-  Alert,
   ScrollView,
   StyleSheet,
   Text,
@@ -26,10 +25,17 @@ import { RomProgressionCard } from '@/components/insights/RomProgressionCard';
 import { SymmetryCard } from '@/components/insights/SymmetryCard';
 import { RepRewindCarousel } from '@/components/insights/RepRewindCarousel';
 import { shareRepData } from '@/lib/services/rep-export';
+import {
+  FormTrackingErrorCode,
+  createError,
+  withErrorHandling,
+} from '@/lib/services/ErrorHandler';
+import { useToast } from '@/contexts/ToastContext';
 import type { FaultHeatmapScope } from '@/lib/services/rep-analytics';
 
 export default function RepInsightsModal() {
   const router = useRouter();
+  const { show: showToast } = useToast();
   const params = useLocalSearchParams<{ exerciseId?: string; sessionId?: string }>();
   const exerciseId = typeof params.exerciseId === 'string' ? params.exerciseId : '';
   const sessionId = typeof params.sessionId === 'string' ? params.sessionId : undefined;
@@ -48,32 +54,45 @@ export default function RepInsightsModal() {
   const handleExport = useCallback(
     async (format: 'csv' | 'json') => {
       if (!exerciseId && !sessionId) {
-        Alert.alert('Nothing to export', 'Open this screen from a session or exercise to enable export.');
+        showToast('Open this screen from a session or exercise to enable export.', { type: 'info' });
         return;
       }
-      try {
-        setExporting(format);
-        setExportError(null);
-        const result = await shareRepData(
+      setExporting(format);
+      setExportError(null);
+
+      const outcome = await withErrorHandling(
+        () => shareRepData(
           sessionId ? { sessionId } : { exerciseId, days: 30 },
           format,
+        ),
+        (err) => createError(
+          'form-tracking',
+          FormTrackingErrorCode.EXPORT_FAILED,
+          err instanceof Error ? err.message : 'Unknown export error',
+          { details: err, retryable: true },
+        ),
+        { feature: 'form-tracking', location: `rep-insights.handleExport.${format}` },
+      );
+
+      setExporting(null);
+
+      if (!outcome.ok) {
+        setExportError({ format, message: outcome.error.message });
+        showToast(`Export failed: ${outcome.error.message}`, { type: 'error' });
+        return;
+      }
+
+      const result = outcome.data;
+      if (!result.shared) {
+        showToast(
+          result.fileUri
+            ? 'Export ready — sharing unavailable; file written locally.'
+            : 'Sharing is unavailable on this build.',
+          { type: 'info' },
         );
-        if (!result.shared) {
-          Alert.alert(
-            'Export ready',
-            result.fileUri
-              ? `File written to:\n${result.fileUri}\n\nSharing is unavailable on this build.`
-              : 'Sharing is unavailable on this build. Data was generated but could not be written to disk.',
-          );
-        }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        setExportError({ format, message });
-      } finally {
-        setExporting(null);
       }
     },
-    [exerciseId, sessionId],
+    [exerciseId, sessionId, showToast],
   );
 
   const handleDismissExportError = useCallback(() => {

--- a/app/(tabs)/coach.tsx
+++ b/app/(tabs)/coach.tsx
@@ -9,7 +9,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { useToast } from '@/contexts/ToastContext';
 import { CoachMessage, sendCoachPrompt } from '@/lib/services/coach-service';
 import { fetchTodaySession, fetchCoachSessionMessages } from '@/lib/services/coach-history-service';
-import { AppError, mapToUserMessage } from '@/lib/services/ErrorHandler';
+import { AppError, createError, logError, mapToUserMessage } from '@/lib/services/ErrorHandler';
 import { CoachProviderBadge } from '@/components/coach/CoachProviderBadge';
 import { styles } from '../../styles/tabs/_index.styles';
 import { spacing } from '../../styles/tabs/_theme-constants';
@@ -138,7 +138,15 @@ export default function CoachScreen() {
           setShowCoachWelcome(true);
         }
       } catch (err) {
-        console.error('[Coach] Failed to check welcome seen status:', err);
+        logError(
+          createError(
+            'coach',
+            'WELCOME_CHECK_FAILED',
+            err instanceof Error ? err.message : 'Failed to check welcome seen status',
+            { details: err, severity: 'warning' },
+          ),
+          { feature: 'coach', location: 'coach.checkWelcomeSeen' },
+        );
         // Default to not showing welcome on error
       }
     };
@@ -159,7 +167,15 @@ export default function CoachScreen() {
           setCoachSessionId(session.sessionId);
         }
       } catch (error) {
-        console.error('[Coach][fetchTodaySession] Failed to restore today session', error);
+        logError(
+          createError(
+            'coach',
+            'SESSION_RESTORE_FAILED',
+            error instanceof Error ? error.message : 'Failed to restore today session',
+            { details: error },
+          ),
+          { feature: 'coach', location: 'coach.fetchTodaySession' },
+        );
         if (!cancelled) {
           showToast('Unable to restore today\'s coach session.', { type: 'error' });
         }
@@ -184,7 +200,15 @@ export default function CoachScreen() {
         const session = await fetchCoachSessionMessages(restoreSessionId);
         if (cancelled) return;
         if (!session) {
-          console.error('[Coach][fetchCoachSessionMessages] No session found', { restoreSessionId });
+          logError(
+            createError(
+              'coach',
+              'SESSION_NOT_FOUND',
+              'No session found for the requested id',
+              { details: { restoreSessionId }, severity: 'warning' },
+            ),
+            { feature: 'coach', location: 'coach.fetchCoachSessionMessages' },
+          );
           if (!cancelled) {
             showToast('Unable to restore that coach session.', { type: 'error' });
           }
@@ -194,7 +218,15 @@ export default function CoachScreen() {
         setCoachMessages(session.messages.map((m, i) => ({ ...m, id: `restored-${i}` })));
         setCoachSessionId(session.sessionId);
       } catch (error) {
-        console.error('[Coach][fetchCoachSessionMessages] Failed to restore session', error);
+        logError(
+          createError(
+            'coach',
+            'SESSION_RESTORE_FAILED',
+            error instanceof Error ? error.message : 'Failed to restore coach session',
+            { details: error },
+          ),
+          { feature: 'coach', location: 'coach.fetchCoachSessionMessages' },
+        );
         if (!cancelled) {
           showToast('Unable to restore that coach session.', { type: 'error' });
         }

--- a/components/form-tracking/AskCoachCTA.tsx
+++ b/components/form-tracking/AskCoachCTA.tsx
@@ -11,6 +11,7 @@ import React, { useCallback } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
+import { useNetwork } from '@/contexts/NetworkContext';
 
 export interface AskCoachCTAProps {
   exerciseName: string;
@@ -60,8 +61,13 @@ export function AskCoachCTA({
   label,
 }: AskCoachCTAProps) {
   const router = useRouter();
+  const { isOnline } = useNetwork();
 
   const handlePress = useCallback(() => {
+    // Offline guard: the coach tab requires network access to produce a
+    // useful reply. Swallow the tap with a visual disabled state + subtext
+    // rather than navigating into a broken conversation.
+    if (!isOnline) return;
     if (onPress) {
       onPress();
       return;
@@ -71,23 +77,37 @@ export function AskCoachCTA({
       pathname: '/(tabs)/coach',
       params: { prefill },
     } as never);
-  }, [onPress, router, exerciseName, repCount, averageFqi, topFault]);
+  }, [isOnline, onPress, router, exerciseName, repCount, averageFqi, topFault]);
 
   const buttonLabel = label ?? 'Ask coach about this session';
+  const accessibilityLabel = isOnline
+    ? buttonLabel
+    : `${buttonLabel}. Offline — check your connection.`;
 
   return (
     <View style={styles.container}>
       <Pressable
         accessibilityRole="button"
-        accessibilityLabel={buttonLabel}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityState={{ disabled: !isOnline }}
+        disabled={!isOnline}
         onPress={handlePress}
-        style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+        style={({ pressed }) => [
+          styles.button,
+          pressed && isOnline && styles.buttonPressed,
+          !isOnline && styles.buttonDisabled,
+        ]}
         testID={testID}
       >
         <Ionicons name="sparkles" size={18} color="#FFFFFF" />
         <Text style={styles.buttonText}>{buttonLabel}</Text>
         <Ionicons name="arrow-forward" size={18} color="#FFFFFF" />
       </Pressable>
+      {!isOnline ? (
+        <Text style={styles.offlineHint} testID={`${testID}-offline-hint`}>
+          Check your connection
+        </Text>
+      ) : null}
     </View>
   );
 }
@@ -111,9 +131,19 @@ const styles = StyleSheet.create({
   buttonPressed: {
     backgroundColor: '#3B76E0',
   },
+  buttonDisabled: {
+    backgroundColor: '#3B5172',
+    opacity: 0.7,
+  },
   buttonText: {
     color: '#FFFFFF',
     fontSize: 16,
     fontWeight: '700',
+  },
+  offlineHint: {
+    textAlign: 'center',
+    color: '#9AACD1',
+    fontSize: 12,
+    marginTop: 6,
   },
 });

--- a/components/form-tracking/AutoDebriefCard.tsx
+++ b/components/form-tracking/AutoDebriefCard.tsx
@@ -13,9 +13,18 @@
  * when to render it.
  */
 
-import React from 'react';
-import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import { Animated, Easing, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import type { AutoDebriefResult, CoachProvider } from '@/lib/services/coach-auto-debrief';
+
+/**
+ * Grace window for the "Coach is preparing your feedback…" empty copy.
+ * After a session ends we may sit in the `data === null && !loading && !error`
+ * window briefly (event bus fanout, buildInput async). During that grace we
+ * want a friendly "we're on it" line rather than the cold "No debrief yet"
+ * placeholder. After the window elapses, we fall back to the history copy.
+ */
+export const AUTO_DEBRIEF_EMPTY_GRACE_MS = 30_000;
 
 // ---------------------------------------------------------------------------
 // Props
@@ -26,6 +35,13 @@ export interface AutoDebriefCardProps {
   error: string | null;
   data: AutoDebriefResult | null;
   onRetry?: () => void;
+  /**
+   * True when the parent considers the user "fresh off a session" — e.g.
+   * the debrief screen was opened right after session end. Signals the card
+   * to show the reassuring "Coach is preparing your feedback…" copy instead
+   * of the cold "No debrief yet" placeholder for up to 30s.
+   */
+  awaitingResult?: boolean;
   /**
    * Optional testID prefix so consumers can target sub-elements without
    * the card hardcoding its own name into the tree.
@@ -56,8 +72,23 @@ export default function AutoDebriefCard({
   error,
   data,
   onRetry,
+  awaitingResult = false,
   testIDPrefix = 'auto-debrief',
 }: AutoDebriefCardProps) {
+  // Track whether we are still within the awaiting-grace window. Starts true
+  // when `awaitingResult` is first seen and flips to false after the grace
+  // timeout — at which point the card falls back to the history empty copy.
+  const [inGrace, setInGrace] = useState(awaitingResult);
+  useEffect(() => {
+    if (!awaitingResult) {
+      setInGrace(false);
+      return;
+    }
+    setInGrace(true);
+    const handle = setTimeout(() => setInGrace(false), AUTO_DEBRIEF_EMPTY_GRACE_MS);
+    return () => clearTimeout(handle);
+  }, [awaitingResult]);
+
   if (loading) {
     return (
       <View
@@ -68,7 +99,7 @@ export default function AutoDebriefCard({
       >
         <View style={styles.header}>
           <Text style={styles.title}>Session debrief</Text>
-          <ActivityIndicator size="small" />
+          <PulsingDot />
         </View>
         <View style={[styles.skeleton, { width: '80%' }]} />
         <View style={[styles.skeleton, { width: '95%' }]} />
@@ -103,6 +134,22 @@ export default function AutoDebriefCard({
   }
 
   if (!data) {
+    if (inGrace) {
+      return (
+        <View
+          testID={`${testIDPrefix}-preparing`}
+          accessibilityRole="alert"
+          accessibilityLabel="Coach is preparing your feedback"
+          style={styles.card}
+        >
+          <View style={styles.header}>
+            <Text style={styles.title}>Session debrief</Text>
+            <PulsingDot />
+          </View>
+          <Text style={styles.empty}>Coach is preparing your feedback…</Text>
+        </View>
+      );
+    }
     return (
       <View testID={`${testIDPrefix}-empty`} style={styles.card}>
         <Text style={styles.title}>Session debrief</Text>
@@ -128,6 +175,41 @@ export default function AutoDebriefCard({
         {data.brief}
       </Text>
     </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function PulsingDot() {
+  const opacity = useRef(new Animated.Value(0.3)).current;
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: 600,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 0.3,
+          duration: 600,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [opacity]);
+  return (
+    <Animated.View
+      accessibilityElementsHidden
+      importantForAccessibility="no"
+      style={[styles.pulsingDot, { opacity }]}
+    />
   );
 }
 
@@ -200,5 +282,11 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
     fontSize: 14,
     fontWeight: '600',
+  },
+  pulsingDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#60A5FA',
   },
 });

--- a/hooks/use-auto-debrief.ts
+++ b/hooks/use-auto-debrief.ts
@@ -64,6 +64,16 @@ function buildSessionBriefFromInput(
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * Hard timeout for a single generateAutoDebrief attempt. The coach pipeline
+ * has its own per-leg timeouts, but a transport-level hang (e.g. kept-alive
+ * connection stalled behind a captive portal) can still cascade into the UI
+ * showing a forever-spinner. 8s gives the happy path plenty of room and
+ * trips fast enough to let the user retry.
+ */
+export const AUTO_DEBRIEF_TIMEOUT_MS = 8000;
+export const AUTO_DEBRIEF_TIMEOUT_MESSAGE = 'Debrief is taking longer than expected';
+
 export interface UseAutoDebriefState {
   /** Most-recent result (cached or freshly generated). null until first run. */
   data: AutoDebriefResult | null;
@@ -114,8 +124,17 @@ export function useAutoDebrief(opts: UseAutoDebriefOptions): UseAutoDebriefState
     lastInputRef.current = input;
     setLoading(true);
     setError(null);
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     try {
-      const result = await generateAutoDebrief(input);
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          reject(new Error(AUTO_DEBRIEF_TIMEOUT_MESSAGE));
+        }, AUTO_DEBRIEF_TIMEOUT_MS);
+      });
+      const result = (await Promise.race([
+        generateAutoDebrief(input),
+        timeoutPromise,
+      ])) as AutoDebriefResult;
       setData(result);
       // Pipeline v2: persist a compact SessionBrief so the next coach turn
       // can prepend cross-session memory (closes gap 1 of intersection-audit
@@ -135,6 +154,7 @@ export function useAutoDebrief(opts: UseAutoDebriefOptions): UseAutoDebriefState
       warnWithTs('[use-auto-debrief] generate failed', err);
       setError(message);
     } finally {
+      if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
       setLoading(false);
     }
   }, []);

--- a/lib/services/ErrorHandler.ts
+++ b/lib/services/ErrorHandler.ts
@@ -13,6 +13,7 @@ export interface AppError {
     | 'storage'
     | 'sync'
     | 'auth'
+    | 'coach'
     | 'form-tracking'
     | 'unknown';
   code: string;
@@ -23,7 +24,7 @@ export interface AppError {
 }
 
 export interface ErrorContext {
-  feature: 'auth' | 'form-feedback' | 'workouts' | 'ui' | 'app' | 'form-tracking';
+  feature: 'auth' | 'form-feedback' | 'workouts' | 'ui' | 'app' | 'form-tracking' | 'coach';
   location?: string;
   meta?: Record<string, unknown>;
 }
@@ -99,6 +100,8 @@ export function mapToUserMessage(err: AppError): string {
       return 'Sync issue. We will retry automatically when online.';
     case 'auth':
       return 'Authentication error. Please try again.';
+    case 'coach':
+      return 'Coach service hit an issue. Please try again.';
     case 'form-tracking':
       return mapFormTrackingMessage(err.code);
     default:

--- a/lib/services/ErrorHandler.ts
+++ b/lib/services/ErrorHandler.ts
@@ -50,6 +50,8 @@ export const FormTrackingErrorCode = {
   CUE_PREEMPTION_FAILED: 'CUE_PREEMPTION_FAILED',
   /** Session-runner state went out of sync with rep-logger expectations. */
   SESSION_STATE_DESYNC: 'SESSION_STATE_DESYNC',
+  /** Rep data export (CSV/JSON) failed to generate or persist a file. */
+  EXPORT_FAILED: 'EXPORT_FAILED',
 } as const;
 export type FormTrackingErrorCodeValue =
   typeof FormTrackingErrorCode[keyof typeof FormTrackingErrorCode];
@@ -161,6 +163,8 @@ function mapFormTrackingMessage(code: string): string {
       return 'A coaching cue could not be played. Continuing without it.';
     case FormTrackingErrorCode.SESSION_STATE_DESYNC:
       return 'Session state got out of sync. Restart the set to continue.';
+    case FormTrackingErrorCode.EXPORT_FAILED:
+      return 'Export failed. Please try again.';
     default:
       return 'Form tracking ran into an issue. Try repositioning your camera.';
   }

--- a/tests/unit/components/AutoDebriefCard.test.tsx
+++ b/tests/unit/components/AutoDebriefCard.test.tsx
@@ -62,6 +62,16 @@ describe('AutoDebriefCard', () => {
     expect(getByText(/No debrief yet/i)).toBeTruthy();
   });
 
+  it('renders the awaiting-grace copy when awaitingResult=true and no data', () => {
+    const { getByTestId, getByText, queryByTestId } = render(
+      <AutoDebriefCard loading={false} error={null} data={null} awaitingResult />,
+    );
+    expect(getByTestId('auto-debrief-preparing')).toBeTruthy();
+    expect(getByText(/Coach is preparing your feedback/i)).toBeTruthy();
+    // The cold "no debrief yet" placeholder must NOT be rendered simultaneously.
+    expect(queryByTestId('auto-debrief-empty')).toBeNull();
+  });
+
   it('renders the shaped brief and the OpenAI provider badge by default', () => {
     const { getByTestId, getByText } = render(
       <AutoDebriefCard loading={false} error={null} data={result()} />,

--- a/tests/unit/components/form-tracking/AskCoachCTA.test.tsx
+++ b/tests/unit/components/form-tracking/AskCoachCTA.test.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/components/form-tracking/AskCoachCTA';
 
 const mockPush = jest.fn();
+const mockNetwork = { isOnline: true, isConnected: true, networkType: 'wifi' as string | null };
 
 jest.mock('expo-router', () => ({
   useRouter: () => ({
@@ -14,9 +15,15 @@ jest.mock('expo-router', () => ({
   }),
 }));
 
+jest.mock('@/contexts/NetworkContext', () => ({
+  useNetwork: () => mockNetwork,
+}));
+
 describe('AskCoachCTA', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockNetwork.isOnline = true;
+    mockNetwork.isConnected = true;
   });
 
   describe('buildCoachPrefill', () => {
@@ -126,6 +133,38 @@ describe('AskCoachCTA', () => {
       const button = getByTestId('ask-coach-cta');
       expect(button.props.accessibilityRole).toBe('button');
       expect(button.props.accessibilityLabel).toBe('Ask coach about this session');
+    });
+  });
+
+  describe('offline state', () => {
+    it('swallows taps and shows "Check your connection" subtext when offline', () => {
+      mockNetwork.isOnline = false;
+      const { getByTestId } = render(
+        <AskCoachCTA
+          exerciseName="Squat"
+          repCount={3}
+          averageFqi={60}
+          topFault="Hips rising"
+        />,
+      );
+
+      fireEvent.press(getByTestId('ask-coach-cta'));
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(getByTestId('ask-coach-cta-offline-hint')).toBeTruthy();
+    });
+
+    it('marks the button disabled via accessibility state when offline', () => {
+      mockNetwork.isOnline = false;
+      const { getByTestId } = render(
+        <AskCoachCTA
+          exerciseName="Squat"
+          repCount={3}
+          averageFqi={60}
+        />,
+      );
+      const button = getByTestId('ask-coach-cta');
+      expect(button.props.accessibilityState?.disabled).toBe(true);
+      expect(button.props.accessibilityLabel).toContain('Offline');
     });
   });
 });

--- a/tests/unit/hooks/use-auto-debrief.test.tsx
+++ b/tests/unit/hooks/use-auto-debrief.test.tsx
@@ -36,7 +36,7 @@ jest.mock('@/lib/stores/session-runner', () => ({
   },
 }));
 
-import { useAutoDebrief } from '@/hooks/use-auto-debrief';
+import { AUTO_DEBRIEF_TIMEOUT_MESSAGE, useAutoDebrief } from '@/hooks/use-auto-debrief';
 
 function makeEvent() {
   return {
@@ -241,6 +241,32 @@ describe('useAutoDebrief', () => {
     expect(mockGenerate).not.toHaveBeenCalled();
     expect(result.current.data).toBeNull();
   });
+
+  it('surfaces a timeout error when generate hangs past the budget', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // generate resolves never — we want the timeout race to win.
+    mockGenerate.mockImplementation(() => new Promise<never>(() => {}));
+
+    const { result } = renderHook(() =>
+      useAutoDebrief({
+        buildInput: () => ({ sessionId: 'sess-1', analytics: makeAnalytics() }),
+      }),
+    );
+
+    await act(async () => {
+      await triggerFinished(makeEvent());
+    });
+
+    // The hook's timeout is 8s. Real timers keep the test contained to a
+    // single file and avoid polluting neighbouring tests with fake-timers.
+    await waitFor(
+      () => {
+        expect(result.current.error).toBe(AUTO_DEBRIEF_TIMEOUT_MESSAGE);
+        expect(result.current.loading).toBe(false);
+      },
+      { timeout: 9000, interval: 100 },
+    );
+  }, 12000);
 
   it('surfaces errors from buildInput', async () => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});

--- a/tests/unit/screens/progression-plan-modal.test.tsx
+++ b/tests/unit/screens/progression-plan-modal.test.tsx
@@ -99,8 +99,9 @@ describe('ProgressionPlanModal', () => {
   });
 
   it('renders a loading state before data resolves', () => {
-    const { getByText } = render(<ProgressionPlanModal />);
-    expect(getByText(/Building your overload plan/)).toBeTruthy();
+    const { getByText, getByTestId } = render(<ProgressionPlanModal />);
+    expect(getByText(/Analyzing your history/)).toBeTruthy();
+    expect(getByTestId('progression-plan-loading')).toBeTruthy();
   });
 
   it('renders summary and PR chips after data loads', async () => {

--- a/tests/unit/screens/rep-export-retry.test.tsx
+++ b/tests/unit/screens/rep-export-retry.test.tsx
@@ -24,6 +24,13 @@ jest.mock('@/lib/services/rep-export', () => ({
   shareRepData: (...args: unknown[]) => mockShareRepData(...args),
 }));
 
+// Rep-insights now surfaces export failures via both the inline banner and
+// a Toast. These tests target the banner UI, so a cheap useToast mock keeps
+// them isolated from the ToastProvider tree.
+jest.mock('@/contexts/ToastContext', () => ({
+  useToast: () => ({ show: jest.fn() }),
+}));
+
 // Stub heavy insight widgets so the test only exercises the export card.
 jest.mock('@/components/insights/FqiTrendChart', () => ({
   FqiTrendChart: () => null,


### PR DESCRIPTION
## Summary

Post-session debrief + coach modal resilience pass (PR B of a 3-PR wave). Nine concrete gaps, atomic commits, no new deps.

## Fixes

1. **AutoDebrief 8s timeout race** — `hooks/use-auto-debrief.ts` now wraps `generateAutoDebrief()` in a `Promise.race` against an 8-second timeout, surfacing "Debrief is taking longer than expected" so the existing `retry()` CTA is actionable.
2. **AutoDebriefCard friendly empty copy** — new `awaitingResult` prop renders "Coach is preparing your feedback…" with a pulsing dot in a 30s grace window after session-end; falls back to the history copy when opened from history.
3. **AskCoachCTA offline state** — via `useNetwork()`: button renders disabled with a "Check your connection" subtext and swallows taps when offline.
4. **generate-session Alert → Toast** — validation `Alert.alert('Describe the session', ...)` replaced with `showToast('Tell the AI what you want to train.', {type:'info'})`.
5. **form-tracking-debrief zero-reps copy** — "No reps recorded yet — Start a live tracking set to see your breakdown." (directed forward, not back), and the debrief screen now passes `awaitingResult` to `AutoDebriefCard` when freshly opened from a session.
6. **rep-insights export via withErrorHandling** — new `EXPORT_FAILED` code on the `form-tracking` domain; `shareRepData` wrapped in `withErrorHandling`; remaining `Alert.alert` swapped for `Toast`; inline retry banner preserved.
7. **coach.tsx structured logging** — all four `console.error` sites now call `logError(createError('coach', <CODE>, ...))` + the existing toast. Adds `'coach'` to `AppError.domain` and `ErrorContext.feature`.
8. **generate-session CrashBoundary + DB try/catch** — wraps the screen body in `CrashBoundary`; `availableSlugsPromise` now catches storage errors and logs via `createError('storage', 'EXERCISE_SLUGS_QUERY_FAILED', ...)`, returning `[]` so the AI can still attempt generation.
9. **progression-plan loading spinner** — centered `ActivityIndicator` with "Analyzing your history…" copy, `accessibilityRole="alert"`, and a testID for deterministic snapshots.

Audit worklog: `docs/overnight/worklog-2026-04-21-form-ux-gemma-wave-close.md`.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run check:types` clean
- [x] `bun run test` — 4908 passed / 24 skipped / 0 failed
- [ ] Manual smoke: open debrief from a just-ended session vs from history — grace copy vs cold copy
- [ ] Manual smoke: toggle airplane mode — AskCoachCTA disables with hint, taps swallowed
- [ ] Manual smoke: generate-session with empty intent — toast, not alert
- [ ] Manual smoke: rep-insights export with flaky network — banner + toast