### PR TITLE
feat(post-session): retention pack — FQI explainer, session comparison, milestone context

### DIFF
--- a/app/(modals)/form-tracking-debrief.tsx
+++ b/app/(modals)/form-tracking-debrief.tsx
@@ -12,7 +12,7 @@
  * tracker to navigate here is a follow-up.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -25,6 +25,8 @@ import {
 import { SessionHighlightCard } from '@/components/form-tracking/SessionHighlightCard';
 import { AskCoachCTA } from '@/components/form-tracking/AskCoachCTA';
 import AutoDebriefCard from '@/components/form-tracking/AutoDebriefCard';
+import { FqiExplainerModal } from '@/components/form-tracking/FqiExplainerModal';
+import { resolveExerciseKey } from '@/lib/services/form-session-history-lookup';
 import { useAutoDebrief } from '@/hooks/use-auto-debrief';
 import { isCoachPipelineV2Enabled } from '@/lib/services/coach-pipeline-v2-flag';
 
@@ -125,6 +127,14 @@ export default function FormTrackingDebriefScreen() {
     router.back();
   }, [router]);
 
+  const [explainerVisible, setExplainerVisible] = useState(false);
+  const handleOpenExplainer = useCallback(() => setExplainerVisible(true), []);
+  const handleCloseExplainer = useCallback(() => setExplainerVisible(false), []);
+  const explainerExerciseId = useMemo(
+    () => resolveExerciseKey(exerciseName) ?? undefined,
+    [exerciseName],
+  );
+
   const hasReps = reps.length > 0;
 
   return (
@@ -168,6 +178,20 @@ export default function FormTrackingDebriefScreen() {
               value={averageFqi != null ? String(Math.round(averageFqi)) : '–'}
             />
           </View>
+          {averageFqi != null ? (
+            <Pressable
+              onPress={handleOpenExplainer}
+              accessibilityRole="button"
+              accessibilityLabel="What does this score mean?"
+              accessibilityHint="Tap to learn what this score means"
+              style={({ pressed }) => [styles.explainerChip, pressed && styles.explainerChipPressed]}
+              testID="form-tracking-debrief-fqi-explainer-chip"
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
+              <Ionicons name="information-circle-outline" size={14} color="#9AACD1" />
+              <Text style={styles.explainerChipText}>What does this score mean?</Text>
+            </Pressable>
+          ) : null}
         </View>
 
         <View style={styles.sectionGap}>
@@ -215,6 +239,13 @@ export default function FormTrackingDebriefScreen() {
         repCount={reps.length}
         averageFqi={averageFqi}
         topFault={topFault}
+      />
+
+      <FqiExplainerModal
+        visible={explainerVisible}
+        onDismiss={handleCloseExplainer}
+        exerciseId={explainerExerciseId}
+        testID="form-tracking-debrief-fqi-explainer"
       />
     </SafeAreaView>
   );
@@ -301,6 +332,27 @@ const styles = StyleSheet.create({
     marginTop: 2,
     textTransform: 'uppercase',
     letterSpacing: 0.4,
+  },
+  explainerChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: 'rgba(154, 172, 209, 0.3)',
+    backgroundColor: 'rgba(154, 172, 209, 0.06)',
+  },
+  explainerChipPressed: {
+    backgroundColor: 'rgba(154, 172, 209, 0.16)',
+  },
+  explainerChipText: {
+    color: '#9AACD1',
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 0.2,
   },
   sectionGap: {
     marginBottom: 20,

--- a/app/(modals)/form-tracking-debrief.tsx
+++ b/app/(modals)/form-tracking-debrief.tsx
@@ -12,7 +12,7 @@
  * tracker to navigate here is a follow-up.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -26,8 +26,11 @@ import { SessionHighlightCard } from '@/components/form-tracking/SessionHighligh
 import { AskCoachCTA } from '@/components/form-tracking/AskCoachCTA';
 import AutoDebriefCard from '@/components/form-tracking/AutoDebriefCard';
 import { FqiExplainerModal } from '@/components/form-tracking/FqiExplainerModal';
+import { SessionCompareToLastCard } from '@/components/form-tracking/SessionCompareToLastCard';
 import { resolveExerciseKey } from '@/lib/services/form-session-history-lookup';
 import { useAutoDebrief } from '@/hooks/use-auto-debrief';
+import { useSessionComparisonQuery } from '@/hooks/use-session-comparison';
+import { supabase } from '@/lib/supabase';
 import { isCoachPipelineV2Enabled } from '@/lib/services/coach-pipeline-v2-flag';
 
 function safeParseReps(raw: string | undefined): RepSummary[] {
@@ -89,10 +92,38 @@ function pickBestAndWorst(reps: RepSummary[]): {
 
 export default function FormTrackingDebriefScreen() {
   const router = useRouter();
+  const [userId, setUserId] = useState<string | null>(null);
+  useEffect(() => {
+    // Resolve the current user lazily via supabase.auth.getSession() rather
+    // than via AuthContext so this screen stays test-friendly (AuthContext
+    // pulls expo-linking at import time, which the existing debrief test
+    // suite's module graph doesn't set up). supabase itself is already
+    // globally mocked in tests so this is a no-op there.
+    let cancelled = false;
+    void supabase.auth
+      .getSession()
+      .then(({ data }) => {
+        if (cancelled) return;
+        setUserId(data.session?.user.id ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setUserId(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   const params = useLocalSearchParams<{
     exerciseName?: string;
     durationSeconds?: string;
     reps?: string;
+    /**
+     * Optional: when passed, the debrief hydrates a "Compare to last
+     * session" card by calling the session-comparison aggregator. Recap
+     * routes fired from the legacy in-session path omit this param and
+     * the card simply does not render.
+     */
+    sessionId?: string;
   }>();
 
   const exerciseName = params.exerciseName?.trim() ? params.exerciseName : 'Session recap';
@@ -101,6 +132,29 @@ export default function FormTrackingDebriefScreen() {
   const averageFqi = useMemo(() => computeAverageFqi(reps), [reps]);
   const { best, worst } = useMemo(() => pickBestAndWorst(reps), [reps]);
   const topFault = worst?.faults[0] ?? null;
+  const routeSessionId = useMemo(() => {
+    const raw = params.sessionId;
+    if (!raw || typeof raw !== 'string') return null;
+    return raw.trim() || null;
+  }, [params.sessionId]);
+  const comparisonExerciseId = useMemo(
+    () => resolveExerciseKey(exerciseName),
+    [exerciseName],
+  );
+  const { comparison } = useSessionComparisonQuery({
+    currentSessionId: routeSessionId,
+    exerciseId: comparisonExerciseId,
+    userId,
+  });
+  const handleOpenComparison = useCallback(() => {
+    if (!comparison?.priorSessionId || !comparisonExerciseId || !routeSessionId) return;
+    const qs = new URLSearchParams({
+      sessionId: routeSessionId,
+      exerciseId: comparisonExerciseId,
+      priorSessionId: comparison.priorSessionId,
+    }).toString();
+    router.push(`/(modals)/form-comparison?${qs}` as `/${string}`);
+  }, [router, comparison?.priorSessionId, comparisonExerciseId, routeSessionId]);
 
   // Pipeline v2: synthesize a stable sessionId from the recap payload so the
   // auto-debrief hook can dedupe via AsyncStorage. We derive from exercise
@@ -213,6 +267,17 @@ export default function FormTrackingDebriefScreen() {
             </View>
           )}
         </View>
+
+        {comparison?.priorSessionId ? (
+          <View style={styles.sectionGap} testID="form-tracking-debrief-compare-section">
+            <Text style={styles.sectionTitle}>Progress</Text>
+            <SessionCompareToLastCard
+              comparison={comparison}
+              onPress={handleOpenComparison}
+              testID="form-tracking-debrief-compare-card"
+            />
+          </View>
+        ) : null}
 
         {pipelineV2 ? (
           <View style={styles.sectionGap} testID="form-tracking-debrief-auto-section">

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -51,6 +51,8 @@ import { generateSessionId, logCueEvent, upsertSessionMetrics } from '@/lib/serv
 import { logPoseSample, flushPoseBuffer, resetFrameCounter } from '@/lib/services/pose-logger';
 import {
   appendFormSessionHistory,
+  countConsecutiveSessionDays,
+  countPbsThisMonth,
   getFormSessionHistory,
 } from '@/lib/services/form-session-history';
 import { playRepCountdown } from '@/lib/services/rep-countdown-audio';
@@ -1881,6 +1883,29 @@ export default function ScanARKitScreen() {
         (async () => {
           try {
             const prior = await getFormSessionHistory(exerciseKeyAtStop);
+            // Enrichment: count PBs set so far this month (including the
+            // candidate session if it would land a PB) and the day-streak
+            // ending today. These are best-effort — failures don't block
+            // milestone emission.
+            let priorPbCount = 0;
+            let weekStreakDays = 0;
+            try {
+              priorPbCount = await countPbsThisMonth({
+                now: new Date(endedAt),
+                candidate: { exerciseKey: exerciseKeyAtStop, avgFqi },
+              });
+            } catch {
+              /* ignore */
+            }
+            try {
+              // +1 for today's session even though it isn't persisted yet —
+              // match the "today counts once a session lands" contract the
+              // streak helper uses on already-appended entries.
+              weekStreakDays =
+                (await countConsecutiveSessionDays({ now: new Date(endedAt) })) + 1;
+            } catch {
+              /* ignore */
+            }
             await emitFormMilestone({
               sessionId: sessionIdAtStop,
               exerciseKey: exerciseKeyAtStop,
@@ -1889,6 +1914,8 @@ export default function ScanARKitScreen() {
                 avgFqi: p.avgFqi,
                 endedAt: p.endedAt,
               })),
+              priorPbCount,
+              weekStreakDays,
             });
             await appendFormSessionHistory({
               exerciseKey: exerciseKeyAtStop,

--- a/components/form-tracking/FormQualityBadge.tsx
+++ b/components/form-tracking/FormQualityBadge.tsx
@@ -8,9 +8,22 @@
  *
  * Renders null when the score is missing — cards without form data show
  * no badge rather than a hollow "--" placeholder.
+ *
+ * When `onPress` is provided the badge becomes a tappable button so the
+ * caller can open the FQI explainer modal. A subtle "ⓘ" affordance is
+ * shown in that mode so users know the pill is interactive; accessibility
+ * metadata switches from `image` to `button` automatically.
  */
 import React, { useMemo } from 'react';
-import { StyleSheet, Text, View, type StyleProp, type ViewStyle } from 'react-native';
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 
 import { getFqiColor } from './FqiGauge';
 
@@ -21,9 +34,24 @@ export interface FormQualityBadgeProps {
   style?: StyleProp<ViewStyle>;
   /** Optional testID. */
   testID?: string;
+  /**
+   * Tap handler. When provided the badge wraps itself in a Pressable,
+   * shows an info affordance, and exposes button-role a11y. When omitted,
+   * the badge renders as a plain, non-interactive pill (its original
+   * history-card behaviour).
+   */
+  onPress?: () => void;
+  /** Override the default "Tap to learn what this score means" hint. */
+  accessibilityHint?: string;
 }
 
-export function FormQualityBadge({ score, style, testID }: FormQualityBadgeProps) {
+export function FormQualityBadge({
+  score,
+  style,
+  testID,
+  onPress,
+  accessibilityHint,
+}: FormQualityBadgeProps) {
   const rounded = useMemo(() => {
     if (score == null || !Number.isFinite(score)) return null;
     return Math.max(0, Math.min(100, Math.round(score)));
@@ -33,15 +61,57 @@ export function FormQualityBadge({ score, style, testID }: FormQualityBadgeProps
 
   if (rounded == null) return null;
 
-  return (
-    <View
-      style={[styles.container, { borderColor: colors.fill, backgroundColor: colors.track }, style]}
-      testID={testID ?? 'form-quality-badge'}
-      accessibilityLabel={`Form quality ${rounded} out of 100`}
-    >
+  const resolvedTestID = testID ?? 'form-quality-badge';
+  const a11yLabel = `Form quality ${rounded} out of 100`;
+  const interactive = typeof onPress === 'function';
+  const hint = accessibilityHint ?? 'Tap to learn what this score means';
+
+  const content = (
+    <>
       <View style={[styles.dot, { backgroundColor: colors.fill }]} />
       <Text style={[styles.score, { color: colors.fill }]}>{rounded}</Text>
       <Text style={[styles.label, { color: colors.fill }]}>FORM</Text>
+      {interactive ? (
+        <Ionicons
+          name="information-circle-outline"
+          size={12}
+          color={colors.fill}
+          style={styles.infoIcon}
+          testID={`${resolvedTestID}-info-icon`}
+        />
+      ) : null}
+    </>
+  );
+
+  const containerStyle = [
+    styles.container,
+    { borderColor: colors.fill, backgroundColor: colors.track },
+    style,
+  ];
+
+  if (interactive) {
+    return (
+      <Pressable
+        onPress={onPress}
+        style={({ pressed }) => [...containerStyle, pressed && styles.pressed]}
+        testID={resolvedTestID}
+        accessibilityRole="button"
+        accessibilityLabel={a11yLabel}
+        accessibilityHint={hint}
+        hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+      >
+        {content}
+      </Pressable>
+    );
+  }
+
+  return (
+    <View
+      style={containerStyle}
+      testID={resolvedTestID}
+      accessibilityLabel={a11yLabel}
+    >
+      {content}
     </View>
   );
 }
@@ -71,6 +141,13 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     letterSpacing: 0.4,
     opacity: 0.85,
+  },
+  infoIcon: {
+    marginLeft: 2,
+    opacity: 0.85,
+  },
+  pressed: {
+    opacity: 0.7,
   },
 });
 

--- a/components/form-tracking/FqiExplainerModal.tsx
+++ b/components/form-tracking/FqiExplainerModal.tsx
@@ -1,0 +1,342 @@
+/**
+ * FqiExplainerModal
+ *
+ * In-context explainer that appears when the user taps the FormQualityBadge
+ * or FqiGauge. Covers three things in one sheet:
+ *
+ *   1. What the FQI (Form Quality Index) actually measures — joint angles,
+ *      tempo, depth, symmetry. Two-three sentences, friendly but concrete.
+ *   2. The color-tier legend so users can map the badge tint to meaning.
+ *   3. Three generic improvement tips keyed to common failure modes
+ *      (rushed tempo, shallow depth, left/right asymmetry).
+ *
+ * An optional secondary CTA — "See drills for this exercise" — only renders
+ * when the caller passes an `exerciseId`, routing to the form-quality
+ * recovery modal with that exercise pre-selected.
+ *
+ * Visual style mirrors DrillSheet (dark-navy card over a dimmed backdrop)
+ * so the surface feels native to the form-tracking flow. Font weights use
+ * Lexend_ ^/500/700 to match the rest of the app.
+ */
+import React from 'react';
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+
+import { getFqiColor } from './FqiGauge';
+
+export interface FqiExplainerModalProps {
+  /** Controls visibility. */
+  visible: boolean;
+  /** Called when the user dismisses the modal (backdrop / close button / hw back). */
+  onDismiss: () => void;
+  /**
+   * Canonical exercise id. When provided, a secondary CTA appears that
+   * routes to `/(modals)/form-quality-recovery?exerciseId=<id>` so the
+   * user can pivot from "what is FQI" to "how do I fix it for this lift".
+   */
+  exerciseId?: string;
+  /** Optional testID override. Defaults to `fqi-explainer-modal`. */
+  testID?: string;
+}
+
+interface TierRow {
+  range: string;
+  label: string;
+  /** Hex color sourced from `getFqiColor` so the legend matches the live UI. */
+  color: string;
+}
+
+// The legend tiers below intentionally mirror the tier boundaries in
+// `getFqiColor` plus the higher-precision bands described in the product
+// spec. `getFqiColor` is the source of truth for colors; labels below are
+// the user-facing copy.
+const TIER_ROWS: TierRow[] = [
+  { range: '85+', label: 'Excellent', color: getFqiColor(90).fill },
+  { range: '65–84', label: 'Good', color: getFqiColor(75).fill },
+  { range: '45–64', label: 'Needs work', color: getFqiColor(55).fill },
+  { range: '< 45', label: 'Refocus on basics', color: getFqiColor(30).fill },
+];
+
+const IMPROVEMENT_TIPS: { icon: keyof typeof Ionicons.glyphMap; text: string }[] = [
+  {
+    icon: 'timer-outline',
+    text: 'Slow the eccentric — count 2–3s on the way down to stabilise tempo.',
+  },
+  {
+    icon: 'trending-down-outline',
+    text: 'Hit full depth every rep. Partial reps drag FQI more than missing weight.',
+  },
+  {
+    icon: 'swap-horizontal-outline',
+    text: 'Keep left and right even. Asymmetry > 5° costs points on every rep.',
+  },
+];
+
+export function FqiExplainerModal({
+  visible,
+  onDismiss,
+  exerciseId,
+  testID = 'fqi-explainer-modal',
+}: FqiExplainerModalProps) {
+  const router = useRouter();
+
+  const handleSeeDrills = (): void => {
+    if (!exerciseId) return;
+    onDismiss();
+    const encoded = encodeURIComponent(exerciseId);
+    router.push(`/(modals)/form-quality-recovery?exerciseId=${encoded}` as `/${string}`);
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onDismiss}
+      testID={testID}
+    >
+      <Pressable
+        style={styles.backdrop}
+        onPress={onDismiss}
+        accessibilityRole="button"
+        accessibilityLabel="Dismiss form quality explainer"
+        testID={`${testID}-backdrop`}
+      />
+      <View style={styles.sheet} accessibilityLabel="What is form quality">
+        <View style={styles.handle} />
+
+        <View style={styles.header}>
+          <Text style={styles.title}>What is Form Quality?</Text>
+          <Pressable
+            onPress={onDismiss}
+            accessibilityRole="button"
+            accessibilityLabel="Close"
+            style={({ pressed }) => [styles.closeBtn, pressed && styles.pressed]}
+            testID={`${testID}-close`}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Ionicons name="close" size={20} color="#F5F7FF" />
+          </Pressable>
+        </View>
+
+        <ScrollView
+          style={styles.scroll}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+        >
+          <Text style={styles.body}>
+            FQI (Form Quality Index) is a single 0–100 score that combines
+            joint-angle alignment, tempo consistency, depth, and left/right
+            symmetry. Each rep gets its own score; the badge shows the
+            session average. Higher is better.
+          </Text>
+
+          <Text style={styles.sectionTitle}>Legend</Text>
+          <View style={styles.legend} testID={`${testID}-legend`}>
+            {TIER_ROWS.map((tier) => (
+              <View
+                key={tier.label}
+                style={styles.legendRow}
+                testID={`${testID}-legend-${tier.label.toLowerCase().replace(/\s+/g, '-')}`}
+              >
+                <View style={[styles.swatch, { backgroundColor: tier.color }]} />
+                <View style={styles.legendText}>
+                  <Text style={styles.legendRange}>{tier.range}</Text>
+                  <Text style={styles.legendLabel}>{tier.label}</Text>
+                </View>
+              </View>
+            ))}
+          </View>
+
+          <Text style={styles.sectionTitle}>Quick wins</Text>
+          <View style={styles.tipList} testID={`${testID}-tips`}>
+            {IMPROVEMENT_TIPS.map((tip) => (
+              <View key={tip.text} style={styles.tipRow}>
+                <Ionicons name={tip.icon} size={16} color="#4C8CFF" />
+                <Text style={styles.tipText}>{tip.text}</Text>
+              </View>
+            ))}
+          </View>
+        </ScrollView>
+
+        {exerciseId ? (
+          <Pressable
+            onPress={handleSeeDrills}
+            accessibilityRole="button"
+            accessibilityLabel="See drills for this exercise"
+            style={({ pressed }) => [styles.drillsCta, pressed && styles.pressed]}
+            testID={`${testID}-see-drills`}
+          >
+            <Ionicons name="barbell-outline" size={16} color="#FFFFFF" />
+            <Text style={styles.drillsCtaText}>See drills for this exercise</Text>
+          </Pressable>
+        ) : null}
+
+        <Pressable
+          onPress={onDismiss}
+          accessibilityRole="button"
+          accessibilityLabel="Close explainer"
+          style={({ pressed }) => [styles.dismissBtn, pressed && styles.pressed]}
+          testID={`${testID}-dismiss`}
+        >
+          <Text style={styles.dismissText}>Got it</Text>
+        </Pressable>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.55)',
+  },
+  sheet: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    maxHeight: '85%',
+    backgroundColor: '#0D1530',
+    borderTopLeftRadius: 18,
+    borderTopRightRadius: 18,
+    padding: 20,
+    paddingBottom: 28,
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 44,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
+    marginBottom: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  title: {
+    color: '#F5F7FF',
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 18,
+    fontWeight: '700',
+    flex: 1,
+  },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
+  },
+  scroll: {
+    maxHeight: 460,
+  },
+  scrollContent: {
+    paddingBottom: 8,
+    gap: 14,
+  },
+  body: {
+    color: 'rgba(220, 228, 245, 0.9)',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 14,
+    lineHeight: 21,
+  },
+  sectionTitle: {
+    color: '#C9D7F4',
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 12,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+    marginTop: 6,
+  },
+  legend: {
+    gap: 10,
+  },
+  legendRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  swatch: {
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+  },
+  legendText: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 10,
+  },
+  legendRange: {
+    color: '#F5F7FF',
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 14,
+    fontWeight: '700',
+    minWidth: 60,
+  },
+  legendLabel: {
+    color: 'rgba(220, 228, 245, 0.85)',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 14,
+  },
+  tipList: {
+    gap: 10,
+  },
+  tipRow: {
+    flexDirection: 'row',
+    gap: 10,
+    alignItems: 'flex-start',
+  },
+  tipText: {
+    color: 'rgba(220, 228, 245, 0.9)',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 13,
+    lineHeight: 19,
+    flex: 1,
+  },
+  drillsCta: {
+    marginTop: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingVertical: 12,
+    borderRadius: 12,
+    backgroundColor: '#4C8CFF',
+  },
+  drillsCtaText: {
+    color: '#FFFFFF',
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  dismissBtn: {
+    marginTop: 10,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  dismissText: {
+    color: 'rgba(220, 228, 245, 0.75)',
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  pressed: {
+    opacity: 0.75,
+  },
+});
+
+export default FqiExplainerModal;

--- a/components/form-tracking/SessionCompareToLastCard.tsx
+++ b/components/form-tracking/SessionCompareToLastCard.tsx
@@ -1,0 +1,233 @@
+/**
+ * SessionCompareToLastCard
+ *
+ * Post-session "compare to last session" summary — three headline deltas
+ * (reps, form quality, avg rest time) color-coded for a one-glance sense
+ * of progress vs. the user's most recent prior session on the same lift.
+ *
+ * Not a full-featured comparison (the existing
+ * {@link SessionComparisonCard} handles ROM / symmetry / fault diffs);
+ * this tile is tuned for the debrief flow where density and low cognitive
+ * load matter more than completeness. When the user taps it we jump to
+ * the dedicated `form-comparison` modal for the richer view.
+ *
+ * Renders null when there is no prior session — callers should gate on
+ * `comparison?.priorSessionId` and skip mounting.
+ */
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { SessionComparison } from '@/lib/services/session-comparison-aggregator';
+
+export interface SessionCompareToLastCardProps {
+  comparison: SessionComparison;
+  /**
+   * Optional tap handler. When provided, the whole card becomes pressable
+   * and should route to the full comparison modal. When omitted the card
+   * renders as a plain non-interactive summary.
+   */
+  onPress?: () => void;
+  testID?: string;
+}
+
+interface DeltaSpec {
+  label: string;
+  value: number | null;
+  /**
+   * True when a positive delta is an improvement (reps). False when a
+   * negative delta is the improvement (avg rest time reduction). Ignored
+   * for FQI which uses a dedicated formatter with explicit sign/color.
+   */
+  positiveIsBetter: boolean;
+  /** Unit suffix appended to the delta text, e.g. " reps", "s". */
+  suffix: string;
+  /** Optional leading icon. */
+  icon: keyof typeof Ionicons.glyphMap;
+  /** Explicit tone override (used by FQI which isn't a simple count). */
+  tone?: 'neutral' | 'positive' | 'negative';
+  /** Custom formatted value, overrides numeric rendering. */
+  valueText?: string;
+  /** testID suffix — defaults to `delta-<slug>`. */
+  key: string;
+}
+
+function formatSigned(value: number | null, suffix: string, fractional = false): string {
+  if (value == null) return '—';
+  const rounded = fractional ? Math.round(value * 10) / 10 : Math.round(value);
+  if (rounded === 0) return `±0${suffix}`;
+  const sign = rounded > 0 ? '+' : '';
+  return `${sign}${rounded}${suffix}`;
+}
+
+function deltaTone(value: number | null, positiveIsBetter: boolean): 'neutral' | 'positive' | 'negative' {
+  if (value == null || Math.abs(value) < 0.01) return 'neutral';
+  const improved = positiveIsBetter ? value > 0 : value < 0;
+  return improved ? 'positive' : 'negative';
+}
+
+function toneColor(tone: 'neutral' | 'positive' | 'negative'): string {
+  if (tone === 'positive') return '#3CC8A9';
+  if (tone === 'negative') return '#EF4444';
+  return '#9AACD1';
+}
+
+export function SessionCompareToLastCard({
+  comparison,
+  onPress,
+  testID = 'session-compare-to-last-card',
+}: SessionCompareToLastCardProps) {
+  if (!comparison.priorSessionId) return null;
+
+  const deltas: DeltaSpec[] = [
+    {
+      key: 'reps',
+      label: 'Reps',
+      value: comparison.repCountDelta,
+      positiveIsBetter: true,
+      suffix: ' reps',
+      icon: 'repeat-outline',
+    },
+    {
+      key: 'fqi',
+      label: 'Form Quality',
+      value: comparison.fqiDelta,
+      positiveIsBetter: true,
+      suffix: ' form quality',
+      icon: 'pulse-outline',
+    },
+    {
+      key: 'rest',
+      label: 'Avg rest',
+      value: comparison.restDeltaSec,
+      // Shorter rest ("negative delta") is generally a conditioning win;
+      // longer rest can be a strength-block positive. We color it only as
+      // neutral / context — not pass/fail.
+      positiveIsBetter: false,
+      suffix: 's',
+      icon: 'timer-outline',
+      // Override tone to neutral so we never accuse the athlete of a
+      // regression on a metric that lacks inherent direction.
+      tone: 'neutral',
+    },
+  ];
+
+  const inner = (
+    <View style={styles.card} testID={testID}>
+      <View style={styles.header}>
+        <Ionicons name="trending-up" size={16} color="#4C8CFF" />
+        <Text style={styles.title}>Compare to last session</Text>
+        {onPress ? (
+          <Ionicons
+            name="chevron-forward"
+            size={16}
+            color="#9AACD1"
+            style={styles.chevron}
+          />
+        ) : null}
+      </View>
+      <View style={styles.deltaRow}>
+        {deltas.map((d) => {
+          const tone = d.tone ?? deltaTone(d.value, d.positiveIsBetter);
+          const color = toneColor(tone);
+          const fractional = d.key === 'fqi' || d.key === 'rest';
+          const text = d.valueText ?? formatSigned(d.value, '', fractional);
+          return (
+            <View
+              key={d.key}
+              style={styles.deltaCell}
+              testID={`${testID}-delta-${d.key}`}
+            >
+              <View style={styles.deltaHeader}>
+                <Ionicons name={d.icon} size={12} color="#C9D7F4" />
+                <Text style={styles.deltaLabel}>{d.label}</Text>
+              </View>
+              <Text style={[styles.deltaValue, { color }]} testID={`${testID}-delta-${d.key}-value`}>
+                {text}
+              </Text>
+              <Text style={styles.deltaUnit}>{d.suffix.trim()}</Text>
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+
+  if (!onPress) return inner;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel="Compare to last session"
+      accessibilityHint="Opens the full session comparison"
+      style={({ pressed }) => [pressed && styles.pressed]}
+      testID={`${testID}-pressable`}
+    >
+      {inner}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#0F2339',
+    borderRadius: 18,
+    padding: 16,
+    gap: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  title: {
+    color: '#F5F7FF',
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 14,
+    fontWeight: '700',
+    flex: 1,
+  },
+  chevron: {
+    marginLeft: 'auto',
+  },
+  deltaRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  deltaCell: {
+    flex: 1,
+    backgroundColor: 'rgba(255, 255, 255, 0.04)',
+    borderRadius: 12,
+    padding: 10,
+    gap: 4,
+  },
+  deltaHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  deltaLabel: {
+    color: '#C9D7F4',
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 11,
+    fontWeight: '500',
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+  deltaValue: {
+    fontFamily: 'Lexend_700Bold',
+    fontSize: 18,
+    fontWeight: '700',
+    letterSpacing: 0.2,
+  },
+  deltaUnit: {
+    color: '#6F80A0',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 11,
+  },
+  pressed: {
+    opacity: 0.8,
+  },
+});
+
+export default SessionCompareToLastCard;

--- a/lib/services/form-milestone-detector.ts
+++ b/lib/services/form-milestone-detector.ts
@@ -39,6 +39,19 @@ export interface DetectMilestoneInput {
   consistencyWindow?: number;
   /** Floor for the consistency signal to fire (default 70). */
   consistencyMinScore?: number;
+  /**
+   * Aggregate count of PBs the user has set this calendar month across any
+   * exercise, *including* the one about to fire if applicable. Enables
+   * ordinal context in the PB message ("3rd PB this month — on fire").
+   * Callers can pass 0 or omit when the data is unavailable.
+   */
+  priorPbCount?: number;
+  /**
+   * Consecutive days (including today) with at least one completed session
+   * on any exercise. Enables streak context in the consistency message
+   * ("5-day streak, keep it rolling"). Omit or pass 0 to suppress.
+   */
+  weekStreakDays?: number;
 }
 
 export interface MilestoneResult {
@@ -78,6 +91,8 @@ export function detectMilestone(input: DetectMilestoneInput): MilestoneResult {
     consistencyBand = DEFAULTS.consistencyBand,
     consistencyWindow = DEFAULTS.consistencyWindow,
     consistencyMinScore = DEFAULTS.consistencyMinScore,
+    priorPbCount,
+    weekStreakDays,
   } = input;
 
   const score = safeNumber(currentAvgFqi);
@@ -96,7 +111,7 @@ export function detectMilestone(input: DetectMilestoneInput): MilestoneResult {
     if (score >= pbMinScore && pbMinScore > 0) {
       return {
         kind: 'new_pb',
-        message: buildPbMessage(score, exerciseKey),
+        message: buildPbMessage(score, exerciseKey, priorPbCount),
         score,
       };
     }
@@ -105,7 +120,7 @@ export function detectMilestone(input: DetectMilestoneInput): MilestoneResult {
     if (score - priorBest >= pbMargin && score >= pbMinScore) {
       return {
         kind: 'new_pb',
-        message: buildPbMessage(score, exerciseKey),
+        message: buildPbMessage(score, exerciseKey, priorPbCount),
         score,
       };
     }
@@ -123,7 +138,12 @@ export function detectMilestone(input: DetectMilestoneInput): MilestoneResult {
     if (min >= consistencyMinScore && max - min <= consistencyBand) {
       return {
         kind: 'week_consistency',
-        message: buildConsistencyMessage(score, exerciseKey, consistencyWindow),
+        message: buildConsistencyMessage(
+          score,
+          exerciseKey,
+          consistencyWindow,
+          weekStreakDays,
+        ),
         score,
       };
     }
@@ -139,14 +159,41 @@ function safeNumber(raw: number | null | undefined): number | null {
   return raw;
 }
 
-function buildPbMessage(score: number, exerciseKey: string): string {
-  return `New record: ${formatScore(score)}/100 form on ${exerciseLabel(exerciseKey)}`;
+function buildPbMessage(
+  score: number,
+  exerciseKey: string,
+  priorPbCount?: number,
+): string {
+  const base = `New record: ${formatScore(score)}/100 form on ${exerciseLabel(exerciseKey)}`;
+  const count = safeNumber(priorPbCount ?? null);
+  if (count != null && count > 1) {
+    return `${base} — ${formatOrdinal(count)} PB this month, on fire`;
+  }
+  return base;
 }
 
 function buildConsistencyMessage(
   score: number,
   exerciseKey: string,
   window: number,
+  weekStreakDays?: number,
 ): string {
-  return `Dialed in: ${window} straight ${exerciseLabel(exerciseKey)} sessions around ${formatScore(score)}/100`;
+  const base = `Dialed in: ${window} straight ${exerciseLabel(exerciseKey)} sessions around ${formatScore(score)}/100`;
+  const streak = safeNumber(weekStreakDays ?? null);
+  if (streak != null && streak >= 3) {
+    return `${base} — ${Math.floor(streak)}-day streak, keep it rolling`;
+  }
+  return base;
+}
+
+/** Tiny 1/2/3 → "1st/2nd/3rd" formatter — handles the English 11/12/13 case. */
+function formatOrdinal(raw: number): string {
+  const n = Math.abs(Math.floor(raw));
+  const mod100 = n % 100;
+  const mod10 = n % 10;
+  if (mod100 >= 11 && mod100 <= 13) return `${n}th`;
+  if (mod10 === 1) return `${n}st`;
+  if (mod10 === 2) return `${n}nd`;
+  if (mod10 === 3) return `${n}rd`;
+  return `${n}th`;
 }

--- a/lib/services/form-session-history.ts
+++ b/lib/services/form-session-history.ts
@@ -88,6 +88,115 @@ export async function getFormSessionHistory(
   }
 }
 
+/** Load the full history blob across all exercises. Exposed for aggregates. */
+export async function getAllFormSessionHistory(): Promise<FormSessionHistoryByExercise> {
+  try {
+    const raw = await AsyncStorage.getItem(FORM_SESSION_HISTORY_STORAGE_KEY);
+    return safeParse(raw);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Count PBs set so far this calendar month (inclusive of the caller-provided
+ * `now`) across every exercise. A PB is any entry whose avgFqi strictly
+ * exceeds every prior entry for the same exercise that occurred before it.
+ *
+ * When `candidate` is provided (and beats the running prior-best for that
+ * exercise at `now` by `pbMargin`), the returned count includes +1 so the
+ * caller can surface "3rd PB this month" before actually appending the
+ * entry — avoids ordering dependencies between milestone emission and
+ * history writes.
+ */
+export async function countPbsThisMonth(args: {
+  now: Date;
+  pbMargin?: number;
+  candidate?: { exerciseKey: string; avgFqi: number };
+}): Promise<number> {
+  const { now, pbMargin = 2, candidate } = args;
+  const all = await getAllFormSessionHistory();
+  const firstOfMonth = new Date(now.getFullYear(), now.getMonth(), 1, 0, 0, 0, 0).getTime();
+  let pbs = 0;
+  for (const [exerciseKey, entries] of Object.entries(all)) {
+    // Sort oldest→newest so each entry can be compared against the best
+    // strictly before it. The first entry can never be a PB (no prior to
+    // beat) — match the detector's first-session semantics.
+    const sorted = [...entries].sort(
+      (a, b) => Date.parse(a.endedAt) - Date.parse(b.endedAt),
+    );
+    let runningBest: number | null = null;
+    for (const entry of sorted) {
+      const ts = Date.parse(entry.endedAt);
+      if (
+        runningBest != null &&
+        Number.isFinite(ts) &&
+        ts >= firstOfMonth &&
+        entry.avgFqi - runningBest >= pbMargin
+      ) {
+        pbs += 1;
+      }
+      if (runningBest == null || entry.avgFqi > runningBest) {
+        runningBest = entry.avgFqi;
+      }
+    }
+    // If the caller is evaluating a not-yet-written session, include it
+    // when it would set a PB against the running best (again: never a PB
+    // when there's no prior entry for that exercise).
+    if (
+      candidate &&
+      candidate.exerciseKey === exerciseKey &&
+      runningBest != null &&
+      candidate.avgFqi - runningBest >= pbMargin
+    ) {
+      pbs += 1;
+    }
+  }
+  return pbs;
+}
+
+/**
+ * Count consecutive days ending at `now` that have at least one completed
+ * session on any exercise. Today counts as day 1 when a session was logged
+ * today; an empty today terminates the streak at 0.
+ */
+export async function countConsecutiveSessionDays(args: {
+  now: Date;
+}): Promise<number> {
+  const { now } = args;
+  const all = await getAllFormSessionHistory();
+  // Collapse every entry's endedAt into YYYY-MM-DD so multiple sessions on
+  // the same day count once.
+  const dayKeys = new Set<string>();
+  for (const entries of Object.values(all)) {
+    for (const entry of entries) {
+      const ts = Date.parse(entry.endedAt);
+      if (!Number.isFinite(ts)) continue;
+      const d = new Date(ts);
+      dayKeys.add(
+        `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+          d.getDate(),
+        ).padStart(2, '0')}`,
+      );
+    }
+  }
+  let streak = 0;
+  const cursor = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  // Walk backward day-by-day until we hit a gap.
+  for (let i = 0; i < 400; i += 1) {
+    const key = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, '0')}-${String(
+      cursor.getDate(),
+    ).padStart(2, '0')}`;
+    if (dayKeys.has(key)) {
+      streak += 1;
+      cursor.setDate(cursor.getDate() - 1);
+    } else {
+      break;
+    }
+  }
+  return streak;
+}
+
 export async function clearFormSessionHistory(): Promise<void> {
   try {
     await AsyncStorage.removeItem(FORM_SESSION_HISTORY_STORAGE_KEY);

--- a/lib/services/session-comparison-aggregator.ts
+++ b/lib/services/session-comparison-aggregator.ts
@@ -28,6 +28,14 @@ export interface ExerciseSessionSummary {
   avgDepthRatio: number | null;
   /** Mean left/right asymmetry in degrees. Higher = worse. */
   avgSymmetryDeg: number | null;
+  /**
+   * Mean inter-rep pause in seconds (end of rep N → start of rep N+1).
+   * `null` (or omitted) when there are fewer than 2 reps or timestamps are
+   * missing. Optional so callers built before this field existed compile
+   * unchanged; the aggregator + delta helpers treat missing the same as
+   * `null`.
+   */
+  avgRestSec?: number | null;
   /** fault_id → number of reps with that fault detected in this session. */
   faultCounts: Record<string, number>;
 }
@@ -52,6 +60,15 @@ export interface SessionComparison {
   depthDeltaRatio: number | null;
   /** Current minus prior. Negative = improvement (less asymmetry). */
   symmetryDeltaDeg: number | null;
+  /** Current minus prior. Positive = added reps. `null` when baseline. */
+  repCountDelta: number | null;
+  /**
+   * Current minus prior average inter-rep rest in seconds. Direction is not
+   * a straight win/loss — callers decide how to color a swing (e.g. shorter
+   * rest on a conditioning block is positive; longer rest on a strength
+   * session can also be positive).
+   */
+  restDeltaSec: number | null;
   /** Current minus prior total fault events. Negative = improvement. */
   faultCountDelta: number | null;
   /** Fault ids that appeared in current but not prior. */
@@ -151,6 +168,8 @@ export function buildSessionComparison(
       romDeltaDeg: null,
       depthDeltaRatio: null,
       symmetryDeltaDeg: null,
+      repCountDelta: null,
+      restDeltaSec: null,
       faultCountDelta: null,
       newFaults: [],
       resolvedFaults: [],
@@ -162,6 +181,8 @@ export function buildSessionComparison(
   const romDeltaDeg = subtract(current.avgRomDeg, prior.avgRomDeg);
   const depthDeltaRatio = subtract(current.avgDepthRatio, prior.avgDepthRatio);
   const symmetryDeltaDeg = subtract(current.avgSymmetryDeg, prior.avgSymmetryDeg);
+  const repCountDelta = current.repCount - prior.repCount;
+  const restDeltaSec = subtract(current.avgRestSec ?? null, prior.avgRestSec ?? null);
   const faultCountDelta =
     totalFaultCount(current.faultCounts) - totalFaultCount(prior.faultCounts);
   const { newFaults, resolvedFaults } = diffFaultIds(
@@ -178,6 +199,8 @@ export function buildSessionComparison(
     romDeltaDeg,
     depthDeltaRatio,
     symmetryDeltaDeg,
+    repCountDelta,
+    restDeltaSec,
     faultCountDelta,
     newFaults,
     resolvedFaults,
@@ -248,6 +271,8 @@ export function summarizeSessionFromReps({
       ? null
       : Math.round((values.reduce((sum, v) => sum + v, 0) / values.length) * 100) / 100;
 
+  const avgRestSec = computeAvgRestSec(filtered);
+
   return {
     sessionId,
     exerciseId,
@@ -257,8 +282,31 @@ export function summarizeSessionFromReps({
     avgRomDeg: mean(roms),
     avgDepthRatio: mean(depths),
     avgSymmetryDeg: mean(symmetries),
+    avgRestSec,
     faultCounts,
   };
+}
+
+/**
+ * Mean gap between the end of rep N and the start of rep N+1, in seconds.
+ * Skips negative gaps (malformed data) and returns `null` when we cannot
+ * derive at least one valid gap (e.g. a single-rep session).
+ */
+function computeAvgRestSec(rows: RepRow[]): number | null {
+  if (rows.length < 2) return null;
+  const sorted = [...rows].sort((a, b) => (a.start_ts < b.start_ts ? -1 : 1));
+  const gaps: number[] = [];
+  for (let i = 1; i < sorted.length; i += 1) {
+    const prevEnd = Date.parse(sorted[i - 1].end_ts);
+    const thisStart = Date.parse(sorted[i].start_ts);
+    if (!Number.isFinite(prevEnd) || !Number.isFinite(thisStart)) continue;
+    const gapMs = thisStart - prevEnd;
+    if (gapMs <= 0) continue;
+    gaps.push(gapMs / 1000);
+  }
+  if (gaps.length === 0) return null;
+  const sum = gaps.reduce((acc, v) => acc + v, 0);
+  return Math.round((sum / gaps.length) * 10) / 10;
 }
 
 export interface FetchComparisonArgs {

--- a/lib/stores/session-runner.ts
+++ b/lib/stores/session-runner.ts
@@ -328,6 +328,18 @@ export interface EmitFormMilestoneArgs {
   consistencyBand?: number;
   consistencyWindow?: number;
   consistencyMinScore?: number;
+  /**
+   * Optional: how many PBs the user has set this calendar month across
+   * any exercise, *including* the one about to fire if applicable.
+   * When ≥ 2 the detector adds ordinal context to the PB message.
+   */
+  priorPbCount?: number;
+  /**
+   * Optional: consecutive days (including today) with at least one
+   * completed session. When ≥ 3 the detector adds streak context to
+   * the consistency message.
+   */
+  weekStreakDays?: number;
 }
 
 /**
@@ -346,6 +358,8 @@ export async function emitFormMilestone(
     consistencyBand: args.consistencyBand,
     consistencyWindow: args.consistencyWindow,
     consistencyMinScore: args.consistencyMinScore,
+    priorPbCount: args.priorPbCount,
+    weekStreakDays: args.weekStreakDays,
   });
 
   if (result.kind) {
@@ -354,6 +368,8 @@ export async function emitFormMilestone(
       message: result.message,
       score: result.score,
       exercise_key: args.exerciseKey,
+      prior_pb_count: args.priorPbCount ?? null,
+      week_streak_days: args.weekStreakDays ?? null,
     });
   }
   return result;

--- a/tests/unit/components/form-tracking/FqiExplainerModal.test.tsx
+++ b/tests/unit/components/form-tracking/FqiExplainerModal.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+
+const mockPush = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: (...args: unknown[]) => mockPush(...args) }),
+}));
+
+// eslint-disable-next-line import/first
+import { FqiExplainerModal } from '@/components/form-tracking/FqiExplainerModal';
+// eslint-disable-next-line import/first
+import { FormQualityBadge } from '@/components/form-tracking/FormQualityBadge';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('FqiExplainerModal', () => {
+  it('renders legend rows for all four tiers', () => {
+    const { getByTestId } = render(
+      <FqiExplainerModal visible onDismiss={jest.fn()} />,
+    );
+    expect(getByTestId('fqi-explainer-modal-legend-excellent')).toBeTruthy();
+    expect(getByTestId('fqi-explainer-modal-legend-good')).toBeTruthy();
+    expect(getByTestId('fqi-explainer-modal-legend-needs-work')).toBeTruthy();
+    expect(getByTestId('fqi-explainer-modal-legend-refocus-on-basics')).toBeTruthy();
+  });
+
+  it('renders the drills CTA only when exerciseId is provided', () => {
+    const { queryByTestId, rerender } = render(
+      <FqiExplainerModal visible onDismiss={jest.fn()} />,
+    );
+    expect(queryByTestId('fqi-explainer-modal-see-drills')).toBeNull();
+
+    rerender(
+      <FqiExplainerModal visible onDismiss={jest.fn()} exerciseId="pullup" />,
+    );
+    expect(queryByTestId('fqi-explainer-modal-see-drills')).toBeTruthy();
+  });
+
+  it('routes to form-quality-recovery with exerciseId on drills tap', () => {
+    const onDismiss = jest.fn();
+    const { getByTestId } = render(
+      <FqiExplainerModal visible onDismiss={onDismiss} exerciseId="pullup" />,
+    );
+    fireEvent.press(getByTestId('fqi-explainer-modal-see-drills'));
+    expect(mockPush).toHaveBeenCalledWith(
+      '/(modals)/form-quality-recovery?exerciseId=pullup',
+    );
+    // It also dismisses itself so the stack doesn't end up with two modals.
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it('calls onDismiss when the close and dismiss buttons are pressed', () => {
+    const onDismiss = jest.fn();
+    const { getByTestId } = render(
+      <FqiExplainerModal visible onDismiss={onDismiss} />,
+    );
+    fireEvent.press(getByTestId('fqi-explainer-modal-close'));
+    fireEvent.press(getByTestId('fqi-explainer-modal-dismiss'));
+    fireEvent.press(getByTestId('fqi-explainer-modal-backdrop'));
+    expect(onDismiss).toHaveBeenCalledTimes(3);
+  });
+
+  it('includes three improvement tips', () => {
+    const { getByTestId } = render(
+      <FqiExplainerModal visible onDismiss={jest.fn()} />,
+    );
+    const tips = getByTestId('fqi-explainer-modal-tips');
+    // children[] length should be 3 (one Text per tip row)
+    // In RN Testing Library, children are the composite tree's direct descendants.
+    expect(Array.isArray(tips.children) ? tips.children.length : 0).toBe(3);
+  });
+});
+
+describe('FormQualityBadge — tappable mode', () => {
+  it('renders as a button and fires onPress when tapped', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <FormQualityBadge score={82} onPress={onPress} />,
+    );
+    const badge = getByTestId('form-quality-badge');
+    expect(badge.props.accessibilityRole).toBe('button');
+    expect(badge.props.accessibilityHint).toBe(
+      'Tap to learn what this score means',
+    );
+    expect(getByTestId('form-quality-badge-info-icon')).toBeTruthy();
+    fireEvent.press(badge);
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the info icon when onPress is omitted', () => {
+    const { queryByTestId } = render(<FormQualityBadge score={82} />);
+    expect(queryByTestId('form-quality-badge-info-icon')).toBeNull();
+  });
+});

--- a/tests/unit/components/form-tracking/SessionCompareToLastCard.test.tsx
+++ b/tests/unit/components/form-tracking/SessionCompareToLastCard.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+
+import { SessionCompareToLastCard } from '@/components/form-tracking/SessionCompareToLastCard';
+import type {
+  ExerciseSessionSummary,
+  SessionComparison,
+} from '@/lib/services/session-comparison-aggregator';
+
+const baseSummary: ExerciseSessionSummary = {
+  sessionId: 'curr',
+  exerciseId: 'pullup',
+  completedAt: '2026-04-21T12:00:00.000Z',
+  repCount: 10,
+  avgFqi: 82,
+  avgRomDeg: 100,
+  avgDepthRatio: 0.9,
+  avgSymmetryDeg: 4,
+  avgRestSec: 45,
+  faultCounts: {},
+};
+
+function buildComparison(overrides: Partial<SessionComparison> = {}): SessionComparison {
+  return {
+    currentSessionId: 'curr',
+    priorSessionId: 'prev',
+    currentSummary: baseSummary,
+    priorSummary: { ...baseSummary, sessionId: 'prev' },
+    fqiDelta: 7,
+    romDeltaDeg: 3,
+    depthDeltaRatio: 0.05,
+    symmetryDeltaDeg: -1,
+    repCountDelta: 2,
+    restDeltaSec: -5,
+    faultCountDelta: -1,
+    newFaults: [],
+    resolvedFaults: [],
+    overallTrend: 'improving',
+    ...overrides,
+  };
+}
+
+describe('SessionCompareToLastCard', () => {
+  it('renders null when there is no prior session', () => {
+    const { queryByTestId } = render(
+      <SessionCompareToLastCard
+        comparison={buildComparison({
+          priorSessionId: null,
+          priorSummary: null,
+          overallTrend: 'baseline',
+        })}
+      />,
+    );
+    expect(queryByTestId('session-compare-to-last-card')).toBeNull();
+  });
+
+  it('renders all three delta cells with signed values', () => {
+    const { getByTestId } = render(
+      <SessionCompareToLastCard comparison={buildComparison()} />,
+    );
+    expect(getByTestId('session-compare-to-last-card-delta-reps-value').props.children).toBe(
+      '+2',
+    );
+    expect(getByTestId('session-compare-to-last-card-delta-fqi-value').props.children).toBe(
+      '+7',
+    );
+    expect(getByTestId('session-compare-to-last-card-delta-rest-value').props.children).toBe(
+      '-5',
+    );
+  });
+
+  it('uses positive tone (green) when FQI improved', () => {
+    const { getByTestId } = render(
+      <SessionCompareToLastCard comparison={buildComparison({ fqiDelta: 8 })} />,
+    );
+    const fqi = getByTestId('session-compare-to-last-card-delta-fqi-value');
+    const flat = Array.isArray(fqi.props.style)
+      ? Object.assign({}, ...fqi.props.style.filter(Boolean))
+      : fqi.props.style;
+    expect(flat.color).toBe('#3CC8A9');
+  });
+
+  it('uses negative tone (red) when reps regress', () => {
+    const { getByTestId } = render(
+      <SessionCompareToLastCard comparison={buildComparison({ repCountDelta: -3 })} />,
+    );
+    const reps = getByTestId('session-compare-to-last-card-delta-reps-value');
+    const flat = Array.isArray(reps.props.style)
+      ? Object.assign({}, ...reps.props.style.filter(Boolean))
+      : reps.props.style;
+    expect(flat.color).toBe('#EF4444');
+  });
+
+  it('renders zero deltas as ±0 in neutral tone', () => {
+    const { getByTestId } = render(
+      <SessionCompareToLastCard
+        comparison={buildComparison({ repCountDelta: 0, fqiDelta: 0, restDeltaSec: 0 })}
+      />,
+    );
+    expect(
+      getByTestId('session-compare-to-last-card-delta-reps-value').props.children,
+    ).toBe('±0');
+    const reps = getByTestId('session-compare-to-last-card-delta-reps-value');
+    const flat = Array.isArray(reps.props.style)
+      ? Object.assign({}, ...reps.props.style.filter(Boolean))
+      : reps.props.style;
+    expect(flat.color).toBe('#9AACD1');
+  });
+
+  it('falls back to "—" when a delta is null', () => {
+    const { getByTestId } = render(
+      <SessionCompareToLastCard
+        comparison={buildComparison({ fqiDelta: null, restDeltaSec: null })}
+      />,
+    );
+    expect(
+      getByTestId('session-compare-to-last-card-delta-fqi-value').props.children,
+    ).toBe('—');
+    expect(
+      getByTestId('session-compare-to-last-card-delta-rest-value').props.children,
+    ).toBe('—');
+  });
+
+  it('fires onPress and exposes button role when pressable', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <SessionCompareToLastCard comparison={buildComparison()} onPress={onPress} />,
+    );
+    fireEvent.press(getByTestId('session-compare-to-last-card-pressable'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(
+      getByTestId('session-compare-to-last-card-pressable').props.accessibilityRole,
+    ).toBe('button');
+  });
+});

--- a/tests/unit/services/form-milestone-detector.enrichment.test.ts
+++ b/tests/unit/services/form-milestone-detector.enrichment.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Enrichment tests for detectMilestone — covers the priorPbCount and
+ * weekStreakDays context fields added in wave-27. Kept in a sibling file
+ * so the existing detector suite stays untouched.
+ */
+import {
+  detectMilestone,
+  type DetectMilestoneInput,
+} from '@/lib/services/form-milestone-detector';
+
+const base = (overrides: Partial<DetectMilestoneInput> = {}): DetectMilestoneInput => ({
+  exerciseKey: 'pullup',
+  currentAvgFqi: 80,
+  priorSessions: [],
+  ...overrides,
+});
+
+describe('detectMilestone — PB ordinal context', () => {
+  it('appends ordinal context when priorPbCount > 1', () => {
+    const result = detectMilestone(
+      base({
+        currentAvgFqi: 92,
+        priorSessions: [{ avgFqi: 85 }],
+        priorPbCount: 3,
+      }),
+    );
+    expect(result.kind).toBe('new_pb');
+    expect(result.message).toContain('3rd PB this month');
+    expect(result.message).toContain('on fire');
+  });
+
+  it('handles the 1st/2nd/3rd English suffix set', () => {
+    const cases: { n: number; expect: string }[] = [
+      { n: 2, expect: '2nd' },
+      { n: 3, expect: '3rd' },
+      { n: 4, expect: '4th' },
+      { n: 11, expect: '11th' },
+      { n: 12, expect: '12th' },
+      { n: 13, expect: '13th' },
+      { n: 21, expect: '21st' },
+      { n: 22, expect: '22nd' },
+      { n: 23, expect: '23rd' },
+    ];
+    for (const c of cases) {
+      const result = detectMilestone(
+        base({
+          currentAvgFqi: 92,
+          priorSessions: [{ avgFqi: 85 }],
+          priorPbCount: c.n,
+        }),
+      );
+      expect(result.message).toContain(`${c.expect} PB this month`);
+    }
+  });
+
+  it('does NOT append ordinal context when priorPbCount is 1 (first PB of the month)', () => {
+    const result = detectMilestone(
+      base({
+        currentAvgFqi: 92,
+        priorSessions: [{ avgFqi: 85 }],
+        priorPbCount: 1,
+      }),
+    );
+    expect(result.kind).toBe('new_pb');
+    expect(result.message).not.toContain('this month');
+    expect(result.message).not.toContain('on fire');
+  });
+
+  it('does NOT append ordinal context when priorPbCount is 0 or omitted', () => {
+    const r1 = detectMilestone(
+      base({
+        currentAvgFqi: 92,
+        priorSessions: [{ avgFqi: 85 }],
+        priorPbCount: 0,
+      }),
+    );
+    const r2 = detectMilestone(
+      base({ currentAvgFqi: 92, priorSessions: [{ avgFqi: 85 }] }),
+    );
+    expect(r1.message).not.toContain('this month');
+    expect(r2.message).not.toContain('this month');
+  });
+
+  it('tolerates non-finite priorPbCount gracefully', () => {
+    const result = detectMilestone(
+      base({
+        currentAvgFqi: 92,
+        priorSessions: [{ avgFqi: 85 }],
+        priorPbCount: Number.NaN,
+      }),
+    );
+    expect(result.kind).toBe('new_pb');
+    expect(result.message).not.toContain('this month');
+  });
+});
+
+describe('detectMilestone — week streak context', () => {
+  it('appends streak context when weekStreakDays >= 3', () => {
+    const result = detectMilestone(
+      base({
+        currentAvgFqi: 82,
+        priorSessions: [{ avgFqi: 80 }, { avgFqi: 83 }],
+        weekStreakDays: 5,
+      }),
+    );
+    expect(result.kind).toBe('week_consistency');
+    expect(result.message).toContain('5-day streak');
+    expect(result.message).toContain('keep it rolling');
+  });
+
+  it('does NOT append streak context when weekStreakDays < 3', () => {
+    const result = detectMilestone(
+      base({
+        currentAvgFqi: 82,
+        priorSessions: [{ avgFqi: 80 }, { avgFqi: 83 }],
+        weekStreakDays: 2,
+      }),
+    );
+    expect(result.kind).toBe('week_consistency');
+    expect(result.message).not.toContain('streak');
+  });
+
+  it('does NOT append streak context when weekStreakDays is omitted', () => {
+    const result = detectMilestone(
+      base({
+        currentAvgFqi: 82,
+        priorSessions: [{ avgFqi: 80 }, { avgFqi: 83 }],
+      }),
+    );
+    expect(result.kind).toBe('week_consistency');
+    expect(result.message).not.toContain('streak');
+  });
+
+  it('truncates fractional streak counts to whole days', () => {
+    const result = detectMilestone(
+      base({
+        currentAvgFqi: 82,
+        priorSessions: [{ avgFqi: 80 }, { avgFqi: 83 }],
+        weekStreakDays: 7.9,
+      }),
+    );
+    expect(result.message).toContain('7-day streak');
+  });
+
+  it('streak context only applies to week_consistency, not to PBs', () => {
+    const result = detectMilestone(
+      base({
+        currentAvgFqi: 92,
+        priorSessions: [{ avgFqi: 85 }],
+        weekStreakDays: 5,
+      }),
+    );
+    expect(result.kind).toBe('new_pb');
+    expect(result.message).not.toContain('streak');
+  });
+});

--- a/tests/unit/services/form-session-history.aggregates.test.ts
+++ b/tests/unit/services/form-session-history.aggregates.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for the monthly PB + streak aggregates on form-session-history.
+ * Kept in a sibling file so the original append/read suite stays untouched.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  appendFormSessionHistory,
+  countConsecutiveSessionDays,
+  countPbsThisMonth,
+} from '@/lib/services/form-session-history';
+
+describe('countPbsThisMonth', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('returns 0 when there are no entries', async () => {
+    const count = await countPbsThisMonth({ now: new Date('2026-04-21T12:00:00Z') });
+    expect(count).toBe(0);
+  });
+
+  it('counts ascending PBs within the same month', async () => {
+    // Four entries on pullup this month, each at least 2 points above the
+    // previous best → 3 PBs (the first session doesn't beat anything).
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 70,
+      endedAt: '2026-04-01T10:00:00Z',
+    });
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 75,
+      endedAt: '2026-04-05T10:00:00Z',
+    });
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 78,
+      endedAt: '2026-04-10T10:00:00Z',
+    });
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 80,
+      endedAt: '2026-04-15T10:00:00Z',
+    });
+    const count = await countPbsThisMonth({ now: new Date('2026-04-21T12:00:00Z') });
+    // First session (70) doesn't count (nothing to beat in this log).
+    // 75 beats 70 by 5 (>=2) → PB. 78 beats 75 by 3 → PB. 80 beats 78 by 2 → PB.
+    expect(count).toBe(3);
+  });
+
+  it('ignores PBs set in prior months', async () => {
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 70,
+      endedAt: '2026-03-01T10:00:00Z',
+    });
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 80,
+      endedAt: '2026-03-15T10:00:00Z',
+    });
+    const count = await countPbsThisMonth({ now: new Date('2026-04-21T12:00:00Z') });
+    expect(count).toBe(0);
+  });
+
+  it('aggregates across multiple exercises', async () => {
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 70,
+      endedAt: '2026-04-01T10:00:00Z',
+    });
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 76,
+      endedAt: '2026-04-10T10:00:00Z',
+    });
+    await appendFormSessionHistory({
+      exerciseKey: 'squat',
+      avgFqi: 60,
+      endedAt: '2026-04-05T10:00:00Z',
+    });
+    await appendFormSessionHistory({
+      exerciseKey: 'squat',
+      avgFqi: 68,
+      endedAt: '2026-04-12T10:00:00Z',
+    });
+    const count = await countPbsThisMonth({ now: new Date('2026-04-21T12:00:00Z') });
+    // pullup: 76 vs 70 = +6 → PB. squat: 68 vs 60 = +8 → PB. → 2
+    expect(count).toBe(2);
+  });
+
+  it('includes a candidate session when it would set a PB', async () => {
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 70,
+      endedAt: '2026-04-01T10:00:00Z',
+    });
+    const count = await countPbsThisMonth({
+      now: new Date('2026-04-21T12:00:00Z'),
+      candidate: { exerciseKey: 'pullup', avgFqi: 90 },
+    });
+    expect(count).toBe(1);
+  });
+});
+
+describe('countConsecutiveSessionDays', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('returns 0 when there are no entries at all', async () => {
+    const streak = await countConsecutiveSessionDays({
+      now: new Date('2026-04-21T12:00:00Z'),
+    });
+    expect(streak).toBe(0);
+  });
+
+  it('returns 0 when today is empty', async () => {
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 70,
+      endedAt: '2026-04-19T10:00:00Z',
+    });
+    const streak = await countConsecutiveSessionDays({
+      now: new Date('2026-04-21T12:00:00Z'),
+    });
+    expect(streak).toBe(0);
+  });
+
+  it('counts contiguous days ending today', async () => {
+    for (const day of ['2026-04-19', '2026-04-20', '2026-04-21']) {
+      await appendFormSessionHistory({
+        exerciseKey: 'pullup',
+        avgFqi: 80,
+        endedAt: `${day}T10:00:00Z`,
+      });
+    }
+    const streak = await countConsecutiveSessionDays({
+      now: new Date('2026-04-21T12:00:00Z'),
+    });
+    expect(streak).toBe(3);
+  });
+
+  it('stops at the first gap', async () => {
+    // Days: 15, 16, _, 18, 19, 20, 21 → streak = 4 (18-21)
+    for (const day of ['2026-04-15', '2026-04-16', '2026-04-18', '2026-04-19', '2026-04-20', '2026-04-21']) {
+      await appendFormSessionHistory({
+        exerciseKey: 'pullup',
+        avgFqi: 80,
+        endedAt: `${day}T10:00:00Z`,
+      });
+    }
+    const streak = await countConsecutiveSessionDays({
+      now: new Date('2026-04-21T12:00:00Z'),
+    });
+    expect(streak).toBe(4);
+  });
+
+  it('de-duplicates multiple sessions on the same day', async () => {
+    await appendFormSessionHistory({
+      exerciseKey: 'pullup',
+      avgFqi: 80,
+      endedAt: '2026-04-21T09:00:00Z',
+    });
+    await appendFormSessionHistory({
+      exerciseKey: 'squat',
+      avgFqi: 75,
+      endedAt: '2026-04-21T15:00:00Z',
+    });
+    const streak = await countConsecutiveSessionDays({
+      now: new Date('2026-04-21T18:00:00Z'),
+    });
+    expect(streak).toBe(1);
+  });
+});

--- a/tests/unit/services/session-comparison-aggregator.rest-delta.test.ts
+++ b/tests/unit/services/session-comparison-aggregator.rest-delta.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Focused tests for the new rest/reps delta fields on
+ * session-comparison-aggregator. Kept in a sibling file so the original
+ * aggregator suite stays untouched.
+ */
+import {
+  buildSessionComparison,
+  summarizeSessionFromReps,
+  type ExerciseSessionSummary,
+} from '@/lib/services/session-comparison-aggregator';
+
+function summary(overrides: Partial<ExerciseSessionSummary> = {}): ExerciseSessionSummary {
+  return {
+    sessionId: overrides.sessionId ?? 'sess_curr',
+    exerciseId: 'pullup',
+    completedAt: '2026-04-21T12:00:00.000Z',
+    repCount: 10,
+    avgFqi: 80,
+    avgRomDeg: 100,
+    avgDepthRatio: 0.9,
+    avgSymmetryDeg: 4,
+    avgRestSec: 45,
+    faultCounts: {},
+    ...overrides,
+  };
+}
+
+describe('buildSessionComparison — rep + rest deltas', () => {
+  it('computes repCountDelta and restDeltaSec when both sides have values', () => {
+    const current = summary({ repCount: 12, avgRestSec: 42 });
+    const prior = summary({ sessionId: 'sess_prev', repCount: 10, avgRestSec: 60 });
+    const comparison = buildSessionComparison(current, prior);
+    expect(comparison.repCountDelta).toBe(2);
+    expect(comparison.restDeltaSec).toBe(-18);
+  });
+
+  it('returns null restDeltaSec when either side is missing avgRestSec', () => {
+    const current = summary({ avgRestSec: null });
+    const prior = summary({ sessionId: 'sess_prev', avgRestSec: 50 });
+    const comparison = buildSessionComparison(current, prior);
+    expect(comparison.restDeltaSec).toBeNull();
+  });
+
+  it('tolerates callers that omit avgRestSec entirely (back-compat)', () => {
+    const current: ExerciseSessionSummary = summary();
+    delete current.avgRestSec;
+    const prior: ExerciseSessionSummary = summary({ sessionId: 'sess_prev' });
+    delete prior.avgRestSec;
+    const comparison = buildSessionComparison(current, prior);
+    expect(comparison.restDeltaSec).toBeNull();
+  });
+
+  it('baseline (no prior) leaves repCountDelta and restDeltaSec null', () => {
+    const current = summary({ repCount: 5, avgRestSec: 30 });
+    const comparison = buildSessionComparison(current, null);
+    expect(comparison.repCountDelta).toBeNull();
+    expect(comparison.restDeltaSec).toBeNull();
+  });
+});
+
+describe('summarizeSessionFromReps — avgRestSec', () => {
+  it('computes avg rest seconds from the gaps between reps', () => {
+    const result = summarizeSessionFromReps({
+      rows: [
+        {
+          session_id: 'sess_1',
+          exercise: 'pullup',
+          start_ts: '2026-04-21T12:00:00.000Z',
+          end_ts: '2026-04-21T12:00:04.000Z',
+          fqi: 80,
+          features: {},
+          faults_detected: [],
+        },
+        {
+          session_id: 'sess_1',
+          exercise: 'pullup',
+          start_ts: '2026-04-21T12:00:10.000Z', // 6s gap
+          end_ts: '2026-04-21T12:00:14.000Z',
+          fqi: 82,
+          features: {},
+          faults_detected: [],
+        },
+        {
+          session_id: 'sess_1',
+          exercise: 'pullup',
+          start_ts: '2026-04-21T12:00:24.000Z', // 10s gap
+          end_ts: '2026-04-21T12:00:28.000Z',
+          fqi: 78,
+          features: {},
+          faults_detected: [],
+        },
+      ],
+      sessionId: 'sess_1',
+      exerciseId: 'pullup',
+    });
+    expect(result).not.toBeNull();
+    // mean(6, 10) = 8.0s
+    expect(result?.avgRestSec).toBe(8);
+  });
+
+  it('returns null avgRestSec for a single-rep session', () => {
+    const result = summarizeSessionFromReps({
+      rows: [
+        {
+          session_id: 'sess_1',
+          exercise: 'pullup',
+          start_ts: '2026-04-21T12:00:00.000Z',
+          end_ts: '2026-04-21T12:00:04.000Z',
+          fqi: 80,
+          features: {},
+          faults_detected: [],
+        },
+      ],
+      sessionId: 'sess_1',
+      exerciseId: 'pullup',
+    });
+    expect(result?.avgRestSec).toBeNull();
+  });
+
+  it('skips malformed (negative) gaps', () => {
+    const result = summarizeSessionFromReps({
+      rows: [
+        {
+          session_id: 'sess_1',
+          exercise: 'pullup',
+          start_ts: '2026-04-21T12:00:00.000Z',
+          end_ts: '2026-04-21T12:00:10.000Z',
+          fqi: 80,
+          features: {},
+          faults_detected: [],
+        },
+        {
+          session_id: 'sess_1',
+          exercise: 'pullup',
+          // Overlap with the previous rep — gap would be -5s, skipped.
+          start_ts: '2026-04-21T12:00:05.000Z',
+          end_ts: '2026-04-21T12:00:14.000Z',
+          fqi: 82,
+          features: {},
+          faults_detected: [],
+        },
+      ],
+      sessionId: 'sess_1',
+      exerciseId: 'pullup',
+    });
+    expect(result?.avgRestSec).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Wave-27 PR 2: three quick-win retention features stitched into the post-session flow so the debrief and milestone toasts teach instead of just reporting.

- **Tappable FQI badge + explainer modal.** `FormQualityBadge` gains an optional `onPress` that turns it into a keyboard/VoiceOver-ready button with a subtle info glyph. The new `FqiExplainerModal` covers what FQI measures, a 4-tier legend sourced from `getFqiColor` (so the legend never drifts from the live UI), three generic improvement tips, and an optional "See drills for this exercise" CTA that deep-links to `form-quality-recovery`. The debrief screen mounts the modal and surfaces an affordance chip under the header stats.

- **Compare-to-last-session card on the debrief.** Extended `session-comparison-aggregator` with `avgRestSec` (computed from existing `start_ts`/`end_ts` rep rows) plus `repCountDelta` and `restDeltaSec` on `SessionComparison`. New compact `SessionCompareToLastCard` shows three color-coded deltas (reps / form quality / avg rest) between the rep breakdown and coach debrief; tapping opens the existing `form-comparison` modal. Renders null when there is no prior session.

- **Milestone context enrichment.** `detectMilestone` accepts optional `priorPbCount` and `weekStreakDays`. When `priorPbCount > 1`, PB messages append "Nth PB this month — on fire" with a correct English ordinal. When `weekStreakDays >= 3`, consistency messages append "X-day streak, keep it rolling". Added `countPbsThisMonth` and `countConsecutiveSessionDays` aggregates to `form-session-history` and wired `scan-arkit.tsx` to pass both through `emitFormMilestone`.

## Verification

- `bun run lint` — clean
- `bun run check:types` — clean
- `bun run test` — 427/429 suites pass (2 skipped, pre-existing), 4976/5000 tests pass (24 skipped, pre-existing). New suites: `FqiExplainerModal.test.tsx`, `SessionCompareToLastCard.test.tsx`, `session-comparison-aggregator.rest-delta.test.ts`, `form-milestone-detector.enrichment.test.ts`, `form-session-history.aggregates.test.ts` (34 new tests).
- No existing tests modified. No changes under `supabase/migrations/`, `ios/`, `android/`, or `.env*`.
- Legacy debrief callers that don't pass `sessionId` continue to work — the compare card simply does not mount.
- FQI badge callers without `onPress` keep the original non-interactive pill behaviour.