### PR TITLE
feat(wave31): form-UX polish + accessibility pack — 8 atomic commits

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'expo-router';
 import { useState } from 'react';
 import { Alert, Image, KeyboardAvoidingView, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { useAuth } from '../../contexts/AuthContext';
+import { useToast } from '../../contexts/ToastContext';
 import { isIOS } from '@/lib/platform-utils';
 
 type FormData = {
@@ -10,11 +11,15 @@ type FormData = {
   fullName?: string;
 };
 
+type FieldError = { field: 'email' | 'password' | 'fullName' | 'form'; message: string };
+
 export default function SignInScreen() {
   const router = useRouter();
+  const { show: showToast } = useToast();
   const [isSignUp, setIsSignUp] = useState(false);
   const [isMagicLink, setIsMagicLink] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>('');
+  const [fieldError, setFieldError] = useState<FieldError | null>(null);
   const [magicLinkSent, setMagicLinkSent] = useState(false);
   const [formData, setFormData] = useState<FormData>({
     email: '',
@@ -76,19 +81,93 @@ export default function SignInScreen() {
     return message || 'An unexpected error occurred. Please try again.';
   };
 
+  /**
+   * Wave-31 Pack A / A8 (#562): map common Supabase auth errors to the
+   * specific form field that owns them, so the validation copy appears
+   * *next to* the field instead of only in the generic banner at the
+   * top of the card. Falls through to the legacy `getErrorMessage` for
+   * anything we don't recognize.
+   */
+  const mapSupabaseError = (error: any): FieldError => {
+    if (!error) return { field: 'form', message: '' };
+
+    const raw = (error.message || error.toString() || '').toLowerCase();
+    const code = (error.code || error.name || '').toString().toLowerCase();
+
+    // email_already_exists
+    if (
+      code === 'email_already_exists' ||
+      raw.includes('email_already_exists') ||
+      raw.includes('user already registered') ||
+      raw.includes('already registered')
+    ) {
+      return { field: 'email', message: 'Email already exists. Sign in instead?' };
+    }
+
+    // weak_password
+    if (
+      code === 'weak_password' ||
+      raw.includes('weak_password') ||
+      raw.includes('password should be at least') ||
+      raw.includes('password is too weak')
+    ) {
+      return {
+        field: 'password',
+        message: 'Password too weak. Use at least 6 characters with letters and numbers.',
+      };
+    }
+
+    // invalid_credentials
+    if (
+      code === 'invalid_credentials' ||
+      raw.includes('invalid_credentials') ||
+      raw.includes('invalid login credentials')
+    ) {
+      return { field: 'password', message: 'Invalid email or password.' };
+    }
+
+    // network_error
+    if (
+      code === 'network_error' ||
+      raw.includes('network request failed') ||
+      raw.includes('network connection failed') ||
+      raw.includes('unable to connect')
+    ) {
+      return {
+        field: 'form',
+        message: 'Network error — check your connection and try again.',
+      };
+    }
+
+    // Fall back to the existing generic mapper for unrecognized codes
+    return { field: 'form', message: getErrorMessage(error) };
+  };
+
+  const applyFieldError = (err: unknown) => {
+    const mapped = mapSupabaseError(err);
+    setFieldError(mapped.message ? mapped : null);
+    if (mapped.field === 'form') {
+      setErrorMessage(mapped.message);
+    } else {
+      setErrorMessage('');
+    }
+  };
+
   const handleEmailAuth = async () => {
     if (!formData.email || !formData.password) {
       setErrorMessage('Please fill in all fields');
+      setFieldError(null);
       return;
     }
 
     setErrorMessage('');
+    setFieldError(null);
     clearError();
 
     try {
       if (isSignUp) {
         if (!formData.fullName?.trim()) {
-          setErrorMessage('Please enter your full name');
+          setFieldError({ field: 'fullName', message: 'Please enter your full name' });
           return;
         }
         const { error } = await signUpWithEmail(
@@ -97,21 +176,25 @@ export default function SignInScreen() {
           { fullName: formData.fullName }
         );
         if (error) {
-          setErrorMessage(getErrorMessage(error));
+          applyFieldError(error);
           return;
         }
+        // Wave-31 Pack A / A8 (#562): celebratory toast on sign-up success.
+        // The Alert below is kept so users on slow networks still see a
+        // blocking confirmation they need to open their inbox.
+        showToast('Account created — check your email', { type: 'success' });
         setIsSignUp(false);
         setFormData((prev) => ({ ...prev, password: '' }));
         Alert.alert('Success', 'Check your email to confirm your account, then sign in.');
       } else {
         const { error } = await signInWithEmail(formData.email, formData.password);
         if (error) {
-          setErrorMessage(getErrorMessage(error));
+          applyFieldError(error);
           return;
         }
       }
     } catch (error) {
-      setErrorMessage(getErrorMessage(error));
+      applyFieldError(error);
     }
   };
 
@@ -200,11 +283,14 @@ export default function SignInScreen() {
             <View style={styles.inputContainer}>
               <Text style={styles.inputLabel}>Email</Text>
               <TextInput
-                style={styles.input}
+                style={[styles.input, fieldError?.field === 'email' && styles.inputError]}
                 placeholder="Email"
                 placeholderTextColor="#6781A6"
                 value={formData.email}
-                onChangeText={(text) => setFormData(prev => ({ ...prev, email: text.trim() }))}
+                onChangeText={(text) => {
+                  setFormData(prev => ({ ...prev, email: text.trim() }));
+                  if (fieldError?.field === 'email') setFieldError(null);
+                }}
                 keyboardType="email-address"
                 autoCapitalize="none"
                 autoComplete="email"
@@ -213,22 +299,31 @@ export default function SignInScreen() {
                 returnKeyType={isSignUp && !isMagicLink ? 'next' : 'done'}
                 editable={!isSigningIn}
               />
+              {fieldError?.field === 'email' && (
+                <Text style={styles.fieldErrorText}>{fieldError.message}</Text>
+              )}
             </View>
 
             {isSignUp && !isMagicLink && (
               <View style={styles.inputContainer}>
                 <Text style={styles.inputLabel}>Full Name</Text>
                 <TextInput
-                  style={styles.input}
+                  style={[styles.input, fieldError?.field === 'fullName' && styles.inputError]}
                   placeholder="Full Name"
                   placeholderTextColor="#6781A6"
                   value={formData.fullName}
-                  onChangeText={(text) => setFormData((prev) => ({ ...prev, fullName: text }))}
+                  onChangeText={(text) => {
+                    setFormData((prev) => ({ ...prev, fullName: text }));
+                    if (fieldError?.field === 'fullName') setFieldError(null);
+                  }}
                   autoCapitalize="words"
                   autoCorrect={false}
                   returnKeyType="next"
                   editable={!isSigningIn}
                 />
+                {fieldError?.field === 'fullName' && (
+                  <Text style={styles.fieldErrorText}>{fieldError.message}</Text>
+                )}
               </View>
             )}
 
@@ -237,17 +332,23 @@ export default function SignInScreen() {
                 <View style={styles.inputContainer}>
                   <Text style={styles.inputLabel}>Password</Text>
                   <TextInput
-                    style={styles.input}
+                    style={[styles.input, fieldError?.field === 'password' && styles.inputError]}
                     placeholder="Password"
                     placeholderTextColor="#6781A6"
                     value={formData.password}
-                    onChangeText={(text) => setFormData(prev => ({ ...prev, password: text }))}
+                    onChangeText={(text) => {
+                      setFormData(prev => ({ ...prev, password: text }));
+                      if (fieldError?.field === 'password') setFieldError(null);
+                    }}
                     secureTextEntry
                     autoComplete={isSignUp ? 'new-password' : 'current-password'}
                     textContentType={isSignUp ? 'newPassword' : 'password'}
                     returnKeyType="done"
                     editable={!isSigningIn}
                   />
+                  {fieldError?.field === 'password' && (
+                    <Text style={styles.fieldErrorText}>{fieldError.message}</Text>
+                  )}
                 </View>
 
                 <TouchableOpacity
@@ -308,6 +409,7 @@ export default function SignInScreen() {
                   setIsMagicLink(false);
                   setMagicLinkSent(false);
                   setErrorMessage('');
+                  setFieldError(null);
                   clearError();
                 }}
                 disabled={isSigningIn}
@@ -430,6 +532,15 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: '#F5F7FF',
     minHeight: 50,
+  },
+  inputError: {
+    borderColor: '#FF453A',
+  },
+  fieldErrorText: {
+    marginTop: 6,
+    marginLeft: 4,
+    fontSize: 12,
+    color: '#FF453A',
   },
   loginButton: {
     backgroundColor: '#007AFF',

--- a/app/(modals)/add-workout.tsx
+++ b/app/(modals)/add-workout.tsx
@@ -59,9 +59,13 @@ interface WheelPickerProps {
   onChange: (value: number) => void;
   accessibilityLabel?: string;
   formatValue?: (value: number) => string;
+  /** Lower bound for the numeric keypad fallback (inclusive). */
+  min?: number;
+  /** Upper bound for the numeric keypad fallback (inclusive). */
+  max?: number;
 }
 
-function WheelPicker({ label, values, selectedValue, onChange, accessibilityLabel, formatValue }: WheelPickerProps) {
+function WheelPicker({ label, values, selectedValue, onChange, accessibilityLabel, formatValue, min, max }: WheelPickerProps) {
   const listRef = useRef<FlatList<number>>(null);
   const loopData = useMemo(() => {
     const repeated = [] as number[];
@@ -72,6 +76,19 @@ function WheelPicker({ label, values, selectedValue, onChange, accessibilityLabe
   }, [values]);
 
   const middleSegmentStart = values.length * Math.floor(LOOP_MULTIPLIER / 2);
+  const [inputText, setInputText] = useState<string>(`${selectedValue}`);
+  const [inputFocused, setInputFocused] = useState(false);
+  const effectiveMin = min ?? (values.length > 0 ? Math.min(...values) : 0);
+  const effectiveMax = max ?? (values.length > 0 ? Math.max(...values) : 0);
+
+  // Keep the keypad value in sync with the wheel when the user scrolls. We
+  // only overwrite while the field isn't focused so in-flight edits aren't
+  // clobbered mid-keystroke.
+  useEffect(() => {
+    if (!inputFocused) {
+      setInputText(`${selectedValue}`);
+    }
+  }, [selectedValue, inputFocused]);
 
   useEffect(() => {
     const targetIndex = loopData.findIndex((value, index) => index >= middleSegmentStart && value === selectedValue);
@@ -95,6 +112,28 @@ function WheelPicker({ label, values, selectedValue, onChange, accessibilityLabe
     // Add haptic feedback when value changes
     Haptics.selectionAsync();
     onChange(value);
+  };
+
+  // Commit the keypad value: clamp to [min, max] and find the nearest
+  // allowed wheel value (handles non-contiguous sets like weight in 5 lb
+  // increments). Empty input clamps to the lower bound.
+  const commitInputText = (raw: string) => {
+    const digitsOnly = raw.replace(/[^0-9]/g, '');
+    if (!digitsOnly) {
+      onChange(effectiveMin);
+      setInputText(`${effectiveMin}`);
+      return;
+    }
+    const parsed = Number(digitsOnly);
+    const clamped = Math.max(effectiveMin, Math.min(effectiveMax, parsed));
+    let nearest = clamped;
+    if (values.length > 0) {
+      nearest = values.reduce((best, candidate) =>
+        Math.abs(candidate - clamped) < Math.abs(best - clamped) ? candidate : best,
+      values[0]);
+    }
+    onChange(nearest);
+    setInputText(`${nearest}`);
   };
 
   return (
@@ -123,6 +162,30 @@ function WheelPicker({ label, values, selectedValue, onChange, accessibilityLabe
         />
         <View pointerEvents="none" style={styles.wheelSelectionOverlay} />
       </View>
+      {/*
+        Wave-31 Pack A / A7 (#562): numeric keypad fallback for motor-
+        impaired users who can't precisely scroll the wheel. Two-way
+        sync: scrolling the wheel updates the field, typing commits on
+        blur / submit and snaps the wheel to the nearest allowed value.
+      */}
+      <TextInput
+        style={styles.wheelInput}
+        keyboardType="number-pad"
+        value={inputText}
+        onChangeText={setInputText}
+        onFocus={() => setInputFocused(true)}
+        onBlur={() => {
+          setInputFocused(false);
+          commitInputText(inputText);
+        }}
+        onSubmitEditing={() => commitInputText(inputText)}
+        selectTextOnFocus
+        returnKeyType="done"
+        accessibilityLabel={`${label} numeric input`}
+        accessibilityHint={`Enter a number between ${effectiveMin} and ${effectiveMax}`}
+        maxLength={5}
+        testID={`wheel-input-${label.toLowerCase()}`}
+      />
     </View>
   );
 }
@@ -276,13 +339,22 @@ export default function AddWorkoutScreen() {
           style={styles.gradientCard}
         >
           <View style={styles.wheelsRow}>
-            <WheelPicker label="Sets" values={SET_OPTIONS} selectedValue={sets} onChange={setSets} />
+            <WheelPicker
+              label="Sets"
+              values={SET_OPTIONS}
+              selectedValue={sets}
+              onChange={setSets}
+              min={1}
+              max={20}
+            />
             <WheelPicker
               label="Reps"
               values={REP_OPTIONS}
               selectedValue={reps}
               onChange={setReps}
               formatValue={(value) => (value === 0 ? '—' : `${value}`)}
+              min={0}
+              max={40}
             />
             <WheelPicker
               label="Weight"
@@ -290,6 +362,8 @@ export default function AddWorkoutScreen() {
               selectedValue={weight}
               onChange={setWeight}
               formatValue={(value) => (value === 0 ? '—' : `${value} lb`)}
+              min={0}
+              max={500}
             />
           </View>
         </LinearGradient>
@@ -502,6 +576,20 @@ const styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderColor: '#1B2E4A',
     backgroundColor: 'rgba(76, 140, 255, 0.08)',
+  },
+  wheelInput: {
+    marginTop: 8,
+    width: '100%',
+    backgroundColor: '#0F2339',
+    borderWidth: 1,
+    borderColor: '#1B2E4A',
+    borderRadius: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    fontSize: 16,
+    color: '#F5F7FF',
+    textAlign: 'center',
+    minHeight: 38,
   },
   saveButton: {
     flexDirection: 'row',

--- a/app/(modals)/followers.tsx
+++ b/app/(modals)/followers.tsx
@@ -109,19 +109,34 @@ export default function FollowersModal() {
     const profile = item.profile;
     const displayName = profile?.display_name || profile?.username || 'User';
     const displayInitial = displayName.charAt(0).toUpperCase();
+    // Wave-31 Pack A / A5 (#562): explicit per-row a11y so VoiceOver
+    // announces "{name}'s profile, double tap to open" rather than a
+    // generic "button". Decorative avatar / chevron are excluded from
+    // the a11y tree so the label isn't repeated.
+    const rowA11yLabel = `${displayName}'s profile`;
     return (
       <TouchableOpacity
         style={styles.row}
         onPress={() => profile?.user_id && router.push(`/(modals)/user-profile?userId=${profile.user_id}`)}
         activeOpacity={0.8}
         accessibilityRole="button"
-        accessibilityLabel={`Open ${displayName}'s profile`}
-        accessibilityHint="Navigates to this user profile"
+        accessibilityLabel={rowA11yLabel}
+        accessibilityHint="Double tap to open"
       >
         {profile?.avatar_url ? (
-          <Image source={{ uri: profile.avatar_url }} style={styles.avatar} />
+          <Image
+            source={{ uri: profile.avatar_url }}
+            style={styles.avatar}
+            accessible={false}
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+          />
         ) : (
-          <View style={[styles.avatar, styles.avatarFallback]}>
+          <View
+            style={[styles.avatar, styles.avatarFallback]}
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+          >
             <Text style={styles.avatarFallbackText}>{displayInitial}</Text>
           </View>
         )}

--- a/app/(tabs)/food.tsx
+++ b/app/(tabs)/food.tsx
@@ -138,8 +138,33 @@ export default function FoodScreen() {
     </TouchableOpacity>
   );
 
+  // Wave-31 Pack A / A6 (#562): long meal names ("Slow Cooker Chicken Teriyaki
+  // w/ Rice & Broccoli") get truncated to `numberOfLines=1` on the card title.
+  // Long-pressing the title now surfaces a full-text Alert with the macro
+  // breakdown so users don't have to open the detail view just to see the
+  // full name.
+  const handleLongPressFood = useCallback((item: FoodEntry) => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+    const dateLabel = new Date(item.date).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+    const macros = [
+      typeof item.protein === 'number' ? `${item.protein}g protein` : null,
+      typeof item.carbs === 'number' ? `${item.carbs}g carbs` : null,
+      typeof item.fat === 'number' ? `${item.fat}g fat` : null,
+    ].filter(Boolean) as string[];
+    const body = [
+      dateLabel,
+      typeof item.calories === 'number' ? `${item.calories} kcal` : null,
+      macros.length > 0 ? macros.join(' • ') : null,
+    ].filter(Boolean) as string[];
+    Alert.alert(item.name, body.join('\n'), [{ text: 'OK' }]);
+  }, []);
+
   const renderItem = ({ item }: { item: FoodEntry }) => (
-    <Swipeable 
+    <Swipeable
       ref={(ref) => {
         if (ref) {
           swipeableRefs.current.set(item.id, ref);
@@ -147,14 +172,16 @@ export default function FoodScreen() {
       }}
       renderRightActions={() => renderRightActions(item.id, item.name)}
     >
-      <TouchableOpacity 
+      <TouchableOpacity
         activeOpacity={0.9}
         accessibilityLabel={`${item.name} meal`}
-        accessibilityHint="Swipe left to reveal delete actions"
+        accessibilityHint="Swipe left to reveal delete actions, or long-press for full name and macros"
         onPress={() => {
           Haptics.selectionAsync();
           // Navigate to food detail
         }}
+        onLongPress={() => handleLongPressFood(item)}
+        delayLongPress={400}
         style={styles.cardWrapper}
       >
         <LinearGradient

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -613,25 +613,42 @@ export default function ProfileScreen() {
   };
 
   const handleClearDatabase = async () => {
+    // Wave-31 Pack A / A4 (#562): two-stage confirmation. The first prompt
+    // is informational and dismissible; the second spells out that the
+    // action is irreversible so a rapid double-tap on the row can't wipe
+    // local data accidentally.
     Alert.alert(
       '⚠️ Clear All Data',
       'This will delete ALL local data. Data on server will be preserved. Continue?',
       [
         { text: 'Cancel', style: 'cancel' },
         {
-          text: 'Clear All',
+          text: 'Continue',
           style: 'destructive',
-          onPress: async () => {
-            setIsClearing(true);
-            try {
-              await localDB.clearAllData();
-              await refreshDebugInfo();
-              Alert.alert('✅ Cleared', 'All local data has been cleared');
-            } catch {
-              Alert.alert('Error', 'Failed to clear data');
-            } finally {
-              setIsClearing(false);
-            }
+          onPress: () => {
+            Alert.alert(
+              'Are you sure?',
+              'This cannot be undone. Workouts, meals, and cached health data on this device will be erased. Server copies remain safe.',
+              [
+                { text: 'Keep My Data', style: 'cancel' },
+                {
+                  text: 'Yes, Erase Everything',
+                  style: 'destructive',
+                  onPress: async () => {
+                    setIsClearing(true);
+                    try {
+                      await localDB.clearAllData();
+                      await refreshDebugInfo();
+                      Alert.alert('✅ Cleared', 'All local data has been cleared');
+                    } catch {
+                      Alert.alert('Error', 'Failed to clear data');
+                    } finally {
+                      setIsClearing(false);
+                    }
+                  },
+                },
+              ]
+            );
           },
         },
       ]

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -6,6 +6,7 @@ import { DeleteAction } from '@/components';
 import { AskCoachCTA } from '@/components/form-tracking/AskCoachCTA';
 import { FormQualityBadgeRow } from '@/components/workouts/FormQualityBadgeRow';
 import { OverloadAnalyticsCard } from '@/components/workouts/OverloadAnalyticsCard';
+import { WorkoutCardSkeleton } from '@/components/workouts/WorkoutCardSkeleton';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUnits } from '@/contexts/UnitsContext';
 import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
@@ -18,7 +19,6 @@ import { exportSession } from '@/lib/services/session-export-service';
 import { isWorkoutCoachRecallEnabled } from '@/lib/services/workout-coach-recall-flag';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-    ActivityIndicator,
     Alert,
     FlatList,
     RefreshControl,
@@ -433,11 +433,19 @@ export default function WorkoutsScreen() {
     );
   };
 
+  // Skeleton placeholders on cold-load keep the tab usable on slow networks
+  // (#562/A1). Render 3 shimmer cards that mirror the real-card dimensions so
+  // users see structure instead of a blank spinner. When the fetch completes,
+  // the FlatList below takes over; when the list arrives empty, the empty
+  // state with illustration + CTA takes over.
   if (loading && !workouts.length) {
     return (
-      <View style={[styles.container, styles.loadingContainer]}>
-        <ActivityIndicator size="large" color="#007AFF" />
-        <Text style={styles.loadingText}>Loading your workouts</Text>
+      <View style={styles.container} testID="workouts-skeleton-container">
+        <View style={styles.list}>
+          <WorkoutCardSkeleton testID="workout-card-skeleton-0" />
+          <WorkoutCardSkeleton testID="workout-card-skeleton-1" />
+          <WorkoutCardSkeleton testID="workout-card-skeleton-2" />
+        </View>
       </View>
     );
   }

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -375,6 +375,9 @@ export default function WorkoutsScreen() {
             <View style={styles.cardFooter}>
               <TouchableOpacity
                 style={styles.actionButton}
+                accessibilityRole="button"
+                accessibilityLabel={`View ${item.exercise} details`}
+                accessibilityHint="Opens workout detail summary"
                 onPress={() => {
                   Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                   const lines = [
@@ -389,16 +392,19 @@ export default function WorkoutsScreen() {
                 }}
                 activeOpacity={0.7}
               >
-                <Ionicons name="eye-outline" size={16} color="#007AFF" />
+                <Ionicons name="eye-outline" size={16} color="#007AFF" accessible={false} />
                 <Text style={styles.actionText}>View</Text>
               </TouchableOpacity>
               <View style={styles.divider} />
               <TouchableOpacity
                 style={[styles.actionButton, styles.shareActionButton]}
+                accessibilityRole="button"
+                accessibilityLabel={`Share ${item.exercise} stats`}
+                accessibilityHint="Opens the native share sheet with your workout summary"
                 onPress={() => handleShareWorkout(item)}
                 activeOpacity={0.85}
               >
-                <Ionicons name="share-outline" size={18} color="#4C8CFF" />
+                <Ionicons name="share-outline" size={18} color="#4C8CFF" accessible={false} />
                 <View style={styles.shareTextWrapper}>
                   <Text style={[styles.actionText, styles.shareActionTitle]}>Share</Text>
                   <Text style={styles.actionSubtext}>Send stats</Text>
@@ -412,6 +418,8 @@ export default function WorkoutsScreen() {
                 confirmTitle="Delete workout?"
                 confirmMessage={`This will permanently remove \"${item.exercise}\".`}
                 style={styles.deleteAction}
+                accessibilityLabel={`Delete ${item.exercise}`}
+                accessibilityHint="Permanently removes this workout from your history"
               />
             </View>
             {coachRecallEnabled ? (

--- a/components/delete-action/DeleteAction.tsx
+++ b/components/delete-action/DeleteAction.tsx
@@ -12,6 +12,15 @@ export interface DeleteActionProps {
   size?: 'small' | 'medium';
   variant?: 'icon' | 'button';
   style?: object;
+  /**
+   * Optional override for the VoiceOver label. When omitted, `label` is
+   * used as-is (e.g. "Delete"). Use this to include the parent
+   * exercise / meal name so screen-reader users can distinguish between
+   * multiple delete buttons on the same tab.
+   */
+  accessibilityLabel?: string;
+  /** Optional VoiceOver hint — what happens when the button is activated. */
+  accessibilityHint?: string;
 }
 
 export function DeleteAction({
@@ -23,6 +32,8 @@ export function DeleteAction({
   size = 'medium',
   variant = 'button',
   style,
+  accessibilityLabel,
+  accessibilityHint,
 }: DeleteActionProps) {
   function handleConfirm() {
     if (Platform.OS !== 'web') {
@@ -64,7 +75,8 @@ export function DeleteAction({
   return (
     <TouchableOpacity
       accessibilityRole="button"
-      accessibilityLabel={label}
+      accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityHint={accessibilityHint}
       onPress={handleConfirm}
       style={[variant === 'button' ? styles.button : styles.iconOnly, style]}
       hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}

--- a/components/workouts/WorkoutCardSkeleton.tsx
+++ b/components/workouts/WorkoutCardSkeleton.tsx
@@ -1,0 +1,183 @@
+/**
+ * WorkoutCardSkeleton
+ *
+ * Lightweight shimmer placeholder that mirrors the dimensions of a real
+ * `Workout` card on the Workouts tab. Replaces the fullscreen
+ * ActivityIndicator used during the cold-load path — on slow networks
+ * users see the expected structure instead of a blank screen, which
+ * makes the wait feel significantly shorter. Designed to stack 3-5
+ * times inside `FlatList.ListEmptyComponent`.
+ *
+ * Keeps the visual tokens (rounded corners, border, dimensions, spacing)
+ * consistent with `styles.card` / `styles.cardGradient` from
+ * `styles/tabs/_workouts.styles.ts` so the transition when data arrives
+ * is imperceptible.
+ */
+import React, { useEffect, useRef } from 'react';
+import {
+  Animated,
+  Platform,
+  StyleSheet,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { CARD_HEIGHT, CARD_MARGIN } from '@/styles/tabs/_workouts.styles';
+
+export interface WorkoutCardSkeletonProps {
+  /** Optional wrapping style — callers may tweak margins per context. */
+  style?: StyleProp<ViewStyle>;
+  /** Optional testID override — defaults to `workout-card-skeleton`. */
+  testID?: string;
+}
+
+const SHIMMER_DURATION_MS = 1100;
+
+/**
+ * Single skeleton card. Consumers render 3-5 of these inside a FlatList
+ * `ListEmptyComponent` while the initial fetch is in flight.
+ */
+export function WorkoutCardSkeleton({
+  style,
+  testID = 'workout-card-skeleton',
+}: WorkoutCardSkeletonProps) {
+  const shimmer = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(shimmer, {
+          toValue: 1,
+          duration: SHIMMER_DURATION_MS,
+          useNativeDriver: Platform.OS !== 'web',
+        }),
+        Animated.timing(shimmer, {
+          toValue: 0,
+          duration: SHIMMER_DURATION_MS,
+          useNativeDriver: Platform.OS !== 'web',
+        }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [shimmer]);
+
+  const opacity = shimmer.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0.35, 0.75],
+  });
+
+  return (
+    <View
+      accessibilityLabel="Loading workout"
+      testID={testID}
+      style={[skeletonStyles.card, style]}
+    >
+      <View
+        style={skeletonStyles.inner}
+        importantForAccessibility="no-hide-descendants"
+        accessibilityElementsHidden
+      >
+        <View style={skeletonStyles.header}>
+          <Animated.View style={[skeletonStyles.titleBar, { opacity }]} />
+          <Animated.View style={[skeletonStyles.dateBar, { opacity }]} />
+        </View>
+
+        <View style={skeletonStyles.statsRow}>
+          <Animated.View style={[skeletonStyles.statBlock, { opacity }]} />
+          <Animated.View style={[skeletonStyles.statBlock, { opacity }]} />
+          <Animated.View style={[skeletonStyles.statBlock, { opacity }]} />
+          <Animated.View style={[skeletonStyles.statBlock, { opacity }]} />
+        </View>
+
+        <View style={skeletonStyles.footer}>
+          <Animated.View style={[skeletonStyles.footerBar, { opacity }]} />
+          <Animated.View style={[skeletonStyles.footerBar, { opacity }]} />
+          <Animated.View style={[skeletonStyles.footerBar, { opacity }]} />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+/**
+ * Convenience helper: render N skeleton cards. Default of 3 matches the
+ * first fold on most iOS devices.
+ */
+export function WorkoutCardSkeletonList({
+  count = 3,
+  testID = 'workout-card-skeleton-list',
+}: { count?: number; testID?: string }) {
+  return (
+    <View testID={testID}>
+      {Array.from({ length: Math.max(1, count) }).map((_, i) => (
+        <WorkoutCardSkeleton key={i} testID={`workout-card-skeleton-${i}`} />
+      ))}
+    </View>
+  );
+}
+
+const SKELETON_BG = '#12253E';
+const SKELETON_FG = '#1E3659';
+
+const skeletonStyles = StyleSheet.create({
+  card: {
+    marginBottom: CARD_MARGIN,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#1B2E4A',
+    backgroundColor: '#0F2339',
+    minHeight: CARD_HEIGHT,
+    overflow: 'hidden',
+  },
+  inner: {
+    padding: 20,
+    flex: 1,
+    justifyContent: 'space-between',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  titleBar: {
+    height: 20,
+    width: '55%',
+    borderRadius: 6,
+    backgroundColor: SKELETON_FG,
+  },
+  dateBar: {
+    height: 14,
+    width: 60,
+    borderRadius: 6,
+    backgroundColor: SKELETON_BG,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 16,
+    paddingHorizontal: 4,
+  },
+  statBlock: {
+    height: 36,
+    width: 48,
+    borderRadius: 8,
+    backgroundColor: SKELETON_FG,
+  },
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    borderTopWidth: 1,
+    borderTopColor: '#1B2E4A',
+    paddingTop: 12,
+  },
+  footerBar: {
+    height: 14,
+    width: 70,
+    borderRadius: 6,
+    backgroundColor: SKELETON_BG,
+  },
+});
+
+export default WorkoutCardSkeleton;

--- a/lib/arkit/ARKitBodyTracker.ios.ts
+++ b/lib/arkit/ARKitBodyTracker.ios.ts
@@ -7,22 +7,49 @@ import { Platform } from 'react-native';
 import { requireNativeModule } from 'expo-modules-core';
 import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
 
-// Load native module safely (don't throw during import)
+// Load native module safely (don't throw during import).
+//
+// Wave-31 Pack A / A2 (#562): we already try/catch this call so the JS
+// bundle doesn't tombstone when the native module is missing, but the
+// consumers (scan-arkit, pre-calibration, etc.) have no ergonomic way
+// to check availability without triggering the retry loop inside
+// `useBodyTracking`. Expose an explicit `moduleAvailable` boolean so
+// the UI can branch straight into a "device not supported" state and
+// skip the 8x300ms retry stall on truly-unsupported builds.
 let ARKitBodyTracker: any = null;
+let moduleAvailable = false;
+let moduleLoadError: unknown = null;
 try {
   if (__DEV__) {
     logWithTs('[ARKitBodyTracker] Attempting to load native module...');
   }
   ARKitBodyTracker = requireNativeModule('ARKitBodyTracker');
+  moduleAvailable = !!ARKitBodyTracker;
   if (__DEV__) {
-    logWithTs('[ARKitBodyTracker] Native module loaded:', !!ARKitBodyTracker);
+    logWithTs('[ARKitBodyTracker] Native module loaded:', moduleAvailable);
   }
 } catch (e) {
   // Log in ALL builds so we can diagnose Release issues
+  moduleLoadError = e;
   errorWithTs('[ARKitBodyTracker] FAILED to load native module:', e);
   errorWithTs('[ARKitBodyTracker] This will cause "Device not supported" error!');
   errorWithTs('[ARKitBodyTracker] Fix: Run `npx expo prebuild --clean --platform ios`');
 }
+
+/**
+ * `true` when the ARKitBodyTracker native module resolved at import time.
+ *
+ * Consumers can gate UI paths on this flag (show a friendly "ARKit not
+ * available on this build" screen) without invoking any BodyTracker
+ * methods first. Reads are safe on any device / thread.
+ */
+export const isARKitBodyTrackerAvailable = (): boolean => moduleAvailable;
+
+/**
+ * The error thrown when the native module failed to load, if any. Useful
+ * for surfacing in debug screens. `null` when the module loaded cleanly.
+ */
+export const getARKitBodyTrackerLoadError = (): unknown => moduleLoadError;
 
 /**
  * Represents a 3D joint position in world space (meters)

--- a/tests/unit/components/workouts/WorkoutCardSkeleton.test.tsx
+++ b/tests/unit/components/workouts/WorkoutCardSkeleton.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import {
+  WorkoutCardSkeleton,
+  WorkoutCardSkeletonList,
+} from '@/components/workouts/WorkoutCardSkeleton';
+
+describe('WorkoutCardSkeleton', () => {
+  it('renders with the default testID', () => {
+    const { getByTestId } = render(<WorkoutCardSkeleton />);
+    expect(getByTestId('workout-card-skeleton')).toBeTruthy();
+  });
+
+  it('honours a custom testID', () => {
+    const { getByTestId } = render(
+      <WorkoutCardSkeleton testID="skeleton-42" />,
+    );
+    expect(getByTestId('skeleton-42')).toBeTruthy();
+  });
+
+  it('marks the host with a loading label for screen readers', () => {
+    const { getByTestId } = render(<WorkoutCardSkeleton />);
+    const node = getByTestId('workout-card-skeleton');
+    // The root keeps a concise "Loading workout" label so VoiceOver users
+    // hear a single status announcement instead of descendants of the
+    // shimmer tree.
+    expect(node.props.accessibilityLabel).toBe('Loading workout');
+  });
+});
+
+describe('WorkoutCardSkeletonList', () => {
+  it('renders the default count of 3 skeletons', () => {
+    const { getByTestId, queryByTestId } = render(<WorkoutCardSkeletonList />);
+    expect(getByTestId('workout-card-skeleton-list')).toBeTruthy();
+    expect(getByTestId('workout-card-skeleton-0')).toBeTruthy();
+    expect(getByTestId('workout-card-skeleton-1')).toBeTruthy();
+    expect(getByTestId('workout-card-skeleton-2')).toBeTruthy();
+    expect(queryByTestId('workout-card-skeleton-3')).toBeNull();
+  });
+
+  it('honours an explicit count prop', () => {
+    const { getByTestId, queryByTestId } = render(
+      <WorkoutCardSkeletonList count={5} />,
+    );
+    for (let i = 0; i < 5; i += 1) {
+      expect(getByTestId(`workout-card-skeleton-${i}`)).toBeTruthy();
+    }
+    expect(queryByTestId('workout-card-skeleton-5')).toBeNull();
+  });
+
+  it('clamps count to at least 1 when caller passes 0 or negative', () => {
+    const { getByTestId, queryByTestId } = render(
+      <WorkoutCardSkeletonList count={0} />,
+    );
+    expect(getByTestId('workout-card-skeleton-0')).toBeTruthy();
+    expect(queryByTestId('workout-card-skeleton-1')).toBeNull();
+  });
+});

--- a/tests/unit/lib/arkit/ARKitBodyTracker-load-guard.test.ts
+++ b/tests/unit/lib/arkit/ARKitBodyTracker-load-guard.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression tests for the ARKitBodyTracker native-module load guard
+ * (wave-31 Pack A / A2 / #562). Ensures that when the iOS native module
+ * fails to resolve — e.g. unsupported device, stale build, or a broken
+ * pod install — the JS bundle:
+ *
+ *   1. does NOT throw during import (module load), and
+ *   2. exposes `isARKitBodyTrackerAvailable()` → `false`, and
+ *   3. the public BodyTracker surface no-ops instead of crashing, so
+ *      consumers can render a friendly "device not supported" screen.
+ *
+ * We test two cases:
+ *   - A) requireNativeModule throws → `moduleAvailable` is false
+ *   - B) requireNativeModule succeeds → `moduleAvailable` is true
+ */
+
+// Mock the logger so we don't spam test output with "FAILED to load …"
+jest.mock('@/lib/logger', () => ({
+  logWithTs: jest.fn(),
+  warnWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+}));
+
+describe('ARKitBodyTracker iOS load guard', () => {
+  const ORIGINAL_DEV = (global as any).__DEV__;
+
+  beforeEach(() => {
+    jest.resetModules();
+    (global as any).__DEV__ = false; // keep log output minimal
+  });
+
+  afterAll(() => {
+    (global as any).__DEV__ = ORIGINAL_DEV;
+  });
+
+  describe('when expo-modules-core throws on requireNativeModule', () => {
+    it('does not throw on module load and reports moduleAvailable === false', () => {
+      jest.doMock('expo-modules-core', () => ({
+        requireNativeModule: jest.fn(() => {
+          throw new Error('native ARKitBodyTracker not linked');
+        }),
+      }));
+
+      expect(() => {
+        // Importing should not throw even though the native require blew up
+        require('../../../../lib/arkit/ARKitBodyTracker.ios');
+      }).not.toThrow();
+
+      const mod = require('../../../../lib/arkit/ARKitBodyTracker.ios');
+      expect(typeof mod.isARKitBodyTrackerAvailable).toBe('function');
+      expect(mod.isARKitBodyTrackerAvailable()).toBe(false);
+
+      const loadError = mod.getARKitBodyTrackerLoadError();
+      expect(loadError).toBeInstanceOf(Error);
+      expect((loadError as Error).message).toMatch(/not linked/);
+    });
+
+    it('BodyTracker.isSupported() returns false without throwing', () => {
+      jest.doMock('expo-modules-core', () => ({
+        requireNativeModule: jest.fn(() => {
+          throw new Error('native module missing');
+        }),
+      }));
+
+      const { BodyTracker } = require('../../../../lib/arkit/ARKitBodyTracker.ios');
+      expect(() => BodyTracker.isSupported()).not.toThrow();
+      expect(BodyTracker.isSupported()).toBe(false);
+    });
+
+    it('BodyTracker stub methods no-op without throwing', () => {
+      jest.doMock('expo-modules-core', () => ({
+        requireNativeModule: jest.fn(() => {
+          throw new Error('native module missing');
+        }),
+      }));
+
+      const { BodyTracker } = require('../../../../lib/arkit/ARKitBodyTracker.ios');
+
+      // Stubs should return sensible defaults
+      expect(BodyTracker.getCurrentPose()).toBeNull();
+      expect(BodyTracker.getCurrentPose2D()).toBeNull();
+      expect(BodyTracker.getSupportDiagnostics()).toBeNull();
+
+      // void stubs should not throw
+      expect(() => BodyTracker.stopTracking()).not.toThrow();
+      expect(() => BodyTracker.setSubjectLockEnabled(true)).not.toThrow();
+      expect(() => BodyTracker.resetSubjectLock()).not.toThrow();
+    });
+
+    it('BodyTracker.startTracking rejects with an actionable error', async () => {
+      jest.doMock('expo-modules-core', () => ({
+        requireNativeModule: jest.fn(() => {
+          throw new Error('native module missing');
+        }),
+      }));
+
+      const { BodyTracker } = require('../../../../lib/arkit/ARKitBodyTracker.ios');
+      await expect(BodyTracker.startTracking()).rejects.toThrow(
+        /native module missing/i,
+      );
+    });
+  });
+
+  describe('when expo-modules-core returns a valid module', () => {
+    it('reports moduleAvailable === true and preserves native calls', () => {
+      const nativeIsSupported = jest.fn().mockReturnValue(true);
+      jest.doMock('expo-modules-core', () => ({
+        requireNativeModule: jest.fn(() => ({
+          isSupported: nativeIsSupported,
+          stopTracking: jest.fn(),
+        })),
+      }));
+
+      const {
+        isARKitBodyTrackerAvailable,
+        getARKitBodyTrackerLoadError,
+        BodyTracker,
+      } = require('../../../../lib/arkit/ARKitBodyTracker.ios');
+
+      expect(isARKitBodyTrackerAvailable()).toBe(true);
+      expect(getARKitBodyTrackerLoadError()).toBeNull();
+      expect(BodyTracker.isSupported()).toBe(true);
+      expect(nativeIsSupported).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Consolidates 8 form-UX + a11y findings from the wave-31 audit (issue #562). Zero file overlap with open PRs #548/#549/#554/#555/#559/#560/#561.

## Commits (8)

| # | Area | Change |
|---|------|--------|
| A1 | workouts | Skeleton cards replace blank spinner on cold-load |
| A2 | arkit | Graceful native-module load guard with `moduleAvailable` flag |
| A3 | workouts | `accessibilityLabel` + role on per-card View / Share / Delete actions |
| A4 | profile | Two-stage confirm on "Clear All Local Data" with irreversible copy |
| A5 | followers | Concise `{name}'s profile` label + "Double tap to open" hint |
| A6 | food | Long-press reveals full meal name + macros (Alert fallback) |
| A7 | add-workout | Numeric keypad alt input alongside wheel picker (min/max-clamped, two-way sync) |
| A8 | auth | Map Supabase errors to field-level inline copy + success toast on sign-up |

## Verification

- [x] `bun run lint` clean
- [x] `bun run check:types` clean
- [x] `bunx jest tests/unit/components/workouts/WorkoutCardSkeleton.test.tsx` — 6 pass
- [x] `bunx jest tests/unit/lib/arkit/ARKitBodyTracker-load-guard.test.ts` — 5 pass
- [x] Existing `form-quality-badge-row.test.tsx` still passes (7 tests — no regressions)

## Files touched (10)

- `app/(tabs)/workouts.tsx` (A1 + A3)
- `app/(tabs)/profile.tsx` (A4)
- `app/(tabs)/food.tsx` (A6)
- `app/(modals)/followers.tsx` (A5)
- `app/(modals)/add-workout.tsx` (A7)
- `app/(auth)/sign-in.tsx` (A8)
- `lib/arkit/ARKitBodyTracker.ios.ts` (A2)
- `components/workouts/WorkoutCardSkeleton.tsx` (A1, new)
- `components/delete-action/DeleteAction.tsx` (A3 — added optional a11y props; not in lock list)
- `tests/unit/lib/arkit/ARKitBodyTracker-load-guard.test.ts` (A2, new)
- `tests/unit/components/workouts/WorkoutCardSkeleton.test.tsx` (A1, new)

## Test plan

- [ ] Workouts tab: cold-launch with slow network simulated → 3 shimmer cards render until data arrives, then real cards replace them without flash
- [ ] VoiceOver on Workouts tab: each card announces "{exercise} workout" then per-action labels read "View {exercise} details" / "Share {exercise} stats" / "Delete {exercise}"
- [ ] Profile: tap "Clear All Local Data" → two consecutive Alerts, rapid double-tap cannot bypass
- [ ] Followers modal: VoiceOver reads "{name}'s profile, Double tap to open" once per row
- [ ] Food tab: long-press a meal card → Alert shows full name + macros; short tap unchanged
- [ ] Add-workout modal: type a number in each keypad → wheel snaps to matching value; scroll the wheel → keypad field updates
- [ ] Sign-up: enter an email already in use → inline "Email already exists. Sign in instead?" under email field with red border
- [ ] Sign-up success: see green "Account created — check your email" toast under the Alert

Closes #562