### PR TITLE
feat(gemma): dispatch-flag consistency + cost-tracker wiring + provider labeling — wave-28

### DIFF
--- a/lib/services/coach-auto-debrief.test.ts
+++ b/lib/services/coach-auto-debrief.test.ts
@@ -28,6 +28,12 @@ jest.mock('@/lib/services/coach-memory-context', () => ({
   synthesizeMemoryClause: (...args: unknown[]) => mockSynth(...args),
 }));
 
+// ---- cost-guard mock (#537) ------------------------------------------------
+const mockAssertUnderWeeklyCap = jest.fn().mockResolvedValue(undefined);
+jest.mock('./coach-cost-guard', () => ({
+  assertUnderWeeklyCap: (...args: unknown[]) => mockAssertUnderWeeklyCap(...args),
+}));
+
 import {
   AUTO_DEBRIEF_KEY_PREFIX,
   cacheAutoDebrief,
@@ -62,6 +68,8 @@ describe('coach-auto-debrief', () => {
     mockSendCoachPrompt.mockReset();
     mockSendCoachGemmaPrompt.mockReset();
     mockSynth.mockReset();
+    mockAssertUnderWeeklyCap.mockReset();
+    mockAssertUnderWeeklyCap.mockResolvedValue(undefined);
     mockSynth.mockResolvedValue({ text: null, lastBrief: null, weekSummary: null });
     delete process.env.EXPO_PUBLIC_COACH_AUTO_DEBRIEF_ENABLED;
     delete process.env.EXPO_PUBLIC_COACH_CLOUD_PROVIDER;
@@ -299,6 +307,34 @@ describe('coach-auto-debrief', () => {
       // provider annotation on result is the *resolved* provider preference,
       // not the path actually taken — keep the existing shape.
       expect(result.provider).toBe('gemma');
+    });
+
+    it('falls back to OpenAI when weekly Gemma cap is exceeded (#537)', async () => {
+      // Dispatch flag is on, but assertUnderWeeklyCap throws — dispatch()
+      // catches and switches to the generic OpenAI path without invoking
+      // sendCoachGemmaPrompt at all.
+      process.env.EXPO_PUBLIC_COACH_DISPATCH = 'on';
+      mockAssertUnderWeeklyCap.mockRejectedValueOnce({
+        domain: 'validation',
+        code: 'COACH_COST_CAP_EXCEEDED',
+        message: 'cap blown',
+      });
+      mockSendCoachPrompt.mockResolvedValueOnce({
+        role: 'assistant',
+        content: 'OpenAI fallback.',
+      });
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await generateAutoDebrief({
+        sessionId: 'sess-cap',
+        analytics: analytics(),
+        provider: 'gemma',
+      });
+
+      expect(mockAssertUnderWeeklyCap).toHaveBeenCalledTimes(1);
+      expect(mockSendCoachGemmaPrompt).not.toHaveBeenCalled();
+      expect(mockSendCoachPrompt).toHaveBeenCalledTimes(1);
+      expect(result.brief).toBe('OpenAI fallback.');
     });
   });
 });

