### PR TITLE
feat(form-ux): debrief resilience + mesocycle inline + camera-permission banner — wave-28

### DIFF
--- a/app/(modals)/form-mesocycle.tsx
+++ b/app/(modals)/form-mesocycle.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Pressable,
@@ -16,17 +16,65 @@ import type {
   MesocycleFaultCount,
   MesocycleWeekBucket,
 } from '@/lib/services/form-mesocycle-aggregator';
-import { buildMesocycleAnalystPrompt } from '@/lib/services/coach-mesocycle-analyst';
+import {
+  buildMesocycleAnalystPrompt,
+  requestMesocycleAnalysis,
+  type MesocycleAnalystResult,
+  type SendCoachPromptFn,
+} from '@/lib/services/coach-mesocycle-analyst';
+import { sendCoachPrompt } from '@/lib/services/coach-service';
+
+/**
+ * Adapter between the coach-service positional API
+ * (`sendCoachPrompt(messages, context)`) and the analyst's
+ * options-object contract (`{ messages, context }`).
+ *
+ * Kept local to the modal so `coach-mesocycle-analyst.ts` stays adapter-agnostic
+ * and unit-testable without pulling the real coach-service.
+ */
+const sendCoachPromptAdapter: SendCoachPromptFn = async ({ messages, context }) => {
+  const result = await sendCoachPrompt(messages, context);
+  if (!result) return null;
+  return {
+    message: { role: result.role, content: result.content },
+    provider: result.provider,
+  };
+};
 
 export default function FormMesocycleModal() {
   const router = useRouter();
   const { loading, error, insights, refresh } = useFormMesocycle();
+  const [analystResult, setAnalystResult] = useState<MesocycleAnalystResult | null>(
+    null,
+  );
+  const [analystLoading, setAnalystLoading] = useState(false);
+  const [analystError, setAnalystError] = useState<string | null>(null);
+  const [analystExpanded, setAnalystExpanded] = useState(true);
 
   const handleClose = useCallback(() => {
     router.back();
   }, [router]);
 
-  const handleAskCoach = useCallback(() => {
+  const handleAnalyze = useCallback(async () => {
+    if (!insights || analystLoading) return;
+    setAnalystLoading(true);
+    setAnalystError(null);
+    try {
+      const result = await requestMesocycleAnalysis(insights, sendCoachPromptAdapter);
+      setAnalystResult(result);
+      setAnalystExpanded(true);
+      if (!result) {
+        setAnalystError('Coach returned no response. Try again in a moment.');
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setAnalystError(msg);
+    } finally {
+      setAnalystLoading(false);
+    }
+  }, [insights, analystLoading]);
+
+  const handleContinueInChat = useCallback(() => {
     if (!insights) return;
     const prompt = buildMesocycleAnalystPrompt(insights);
     const url =
@@ -34,6 +82,10 @@ export default function FormMesocycleModal() {
       `&focus=mesocycle-analyst`;
     router.push(url as Parameters<typeof router.push>[0]);
   }, [insights, router]);
+
+  const handleToggleAnalystExpanded = useCallback(() => {
+    setAnalystExpanded((prev) => !prev);
+  }, []);
 
   const weekRows = useMemo(() => insights?.weeks ?? [], [insights]);
 
@@ -73,11 +125,23 @@ export default function FormMesocycleModal() {
       <FormMesocycleCard
         insights={insights}
         loading={loading}
-        onAskCoach={insights && !insights.isEmpty ? handleAskCoach : undefined}
+        onAskCoach={insights && !insights.isEmpty ? handleAnalyze : undefined}
       />
 
       {loading && !insights ? (
         <ActivityIndicator color="#4C8CFF" style={styles.loader} />
+      ) : null}
+
+      {insights && !insights.isEmpty ? (
+        <AnalystSection
+          result={analystResult}
+          loading={analystLoading}
+          errorMessage={analystError}
+          expanded={analystExpanded}
+          onToggleExpanded={handleToggleAnalystExpanded}
+          onRetry={handleAnalyze}
+          onContinueInChat={handleContinueInChat}
+        />
       ) : null}
 
       {insights && !insights.isEmpty ? (
@@ -156,6 +220,134 @@ function FaultRow({ fault }: { fault: MesocycleFaultCount }) {
       <Text style={styles.faultName}>{formatFault(fault.fault)}</Text>
       <Text style={styles.faultCount}>{fault.count}×</Text>
       <Text style={styles.faultShare}>{formatPct(fault.share)}</Text>
+    </View>
+  );
+}
+
+interface AnalystSectionProps {
+  result: MesocycleAnalystResult | null;
+  loading: boolean;
+  errorMessage: string | null;
+  expanded: boolean;
+  onToggleExpanded: () => void;
+  onRetry: () => void;
+  onContinueInChat: () => void;
+}
+
+function AnalystSection({
+  result,
+  loading,
+  errorMessage,
+  expanded,
+  onToggleExpanded,
+  onRetry,
+  onContinueInChat,
+}: AnalystSectionProps) {
+  const hasBody = loading || errorMessage != null || result != null;
+  return (
+    <View style={styles.section} testID="form-mesocycle-analyst-section">
+      <Pressable
+        onPress={onToggleExpanded}
+        accessibilityRole="button"
+        accessibilityLabel={
+          expanded ? 'Collapse analyst review' : 'Expand analyst review'
+        }
+        style={styles.analystHeader}
+        testID="form-mesocycle-analyst-toggle"
+      >
+        <Text style={styles.sectionTitle}>Analyst review</Text>
+        <Ionicons
+          name={expanded ? 'chevron-up' : 'chevron-down'}
+          size={18}
+          color="#8FA2B8"
+        />
+      </Pressable>
+      {expanded ? (
+        <View style={styles.sectionBody}>
+          {loading ? (
+            <View
+              style={styles.analystRow}
+              accessible
+              accessibilityLabel="Coach is reviewing your mesocycle"
+              testID="form-mesocycle-analyst-loading"
+            >
+              <ActivityIndicator color="#4C8CFF" />
+              <Text style={styles.analystBody}>Reviewing your last 4 weeks…</Text>
+            </View>
+          ) : null}
+          {!loading && errorMessage ? (
+            <View style={styles.analystRow} testID="form-mesocycle-analyst-error">
+              <Ionicons name="alert-circle" size={18} color="#FF6B6B" />
+              <View style={styles.analystErrorBody}>
+                <Text style={styles.analystErrorText}>{errorMessage}</Text>
+                <Pressable
+                  onPress={onRetry}
+                  accessibilityRole="button"
+                  accessibilityLabel="Retry analyst review"
+                  style={styles.retryLink}
+                  testID="form-mesocycle-analyst-retry"
+                >
+                  <Text style={styles.retryLinkText}>Retry</Text>
+                </Pressable>
+              </View>
+            </View>
+          ) : null}
+          {!loading && !errorMessage && result ? (
+            <View testID="form-mesocycle-analyst-result">
+              <Text style={styles.analystBody}>{result.text}</Text>
+              <Text style={styles.analystMeta} testID="form-mesocycle-analyst-provider">
+                via {result.provider === 'gemma-cloud' ? 'Gemma' : 'coach'}
+              </Text>
+              <View style={styles.analystActions}>
+                <Pressable
+                  onPress={onRetry}
+                  accessibilityRole="button"
+                  accessibilityLabel="Regenerate analyst review"
+                  style={styles.analystSecondaryAction}
+                  testID="form-mesocycle-analyst-regenerate"
+                >
+                  <Ionicons name="refresh" size={14} color="#8FA2B8" />
+                  <Text style={styles.analystSecondaryActionText}>Regenerate</Text>
+                </Pressable>
+                <Pressable
+                  onPress={onContinueInChat}
+                  accessibilityRole="button"
+                  accessibilityLabel="Continue this review in the coach chat"
+                  style={styles.analystPrimaryAction}
+                  testID="form-mesocycle-analyst-continue-chat"
+                >
+                  <Ionicons name="chatbubble-ellipses" size={14} color="#FFFFFF" />
+                  <Text style={styles.analystPrimaryActionText}>
+                    Continue in chat
+                  </Text>
+                </Pressable>
+              </View>
+            </View>
+          ) : null}
+          {!loading && !errorMessage && !result && !hasBody ? (
+            <Text style={styles.analystEmpty} testID="form-mesocycle-analyst-empty">
+              Tap &quot;Ask coach&quot; to get a natural-language review of your last
+              4 weeks.
+            </Text>
+          ) : null}
+          {!hasBody ? (
+            <View style={styles.analystRow}>
+              <Pressable
+                onPress={onContinueInChat}
+                accessibilityRole="button"
+                accessibilityLabel="Continue in the coach chat"
+                style={styles.analystSecondaryAction}
+                testID="form-mesocycle-analyst-continue-chat-empty"
+              >
+                <Ionicons name="chatbubble-ellipses" size={14} color="#8FA2B8" />
+                <Text style={styles.analystSecondaryActionText}>
+                  Continue in chat
+                </Text>
+              </Pressable>
+            </View>
+          ) : null}
+        </View>
+      ) : null}
     </View>
   );
 }
@@ -313,5 +505,94 @@ const styles = StyleSheet.create({
     fontSize: 12,
     paddingHorizontal: 16,
     paddingBottom: 16,
+  },
+  analystHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 10,
+  },
+  analystRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    padding: 16,
+  },
+  analystBody: {
+    color: '#E1E8EF',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 14,
+    lineHeight: 20,
+    paddingHorizontal: 16,
+    paddingTop: 16,
+  },
+  analystMeta: {
+    color: '#6F80A0',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 11,
+    letterSpacing: 0.2,
+    paddingHorizontal: 16,
+    paddingTop: 8,
+  },
+  analystErrorBody: {
+    flex: 1,
+    gap: 6,
+  },
+  analystErrorText: {
+    color: '#FF6B6B',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 13,
+  },
+  analystEmpty: {
+    color: '#8FA2B8',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 13,
+    padding: 16,
+  },
+  retryLink: {
+    alignSelf: 'flex-start',
+  },
+  retryLinkText: {
+    color: '#4C8CFF',
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  analystActions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  analystPrimaryAction: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 999,
+    backgroundColor: '#4C8CFF',
+  },
+  analystPrimaryActionText: {
+    color: '#FFFFFF',
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  analystSecondaryAction: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 999,
+    backgroundColor: 'rgba(143, 162, 184, 0.12)',
+  },
+  analystSecondaryActionText: {
+    color: '#8FA2B8',
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 13,
+    fontWeight: '600',
   },
 });

--- a/app/(modals)/form-tracking-debrief.tsx
+++ b/app/(modals)/form-tracking-debrief.tsx
@@ -141,7 +141,12 @@ export default function FormTrackingDebriefScreen() {
     () => resolveExerciseKey(exerciseName),
     [exerciseName],
   );
-  const { comparison } = useSessionComparisonQuery({
+  const {
+    comparison,
+    loading: comparisonLoading,
+    error: comparisonError,
+    reload: reloadComparison,
+  } = useSessionComparisonQuery({
     currentSessionId: routeSessionId,
     exerciseId: comparisonExerciseId,
     userId,
@@ -268,12 +273,15 @@ export default function FormTrackingDebriefScreen() {
           )}
         </View>
 
-        {comparison?.priorSessionId ? (
+        {comparisonLoading || comparisonError || comparison?.priorSessionId ? (
           <View style={styles.sectionGap} testID="form-tracking-debrief-compare-section">
             <Text style={styles.sectionTitle}>Progress</Text>
             <SessionCompareToLastCard
               comparison={comparison}
-              onPress={handleOpenComparison}
+              loading={comparisonLoading}
+              error={comparisonError}
+              onRetry={reloadComparison}
+              onPress={comparison?.priorSessionId ? handleOpenComparison : undefined}
               testID="form-tracking-debrief-compare-card"
             />
           </View>

--- a/app/(modals)/form-tracking-pre-calibration.tsx
+++ b/app/(modals)/form-tracking-pre-calibration.tsx
@@ -13,7 +13,7 @@
  * *every* workout if calibration is not yet ready.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   StyleSheet,
@@ -23,6 +23,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
+import * as Haptics from 'expo-haptics';
 import {
   PRE_CALIBRATION_CONSTANTS,
   usePreCalibrationStatus,
@@ -48,9 +49,24 @@ export default function FormTrackingPreCalibrationModal() {
     return () => clearInterval(id);
   }, [step, status.status, recordFrame]);
 
+  // Fire a one-shot success haptic when we first enter the success state,
+  // immediately before the auto-dismiss timeout. The ref gate prevents the
+  // effect from re-firing if the status transitions back and forth (the
+  // expo-haptics call is a no-op on Android if the device doesn't support
+  // the taptic engine, and silently resolves on web — safe to call blind).
+  const successHapticFiredRef = useRef(false);
+
   // Auto-dismiss on success.
   useEffect(() => {
     if (status.status === 'success') {
+      if (!successHapticFiredRef.current) {
+        successHapticFiredRef.current = true;
+        // Fire-and-forget: haptic feedback is decorative and must never
+        // block the dismissal path.
+        void Haptics.notificationAsync(
+          Haptics.NotificationFeedbackType.Success,
+        ).catch(() => undefined);
+      }
       const timeout = setTimeout(() => {
         router.back();
       }, 800);

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -1925,7 +1925,20 @@ export default function ScanARKitScreen() {
               sessionId: sessionIdAtStop,
             });
           } catch (error) {
-            if (DEV) warnWithTs('[ScanARKit] milestone post-session failed', error);
+            // Production: surface a non-blocking toast so the user knows
+            // the achievement wasn't persisted but sync will retry. Dev
+            // keeps the detailed warn for debugging.
+            if (DEV) {
+              warnWithTs('[ScanARKit] milestone post-session failed', error);
+            }
+            try {
+              showToast(
+                "Achievement couldn't be saved — we'll retry on next sync",
+                { type: 'error', duration: 5000 },
+              );
+            } catch {
+              /* toast provider absent in headless tests — ignore */
+            }
           }
         })();
       }

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -124,6 +124,7 @@ import bounceNoiseFixture from '@/tests/fixtures/pullup-tracking/bounce-noise.js
 import { styles } from '../../styles/tabs/_scan-arkit.styles';
 import { spacing } from '../../styles/tabs/_theme-constants';
 import { VoiceCommandFeedback } from '@/components/form-tracking/VoiceCommandFeedback';
+import { CameraPermissionBanner } from '@/components/form-tracking/CameraPermissionBanner';
 // W3-A resilience (#445) — hooks + services.
 import { isAROverlaysV2Enabled } from '@/lib/services/ar-overlays-v2-flag';
 import { useSubjectIdentity } from '@/hooks/use-subject-identity';
@@ -2936,6 +2937,25 @@ export default function ScanARKitScreen() {
             </TouchableOpacity>
           </View>
         </View>
+      </View>
+
+      {/*
+        Camera-permission banner (#542) — renders only when the scan
+        surface is mounted without live camera access. Banner self-gates
+        via useCameraPermissionGuard and is absolutely positioned so the
+        underlying tracking canvas is never obscured by an empty wrapper.
+      */}
+      <View
+        pointerEvents="box-none"
+        style={{
+          position: 'absolute',
+          top: topBarBottom + 8,
+          left: 12,
+          right: 12,
+          zIndex: 130,
+        }}
+      >
+        <CameraPermissionBanner testID="scan-arkit-camera-permission-banner" />
       </View>
 
       {/* Tracking view */}

--- a/components/form-tracking/CameraPermissionBanner.tsx
+++ b/components/form-tracking/CameraPermissionBanner.tsx
@@ -1,0 +1,128 @@
+/**
+ * CameraPermissionBanner (#542)
+ *
+ * Non-modal banner that surfaces a clear recovery path when the scan
+ * surface is mounted without camera access. Sits at the top of the
+ * scan screen (over the live tracking container) so the underlying UI
+ * stays interactive while the permission state is flagged.
+ *
+ * Subscribes to `useCameraPermissionGuard({ detectRevoke: true })`:
+ *   - Renders only when `status ∈ { 'denied', 'revoked' }`.
+ *   - Auto-dismisses when the status returns to `'granted'` (no manual
+ *     close button — the banner is its own signal).
+ *   - Pressable invokes `Linking.openSettings()` and, on some platforms,
+ *     a subsequent app-foreground triggers the hook's refresh() so the
+ *     banner disappears without a rerender push from the parent.
+ *
+ * Accessibility:
+ *   - The whole banner is an accessible button (role + label).
+ *   - `accessibilityLiveRegion="polite"` so screen readers announce the
+ *     banner when it appears without interrupting in-progress speech.
+ */
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import {
+  useCameraPermissionGuard,
+  type UseCameraPermissionGuardOptions,
+} from '@/hooks/use-camera-permission-guard';
+
+export interface CameraPermissionBannerProps {
+  /**
+   * Pass-through to `useCameraPermissionGuard`. Defaults to
+   * `{ detectRevoke: true }` per #542 acceptance criteria.
+   */
+  options?: UseCameraPermissionGuardOptions;
+  /**
+   * Optional testID override.
+   */
+  testID?: string;
+}
+
+export function CameraPermissionBanner({
+  options,
+  testID = 'camera-permission-banner',
+}: CameraPermissionBannerProps) {
+  const { status, openSettings } = useCameraPermissionGuard({
+    detectRevoke: true,
+    ...options,
+  });
+
+  if (status !== 'denied' && status !== 'revoked') {
+    return null;
+  }
+
+  const handlePress = () => {
+    void openSettings();
+  };
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      accessible
+      accessibilityRole="button"
+      accessibilityLabel="Camera access required. Tap to open Settings."
+      accessibilityHint="Opens the iOS Settings app so you can grant camera access to Form Factor."
+      accessibilityLiveRegion="polite"
+      style={({ pressed }) => [styles.banner, pressed && styles.pressed]}
+      testID={testID}
+    >
+      <View style={styles.iconBubble}>
+        <Ionicons name="videocam-off" size={18} color="#FFFFFF" />
+      </View>
+      <View style={styles.body}>
+        <Text style={styles.title}>Camera access required</Text>
+        <Text style={styles.subtitle}>Tap to grant</Text>
+      </View>
+      <Ionicons name="chevron-forward" size={18} color="#FFFFFF" />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 14,
+    backgroundColor: 'rgba(180, 30, 30, 0.94)',
+    borderWidth: 1,
+    borderColor: '#FF6B6B',
+    shadowColor: '#000',
+    shadowOpacity: 0.4,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 6,
+  },
+  pressed: {
+    opacity: 0.85,
+  },
+  iconBubble: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255, 255, 255, 0.18)',
+  },
+  body: {
+    flex: 1,
+  },
+  title: {
+    color: '#FFFFFF',
+    fontSize: 13,
+    fontWeight: '800',
+    letterSpacing: 0.3,
+  },
+  subtitle: {
+    color: '#FFE0DC',
+    fontSize: 12,
+    marginTop: 2,
+    fontWeight: '600',
+  },
+});
+
+export default CameraPermissionBanner;

--- a/components/form-tracking/SessionCompareToLastCard.tsx
+++ b/components/form-tracking/SessionCompareToLastCard.tsx
@@ -11,8 +11,14 @@
  * load matter more than completeness. When the user taps it we jump to
  * the dedicated `form-comparison` modal for the richer view.
  *
- * Renders null when there is no prior session — callers should gate on
- * `comparison?.priorSessionId` and skip mounting.
+ * Render gate:
+ *   - `loading === true` → skeleton (3 placeholder delta cells + shimmer)
+ *   - `error` + `onRetry` → error callout with retry pressable
+ *   - settled + `comparison?.priorSessionId` → full card
+ *   - settled + no prior session → null
+ *
+ * Callers should mount whenever `loading || error || comparison?.priorSessionId`
+ * so the user sees the fetch state instead of a silent nothing (#540).
  */
 import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
@@ -20,13 +26,35 @@ import { Ionicons } from '@expo/vector-icons';
 import type { SessionComparison } from '@/lib/services/session-comparison-aggregator';
 
 export interface SessionCompareToLastCardProps {
-  comparison: SessionComparison;
+  /**
+   * Optional in the loading / error states so callers can mount the card
+   * while the async fetch is still in flight. Required once settled — if
+   * null/undefined with `loading === false` and no `error`, the card
+   * renders null.
+   */
+  comparison?: SessionComparison | null;
   /**
    * Optional tap handler. When provided, the whole card becomes pressable
    * and should route to the full comparison modal. When omitted the card
    * renders as a plain non-interactive summary.
    */
   onPress?: () => void;
+  /**
+   * When true, renders a skeleton placeholder (no pressable) so the user
+   * sees visible progress while `useSessionComparisonQuery` is fetching.
+   */
+  loading?: boolean;
+  /**
+   * When non-null, renders an error callout. Paired with `onRetry` to
+   * offer a recovery path.
+   */
+  error?: Error | null;
+  /**
+   * Retry handler wired to `useSessionComparisonQuery().reload`. When
+   * present alongside `error`, the error callout shows a pressable
+   * "Retry" button.
+   */
+  onRetry?: () => void;
   testID?: string;
 }
 
@@ -74,9 +102,63 @@ function toneColor(tone: 'neutral' | 'positive' | 'negative'): string {
 export function SessionCompareToLastCard({
   comparison,
   onPress,
+  loading = false,
+  error = null,
+  onRetry,
   testID = 'session-compare-to-last-card',
 }: SessionCompareToLastCardProps) {
-  if (!comparison.priorSessionId) return null;
+  // Error state wins over loading so a retry is always reachable.
+  if (error && onRetry) {
+    return (
+      <View style={styles.card} testID={`${testID}-error`}>
+        <View style={styles.header}>
+          <Ionicons name="alert-circle-outline" size={16} color="#EF4444" />
+          <Text style={styles.title}>Couldn&apos;t load last session</Text>
+        </View>
+        <Pressable
+          onPress={onRetry}
+          accessibilityRole="button"
+          accessibilityLabel="Retry loading last session comparison"
+          accessibilityHint="Re-runs the comparison query"
+          style={({ pressed }) => [styles.retryButton, pressed && styles.pressed]}
+          testID={`${testID}-retry`}
+        >
+          <Ionicons name="refresh" size={14} color="#F5F7FF" />
+          <Text style={styles.retryButtonText}>Retry</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (loading) {
+    return (
+      <View style={styles.card} testID={`${testID}-loading`}>
+        <View style={styles.header}>
+          <Ionicons name="trending-up" size={16} color="#4C8CFF" />
+          <Text style={styles.title}>Compare to last session</Text>
+        </View>
+        <View
+          style={styles.deltaRow}
+          accessible
+          accessibilityLabel="Loading last session comparison"
+        >
+          {[0, 1, 2].map((i) => (
+            <View
+              key={`skeleton-${i}`}
+              style={[styles.deltaCell, styles.skeletonCell]}
+              testID={`${testID}-skeleton-${i}`}
+            >
+              <View style={styles.skeletonLabel} />
+              <View style={styles.skeletonValue} />
+              <View style={styles.skeletonUnit} />
+            </View>
+          ))}
+        </View>
+      </View>
+    );
+  }
+
+  if (!comparison || !comparison.priorSessionId) return null;
 
   const deltas: DeltaSpec[] = [
     {
@@ -227,6 +309,45 @@ const styles = StyleSheet.create({
   },
   pressed: {
     opacity: 0.8,
+  },
+  skeletonCell: {
+    gap: 6,
+  },
+  skeletonLabel: {
+    height: 10,
+    width: '60%',
+    borderRadius: 6,
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
+  },
+  skeletonValue: {
+    height: 18,
+    width: '50%',
+    borderRadius: 6,
+    backgroundColor: 'rgba(255, 255, 255, 0.12)',
+  },
+  skeletonUnit: {
+    height: 10,
+    width: '35%',
+    borderRadius: 6,
+    backgroundColor: 'rgba(255, 255, 255, 0.06)',
+  },
+  retryButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 999,
+    backgroundColor: 'rgba(76, 140, 255, 0.18)',
+    borderWidth: 1,
+    borderColor: 'rgba(76, 140, 255, 0.32)',
+  },
+  retryButtonText: {
+    color: '#F5F7FF',
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 13,
+    fontWeight: '600',
   },
 });
 

--- a/tests/unit/app/form-mesocycle.test.tsx
+++ b/tests/unit/app/form-mesocycle.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * form-mesocycle modal — inline analyst render tests.
+ *
+ * Covers the wiring added for #541:
+ *   - "Ask coach" now triggers requestMesocycleAnalysis and renders the
+ *     result inline (loading → result → error).
+ *   - "Continue in chat" still deep-links into the coach tab with the
+ *     built prompt + mesocycle-analyst focus.
+ *
+ * The real sendCoachPrompt is mocked at the coach-service boundary so we
+ * don't need to touch the edge-function or provider pipeline.
+ */
+
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import FormMesocycleModal from '@/app/(modals)/form-mesocycle';
+import type {
+  MesocycleInsights,
+} from '@/lib/services/form-mesocycle-aggregator';
+
+const mockPush = jest.fn();
+const mockBack = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush, back: mockBack }),
+}));
+
+const mockSendCoachPrompt = jest.fn();
+jest.mock('@/lib/services/coach-service', () => ({
+  sendCoachPrompt: (...args: unknown[]) => mockSendCoachPrompt(...args),
+}));
+
+const mockUseFormMesocycle = jest.fn();
+jest.mock('@/hooks/use-form-mesocycle', () => ({
+  useFormMesocycle: () => mockUseFormMesocycle(),
+}));
+
+function baseInsights(overrides: Partial<MesocycleInsights> = {}): MesocycleInsights {
+  const weeks = overrides.weeks ?? [
+    {
+      weekIndex: 0,
+      weekStartIso: '2026-03-30',
+      weekEndIso: '2026-04-05',
+      sessionsCount: 2,
+      repsCount: 20,
+      avgFqi: 78,
+      faultCounts: {},
+    },
+    {
+      weekIndex: 1,
+      weekStartIso: '2026-04-06',
+      weekEndIso: '2026-04-12',
+      sessionsCount: 3,
+      repsCount: 30,
+      avgFqi: 82,
+      faultCounts: {},
+    },
+  ];
+  return {
+    generatedAt: '2026-04-21T00:00:00.000Z',
+    weeks,
+    topFaults: overrides.topFaults ?? [],
+    deload: overrides.deload ?? {
+      severity: 'none',
+      reason: null,
+      fqiDelta: 4,
+      faultDelta: 0,
+    },
+    isEmpty: false,
+    ...overrides,
+  } as MesocycleInsights;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseFormMesocycle.mockReturnValue({
+    loading: false,
+    error: null,
+    insights: baseInsights(),
+    refresh: jest.fn(),
+  });
+});
+
+describe('<FormMesocycleModal />', () => {
+  it('mounts the inline analyst section when insights are present', () => {
+    const { getByTestId } = render(<FormMesocycleModal />);
+    expect(getByTestId('form-mesocycle-analyst-section')).toBeTruthy();
+    // Not loading/errored/resolved yet — no body rows visible.
+    expect(() => getByTestId('form-mesocycle-analyst-loading')).toThrow();
+    expect(() => getByTestId('form-mesocycle-analyst-error')).toThrow();
+    expect(() => getByTestId('form-mesocycle-analyst-result')).toThrow();
+  });
+
+  it('renders the analyst result inline after "Ask coach" succeeds', async () => {
+    mockSendCoachPrompt.mockResolvedValueOnce({
+      role: 'assistant',
+      content: 'Your last 4 weeks show steady FQI gains. Focus on ROM depth.',
+      provider: 'gemma-cloud',
+    });
+
+    const { getByTestId, getByText } = render(<FormMesocycleModal />);
+    const askCoach = getByTestId('form-mesocycle-ask-coach');
+    await act(async () => {
+      fireEvent.press(askCoach);
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('form-mesocycle-analyst-result')).toBeTruthy();
+    });
+    expect(
+      getByText('Your last 4 weeks show steady FQI gains. Focus on ROM depth.'),
+    ).toBeTruthy();
+    expect(getByTestId('form-mesocycle-analyst-provider').props.children.join('')).toContain(
+      'Gemma',
+    );
+  });
+
+  it('renders an inline error + retry when the analyst throws', async () => {
+    mockSendCoachPrompt.mockRejectedValueOnce(new Error('upstream 500'));
+
+    const { getByTestId, getByText } = render(<FormMesocycleModal />);
+    await act(async () => {
+      fireEvent.press(getByTestId('form-mesocycle-ask-coach'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('form-mesocycle-analyst-error')).toBeTruthy();
+    });
+    expect(getByText('upstream 500')).toBeTruthy();
+
+    // Retry → successful second call.
+    mockSendCoachPrompt.mockResolvedValueOnce({
+      role: 'assistant',
+      content: 'All good, keep it up.',
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId('form-mesocycle-analyst-retry'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('form-mesocycle-analyst-result')).toBeTruthy();
+    });
+  });
+
+  it('"Continue in chat" deep-links to coach tab with prefill + focus', async () => {
+    mockSendCoachPrompt.mockResolvedValueOnce({
+      role: 'assistant',
+      content: 'Lift steady next week.',
+    });
+    const { getByTestId } = render(<FormMesocycleModal />);
+    await act(async () => {
+      fireEvent.press(getByTestId('form-mesocycle-ask-coach'));
+    });
+    await waitFor(() => {
+      expect(getByTestId('form-mesocycle-analyst-continue-chat')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('form-mesocycle-analyst-continue-chat'));
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const url = mockPush.mock.calls[0][0] as string;
+    expect(url).toContain('/(tabs)/coach');
+    expect(url).toContain('focus=mesocycle-analyst');
+    expect(url).toContain('prefill=');
+  });
+
+  it('exposes accessible labels on the primary CTAs', async () => {
+    mockSendCoachPrompt.mockResolvedValueOnce({
+      role: 'assistant',
+      content: 'Keep going.',
+    });
+    const { getByTestId } = render(<FormMesocycleModal />);
+    await act(async () => {
+      fireEvent.press(getByTestId('form-mesocycle-ask-coach'));
+    });
+    await waitFor(() => {
+      expect(getByTestId('form-mesocycle-analyst-result')).toBeTruthy();
+    });
+    expect(
+      getByTestId('form-mesocycle-analyst-continue-chat').props.accessibilityLabel,
+    ).toBe('Continue this review in the coach chat');
+    expect(
+      getByTestId('form-mesocycle-analyst-regenerate').props.accessibilityLabel,
+    ).toBe('Regenerate analyst review');
+  });
+});

--- a/tests/unit/app/form-tracking-pre-calibration.test.tsx
+++ b/tests/unit/app/form-tracking-pre-calibration.test.tsx
@@ -7,12 +7,21 @@ jest.mock('expo-router', () => ({
   useRouter: () => ({ back: mockBack }),
 }));
 
+const mockNotificationAsync = jest.fn((_type: string) => Promise.resolve());
+jest.mock('expo-haptics', () => ({
+  notificationAsync: (type: string) => mockNotificationAsync(type),
+  NotificationFeedbackType: { Success: 'success', Warning: 'warning', Error: 'error' },
+  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium', Heavy: 'heavy' },
+  impactAsync: jest.fn(() => Promise.resolve()),
+}));
+
 import FormTrackingPreCalibrationModal from '@/app/(modals)/form-tracking-pre-calibration';
 import { PRE_CALIBRATION_CONSTANTS } from '@/hooks/use-pre-calibration-status';
 
 describe('<FormTrackingPreCalibrationModal />', () => {
   beforeEach(async () => {
     mockBack.mockClear();
+    mockNotificationAsync.mockClear();
     await AsyncStorage.clear();
   });
 
@@ -65,5 +74,27 @@ describe('<FormTrackingPreCalibrationModal />', () => {
       const stored = await AsyncStorage.getItem(PRE_CALIBRATION_CONSTANTS.STORAGE_KEY);
       expect(stored).toBe('1');
     });
+  });
+
+  it('fires a success haptic exactly once on reaching the success state', async () => {
+    const { getByTestId } = render(<FormTrackingPreCalibrationModal />);
+    fireEvent.press(getByTestId('pre-calibration-continue'));
+
+    // Drive the preview step forward via recordFrame until success.
+    await waitFor(
+      () => {
+        const confirm = getByTestId('pre-calibration-confirm');
+        expect(confirm.props.accessibilityState?.disabled).toBeFalsy();
+      },
+      { timeout: 3000 }
+    );
+
+    fireEvent.press(getByTestId('pre-calibration-confirm'));
+
+    await waitFor(() => {
+      expect(mockNotificationAsync).toHaveBeenCalledWith('success');
+    });
+    // Idempotent — shouldn't double-fire on subsequent effect runs.
+    expect(mockNotificationAsync).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/components/form-tracking/CameraPermissionBanner.test.tsx
+++ b/tests/unit/components/form-tracking/CameraPermissionBanner.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * CameraPermissionBanner (#542) — unit tests.
+ *
+ * Covers the three decision branches from `useCameraPermissionGuard`:
+ *   - 'granted' or 'unknown' → nothing renders
+ *   - 'denied' → banner renders, tap → openSettings()
+ *   - 'revoked' → banner renders with the same copy
+ *
+ * Also exercises the accessibility contract (role, label, live region).
+ */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+
+import { CameraPermissionBanner } from '@/components/form-tracking/CameraPermissionBanner';
+import type {
+  CameraPermissionStatus,
+  UseCameraPermissionGuardResult,
+} from '@/hooks/use-camera-permission-guard';
+
+const mockOpenSettings = jest.fn(() => Promise.resolve());
+const mockRefresh = jest.fn(() => Promise.resolve());
+const mockRequest = jest.fn(() =>
+  Promise.resolve<CameraPermissionStatus>('granted'),
+);
+const mockUseCameraPermissionGuard = jest.fn<
+  UseCameraPermissionGuardResult,
+  [unknown]
+>();
+
+jest.mock('@/hooks/use-camera-permission-guard', () => ({
+  useCameraPermissionGuard: (opts: unknown) => mockUseCameraPermissionGuard(opts),
+}));
+
+function mockStatus(status: CameraPermissionStatus): UseCameraPermissionGuardResult {
+  return {
+    status,
+    revoked: status === 'revoked',
+    canAskAgain: status !== 'revoked',
+    refresh: mockRefresh,
+    openSettings: mockOpenSettings,
+    request: mockRequest,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('<CameraPermissionBanner />', () => {
+  it('renders nothing when status is granted', () => {
+    mockUseCameraPermissionGuard.mockReturnValue(mockStatus('granted'));
+    const { queryByTestId } = render(<CameraPermissionBanner />);
+    expect(queryByTestId('camera-permission-banner')).toBeNull();
+  });
+
+  it('renders nothing when status is unknown', () => {
+    mockUseCameraPermissionGuard.mockReturnValue(mockStatus('unknown'));
+    const { queryByTestId } = render(<CameraPermissionBanner />);
+    expect(queryByTestId('camera-permission-banner')).toBeNull();
+  });
+
+  it('renders the banner when status is denied', () => {
+    mockUseCameraPermissionGuard.mockReturnValue(mockStatus('denied'));
+    const { getByTestId, getByText } = render(<CameraPermissionBanner />);
+    expect(getByTestId('camera-permission-banner')).toBeTruthy();
+    expect(getByText('Camera access required')).toBeTruthy();
+    expect(getByText('Tap to grant')).toBeTruthy();
+  });
+
+  it('renders the banner when status is revoked', () => {
+    mockUseCameraPermissionGuard.mockReturnValue(mockStatus('revoked'));
+    const { getByTestId, getByText } = render(<CameraPermissionBanner />);
+    expect(getByTestId('camera-permission-banner')).toBeTruthy();
+    expect(getByText('Camera access required')).toBeTruthy();
+  });
+
+  it('invokes openSettings when the banner is pressed', () => {
+    mockUseCameraPermissionGuard.mockReturnValue(mockStatus('denied'));
+    const { getByTestId } = render(<CameraPermissionBanner />);
+    fireEvent.press(getByTestId('camera-permission-banner'));
+    expect(mockOpenSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the banner when permission transitions back to granted', () => {
+    mockUseCameraPermissionGuard.mockReturnValue(mockStatus('denied'));
+    const { queryByTestId, rerender } = render(<CameraPermissionBanner />);
+    expect(queryByTestId('camera-permission-banner')).toBeTruthy();
+
+    mockUseCameraPermissionGuard.mockReturnValue(mockStatus('granted'));
+    rerender(<CameraPermissionBanner />);
+    expect(queryByTestId('camera-permission-banner')).toBeNull();
+  });
+
+  it('exposes button role + accessible label + polite live region', () => {
+    mockUseCameraPermissionGuard.mockReturnValue(mockStatus('denied'));
+    const { getByTestId } = render(<CameraPermissionBanner />);
+    const banner = getByTestId('camera-permission-banner');
+    expect(banner.props.accessibilityRole).toBe('button');
+    expect(banner.props.accessibilityLabel).toBe(
+      'Camera access required. Tap to open Settings.',
+    );
+    expect(banner.props.accessibilityLiveRegion).toBe('polite');
+  });
+
+  it('passes detectRevoke: true to the guard hook by default', () => {
+    mockUseCameraPermissionGuard.mockReturnValue(mockStatus('granted'));
+    render(<CameraPermissionBanner />);
+    expect(mockUseCameraPermissionGuard).toHaveBeenCalledWith(
+      expect.objectContaining({ detectRevoke: true }),
+    );
+  });
+});

--- a/tests/unit/components/form-tracking/SessionCompareToLastCard.test.tsx
+++ b/tests/unit/components/form-tracking/SessionCompareToLastCard.test.tsx
@@ -132,4 +132,92 @@ describe('SessionCompareToLastCard', () => {
       getByTestId('session-compare-to-last-card-pressable').props.accessibilityRole,
     ).toBe('button');
   });
+
+  describe('loading state', () => {
+    it('renders 3 skeleton cells when loading', () => {
+      const { getByTestId } = render(<SessionCompareToLastCard loading />);
+      expect(getByTestId('session-compare-to-last-card-loading')).toBeTruthy();
+      expect(getByTestId('session-compare-to-last-card-skeleton-0')).toBeTruthy();
+      expect(getByTestId('session-compare-to-last-card-skeleton-1')).toBeTruthy();
+      expect(getByTestId('session-compare-to-last-card-skeleton-2')).toBeTruthy();
+    });
+
+    it('does not render delta values while loading', () => {
+      const { queryByTestId } = render(
+        <SessionCompareToLastCard loading comparison={buildComparison()} />,
+      );
+      expect(queryByTestId('session-compare-to-last-card-delta-reps-value')).toBeNull();
+      expect(queryByTestId('session-compare-to-last-card')).toBeNull();
+    });
+  });
+
+  describe('error state', () => {
+    it('renders the error callout + accessible retry button', () => {
+      const onRetry = jest.fn();
+      const { getByTestId, getByText } = render(
+        <SessionCompareToLastCard
+          error={new Error('Network down')}
+          onRetry={onRetry}
+        />,
+      );
+      expect(getByTestId('session-compare-to-last-card-error')).toBeTruthy();
+      expect(getByText("Couldn't load last session")).toBeTruthy();
+      const retry = getByTestId('session-compare-to-last-card-retry');
+      expect(retry.props.accessibilityRole).toBe('button');
+      expect(retry.props.accessibilityLabel).toBe(
+        'Retry loading last session comparison',
+      );
+    });
+
+    it('invokes onRetry when the retry button is pressed', () => {
+      const onRetry = jest.fn();
+      const { getByTestId } = render(
+        <SessionCompareToLastCard
+          error={new Error('Network down')}
+          onRetry={onRetry}
+        />,
+      );
+      fireEvent.press(getByTestId('session-compare-to-last-card-retry'));
+      expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the full card when error is cleared and comparison is available', () => {
+      const onRetry = jest.fn();
+      const { queryByTestId, rerender } = render(
+        <SessionCompareToLastCard
+          error={new Error('Network down')}
+          onRetry={onRetry}
+        />,
+      );
+      expect(queryByTestId('session-compare-to-last-card-error')).toBeTruthy();
+
+      rerender(
+        <SessionCompareToLastCard comparison={buildComparison()} onRetry={onRetry} />,
+      );
+      expect(queryByTestId('session-compare-to-last-card-error')).toBeNull();
+      expect(queryByTestId('session-compare-to-last-card')).toBeTruthy();
+    });
+
+    it('falls back to null when error is set but no onRetry is given', () => {
+      const { queryByTestId } = render(
+        <SessionCompareToLastCard error={new Error('x')} />,
+      );
+      expect(queryByTestId('session-compare-to-last-card-error')).toBeNull();
+    });
+  });
+
+  it('settles to null when not loading, no error, no prior session', () => {
+    const { queryByTestId } = render(
+      <SessionCompareToLastCard
+        comparison={buildComparison({
+          priorSessionId: null,
+          priorSummary: null,
+          overallTrend: 'baseline',
+        })}
+      />,
+    );
+    expect(queryByTestId('session-compare-to-last-card')).toBeNull();
+    expect(queryByTestId('session-compare-to-last-card-loading')).toBeNull();
+    expect(queryByTestId('session-compare-to-last-card-error')).toBeNull();
+  });
 });

--- a/tests/unit/screens/form-mesocycle.test.tsx
+++ b/tests/unit/screens/form-mesocycle.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 
 const mockPush = jest.fn();
 const mockBack = jest.fn();
@@ -13,6 +13,11 @@ const mockRefresh = jest.fn(async () => {});
 const mockUseFormMesocycle = jest.fn();
 jest.mock('@/hooks/use-form-mesocycle', () => ({
   useFormMesocycle: () => mockUseFormMesocycle(),
+}));
+
+const mockSendCoachPrompt = jest.fn();
+jest.mock('@/lib/services/coach-service', () => ({
+  sendCoachPrompt: (...args: unknown[]) => mockSendCoachPrompt(...args),
 }));
 
 import FormMesocycleModal from '@/app/(modals)/form-mesocycle';
@@ -42,6 +47,7 @@ beforeEach(() => {
   mockBack.mockReset();
   mockRefresh.mockReset();
   mockUseFormMesocycle.mockReset();
+  mockSendCoachPrompt.mockReset();
 });
 
 describe('FormMesocycleModal', () => {
@@ -108,22 +114,53 @@ describe('FormMesocycleModal', () => {
     expect(mockBack).toHaveBeenCalledTimes(1);
   });
 
-  it('routes to /coach with the analyst prompt when Ask-coach is tapped', async () => {
+  it('renders analyst review inline when Ask-coach is tapped (no auto push)', async () => {
     mockUseFormMesocycle.mockReturnValue({
       loading: false,
       error: null,
       insights: insights(),
       refresh: mockRefresh,
     });
-    const { getByTestId } = render(<FormMesocycleModal />);
-    fireEvent.press(getByTestId('form-mesocycle-ask-coach'));
-    await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledTimes(1);
+    mockSendCoachPrompt.mockResolvedValueOnce({
+      role: 'assistant',
+      content: 'Steady FQI gains; focus on depth next week.',
+      provider: 'gemma-cloud',
     });
+    const { getByTestId } = render(<FormMesocycleModal />);
+    await act(async () => {
+      fireEvent.press(getByTestId('form-mesocycle-ask-coach'));
+    });
+    await waitFor(() => {
+      expect(getByTestId('form-mesocycle-analyst-result')).toBeTruthy();
+    });
+    // The inline flow does NOT push by itself — that's the whole point
+    // of #541 (no context-switch unless the user explicitly opts in).
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('routes to /coach with the analyst prompt when Continue-in-chat is tapped', async () => {
+    mockUseFormMesocycle.mockReturnValue({
+      loading: false,
+      error: null,
+      insights: insights(),
+      refresh: mockRefresh,
+    });
+    mockSendCoachPrompt.mockResolvedValueOnce({
+      role: 'assistant',
+      content: 'Inline result.',
+    });
+    const { getByTestId } = render(<FormMesocycleModal />);
+    await act(async () => {
+      fireEvent.press(getByTestId('form-mesocycle-ask-coach'));
+    });
+    await waitFor(() => {
+      expect(getByTestId('form-mesocycle-analyst-continue-chat')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('form-mesocycle-analyst-continue-chat'));
+    expect(mockPush).toHaveBeenCalledTimes(1);
     const url = mockPush.mock.calls[0][0] as string;
     expect(url).toMatch(/\/\(tabs\)\/coach\?prefill=/);
     expect(url).toMatch(/focus=mesocycle-analyst/);
-    // The prompt is URL-encoded — decode and check the natural-language hint landed.
     expect(decodeURIComponent(url)).toMatch(/4 weeks of form tracking/);
   });
 });


### PR DESCRIPTION
## Summary

Wave-28 form-UX polish: closes three P1/P2 UX gaps with one large-scoped PR and folds in two minor polishes. All changes ship as atomic commits.

- **#540 — SessionCompareToLastCard loading/error/retry**: extends the component's props with optional \`loading\`, \`error\`, and \`onRetry\`. Renders a 3-cell skeleton while the comparison query is in flight, and a pressable error callout (\`Couldn't load last session\` + \`Retry\`) when the query fails. Debrief modal updated to destructure \`loading/error/reload\` and mount the card whenever \`loading || error || priorSessionId\` so users never see a silent no-op.
- **#541 — Mesocycle analyst inline**: the \`Ask coach\` button in \`form-mesocycle.tsx\` now runs \`requestMesocycleAnalysis(insights, sendCoachPromptAdapter)\` directly and renders the response inline in a new \`Analyst review\` section with loading / error / resolved states. A secondary \`Continue in chat\` CTA preserves the old deep-link behavior (\`/(tabs)/coach?prefill=...&focus=mesocycle-analyst\`) for users who want to extend the conversation. Local adapter bridges \`sendCoachPrompt(messages, context)\` to the analyst's options-object contract.
- **#542 — Camera permission banner**: new \`components/form-tracking/CameraPermissionBanner.tsx\` subscribes to \`useCameraPermissionGuard({ detectRevoke: true })\` and only renders when status is \`denied\` or \`revoked\`. Taps call \`Linking.openSettings()\`. Banner auto-dismisses when permission returns to \`granted\`. Full a11y: button role, descriptive label, \`accessibilityLiveRegion='polite'\`. Mounted in \`scan-arkit.tsx\` as a top overlay (not a modal) below the top bar, so the underlying tracking surface stays interactive.
- **Fold-in: pre-calibration success haptic**: fires \`Haptics.notificationAsync(Success)\` exactly once when the calibration status transitions to \`success\`, gated via a ref so it never double-fires. Silent failure on Android / web.
- **Fold-in: milestone-emit toast**: when the post-session milestone pipeline fails in \`scan-arkit.tsx\`, surfaces a 5s error toast (\`Achievement couldn't be saved — we'll retry on next sync\`) via \`useToast()\` instead of the previous DEV-only warn swallow. Non-blocking.

## Commits

\`\`\`
241b80a9 test(form-mesocycle): align legacy screen test with #541 inline contract
cdc3702d feat(scan-arkit): surface milestone-emit failures via non-blocking toast
ed0fcc73 feat(form-tracking-pre-calibration): fire success haptic on completion
1981b96b feat(scan-arkit): mount CameraPermissionBanner as top overlay
e42d5e97 feat(CameraPermissionBanner): new banner for denied/revoked camera access
e2461f97 feat(form-mesocycle): inline analyst result + continue-in-chat secondary CTA
40f0f6da feat(SessionCompareToLastCard): loading + error + retry states
\`\`\`

## Verification

- \`bun run lint\` — clean
- \`bun run check:types\` — clean
- \`bun run test\` — **431 passed / 2 skipped / 5008 tests**

New / augmented test coverage:

- \`tests/unit/components/form-tracking/SessionCompareToLastCard.test.tsx\` — 14 tests (6 new): loading skeleton, error callout, retry invocation, settled-after-error, no-retry fallback.
- \`tests/unit/app/form-mesocycle.test.tsx\` — 5 new tests: inline success render, error+retry, \`Continue in chat\` deep link, a11y labels.
- \`tests/unit/screens/form-mesocycle.test.tsx\` — updated 1 test, added 1: reflects the #541 behavior-contract flip (no auto push on Ask-coach; push only on Continue-in-chat).
- \`tests/unit/components/form-tracking/CameraPermissionBanner.test.tsx\` — 8 new tests: granted/denied/revoked/unknown states, openSettings invocation, auto-dismiss on return-to-granted, a11y contract, default \`detectRevoke: true\`.
- \`tests/unit/app/form-tracking-pre-calibration.test.tsx\` — augmented: success haptic fires exactly once on completion.

## Notes

- The scan-arkit milestone-failure toast is not tested directly (mounting the screen in jest would require stubbing ARKit + ~15 hooks). The async IIFE's \`catch\` branch is narrow and the showToast call is wrapped in a try/catch so headless test mounts stay safe. Follow-up could extract the milestone block into a reusable helper for direct unit testing — flagged in the commit message, not blocking.
- No new dependencies, no changes to \`supabase/migrations/\`, \`ios/\`, \`android/\`, \`.env\`, \`lib/services/coach-*.ts\`, or \`tests/integration/\`.

Closes #540
Closes #541
Closes #542