--- a/lib/services/coach-auto-debrief.test.ts
+++ b/lib/services/coach-auto-debrief.test.ts
@@ -55,6 +55,8 @@ function analytics(overrides: Partial<DebriefAnalytics> = {}): DebriefAnalytics 
 }
 
 describe('coach-auto-debrief', () => {
+  const ORIGINAL_DISPATCH = process.env.EXPO_PUBLIC_COACH_DISPATCH;
+
   beforeEach(async () => {
     await AsyncStorage.clear();
     mockSendCoachPrompt.mockReset();
@@ -63,6 +65,15 @@ describe('coach-auto-debrief', () => {
     mockSynth.mockResolvedValue({ text: null, lastBrief: null, weekSummary: null });
     delete process.env.EXPO_PUBLIC_COACH_AUTO_DEBRIEF_ENABLED;
     delete process.env.EXPO_PUBLIC_COACH_CLOUD_PROVIDER;
+    delete process.env.EXPO_PUBLIC_COACH_DISPATCH;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_DISPATCH === undefined) {
+      delete process.env.EXPO_PUBLIC_COACH_DISPATCH;
+    } else {
+      process.env.EXPO_PUBLIC_COACH_DISPATCH = ORIGINAL_DISPATCH;
+    }
   });
 
   // -------------------------------------------------------------------
@@ -244,6 +255,9 @@ describe('coach-auto-debrief', () => {
     it('gemma provider falls back to sendCoachPrompt on sendCoachGemmaPrompt failure', async () => {
       // Gemma path now calls sendCoachGemmaPrompt directly; on failure we
       // fall back to sendCoachPrompt (the OpenAI-backed generic path).
+      // Dispatch-flag gate (#536): the direct Gemma call is only attempted
+      // when the global dispatch flag is on — flip it on explicitly here.
+      process.env.EXPO_PUBLIC_COACH_DISPATCH = 'on';
       mockSendCoachGemmaPrompt.mockRejectedValueOnce(new Error('gemma unavailable'));
       mockSendCoachPrompt.mockResolvedValueOnce({
         role: 'assistant',
@@ -260,6 +274,30 @@ describe('coach-auto-debrief', () => {
       expect(mockSendCoachGemmaPrompt).toHaveBeenCalledTimes(1);
       expect(mockSendCoachPrompt).toHaveBeenCalledTimes(1);
       expect(result.brief).toBe('Fallback brief.');
+      expect(result.provider).toBe('gemma');
+    });
+
+    it('skips direct Gemma call and falls through to OpenAI when dispatch flag is off (#536)', async () => {
+      // When EXPO_PUBLIC_COACH_DISPATCH is unset or !== 'on', the gemma
+      // branch in `dispatch()` is bypassed entirely — sendCoachGemmaPrompt
+      // is never called, and sendCoachPrompt (OpenAI by default) owns the turn.
+      delete process.env.EXPO_PUBLIC_COACH_DISPATCH;
+      mockSendCoachPrompt.mockResolvedValueOnce({
+        role: 'assistant',
+        content: 'OpenAI brief.',
+      });
+
+      const result = await generateAutoDebrief({
+        sessionId: 'sess-no-dispatch',
+        analytics: analytics(),
+        provider: 'gemma',
+      });
+
+      expect(mockSendCoachGemmaPrompt).not.toHaveBeenCalled();
+      expect(mockSendCoachPrompt).toHaveBeenCalledTimes(1);
+      expect(result.brief).toBe('OpenAI brief.');
+      // provider annotation on result is the *resolved* provider preference,
+      // not the path actually taken — keep the existing shape.
       expect(result.provider).toBe('gemma');
     });
   });

--- a/lib/services/coach-auto-debrief.ts
+++ b/lib/services/coach-auto-debrief.ts
@@ -29,6 +29,7 @@ import { synthesizeMemoryClause } from './coach-memory-context';
 import { getExercisePreferences, type CuePreference } from './coach-cue-feedback';
 import { isCoachPipelineV2Enabled } from './coach-pipeline-v2-flag';
 import { isDispatchEnabled } from './coach-model-dispatch-flag';
+import { assertUnderWeeklyCap } from './coach-cost-guard';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -226,9 +227,22 @@ async function dispatch(
   // OpenAI path. This lets the ops team pause Gemma rollouts without
   // redeploying — any caller that resolved `provider: 'gemma'` via env
   // still lands on OpenAI.
+  //
+  // Cost-guard (#537): before attempting Gemma, check the weekly cap — if
+  // this user has blown past their budget, silently switch to the OpenAI
+  // path. The guard is a no-op when the env cap is unset.
   if (provider === 'gemma' && isDispatchEnabled()) {
     try {
-      return await sendCoachGemmaPrompt(messages, context);
+      await assertUnderWeeklyCap('gemma_cloud');
+    } catch (capErr) {
+      warnWithTs(
+        '[coach-auto-debrief] weekly Gemma cap hit, falling back to openai',
+        capErr,
+      );
+      return sendCoachPrompt(messages, { ...context, focus: 'post_session_debrief' });
+    }
+    try {
+      return await sendCoachGemmaPrompt(messages, context, { taskKind: 'debrief' });
     } catch (err) {
       warnWithTs('[coach-auto-debrief] gemma dispatch failed, falling back to openai', err);
       return sendCoachPrompt(messages, { ...context, focus: 'post_session_debrief' });

--- a/lib/services/coach-auto-debrief.ts
+++ b/lib/services/coach-auto-debrief.ts
@@ -28,6 +28,7 @@ import {
 import { synthesizeMemoryClause } from './coach-memory-context';
 import { getExercisePreferences, type CuePreference } from './coach-cue-feedback';
 import { isCoachPipelineV2Enabled } from './coach-pipeline-v2-flag';
+import { isDispatchEnabled } from './coach-model-dispatch-flag';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -214,12 +215,18 @@ async function dispatch(
   messages: CoachMessage[],
   context: CoachContext,
 ): Promise<CoachMessage> {
-  // Direct-call routing: the gemma branch now targets the coach-gemma edge
+  // Direct-call routing: the gemma branch targets the coach-gemma edge
   // function directly so Gemma-specific parameters (model, etc.) flow
   // through without going through the generic `coach` function. Failures
   // on the Gemma path still fall back to OpenAI via sendCoachPrompt so a
   // transient Gemma outage doesn't break the auto-debrief.
-  if (provider === 'gemma') {
+  //
+  // Dispatch-flag gate (#536): when `EXPO_PUBLIC_COACH_DISPATCH` is off we
+  // skip the Gemma direct call entirely and fall through to the generic
+  // OpenAI path. This lets the ops team pause Gemma rollouts without
+  // redeploying — any caller that resolved `provider: 'gemma'` via env
+  // still lands on OpenAI.
+  if (provider === 'gemma' && isDispatchEnabled()) {
     try {
       return await sendCoachGemmaPrompt(messages, context);
     } catch (err) {

--- a/lib/services/coach-cost-guard.ts
+++ b/lib/services/coach-cost-guard.ts
@@ -1,0 +1,64 @@
+/**
+ * Coach cost guard — weekly-cap wrapper over `coach-cost-tracker`.
+ *
+ * Callers wrap a Gemma invocation with `assertUnderWeeklyCap(provider)` to
+ * check if the provider's weekly token usage is still under the configured
+ * budget. If we're over, a typed `COACH_COST_CAP_EXCEEDED` error is thrown —
+ * callers catch it and silently fall back to a different provider (usually
+ * OpenAI). When the env cap is unset, the function is a no-op.
+ *
+ * Per #537: only wired into the three Gemma entry points (coach-service
+ * Gemma branch, coach-auto-debrief direct call, pre-set-preview direct call).
+ * The OpenAI default path stays unguarded to preserve existing behavior.
+ */
+
+import { createError } from './ErrorHandler';
+import {
+  getWeeklyAggregate,
+  type CoachProvider as TrackerProvider,
+} from './coach-cost-tracker';
+
+const CAP_ENV_VAR = 'EXPO_PUBLIC_COACH_WEEKLY_TOKEN_CAP';
+
+/**
+ * Read the configured weekly token cap. Returns `Number.POSITIVE_INFINITY`
+ * (i.e. cap disabled) when the env var is unset, empty, or unparseable.
+ * Matches the pattern used elsewhere for feature-flag style env vars — we
+ * fail *open* (unlimited) so a mis-set env never blocks coach requests.
+ */
+export function getWeeklyTokenCap(): number {
+  const raw = process.env[CAP_ENV_VAR];
+  if (typeof raw !== 'string' || raw.trim() === '') return Number.POSITIVE_INFINITY;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return Number.POSITIVE_INFINITY;
+  return parsed;
+}
+
+/**
+ * Assert the given provider is still under its weekly token cap. Throws a
+ * domain-shaped `COACH_COST_CAP_EXCEEDED` error when the cap is exceeded so
+ * callers can `.catch()` and fall back to OpenAI. When no cap is configured
+ * (env unset) this is a cheap no-op — we still read the aggregate for a
+ * single-roundtrip consistency check, then return immediately.
+ */
+export async function assertUnderWeeklyCap(provider: TrackerProvider): Promise<void> {
+  const cap = getWeeklyTokenCap();
+  if (!Number.isFinite(cap)) return;
+
+  const agg = await getWeeklyAggregate();
+  const providerTotals = agg.byProvider[provider];
+  if (!providerTotals) return;
+  const used = providerTotals.tokensIn + providerTotals.tokensOut;
+  if (used < cap) return;
+
+  throw createError(
+    'validation',
+    'COACH_COST_CAP_EXCEEDED',
+    `Weekly token cap exceeded for ${provider} (${used}/${cap})`,
+    {
+      retryable: false,
+      severity: 'warning',
+      details: { provider, used, cap },
+    },
+  );
+}

--- a/lib/services/coach-drill-explainer.ts
+++ b/lib/services/coach-drill-explainer.ts
@@ -79,9 +79,13 @@ export function buildDrillExplainerMessages(input: ExplainDrillInput): CoachMess
  * Gemma-first fallback: when BOTH the pipeline master flag AND the model
  * dispatch flag are on, we attempt Gemma first (regardless of the env
  * resolver, since the cost-aware dispatcher considers drill explanations
- * tactical), and fall back to the cloud on any error. The returned
- * `provider` field reflects whichever path ultimately produced the text.
- * Either flag off preserves legacy single-shot behavior.
+ * tactical), and fall back to the cloud on any error.
+ *
+ * Provider label (#539): the returned `provider` field always reflects
+ * which path actually produced the text — `'gemma'` when the Gemma-first
+ * attempt succeeded, `'openai'` when the OpenAI edge function produced
+ * the reply (either as primary or as the Gemma-fallback). Legacy mode
+ * (pipelineV2 off) still returns `'cloud'` for backward compatibility.
  */
 export async function explainDrill(input: ExplainDrillInput): Promise<ExplainDrillResult> {
   const messages = buildDrillExplainerMessages(input);
@@ -91,12 +95,11 @@ export async function explainDrill(input: ExplainDrillInput): Promise<ExplainDri
   const resolvedProvider: 'gemma' | 'openai' | null = pipelineV2
     ? resolveDrillProvider()
     : null;
-  const returnedProvider: DrillExplainerProvider = resolvedProvider ?? 'cloud';
 
   const context = { focus: 'drill-explainer', sessionId: undefined };
 
   // Gemma-first attempt (both flags on). On any error we fall through to the
-  // env-resolved provider below.
+  // env-resolved provider below. Success returns provider='gemma' (#539).
   if (gemmaFirst) {
     try {
       const reply = await sendCoachPrompt(messages, context, { provider: 'gemma' });
@@ -113,22 +116,30 @@ export async function explainDrill(input: ExplainDrillInput): Promise<ExplainDri
     }
   }
 
+  // Provider label (#539): the fallback path always lands on the OpenAI
+  // edge function — we either hint 'openai' explicitly, let the resolver
+  // resolve to 'openai' (when env=openai), OR we arrive here as the
+  // Gemma-fallback. In every modern case the reply is authored by
+  // OpenAI, so the returned label is 'openai'. Legacy mode (pipelineV2
+  // off) preserves the historical 'cloud' label.
+  const fallbackProvider: DrillExplainerProvider = pipelineV2 ? 'openai' : 'cloud';
+  // Forward an explicit provider hint only when the env-resolver picked one;
+  // otherwise let sendCoachPrompt fall through its own resolution (which
+  // will default to OpenAI when no user preference is set).
+  const sendOpts = resolvedProvider ? { provider: resolvedProvider } : undefined;
+
   try {
-    const reply = await sendCoachPrompt(
-      messages,
-      context,
-      resolvedProvider ? { provider: resolvedProvider } : undefined,
-    );
+    const reply = await sendCoachPrompt(messages, context, sendOpts);
     const text = (reply.content ?? '').trim();
     if (!text) {
-      return { explanation: '', provider: returnedProvider, error: 'Empty response from coach.' };
+      return { explanation: '', provider: fallbackProvider, error: 'Empty response from coach.' };
     }
-    return { explanation: text, provider: returnedProvider };
+    return { explanation: text, provider: fallbackProvider };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown coach error';
     return {
       explanation: '',
-      provider: returnedProvider,
+      provider: fallbackProvider,
       error: message,
     };
   }

--- a/lib/services/coach-gemma-service.ts
+++ b/lib/services/coach-gemma-service.ts
@@ -1,12 +1,24 @@
 import { supabase } from '@/lib/supabase';
 import { warnWithTs } from '@/lib/logger';
-import { createError } from './ErrorHandler';
+import { createError, logError } from './ErrorHandler';
 import type { CoachContext, CoachMessage } from './coach-service';
 import type { CoachProvider } from './coach-provider-types';
 import {
   recordCoachUsage,
   type CoachTaskKind as TrackerTaskKind,
 } from './coach-cost-tracker';
+
+/** Fallback model identifier emitted when the coach-gemma edge function
+ * does not return a `model` field. Per the fold of Gemma-4 we always emit
+ * a non-empty `model` annotation on the reply so downstream telemetry and
+ * provider badges always have *something* to display. */
+export const UNKNOWN_GEMMA_MODEL = 'gemma-unknown';
+let hasWarnedAboutMissingGemmaModel = false;
+
+/** Test-only hook for resetting the once-per-process warn flag. */
+export function __resetMissingModelWarnForTests(): void {
+  hasWarnedAboutMissingGemmaModel = false;
+}
 
 interface RawCoachGemmaResponse {
   message?: string;
@@ -157,13 +169,47 @@ export async function sendCoachGemmaPrompt(
       configurable: true,
       writable: true,
     });
-    if (typeof data?.model === 'string' && data.model.trim().length > 0) {
-      Object.defineProperty(reply, 'model', {
-        value: data.model.trim(),
-        enumerable: false,
-        configurable: true,
-        writable: true,
-      });
+    // Always emit the `model` annotation (fold of Gemma-4). When the edge
+    // function returns a model, we use that; when it doesn't we tag the
+    // reply with UNKNOWN_GEMMA_MODEL so callers never have to null-check
+    // — that simplifies downstream telemetry / UI badges. The first time
+    // we fall back, emit a once-per-process warn-level structured log
+    // so the server-side gap is visible without spamming on every reply.
+    const rawModel =
+      typeof data?.model === 'string' && data.model.trim().length > 0
+        ? data.model.trim()
+        : undefined;
+    const modelValue = rawModel ?? UNKNOWN_GEMMA_MODEL;
+    Object.defineProperty(reply, 'model', {
+      value: modelValue,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+    if (!rawModel && !hasWarnedAboutMissingGemmaModel) {
+      hasWarnedAboutMissingGemmaModel = true;
+      try {
+        logError(
+          createError(
+            'coach',
+            'COACH_GEMMA_MODEL_MISSING',
+            'coach-gemma edge function did not return a model field; tagged reply as gemma-unknown',
+            {
+              retryable: false,
+              severity: 'warning',
+              details: { responseKeys: data ? Object.keys(data) : [] },
+            },
+          ),
+          {
+            feature: 'coach',
+            location: 'coach-gemma-service.sendCoachGemmaPrompt',
+          },
+        );
+      } catch {
+        // logError never throws in prod; swallow defensively so a test
+        // env that misconfigures expo-constants can't cascade into a
+        // coach failure.
+      }
     }
 
     // Cost-tracker wiring (#537). Fire-and-forget; never block the reply.

--- a/lib/services/coach-gemma-service.ts
+++ b/lib/services/coach-gemma-service.ts
@@ -1,7 +1,12 @@
 import { supabase } from '@/lib/supabase';
+import { warnWithTs } from '@/lib/logger';
 import { createError } from './ErrorHandler';
 import type { CoachContext, CoachMessage } from './coach-service';
 import type { CoachProvider } from './coach-provider-types';
+import {
+  recordCoachUsage,
+  type CoachTaskKind as TrackerTaskKind,
+} from './coach-cost-tracker';
 
 interface RawCoachGemmaResponse {
   message?: string;
@@ -9,6 +14,36 @@ interface RawCoachGemmaResponse {
   reply?: string;
   error?: string;
   model?: string;
+}
+
+/**
+ * STUB: char/4 token estimator used when the coach-gemma edge function
+ * doesn't return usage counts. Replace when real `usage` plumbing lands.
+ */
+function estimateGemmaTokens(text: string): number {
+  if (!text) return 0;
+  return Math.ceil(text.length / 4);
+}
+
+function mapGemmaTaskKind(input?: string): TrackerTaskKind {
+  switch (input) {
+    case 'debrief':
+    case 'multi_turn_debrief':
+    case 'post_session_debrief':
+      return 'debrief';
+    case 'drill_explainer':
+    case 'fault_explainer':
+      return 'drill_explainer';
+    case 'session_generator':
+      return 'session_generator';
+    case 'program_design':
+      return 'progression_planner';
+    case undefined:
+    case '':
+      return 'chat';
+    default:
+      return 'chat';
+  }
 }
 
 const DEFAULT_FUNCTION_NAME = 'coach-gemma';
@@ -29,7 +64,7 @@ function functionName(): string {
 export async function sendCoachGemmaPrompt(
   messages: CoachMessage[],
   context?: CoachContext,
-  opts?: { model?: string },
+  opts?: { model?: string; taskKind?: string },
 ): Promise<CoachMessage> {
   try {
     const body: Record<string, unknown> = { messages, context };
@@ -130,6 +165,18 @@ export async function sendCoachGemmaPrompt(
         writable: true,
       });
     }
+
+    // Cost-tracker wiring (#537). Fire-and-forget; never block the reply.
+    const promptText = messages.map((m) => m.content ?? '').join('\n');
+    void recordCoachUsage({
+      provider: 'gemma_cloud',
+      taskKind: mapGemmaTaskKind(opts?.taskKind),
+      tokensIn: estimateGemmaTokens(promptText),
+      tokensOut: estimateGemmaTokens(responseText),
+    }).catch((err) => {
+      warnWithTs('[coach-gemma-service] recordCoachUsage failed', err);
+    });
+
     return reply;
   } catch (err) {
     if (err && typeof err === 'object' && 'domain' in err) {

--- a/lib/services/coach-service.ts
+++ b/lib/services/coach-service.ts
@@ -20,6 +20,12 @@ import {
 } from './coach-model-dispatch';
 import { isDispatchEnabled } from './coach-model-dispatch-flag';
 import { recordDispatchDecision } from './coach-model-dispatch-telemetry';
+import {
+  recordCoachUsage,
+  type CoachTaskKind as TrackerTaskKind,
+  type CoachProvider as TrackerProvider,
+} from './coach-cost-tracker';
+import { assertUnderWeeklyCap } from './coach-cost-guard';
 
 export type { CoachProvider } from './coach-provider-types';
 import type { LiveSessionSnapshot } from './coach-live-snapshot';
@@ -130,6 +136,85 @@ const DEFAULT_MODEL_ID = 'gpt-5.4-mini';
 const functionName = (process.env.EXPO_PUBLIC_COACH_FUNCTION || 'coach').trim();
 
 /**
+ * Cost-tracker wiring helpers (#537).
+ *
+ * The edge function does not currently return OpenAI/Gemini usage counts,
+ * so we estimate tokens as `ceil(chars/4)` — a conservative industry rule
+ * of thumb. When the edge function starts emitting `usage` (promptTokens /
+ * completionTokens), callers can pass those through and the stub estimate
+ * is bypassed.
+ */
+function estimateTokens(text: string): number {
+  // STUB: replace when the edge function returns real token usage.
+  if (!text) return 0;
+  return Math.ceil(text.length / 4);
+}
+
+function mapTaskKindToTracker(
+  kind: CoachTaskKind | undefined,
+): TrackerTaskKind {
+  switch (kind) {
+    case 'multi_turn_debrief':
+      return 'debrief';
+    case 'fault_explainer':
+      return 'drill_explainer';
+    case 'session_generator':
+      return 'session_generator';
+    case 'program_design':
+      return 'progression_planner';
+    case 'form_cue_lookup':
+    case 'rest_calc':
+    case 'encouragement':
+    case 'form_vision_check':
+    case 'nutrition_balance':
+    case 'general_chat':
+    case undefined:
+      return 'chat';
+    default:
+      return 'other';
+  }
+}
+
+function mapProviderToTracker(
+  provider: CoachProvider,
+): TrackerProvider {
+  switch (provider) {
+    case 'openai':
+      return 'openai';
+    case 'gemma-cloud':
+      return 'gemma_cloud';
+    case 'gemma-on-device':
+      return 'gemma_ondevice';
+    case 'cached':
+    case 'local-fallback':
+      return 'stub';
+    default:
+      return 'stub';
+  }
+}
+
+function fireAndForgetRecordUsage(
+  provider: CoachProvider,
+  taskKind: CoachTaskKind | undefined,
+  promptText: string,
+  completionText: string,
+  cacheHit = false,
+): void {
+  // Fire-and-forget: tracker persistence is background work; never block
+  // the user-visible coach response on it, and swallow any error so
+  // tracker fault never escalates to a coach failure.
+  void recordCoachUsage({
+    provider: mapProviderToTracker(provider),
+    taskKind: mapTaskKindToTracker(taskKind),
+    tokensIn: estimateTokens(promptText),
+    tokensOut: estimateTokens(completionText),
+    cacheHit,
+  }).catch((err) => {
+    warnWithTs('[coach-service] recordCoachUsage failed', err);
+  });
+}
+
+/**
  * Feature-flag gate for prepending cross-session memory to coach prompts.
  * Defaults to ON (value 'true' or unset). Any other value disables the
  * memory clause so the coach behaves as before.
@@ -214,7 +299,7 @@ export async function sendCoachPrompt(
       messages,
       context,
       opts.cacheMs,
-      () => sendCoachPromptInner(messages, context),
+      () => sendCoachPromptInner(messages, context, opts?.taskKind),
       { shaper: opts.shaper }
     );
   }
@@ -255,9 +340,31 @@ export async function sendCoachPrompt(
   // branch above is already gated, so this check only matters for the explicit
   // / env-resolved paths.
   if (provider === 'gemma' && isDispatchEnabled()) {
-    return sendCoachGemmaPrompt(messages, context);
+    // Cost-guard (#537): before attempting the Gemma edge function, check
+    // the weekly cap. When exceeded we silently fall through to the OpenAI
+    // path — the fallback provider stays usable and the user sees no
+    // billing-shaped error. The guard is a no-op when the env cap is unset.
+    try {
+      await assertUnderWeeklyCap('gemma_cloud');
+      return await sendCoachGemmaPrompt(messages, context, {
+        taskKind: opts?.taskKind as string | undefined,
+      });
+    } catch (err) {
+      const code =
+        err && typeof err === 'object' && 'code' in err
+          ? (err as { code?: string }).code
+          : undefined;
+      if (code === 'COACH_COST_CAP_EXCEEDED') {
+        warnWithTs(
+          '[coach-service] weekly Gemma cap hit, falling back to OpenAI',
+          err,
+        );
+        return sendCoachPromptInner(messages, context, opts?.taskKind);
+      }
+      throw err;
+    }
   }
-  return sendCoachPromptInner(messages, context);
+  return sendCoachPromptInner(messages, context, opts?.taskKind);
 }
 
 async function sendCoachPromptStreaming(
@@ -311,7 +418,8 @@ async function sendCoachPromptStreaming(
 
 async function sendCoachPromptInner(
   messages: CoachMessage[],
-  context?: CoachContext
+  context?: CoachContext,
+  taskKind?: CoachTaskKind,
 ): Promise<CoachMessage> {
   try {
     const memoryClause = await resolveMemoryClause(context);
@@ -506,6 +614,19 @@ async function sendCoachPromptInner(
         hasSessionId: Boolean(context?.sessionId),
       });
     }
+
+    // Cost-tracker wiring (#537). Fire-and-forget so persistence never
+    // blocks the coach response. Token counts are estimated from char
+    // length since the edge function doesn't yet emit `usage` — see
+    // `estimateTokens()` for the stub contract.
+    const promptText = messages.map((m) => m.content ?? '').join('\n');
+    fireAndForgetRecordUsage(
+      provider,
+      taskKind,
+      promptText,
+      responseText,
+      signal.source === 'cache',
+    );
 
     // WHY non-enumerable: `provider` is a supplementary annotation on the
     // assistant reply. Keeping it non-enumerable preserves backward-compatible

--- a/lib/services/coach-service.ts
+++ b/lib/services/coach-service.ts
@@ -248,7 +248,13 @@ export async function sendCoachPrompt(
 
   // No advanced opts: pick cloud provider (explicit hint, dispatcher, user pref, env, or openai default).
   const provider = opts?.provider ?? routedProvider ?? (await resolveCloudProvider());
-  if (provider === 'gemma') {
+  // Dispatch-flag gate (#536): route to the Gemma edge function only when the
+  // global dispatch flag is on. When off, even an explicit `provider: 'gemma'`
+  // hint falls through to the OpenAI path so we never silently hit the
+  // coach-gemma function during a rollout pause. The pipeline-v2 dispatcher
+  // branch above is already gated, so this check only matters for the explicit
+  // / env-resolved paths.
+  if (provider === 'gemma' && isDispatchEnabled()) {
     return sendCoachGemmaPrompt(messages, context);
   }
   return sendCoachPromptInner(messages, context);

--- a/lib/services/coach-streaming.ts
+++ b/lib/services/coach-streaming.ts
@@ -10,6 +10,7 @@ import { supabase } from '@/lib/supabase';
 import { createError } from './ErrorHandler';
 import { sendCoachGemmaPrompt } from './coach-gemma-service';
 import type { CoachContext, CoachMessage } from './coach-service';
+import type { CoachProvider } from './coach-provider-types';
 
 export interface StreamCoachOptions {
   /** Provider hint forwarded as `?provider=` (gemma|openai). */
@@ -53,6 +54,18 @@ export interface StreamCoachResult {
   durationMs: number;
   /** finishReason from the upstream provider, when present. */
   finishReason?: string;
+  /**
+   * Provider that generated the stream. Optional — set when the stream
+   * source can be attributed (e.g. Gemma non-streaming fallback returns
+   * `'gemma-cloud'`, SSE frames with a `provider` tail-frame). Absent for
+   * older NDJSON sources that don't emit provider info (#538).
+   */
+  provider?: CoachProvider;
+  /**
+   * Model identifier from the upstream source, if available. Absent when
+   * the upstream doesn't surface a model name (#538).
+   */
+  model?: string;
 }
 
 interface StreamFrame {
@@ -60,6 +73,10 @@ interface StreamFrame {
   done?: boolean;
   finishReason?: string;
   error?: string;
+  /** Optional provider annotation emitted by the upstream server. */
+  provider?: CoachProvider | string;
+  /** Optional model annotation emitted by the upstream server. */
+  model?: string;
 }
 
 const DEFAULT_FUNCTION_NAME = (
@@ -156,6 +173,13 @@ export async function streamCoachPrompt(
   let ttftMs = 0;
   let text = '';
   let finishReason: string | undefined;
+  // Provider / model annotations are optional (#538). We collect them
+  // from any frame that emits them (the HTTP path's SSE producer or
+  // Gemma's NDJSON tail frame). Fall back to the hint passed by the
+  // caller (opts.provider) if the server never tells us — better than
+  // leaving it undefined in the common case.
+  let streamProvider: CoachProvider | undefined;
+  let streamModel: string | undefined;
 
   for await (const frame of readNdjsonFrames(response.body)) {
     if (frame.error) {
@@ -172,10 +196,26 @@ export async function streamCoachPrompt(
       text += frame.delta;
       onChunk(frame.delta);
     }
+    // Tail-frame annotations: a frame can carry provider/model either
+    // inline with a delta or on the `{done:true}` frame. Merge either.
+    if (typeof frame.provider === 'string' && frame.provider.trim()) {
+      streamProvider = frame.provider as CoachProvider;
+    }
+    if (typeof frame.model === 'string' && frame.model.trim()) {
+      streamModel = frame.model.trim();
+    }
     if (frame.done) {
       finishReason = frame.finishReason;
       break;
     }
+  }
+
+  // If the server did not emit a provider tail-frame, fall back to the
+  // caller's hint so the result is still attributable. When the hint is
+  // 'gemma' we upgrade it to the fully-qualified 'gemma-cloud' provider
+  // value so downstream UI / telemetry uses the same enum everywhere.
+  if (!streamProvider && opts?.provider) {
+    streamProvider = opts.provider === 'gemma' ? 'gemma-cloud' : 'openai';
   }
 
   return {
@@ -184,6 +224,8 @@ export async function streamCoachPrompt(
     ttftMs,
     durationMs: Date.now() - startedAt,
     finishReason,
+    provider: streamProvider,
+    model: streamModel,
   };
 }
 
@@ -299,10 +341,19 @@ async function streamGemmaViaNonStreamingFallback(
     onChunk(text);
   }
 
+  // Provider/model propagation (#538). sendCoachGemmaPrompt annotates the
+  // reply with `provider: 'gemma-cloud'` and optionally `model` as
+  // non-enumerable properties — read them here so the streaming result
+  // carries attribution consistent with the non-streaming path.
+  const replyProvider = (reply as CoachMessage & { provider?: CoachProvider }).provider;
+  const replyModel = (reply as CoachMessage & { model?: string }).model;
+
   return {
     text,
     chunkCount: text.length > 0 ? 1 : 0,
     ttftMs,
     durationMs: Date.now() - startedAt,
+    provider: replyProvider ?? 'gemma-cloud',
+    model: replyModel,
   };
 }

--- a/lib/services/pre-set-preview.ts
+++ b/lib/services/pre-set-preview.ts
@@ -17,6 +17,7 @@
 import type { FrameSnapshot, JointAngles } from '@/lib/arkit/ARKitBodyTracker';
 import { sendCoachPrompt, type CoachMessage } from './coach-service';
 import { sendCoachGemmaPrompt } from './coach-gemma-service';
+import { isDispatchEnabled } from './coach-model-dispatch-flag';
 
 export type PreSetPreviewProvider = 'gemma' | 'openai';
 
@@ -79,7 +80,11 @@ function interpretVerdict(raw: string): { verdict: string; isFormGood: boolean }
 
 function isGemmaEnabled(): boolean {
   // Evaluated at call-time so tests can mutate process.env between cases.
-  return process.env[GEMMA_PROVIDER_ENV] === 'gemma';
+  // Dispatch-flag gate (#536): both the env-level provider choice and the
+  // global dispatch flag must be on before we try Gemma. This keeps the
+  // Gemma path cleanly pausable via `EXPO_PUBLIC_COACH_DISPATCH=off` even
+  // when env already points at Gemma.
+  return process.env[GEMMA_PROVIDER_ENV] === 'gemma' && isDispatchEnabled();
 }
 
 async function callGemma(prompt: string): Promise<string> {

--- a/lib/services/pre-set-preview.ts
+++ b/lib/services/pre-set-preview.ts
@@ -14,10 +14,12 @@
  *   PR stands on its own.
  */
 
+import { warnWithTs } from '@/lib/logger';
 import type { FrameSnapshot, JointAngles } from '@/lib/arkit/ARKitBodyTracker';
 import { sendCoachPrompt, type CoachMessage } from './coach-service';
 import { sendCoachGemmaPrompt } from './coach-gemma-service';
 import { isDispatchEnabled } from './coach-model-dispatch-flag';
+import { assertUnderWeeklyCap } from './coach-cost-guard';
 
 export type PreSetPreviewProvider = 'gemma' | 'openai';
 
@@ -91,10 +93,14 @@ async function callGemma(prompt: string): Promise<string> {
   // Direct call to the canonical Gemma service — routes through the
   // coach-gemma edge function rather than the generic `coach` function so
   // model-specific parameters and provider annotations flow through cleanly.
+  // `taskKind` is forwarded to the cost-tracker wiring so the preview
+  // counts against the right task-kind bucket (chat, since it's ephemeral).
   const messages: CoachMessage[] = [{ role: 'user', content: prompt }];
-  const reply = await sendCoachGemmaPrompt(messages, {
-    focus: 'pre-set-stance-preview-gemma',
-  });
+  const reply = await sendCoachGemmaPrompt(
+    messages,
+    { focus: 'pre-set-stance-preview-gemma' },
+    { taskKind: 'chat' },
+  );
   return reply.content;
 }
 
@@ -126,12 +132,25 @@ export async function checkPreSetStance(
   const prompt = buildPreSetPrompt(exerciseName, serialized);
 
   if (isGemmaEnabled()) {
+    // Cost-guard (#537): skip Gemma when the weekly token cap has been
+    // exceeded. Silent fall-through to OpenAI — the preview is best-effort
+    // and shouldn't surface a billing error to the user.
+    let capExceeded = false;
     try {
-      const reply = await callGemma(prompt);
-      const interpreted = interpretVerdict(reply);
-      return { ...interpreted, provider: 'gemma' };
-    } catch {
-      // Fall through to OpenAI — Gemma path is best-effort.
+      await assertUnderWeeklyCap('gemma_cloud');
+    } catch (err) {
+      capExceeded = true;
+      warnWithTs('[pre-set-preview] weekly Gemma cap hit, using OpenAI', err);
+    }
+
+    if (!capExceeded) {
+      try {
+        const reply = await callGemma(prompt);
+        const interpreted = interpretVerdict(reply);
+        return { ...interpreted, provider: 'gemma' };
+      } catch {
+        // Fall through to OpenAI — Gemma path is best-effort.
+      }
     }
   }
 

--- a/tests/unit/pre-set-preview.test.ts
+++ b/tests/unit/pre-set-preview.test.ts
@@ -51,11 +51,16 @@ describe('buildPreSetPrompt', () => {
 
 describe('checkPreSetStance', () => {
   const originalProvider = process.env.EXPO_PUBLIC_COACH_CLOUD_PROVIDER;
+  const originalDispatch = process.env.EXPO_PUBLIC_COACH_DISPATCH;
 
   beforeEach(() => {
     mockSendCoachPrompt.mockReset();
     mockSendCoachGemmaPrompt.mockReset();
     delete process.env.EXPO_PUBLIC_COACH_CLOUD_PROVIDER;
+    // Dispatch-flag gate (#536): Gemma path requires both env=gemma AND
+    // dispatch flag on. Individual tests turn it on when they want the
+    // Gemma branch; it's off by default.
+    delete process.env.EXPO_PUBLIC_COACH_DISPATCH;
   });
 
   afterAll(() => {
@@ -63,6 +68,11 @@ describe('checkPreSetStance', () => {
       delete process.env.EXPO_PUBLIC_COACH_CLOUD_PROVIDER;
     } else {
       process.env.EXPO_PUBLIC_COACH_CLOUD_PROVIDER = originalProvider;
+    }
+    if (originalDispatch === undefined) {
+      delete process.env.EXPO_PUBLIC_COACH_DISPATCH;
+    } else {
+      process.env.EXPO_PUBLIC_COACH_DISPATCH = originalDispatch;
     }
   });
 
@@ -95,8 +105,9 @@ describe('checkPreSetStance', () => {
     expect(result.provider).toBe('openai');
   });
 
-  it('routes through Gemma when EXPO_PUBLIC_COACH_CLOUD_PROVIDER=gemma', async () => {
+  it('routes through Gemma when EXPO_PUBLIC_COACH_CLOUD_PROVIDER=gemma and dispatch flag is on', async () => {
     process.env.EXPO_PUBLIC_COACH_CLOUD_PROVIDER = 'gemma';
+    process.env.EXPO_PUBLIC_COACH_DISPATCH = 'on';
     mockSendCoachGemmaPrompt.mockResolvedValueOnce({
       role: 'assistant',
       content: '✓ Good setup',
@@ -114,6 +125,7 @@ describe('checkPreSetStance', () => {
 
   it('falls back to OpenAI when the Gemma path throws', async () => {
     process.env.EXPO_PUBLIC_COACH_CLOUD_PROVIDER = 'gemma';
+    process.env.EXPO_PUBLIC_COACH_DISPATCH = 'on';
     mockSendCoachGemmaPrompt.mockRejectedValueOnce(new Error('gemma-offline'));
     mockSendCoachPrompt.mockResolvedValueOnce({
       role: 'assistant',
@@ -132,6 +144,23 @@ describe('checkPreSetStance', () => {
     expect(mockSendCoachPrompt.mock.calls[0][1].focus).toBe(
       'pre-set-stance-preview'
     );
+  });
+
+  it('skips the Gemma path when env=gemma but dispatch flag is off (#536)', async () => {
+    // With env pointing at gemma but the dispatch flag unset, isGemmaEnabled()
+    // now returns false so we go straight to OpenAI without calling Gemma.
+    process.env.EXPO_PUBLIC_COACH_CLOUD_PROVIDER = 'gemma';
+    delete process.env.EXPO_PUBLIC_COACH_DISPATCH;
+    mockSendCoachPrompt.mockResolvedValueOnce({
+      role: 'assistant',
+      content: '✓ Good',
+    });
+
+    const result = await checkPreSetStance(snapshot, 'squat', angles);
+
+    expect(result.provider).toBe('openai');
+    expect(mockSendCoachGemmaPrompt).not.toHaveBeenCalled();
+    expect(mockSendCoachPrompt).toHaveBeenCalledTimes(1);
   });
 
   it('propagates OpenAI errors when there is no Gemma fallback path', async () => {

--- a/tests/unit/pre-set-preview.test.ts
+++ b/tests/unit/pre-set-preview.test.ts
@@ -1,5 +1,6 @@
 const mockSendCoachPrompt = jest.fn();
 const mockSendCoachGemmaPrompt = jest.fn();
+const mockAssertUnderWeeklyCap = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('@/lib/services/coach-service', () => ({
   sendCoachPrompt: (...args: unknown[]) => mockSendCoachPrompt(...args),
@@ -7,6 +8,10 @@ jest.mock('@/lib/services/coach-service', () => ({
 
 jest.mock('@/lib/services/coach-gemma-service', () => ({
   sendCoachGemmaPrompt: (...args: unknown[]) => mockSendCoachGemmaPrompt(...args),
+}));
+
+jest.mock('@/lib/services/coach-cost-guard', () => ({
+  assertUnderWeeklyCap: (...args: unknown[]) => mockAssertUnderWeeklyCap(...args),
 }));
 
 // The service imports FrameSnapshot + JointAngles from the ARKit tracker
@@ -56,6 +61,8 @@ describe('checkPreSetStance', () => {
   beforeEach(() => {
     mockSendCoachPrompt.mockReset();
     mockSendCoachGemmaPrompt.mockReset();
+    mockAssertUnderWeeklyCap.mockReset();
+    mockAssertUnderWeeklyCap.mockResolvedValue(undefined);
     delete process.env.EXPO_PUBLIC_COACH_CLOUD_PROVIDER;
     // Dispatch-flag gate (#536): Gemma path requires both env=gemma AND
     // dispatch flag on. Individual tests turn it on when they want the
@@ -161,6 +168,30 @@ describe('checkPreSetStance', () => {
     expect(result.provider).toBe('openai');
     expect(mockSendCoachGemmaPrompt).not.toHaveBeenCalled();
     expect(mockSendCoachPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to OpenAI when weekly Gemma cap is exceeded (#537)', async () => {
+    // Both env and dispatch flag point at Gemma, but the weekly cap guard
+    // throws → Gemma is never called, OpenAI owns the turn.
+    process.env.EXPO_PUBLIC_COACH_CLOUD_PROVIDER = 'gemma';
+    process.env.EXPO_PUBLIC_COACH_DISPATCH = 'on';
+    mockAssertUnderWeeklyCap.mockRejectedValueOnce({
+      domain: 'validation',
+      code: 'COACH_COST_CAP_EXCEEDED',
+      message: 'cap blown',
+    });
+    mockSendCoachPrompt.mockResolvedValueOnce({
+      role: 'assistant',
+      content: '✓ Good (openai)',
+    });
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await checkPreSetStance(snapshot, 'squat', angles);
+
+    expect(mockAssertUnderWeeklyCap).toHaveBeenCalledTimes(1);
+    expect(mockSendCoachGemmaPrompt).not.toHaveBeenCalled();
+    expect(mockSendCoachPrompt).toHaveBeenCalledTimes(1);
+    expect(result.provider).toBe('openai');
   });
 
   it('propagates OpenAI errors when there is no Gemma fallback path', async () => {

--- a/tests/unit/services/coach-cost-guard.test.ts
+++ b/tests/unit/services/coach-cost-guard.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for coach-cost-guard — weekly-cap wrapper that throws a typed
+ * COACH_COST_CAP_EXCEEDED error when the caller's provider has exceeded
+ * its token budget.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  __invalidateHydrationForTests,
+  recordCoachUsage,
+} from '@/lib/services/coach-cost-tracker';
+import {
+  assertUnderWeeklyCap,
+  getWeeklyTokenCap,
+} from '@/lib/services/coach-cost-guard';
+
+const CAP_ENV = 'EXPO_PUBLIC_COACH_WEEKLY_TOKEN_CAP';
+const ORIGINAL_CAP = process.env[CAP_ENV];
+
+describe('coach-cost-guard — getWeeklyTokenCap', () => {
+  afterEach(() => {
+    if (ORIGINAL_CAP === undefined) delete process.env[CAP_ENV];
+    else process.env[CAP_ENV] = ORIGINAL_CAP;
+  });
+
+  it('returns POSITIVE_INFINITY when env var is unset', () => {
+    delete process.env[CAP_ENV];
+    expect(getWeeklyTokenCap()).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('returns POSITIVE_INFINITY when env var is empty', () => {
+    process.env[CAP_ENV] = '';
+    expect(getWeeklyTokenCap()).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('returns POSITIVE_INFINITY when env var is NaN', () => {
+    process.env[CAP_ENV] = 'not-a-number';
+    expect(getWeeklyTokenCap()).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('returns POSITIVE_INFINITY when env var is zero or negative (fail-open)', () => {
+    process.env[CAP_ENV] = '0';
+    expect(getWeeklyTokenCap()).toBe(Number.POSITIVE_INFINITY);
+    process.env[CAP_ENV] = '-5';
+    expect(getWeeklyTokenCap()).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('parses a positive integer cap', () => {
+    process.env[CAP_ENV] = '50000';
+    expect(getWeeklyTokenCap()).toBe(50000);
+  });
+});
+
+describe('coach-cost-guard — assertUnderWeeklyCap', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    __invalidateHydrationForTests();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_CAP === undefined) delete process.env[CAP_ENV];
+    else process.env[CAP_ENV] = ORIGINAL_CAP;
+  });
+
+  it('is a no-op when cap env is unset (disabled)', async () => {
+    delete process.env[CAP_ENV];
+    // Even if we've recorded millions of tokens, no cap means no throw.
+    await recordCoachUsage({
+      provider: 'gemma_cloud',
+      taskKind: 'chat',
+      tokensIn: 1_000_000,
+      tokensOut: 1_000_000,
+    });
+    await expect(assertUnderWeeklyCap('gemma_cloud')).resolves.toBeUndefined();
+  });
+
+  it('passes silently when usage is under the cap', async () => {
+    process.env[CAP_ENV] = '10000';
+    await recordCoachUsage({
+      provider: 'gemma_cloud',
+      taskKind: 'chat',
+      tokensIn: 500,
+      tokensOut: 500,
+    });
+    await expect(assertUnderWeeklyCap('gemma_cloud')).resolves.toBeUndefined();
+  });
+
+  it('throws COACH_COST_CAP_EXCEEDED when usage >= cap', async () => {
+    process.env[CAP_ENV] = '1000';
+    await recordCoachUsage({
+      provider: 'gemma_cloud',
+      taskKind: 'chat',
+      tokensIn: 600,
+      tokensOut: 500, // total 1100 > cap 1000
+    });
+
+    await expect(assertUnderWeeklyCap('gemma_cloud')).rejects.toMatchObject({
+      domain: 'validation',
+      code: 'COACH_COST_CAP_EXCEEDED',
+      retryable: false,
+    });
+  });
+
+  it('throws at boundary (usage exactly equal to cap)', async () => {
+    process.env[CAP_ENV] = '1000';
+    await recordCoachUsage({
+      provider: 'gemma_cloud',
+      taskKind: 'chat',
+      tokensIn: 500,
+      tokensOut: 500, // total 1000 === cap
+    });
+
+    await expect(assertUnderWeeklyCap('gemma_cloud')).rejects.toMatchObject({
+      code: 'COACH_COST_CAP_EXCEEDED',
+    });
+  });
+
+  it('tracks per-provider: OpenAI cap state is independent of Gemma', async () => {
+    process.env[CAP_ENV] = '1000';
+    // Exhaust OpenAI's budget
+    await recordCoachUsage({
+      provider: 'openai',
+      taskKind: 'chat',
+      tokensIn: 800,
+      tokensOut: 400,
+    });
+    // Gemma is untouched → still under cap
+    await expect(assertUnderWeeklyCap('gemma_cloud')).resolves.toBeUndefined();
+    // But OpenAI itself would be over
+    await expect(assertUnderWeeklyCap('openai')).rejects.toMatchObject({
+      code: 'COACH_COST_CAP_EXCEEDED',
+    });
+  });
+
+  it('includes the consumption/cap numbers in error details for telemetry', async () => {
+    process.env[CAP_ENV] = '500';
+    await recordCoachUsage({
+      provider: 'gemma_cloud',
+      taskKind: 'chat',
+      tokensIn: 300,
+      tokensOut: 300, // total 600
+    });
+
+    await expect(assertUnderWeeklyCap('gemma_cloud')).rejects.toMatchObject({
+      details: expect.objectContaining({
+        provider: 'gemma_cloud',
+        used: 600,
+        cap: 500,
+      }),
+    });
+  });
+
+  it('only counts tokens inside the weekly window', async () => {
+    process.env[CAP_ENV] = '1000';
+    // 10 days ago — outside the 7-day weekly window → should NOT count.
+    const oldIso = new Date(Date.now() - 10 * 86400_000).toISOString();
+    await recordCoachUsage({
+      at: oldIso,
+      provider: 'gemma_cloud',
+      taskKind: 'chat',
+      tokensIn: 5000,
+      tokensOut: 5000,
+    });
+
+    // Today, small usage → under cap.
+    await recordCoachUsage({
+      provider: 'gemma_cloud',
+      taskKind: 'chat',
+      tokensIn: 100,
+      tokensOut: 100,
+    });
+
+    await expect(assertUnderWeeklyCap('gemma_cloud')).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/services/coach-cost-tracker.test.ts
+++ b/tests/unit/services/coach-cost-tracker.test.ts
@@ -221,3 +221,73 @@ describe('coach-cost-tracker — recordCoachUsage + getWeeklyAggregate', () => {
     expect(rehydrated.totalCalls).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Integration smoke: coach-service Gemma path records usage (#537).
+//
+// The production wiring fires recordCoachUsage fire-and-forget so a coach
+// turn never blocks on the tracker. Here we call recordCoachUsage directly
+// to mirror what the wiring does, then read getWeeklyAggregate back — if
+// the bucket shape / provider enum drift, this catches it.
+// ---------------------------------------------------------------------------
+describe('coach-cost-tracker — wiring smoke (#537)', () => {
+  it('records a gemma_cloud chat event that rolls up into the weekly aggregate', async () => {
+    await recordCoachUsage({
+      at: '2026-04-17T10:00:00.000Z',
+      provider: 'gemma_cloud',
+      taskKind: 'chat',
+      tokensIn: 25, // 100 chars of prompt / 4
+      tokensOut: 13, // 50 chars of reply / 4
+    });
+    const agg = await getWeeklyAggregate('2026-04-17T12:00:00.000Z');
+    expect(agg.byProvider.gemma_cloud.calls).toBe(1);
+    expect(agg.byProvider.gemma_cloud.tokensIn).toBe(25);
+    expect(agg.byProvider.gemma_cloud.tokensOut).toBe(13);
+    expect(agg.byTaskKind.chat.calls).toBe(1);
+  });
+
+  it('records an openai debrief event with estimated tokens', async () => {
+    await recordCoachUsage({
+      at: '2026-04-17T10:00:00.000Z',
+      provider: 'openai',
+      taskKind: 'debrief',
+      tokensIn: 120,
+      tokensOut: 80,
+    });
+    const agg = await getWeeklyAggregate('2026-04-17T12:00:00.000Z');
+    expect(agg.byProvider.openai.calls).toBe(1);
+    expect(agg.byTaskKind.debrief.tokensIn).toBe(120);
+    expect(agg.byTaskKind.debrief.tokensOut).toBe(80);
+  });
+
+  it('rolls up mixed provider/taskKind events across the week', async () => {
+    await recordCoachUsage({
+      at: '2026-04-17T10:00:00.000Z',
+      provider: 'gemma_cloud',
+      taskKind: 'chat',
+      tokensIn: 10,
+      tokensOut: 10,
+    });
+    await recordCoachUsage({
+      at: '2026-04-17T11:00:00.000Z',
+      provider: 'gemma_cloud',
+      taskKind: 'debrief',
+      tokensIn: 40,
+      tokensOut: 20,
+    });
+    await recordCoachUsage({
+      at: '2026-04-16T10:00:00.000Z',
+      provider: 'openai',
+      taskKind: 'drill_explainer',
+      tokensIn: 30,
+      tokensOut: 15,
+    });
+    const agg = await getWeeklyAggregate('2026-04-17T12:00:00.000Z');
+    expect(agg.totalCalls).toBe(3);
+    expect(agg.byProvider.gemma_cloud.calls).toBe(2);
+    expect(agg.byProvider.openai.calls).toBe(1);
+    expect(agg.byTaskKind.chat.calls).toBe(1);
+    expect(agg.byTaskKind.debrief.calls).toBe(1);
+    expect(agg.byTaskKind.drill_explainer.calls).toBe(1);
+  });
+});

--- a/tests/unit/services/coach-drill-explainer.provider-dispatch.test.ts
+++ b/tests/unit/services/coach-drill-explainer.provider-dispatch.test.ts
@@ -2,6 +2,12 @@
  * Pipeline-v2 provider dispatch tests for coach-drill-explainer.
  * Verifies EXPO_PUBLIC_COACH_CLOUD_PROVIDER is honoured when the master
  * flag is on; legacy behavior (hardcoded 'cloud') when the flag is off.
+ *
+ * Provider label semantics (#539): the returned `provider` field reflects
+ * which path *actually* authored the reply, not just which one we hinted
+ * at. With dispatch flag OFF the Gemma-first attempt is skipped and the
+ * fallback path runs; since the fallback always lands on the OpenAI edge
+ * function, the label is 'openai' even when env=gemma.
  */
 
 const mockSendCoachPrompt = jest.fn();
@@ -16,8 +22,10 @@ let explainDrill: typeof import('@/lib/services/coach-drill-explainer')['explain
 
 const FLAG = 'EXPO_PUBLIC_COACH_PIPELINE_V2';
 const PROVIDER = 'EXPO_PUBLIC_COACH_CLOUD_PROVIDER';
+const DISPATCH = 'EXPO_PUBLIC_COACH_DISPATCH';
 const originalFlag = process.env[FLAG];
 const originalProvider = process.env[PROVIDER];
+const originalDispatch = process.env[DISPATCH];
 
 const baseInput: ExplainDrillInput = {
   drillTitle: 'Tempo squat',
@@ -41,14 +49,17 @@ describe('coach-drill-explainer provider dispatch (pipeline-v2)', () => {
     for (const [k, v] of [
       [FLAG, originalFlag],
       [PROVIDER, originalProvider],
+      [DISPATCH, originalDispatch],
     ] as const) {
       if (v === undefined) delete process.env[k];
       else process.env[k] = v;
     }
   });
 
-  it('passes provider=gemma through sendCoachPrompt when flag is on and env=gemma', async () => {
+  it('passes provider=gemma through sendCoachPrompt and labels reply gemma when both flags on (#539)', async () => {
+    // Both flags on → gemma-first path. Gemma replies → label 'gemma'.
     process.env[FLAG] = 'on';
+    process.env[DISPATCH] = 'on';
     process.env[PROVIDER] = 'gemma';
     const result = await explainDrill(baseInput);
 
@@ -59,6 +70,8 @@ describe('coach-drill-explainer provider dispatch (pipeline-v2)', () => {
   });
 
   it('passes provider=openai through sendCoachPrompt when flag is on and env=openai', async () => {
+    // Pipeline-v2 on, dispatch off → no gemma-first attempt. Env points
+    // at openai → hint it through, reply authored by openai, label 'openai'.
     process.env[FLAG] = 'on';
     process.env[PROVIDER] = 'openai';
     const result = await explainDrill(baseInput);
@@ -68,7 +81,54 @@ describe('coach-drill-explainer provider dispatch (pipeline-v2)', () => {
     expect(result.provider).toBe('openai');
   });
 
-  it('preserves legacy cloud behavior when flag is off', async () => {
+  it('labels reply openai when env=gemma but dispatch flag is off (#539 — actual path wins)', async () => {
+    // Pipeline-v2 on, dispatch OFF → gemma-first is skipped. We still
+    // forward the provider hint from the env resolver, but since the
+    // dispatch flag is off inside sendCoachPrompt, Gemma is not actually
+    // called — OpenAI owns the turn. Label reflects the authoring path.
+    process.env[FLAG] = 'on';
+    delete process.env[DISPATCH];
+    process.env[PROVIDER] = 'gemma';
+    const result = await explainDrill(baseInput);
+
+    expect(mockSendCoachPrompt).toHaveBeenCalledTimes(1);
+    expect(result.provider).toBe('openai');
+  });
+
+  it('labels reply openai when Gemma-first fails and falls back (#539)', async () => {
+    // Gemma-first path errors → fallback to OpenAI. Label reflects the
+    // path that actually produced the text, not the preferred one.
+    process.env[FLAG] = 'on';
+    process.env[DISPATCH] = 'on';
+    process.env[PROVIDER] = 'gemma';
+    mockSendCoachPrompt
+      .mockRejectedValueOnce(new Error('gemma unavailable'))
+      .mockResolvedValueOnce({ role: 'assistant', content: 'openai fallback reply' });
+
+    const result = await explainDrill(baseInput);
+
+    expect(mockSendCoachPrompt).toHaveBeenCalledTimes(2);
+    expect(result.explanation).toBe('openai fallback reply');
+    expect(result.provider).toBe('openai');
+  });
+
+  it('labels reply openai when Gemma-first returns empty and falls back (#539)', async () => {
+    // Empty Gemma reply is indistinguishable from a real failure from the
+    // user's perspective — fall through to OpenAI and label accordingly.
+    process.env[FLAG] = 'on';
+    process.env[DISPATCH] = 'on';
+    process.env[PROVIDER] = 'gemma';
+    mockSendCoachPrompt
+      .mockResolvedValueOnce({ role: 'assistant', content: '   ' })
+      .mockResolvedValueOnce({ role: 'assistant', content: 'openai fallback' });
+
+    const result = await explainDrill(baseInput);
+    expect(result.explanation).toBe('openai fallback');
+    expect(result.provider).toBe('openai');
+  });
+
+  it('preserves legacy cloud behavior when pipeline-v2 flag is off', async () => {
+    // Pipeline-v2 off → no provider resolution, legacy 'cloud' label.
     delete process.env[FLAG];
     process.env[PROVIDER] = 'gemma';
     const result = await explainDrill(baseInput);

--- a/tests/unit/services/coach-drill-explainer.test.ts
+++ b/tests/unit/services/coach-drill-explainer.test.ts
@@ -107,6 +107,8 @@ describe('coach-drill-explainer', () => {
     const result = await explainDrill(baseInput);
     expect(result.explanation).toBe('');
     expect(result.error).toBe('Coach down');
+    // Pipeline-v2 flag is OFF in this test (not set in env), so legacy
+    // 'cloud' label applies.
     expect(result.provider).toBe('cloud');
   });
 

--- a/tests/unit/services/coach-gemma-service.test.ts
+++ b/tests/unit/services/coach-gemma-service.test.ts
@@ -1,4 +1,5 @@
 const mockInvoke = jest.fn();
+const mockRecordCoachUsage = jest.fn().mockResolvedValue(undefined);
 const mockCreateError = jest.fn(
   (
     domain: string,
@@ -29,6 +30,12 @@ jest.mock('@/lib/services/ErrorHandler', () => ({
 
 jest.mock('../../../lib/services/ErrorHandler', () => ({
   createError: mockCreateError,
+}));
+
+// Cost-tracker wiring (#537): intercept recordCoachUsage so we can verify
+// the Gemma service reports usage and doesn't block on tracker failures.
+jest.mock('@/lib/services/coach-cost-tracker', () => ({
+  recordCoachUsage: (...args: unknown[]) => mockRecordCoachUsage(...args),
 }));
 
 let sendCoachGemmaPrompt: typeof import('@/lib/services/coach-gemma-service')['sendCoachGemmaPrompt'];
@@ -357,6 +364,87 @@ describe('coach-gemma-service', () => {
 
     await expect(sendCoachGemmaPrompt(baseMessages)).rejects.toMatchObject({
       code: 'COACH_GEMMA_EMPTY_RESPONSE',
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cost-tracker wiring (#537)
+  // ---------------------------------------------------------------------------
+
+  describe('cost-tracker wiring (#537)', () => {
+    beforeEach(() => {
+      mockRecordCoachUsage.mockClear();
+      mockRecordCoachUsage.mockResolvedValue(undefined);
+    });
+
+    it('records a gemma_cloud usage event on the happy path with estimated tokens', async () => {
+      // 100-char prompt + 50-char reply → ceil(100/4)=25 in, ceil(50/4)=13 out
+      const longPrompt = 'a'.repeat(100);
+      const longReply = 'b'.repeat(50);
+      mockInvoke.mockResolvedValue({
+        data: { message: longReply },
+        error: null,
+      });
+      await sendCoachGemmaPrompt([{ role: 'user', content: longPrompt }]);
+
+      expect(mockRecordCoachUsage).toHaveBeenCalledTimes(1);
+      expect(mockRecordCoachUsage.mock.calls[0][0]).toMatchObject({
+        provider: 'gemma_cloud',
+        taskKind: 'chat',
+        tokensIn: 25,
+        tokensOut: 13,
+      });
+    });
+
+    it('maps taskKind="debrief" into the debrief tracker bucket', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'debrief reply' },
+        error: null,
+      });
+      await sendCoachGemmaPrompt(baseMessages, undefined, { taskKind: 'debrief' });
+      expect(mockRecordCoachUsage.mock.calls[0][0]).toMatchObject({
+        taskKind: 'debrief',
+      });
+    });
+
+    it('maps taskKind="drill_explainer" into the drill_explainer tracker bucket', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'explainer' },
+        error: null,
+      });
+      await sendCoachGemmaPrompt(baseMessages, undefined, { taskKind: 'drill_explainer' });
+      expect(mockRecordCoachUsage.mock.calls[0][0]).toMatchObject({
+        taskKind: 'drill_explainer',
+      });
+    });
+
+    it('defaults to chat when taskKind is omitted', async () => {
+      await sendCoachGemmaPrompt(baseMessages);
+      expect(mockRecordCoachUsage.mock.calls[0][0]).toMatchObject({
+        taskKind: 'chat',
+      });
+    });
+
+    it('does not block the reply when recordCoachUsage throws', async () => {
+      mockRecordCoachUsage.mockRejectedValueOnce(new Error('tracker-down'));
+      mockInvoke.mockResolvedValue({
+        data: { message: 'Reply is returned.' },
+        error: null,
+      });
+      const result = await sendCoachGemmaPrompt(baseMessages);
+      // Reply still lands. Fire-and-forget tracker failure is logged as a warn.
+      expect(result.content).toBe('Reply is returned.');
+    });
+
+    it('does not record usage when the call errors out', async () => {
+      mockInvoke.mockResolvedValue({
+        data: null,
+        error: { message: '404 Not Found', status: 404 },
+      });
+      await expect(sendCoachGemmaPrompt(baseMessages)).rejects.toMatchObject({
+        code: 'COACH_GEMMA_NOT_DEPLOYED',
+      });
+      expect(mockRecordCoachUsage).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/services/coach-gemma-service.test.ts
+++ b/tests/unit/services/coach-gemma-service.test.ts
@@ -24,12 +24,16 @@ jest.mock('@/lib/supabase', () => ({
   },
 }));
 
+const mockLogError = jest.fn();
+
 jest.mock('@/lib/services/ErrorHandler', () => ({
   createError: mockCreateError,
+  logError: mockLogError,
 }));
 
 jest.mock('../../../lib/services/ErrorHandler', () => ({
   createError: mockCreateError,
+  logError: mockLogError,
 }));
 
 // Cost-tracker wiring (#537): intercept recordCoachUsage so we can verify
@@ -39,6 +43,7 @@ jest.mock('@/lib/services/coach-cost-tracker', () => ({
 }));
 
 let sendCoachGemmaPrompt: typeof import('@/lib/services/coach-gemma-service')['sendCoachGemmaPrompt'];
+type CoachMessage = import('@/lib/services/coach-service').CoachMessage;
 
 describe('coach-gemma-service', () => {
   const baseMessages = [{ role: 'user' as const, content: 'How should I squat?' }];
@@ -445,6 +450,109 @@ describe('coach-gemma-service', () => {
         code: 'COACH_GEMMA_NOT_DEPLOYED',
       });
       expect(mockRecordCoachUsage).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Model field reliability (fold of Gemma-4)
+  //
+  // The reply must ALWAYS carry a `model` annotation. When the edge function
+  // returns one we use it verbatim; when it doesn't we tag 'gemma-unknown'
+  // and emit a once-per-process warn via logError. Downstream consumers
+  // (provider badges, telemetry) can read `reply.model` without a null-check.
+  // ---------------------------------------------------------------------------
+
+  describe('model field reliability (fold of Gemma-4)', () => {
+    const UNKNOWN_GEMMA_MODEL = 'gemma-unknown';
+    // Use a module-local `send` to guarantee both sendCoachGemmaPrompt and
+    // __resetMissingModelWarnForTests come from the SAME module instance.
+    // A prior test in this file calls `jest.resetModules()`, which blows
+    // away the cached module; the outer `sendCoachGemmaPrompt` captured in
+    // the outer beforeAll then points at a different module than the one
+    // freshly resolved inside this describe — state is split between them
+    // and the warn flag can never be reset cleanly.
+    let send: typeof sendCoachGemmaPrompt;
+
+    beforeEach(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mod = require('@/lib/services/coach-gemma-service');
+      send = mod.sendCoachGemmaPrompt;
+      mod.__resetMissingModelWarnForTests();
+      mockLogError.mockClear();
+    });
+
+    it('uses the edge-function model when provided', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'ok', model: 'gemma-3-4b-it' },
+        error: null,
+      });
+      const reply = await send(baseMessages);
+      // Non-enumerable — read directly.
+      expect((reply as CoachMessage & { model?: string }).model).toBe('gemma-3-4b-it');
+    });
+
+    it('trims whitespace from the edge-function model', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'ok', model: '   gemma-3-27b-it  ' },
+        error: null,
+      });
+      const reply = await send(baseMessages);
+      expect((reply as CoachMessage & { model?: string }).model).toBe('gemma-3-27b-it');
+    });
+
+    it('tags reply as UNKNOWN_GEMMA_MODEL when edge function omits model', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'ok' }, // no model field
+        error: null,
+      });
+      const reply = await send(baseMessages);
+      expect((reply as CoachMessage & { model?: string }).model).toBe(UNKNOWN_GEMMA_MODEL);
+      expect((reply as CoachMessage & { model?: string }).model).toBe('gemma-unknown');
+    });
+
+    it('tags reply as UNKNOWN_GEMMA_MODEL when model is an empty string', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'ok', model: '' },
+        error: null,
+      });
+      const reply = await send(baseMessages);
+      expect((reply as CoachMessage & { model?: string }).model).toBe('gemma-unknown');
+    });
+
+    it('tags reply as UNKNOWN_GEMMA_MODEL when model is whitespace-only', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'ok', model: '   ' },
+        error: null,
+      });
+      const reply = await send(baseMessages);
+      expect((reply as CoachMessage & { model?: string }).model).toBe('gemma-unknown');
+    });
+
+    it('logs a warn-classified error exactly once when model is missing', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'ok' },
+        error: null,
+      });
+      // First call → warn. Second call → no additional warn.
+      await send(baseMessages);
+      await send(baseMessages);
+
+      expect(mockLogError).toHaveBeenCalledTimes(1);
+      const [errArg] = mockLogError.mock.calls[0];
+      expect(errArg).toMatchObject({
+        domain: 'coach',
+        code: 'COACH_GEMMA_MODEL_MISSING',
+        severity: 'warning',
+      });
+    });
+
+    it('does not log when model is present', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'ok', model: 'gemma-3-4b-it' },
+        error: null,
+      });
+      await send(baseMessages);
+      expect(mockLogError).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/services/coach-service.dispatch-flag.test.ts
+++ b/tests/unit/services/coach-service.dispatch-flag.test.ts
@@ -1,0 +1,152 @@
+// Verifies the dispatch-flag gate on coach-service's Gemma provider branch
+// (fix #536, site 1). When EXPO_PUBLIC_COACH_DISPATCH !== 'on', even an
+// explicit `provider: 'gemma'` hint must fall through to the OpenAI edge
+// function; when the flag is on, the Gemma path is honoured as before.
+
+const mockInvoke = jest.fn();
+const mockSendCoachGemmaPrompt = jest.fn();
+const mockResolveCloudProvider = jest.fn();
+const mockCreateError = jest.fn(
+  (
+    domain: string,
+    code: string,
+    message: string,
+    opts?: { details?: unknown; retryable?: boolean; severity?: string },
+  ) => ({
+    domain,
+    code,
+    message,
+    retryable: opts?.retryable ?? false,
+    severity: opts?.severity ?? 'error',
+    details: opts?.details,
+  }),
+);
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    functions: { invoke: mockInvoke },
+    from: jest.fn(() => ({ insert: jest.fn().mockResolvedValue({ error: null }) })),
+  },
+}));
+
+jest.mock('@/lib/services/ErrorHandler', () => ({
+  createError: mockCreateError,
+  logError: jest.fn(),
+}));
+
+jest.mock('../../../lib/services/ErrorHandler', () => ({
+  createError: mockCreateError,
+  logError: jest.fn(),
+}));
+
+jest.mock('@/lib/services/coach-gemma-service', () => ({
+  sendCoachGemmaPrompt: mockSendCoachGemmaPrompt,
+}));
+
+jest.mock('@/lib/services/coach-cloud-provider', () => ({
+  resolveCloudProvider: mockResolveCloudProvider,
+}));
+
+let sendCoachPrompt: typeof import('@/lib/services/coach-service')['sendCoachPrompt'];
+
+const DISPATCH_ENV = 'EXPO_PUBLIC_COACH_DISPATCH';
+const ORIGINAL_DISPATCH = process.env[DISPATCH_ENV];
+
+describe('coach-service dispatch-flag gate (#536)', () => {
+  const baseMessages = [{ role: 'user' as const, content: 'Help me deadlift' }];
+
+  beforeAll(() => {
+    ({ sendCoachPrompt } = require('@/lib/services/coach-service'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInvoke.mockResolvedValue({
+      data: { message: 'OpenAI reply.' },
+      error: null,
+    });
+    mockSendCoachGemmaPrompt.mockResolvedValue({
+      role: 'assistant',
+      content: 'Gemma reply.',
+    });
+    mockResolveCloudProvider.mockResolvedValue('openai');
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (ORIGINAL_DISPATCH === undefined) {
+      delete process.env[DISPATCH_ENV];
+    } else {
+      process.env[DISPATCH_ENV] = ORIGINAL_DISPATCH;
+    }
+  });
+
+  it('falls through to OpenAI when provider=gemma but dispatch flag is unset', async () => {
+    delete process.env[DISPATCH_ENV];
+
+    const result = await sendCoachPrompt(baseMessages, undefined, { provider: 'gemma' });
+
+    expect(result.content).toBe('OpenAI reply.');
+    expect(mockSendCoachGemmaPrompt).not.toHaveBeenCalled();
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through to OpenAI when provider=gemma and dispatch flag is "off"', async () => {
+    process.env[DISPATCH_ENV] = 'off';
+
+    const result = await sendCoachPrompt(baseMessages, undefined, { provider: 'gemma' });
+
+    expect(result.content).toBe('OpenAI reply.');
+    expect(mockSendCoachGemmaPrompt).not.toHaveBeenCalled();
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through to OpenAI when resolver returns gemma but dispatch flag is off', async () => {
+    delete process.env[DISPATCH_ENV];
+    mockResolveCloudProvider.mockResolvedValue('gemma');
+
+    const result = await sendCoachPrompt(baseMessages);
+
+    expect(result.content).toBe('OpenAI reply.');
+    expect(mockSendCoachGemmaPrompt).not.toHaveBeenCalled();
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('honours provider=gemma when dispatch flag is "on"', async () => {
+    process.env[DISPATCH_ENV] = 'on';
+
+    const result = await sendCoachPrompt(baseMessages, undefined, { provider: 'gemma' });
+
+    expect(result.content).toBe('Gemma reply.');
+    expect(mockSendCoachGemmaPrompt).toHaveBeenCalledTimes(1);
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it('honours resolver=gemma when dispatch flag is "on"', async () => {
+    process.env[DISPATCH_ENV] = 'on';
+    mockResolveCloudProvider.mockResolvedValue('gemma');
+
+    const result = await sendCoachPrompt(baseMessages);
+
+    expect(result.content).toBe('Gemma reply.');
+    expect(mockSendCoachGemmaPrompt).toHaveBeenCalledTimes(1);
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it('provider=openai is unaffected by the dispatch flag', async () => {
+    // When the caller explicitly pins OpenAI the flag state is irrelevant —
+    // we always take the OpenAI edge function path.
+    for (const state of ['on', 'off', undefined] as const) {
+      if (state === undefined) delete process.env[DISPATCH_ENV];
+      else process.env[DISPATCH_ENV] = state;
+      mockInvoke.mockClear();
+      mockSendCoachGemmaPrompt.mockClear();
+
+      const result = await sendCoachPrompt(baseMessages, undefined, { provider: 'openai' });
+      expect(result.content).toBe('OpenAI reply.');
+      expect(mockInvoke).toHaveBeenCalledTimes(1);
+      expect(mockSendCoachGemmaPrompt).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/tests/unit/services/coach-service.dispatch-flag.test.ts
+++ b/tests/unit/services/coach-service.dispatch-flag.test.ts
@@ -6,6 +6,7 @@
 const mockInvoke = jest.fn();
 const mockSendCoachGemmaPrompt = jest.fn();
 const mockResolveCloudProvider = jest.fn();
+const mockAssertUnderWeeklyCap = jest.fn().mockResolvedValue(undefined);
 const mockCreateError = jest.fn(
   (
     domain: string,
@@ -47,6 +48,10 @@ jest.mock('@/lib/services/coach-cloud-provider', () => ({
   resolveCloudProvider: mockResolveCloudProvider,
 }));
 
+jest.mock('@/lib/services/coach-cost-guard', () => ({
+  assertUnderWeeklyCap: (...args: unknown[]) => mockAssertUnderWeeklyCap(...args),
+}));
+
 let sendCoachPrompt: typeof import('@/lib/services/coach-service')['sendCoachPrompt'];
 
 const DISPATCH_ENV = 'EXPO_PUBLIC_COACH_DISPATCH';
@@ -61,6 +66,7 @@ describe('coach-service dispatch-flag gate (#536)', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAssertUnderWeeklyCap.mockResolvedValue(undefined);
     mockInvoke.mockResolvedValue({
       data: { message: 'OpenAI reply.' },
       error: null,
@@ -148,5 +154,44 @@ describe('coach-service dispatch-flag gate (#536)', () => {
       expect(mockInvoke).toHaveBeenCalledTimes(1);
       expect(mockSendCoachGemmaPrompt).not.toHaveBeenCalled();
     }
+  });
+
+  it('falls back to OpenAI when weekly Gemma cap is exceeded (#537)', async () => {
+    // Dispatch flag is on but the cost guard throws — coach-service catches
+    // the COACH_COST_CAP_EXCEEDED error and silently routes the turn to the
+    // OpenAI edge function. Gemma is never called.
+    process.env[DISPATCH_ENV] = 'on';
+    mockAssertUnderWeeklyCap.mockRejectedValueOnce({
+      domain: 'validation',
+      code: 'COACH_COST_CAP_EXCEEDED',
+      message: 'cap blown',
+    });
+
+    const result = await sendCoachPrompt(baseMessages, undefined, { provider: 'gemma' });
+
+    expect(mockAssertUnderWeeklyCap).toHaveBeenCalledTimes(1);
+    expect(mockSendCoachGemmaPrompt).not.toHaveBeenCalled();
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+    expect(result.content).toBe('OpenAI reply.');
+  });
+
+  it('propagates non-cap errors from the cost guard without falling back (#537)', async () => {
+    // If assertUnderWeeklyCap throws a different error code (bug in tracker
+    // etc.), we do NOT silently collapse to OpenAI — re-throw so callers see
+    // the fault.
+    process.env[DISPATCH_ENV] = 'on';
+    const unrelated = {
+      domain: 'storage',
+      code: 'TRACKER_CORRUPT',
+      message: 'corrupt state',
+    };
+    mockAssertUnderWeeklyCap.mockRejectedValueOnce(unrelated);
+
+    await expect(
+      sendCoachPrompt(baseMessages, undefined, { provider: 'gemma' }),
+    ).rejects.toBe(unrelated);
+
+    expect(mockSendCoachGemmaPrompt).not.toHaveBeenCalled();
+    expect(mockInvoke).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/services/coach-service.provider-dispatch.test.ts
+++ b/tests/unit/services/coach-service.provider-dispatch.test.ts
@@ -49,6 +49,12 @@ let sendCoachPrompt: typeof import('@/lib/services/coach-service')['sendCoachPro
 
 describe('coach-service provider dispatch', () => {
   const baseMessages = [{ role: 'user' as const, content: 'Help me deadlift' }];
+  // Dispatch-flag gate (#536): Gemma dispatch now requires
+  // `EXPO_PUBLIC_COACH_DISPATCH=on`. These tests assert end-to-end routing
+  // to the Gemma path, so the flag is set on in beforeEach and cleared in
+  // afterEach. The off-by-default case (Gemma collapses to OpenAI) is
+  // covered by coach-service.dispatch-flag.test.ts.
+  const ORIGINAL_DISPATCH = process.env.EXPO_PUBLIC_COACH_DISPATCH;
 
   beforeAll(() => {
     ({ sendCoachPrompt } = require('@/lib/services/coach-service'));
@@ -56,6 +62,7 @@ describe('coach-service provider dispatch', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.EXPO_PUBLIC_COACH_DISPATCH = 'on';
     mockInvoke.mockResolvedValue({
       data: { message: 'Hinge at the hips.' },
       error: null,
@@ -70,6 +77,11 @@ describe('coach-service provider dispatch', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    if (ORIGINAL_DISPATCH === undefined) {
+      delete process.env.EXPO_PUBLIC_COACH_DISPATCH;
+    } else {
+      process.env.EXPO_PUBLIC_COACH_DISPATCH = ORIGINAL_DISPATCH;
+    }
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/services/coach-service.provider-dispatch.test.ts
+++ b/tests/unit/services/coach-service.provider-dispatch.test.ts
@@ -102,7 +102,13 @@ describe('coach-service provider dispatch', () => {
 
     expect(result.content).toBe('Drive through the floor.');
     expect(mockSendCoachGemmaPrompt).toHaveBeenCalledTimes(1);
-    expect(mockSendCoachGemmaPrompt).toHaveBeenCalledWith(baseMessages, undefined);
+    // Third arg is the Gemma opts object — contains `taskKind` (undefined
+    // when no task kind was passed) used by the cost-tracker wiring.
+    expect(mockSendCoachGemmaPrompt).toHaveBeenCalledWith(
+      baseMessages,
+      undefined,
+      { taskKind: undefined },
+    );
     expect(mockInvoke).not.toHaveBeenCalled();
     expect(mockResolveCloudProvider).not.toHaveBeenCalled();
   });
@@ -111,7 +117,11 @@ describe('coach-service provider dispatch', () => {
     const context = { profile: { id: 'u1', name: 'Pat' }, focus: 'squat' };
     await sendCoachPrompt(baseMessages, context, { provider: 'gemma' });
 
-    expect(mockSendCoachGemmaPrompt).toHaveBeenCalledWith(baseMessages, context);
+    expect(mockSendCoachGemmaPrompt).toHaveBeenCalledWith(
+      baseMessages,
+      context,
+      { taskKind: undefined },
+    );
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/services/coach-service.test.ts
+++ b/tests/unit/services/coach-service.test.ts
@@ -3,6 +3,7 @@ const mockInsert = jest.fn();
 const mockFrom = jest.fn(() => ({
   insert: mockInsert,
 }));
+const mockRecordCoachUsage = jest.fn().mockResolvedValue(undefined);
 const mockCreateError = jest.fn(
   (
     domain: string,
@@ -30,10 +31,17 @@ jest.mock('@/lib/supabase', () => ({
 
 jest.mock('@/lib/services/ErrorHandler', () => ({
   createError: mockCreateError,
+  logError: jest.fn(),
 }));
 
 jest.mock('../../../lib/services/ErrorHandler', () => ({
   createError: mockCreateError,
+  logError: jest.fn(),
+}));
+
+// Cost-tracker wiring (#537): verify recordCoachUsage fires on happy path.
+jest.mock('@/lib/services/coach-cost-tracker', () => ({
+  recordCoachUsage: (...args: unknown[]) => mockRecordCoachUsage(...args),
 }));
 
 let sendCoachPrompt: typeof import('@/lib/services/coach-service')['sendCoachPrompt'];
@@ -353,5 +361,68 @@ describe('coach-service', () => {
     expect(mockInsert).toHaveBeenCalledWith(
       expect.objectContaining({ turn_index: 0 })
     );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cost-tracker wiring (#537)
+  // ---------------------------------------------------------------------------
+
+  describe('cost-tracker wiring (#537)', () => {
+    beforeEach(() => {
+      mockRecordCoachUsage.mockClear();
+    });
+
+    it('records a usage event on the happy path', async () => {
+      const messages = [{ role: 'user' as const, content: 'How to squat?' }];
+      mockInvoke.mockResolvedValue({
+        data: { message: 'Brace your core.', model: 'gpt-5.4-mini' },
+        error: null,
+      });
+
+      await sendCoachPrompt(messages);
+      // Fire-and-forget: wait a tick to let the promise resolve.
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(mockRecordCoachUsage).toHaveBeenCalledTimes(1);
+      const evt = mockRecordCoachUsage.mock.calls[0][0];
+      expect(evt.provider).toBe('openai');
+      expect(evt.taskKind).toBe('chat');
+      expect(evt.tokensIn).toBeGreaterThan(0);
+      expect(evt.tokensOut).toBeGreaterThan(0);
+    });
+
+    it('tags cache-sourced replies with cacheHit=true', async () => {
+      mockInvoke.mockResolvedValue({
+        data: { message: 'cached', source: 'cache', model: 'gpt-5.4-mini' },
+        error: null,
+      });
+      await sendCoachPrompt(baseMessages);
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(mockRecordCoachUsage.mock.calls[0][0]).toMatchObject({
+        cacheHit: true,
+      });
+    });
+
+    it('does not record usage when the call errors', async () => {
+      mockInvoke.mockResolvedValue({
+        data: null,
+        error: { message: '404 Not Found', status: 404 },
+      });
+      await expect(sendCoachPrompt(baseMessages)).rejects.toMatchObject({
+        code: 'COACH_NOT_DEPLOYED',
+      });
+      expect(mockRecordCoachUsage).not.toHaveBeenCalled();
+    });
+
+    it('does not block when recordCoachUsage rejects', async () => {
+      mockRecordCoachUsage.mockRejectedValueOnce(new Error('tracker-down'));
+      mockInvoke.mockResolvedValue({
+        data: { message: 'Reply.' },
+        error: null,
+      });
+      const result = await sendCoachPrompt(baseMessages);
+      expect(result.content).toBe('Reply.');
+    });
   });
 });

--- a/tests/unit/services/coach-streaming.test.ts
+++ b/tests/unit/services/coach-streaming.test.ts
@@ -237,4 +237,105 @@ describe('streamCoachPrompt', () => {
     );
     expect(fakeFetch).toHaveBeenCalledTimes(1);
   });
+
+  // ---------------------------------------------------------------------------
+  // Provider / model propagation (#538)
+  // ---------------------------------------------------------------------------
+
+  describe('StreamCoachResult provider/model (#538)', () => {
+    it('picks up provider + model from an NDJSON tail frame', async () => {
+      const fakeFetch: typeof fetch = jest.fn(
+        async () =>
+          new Response(
+            ndjsonStream([
+              { delta: 'hello' },
+              { done: true, provider: 'openai', model: 'gpt-5.4-mini' },
+            ]),
+            { status: 200 }
+          )
+      );
+
+      const result = await streamCoachPrompt(
+        [{ role: 'user', content: 'x' }],
+        undefined,
+        () => undefined,
+        { fetchImpl: fakeFetch }
+      );
+      expect(result.provider).toBe('openai');
+      expect(result.model).toBe('gpt-5.4-mini');
+    });
+
+    it('falls back to the caller-supplied provider hint when the stream is silent', async () => {
+      // No tail frame with provider/model — streaming result still gets
+      // attributed via opts.provider → CoachProvider mapping.
+      const fakeFetch: typeof fetch = jest.fn(
+        async () => new Response(ndjsonStream([{ delta: 'a' }, { done: true }]), { status: 200 })
+      );
+
+      const openaiResult = await streamCoachPrompt(
+        [{ role: 'user', content: 'x' }],
+        undefined,
+        () => undefined,
+        { fetchImpl: fakeFetch, provider: 'openai' }
+      );
+      expect(openaiResult.provider).toBe('openai');
+      expect(openaiResult.model).toBeUndefined();
+    });
+
+    it('leaves provider undefined when neither the stream nor the caller annotates it', async () => {
+      const fakeFetch: typeof fetch = jest.fn(
+        async () => new Response(ndjsonStream([{ delta: 'a' }, { done: true }]), { status: 200 })
+      );
+
+      const result = await streamCoachPrompt(
+        [{ role: 'user', content: 'x' }],
+        undefined,
+        () => undefined,
+        { fetchImpl: fakeFetch }
+      );
+      expect(result.provider).toBeUndefined();
+      expect(result.model).toBeUndefined();
+    });
+
+    it('Gemma fallback path surfaces provider=gemma-cloud via non-enumerable reply annotation', async () => {
+      // Emulate sendCoachGemmaPrompt's non-enumerable annotations — the
+      // fallback reads them directly off the returned message.
+      const fakeReply = { role: 'assistant' as const, content: 'Gemma says hi.' };
+      Object.defineProperty(fakeReply, 'provider', {
+        value: 'gemma-cloud',
+        enumerable: false,
+      });
+      Object.defineProperty(fakeReply, 'model', {
+        value: 'gemma-3-4b-it',
+        enumerable: false,
+      });
+      const gemmaFallbackImpl = jest.fn().mockResolvedValue(fakeReply);
+
+      const result = await streamCoachPrompt(
+        [{ role: 'user', content: 'x' }],
+        undefined,
+        () => undefined,
+        { provider: 'gemma', gemmaFallbackImpl }
+      );
+
+      expect(result.provider).toBe('gemma-cloud');
+      expect(result.model).toBe('gemma-3-4b-it');
+      expect(result.text).toBe('Gemma says hi.');
+      expect(result.chunkCount).toBe(1);
+    });
+
+    it('Gemma fallback defaults provider to gemma-cloud when reply has no annotation', async () => {
+      const plainReply = { role: 'assistant' as const, content: 'Plain reply.' };
+      const gemmaFallbackImpl = jest.fn().mockResolvedValue(plainReply);
+
+      const result = await streamCoachPrompt(
+        [{ role: 'user', content: 'x' }],
+        undefined,
+        () => undefined,
+        { provider: 'gemma', gemmaFallbackImpl }
+      );
+      expect(result.provider).toBe('gemma-cloud');
+      expect(result.model).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes 4 Gemma-dispatch and cost-tracker gaps as a single wave-28 PR. Six atomic commits:

- **fix(gemma): gate Gemma dispatch paths on `EXPO_PUBLIC_COACH_DISPATCH`** (#536). Three call sites previously bypassed `isDispatchEnabled()` — coach-service.ts's explicit/resolver Gemma branch, coach-auto-debrief.ts's direct Gemma dispatch, pre-set-preview.ts's `isGemmaEnabled()`. All three now AND the flag into their Gemma-routing check so ops can pause Gemma with a single env flip.
- **feat(coach-cost-guard): weekly-cap wrapper over cost-tracker** (#537). New `lib/services/coach-cost-guard.ts` exposes `assertUnderWeeklyCap(provider)` that throws a typed `COACH_COST_CAP_EXCEEDED` error when a provider's 7-day usage meets/exceeds `EXPO_PUBLIC_COACH_WEEKLY_TOKEN_CAP`. Fail-open semantics when env is unset. 12 new tests.
- **feat(coach-cost): wire `recordCoachUsage` into 4 entry points + cap-guard fallback** (#537). Before this change `coach-cost-tracker.ts` had **zero** production call sites. Now: `sendCoachPromptInner`, `sendCoachGemmaPrompt`, the coach-service Gemma branch, `coach-auto-debrief.dispatch`, and `pre-set-preview.checkPreSetStance` all record usage fire-and-forget. Every Gemma entry point is additionally wrapped with `assertUnderWeeklyCap` — cap-exceeded silently falls back to OpenAI. Token counts use a `ceil(chars/4)` stub (clearly commented).
- **feat(coach-streaming): expose `provider`/`model` on `StreamCoachResult`** (#538). `StreamCoachResult` now carries optional `provider?: CoachProvider` and `model?: string`. Propagated from NDJSON tail frames, caller-supplied hint (`opts.provider`), or the Gemma non-streaming fallback's non-enumerable reply annotations. Fully backward-compatible.
- **fix(coach-drill-explainer): label reply provider by actual authoring path** (#539). Previously returned `provider: 'gemma'` even when OpenAI authored the text (because the env preference was gemma). Now the label reflects the authoring path: `'gemma'` when Gemma-first succeeds, `'openai'` for any OpenAI-authored reply (primary or fallback), `'cloud'` when pipeline-v2 is off.
- **fix(coach-gemma): always emit model annotation on reply** (fold of Gemma-4). `sendCoachGemmaPrompt` no longer conditionally sets `model`. When the edge function omits the field, we tag the reply `'gemma-unknown'` and emit a once-per-process warn-level structured log via `logError`. Downstream code can read `reply.model` without null-checks.

## Verification

- `bun run lint` — clean
- `bun run check:types` — clean
- `bun run test` — **5038 passed, 25 skipped, 0 failed** (431/433 suites pass; 2 skipped are pre-existing)
- New/augmented tests across 9 files cover every new branch: flag-on/off matrix, cost-guard boundary cases, cost-tracker wiring roll-up, streaming provider/model propagation, drill-explainer label semantics, and missing-model annotation behavior.

## Scope constraints respected

- No changes to `supabase/migrations/`, `ios/`, `android/`, or `.env*` files
- No new dependencies
- No modifications to `app/(modals)/form-*.tsx`, `app/(tabs)/scan-arkit.tsx`, or `components/form-tracking/` (reserved for parallel PRs)

Closes #536
Closes #537
Closes #538
Closes #539