### PR TITLE
feat(wave31): Gemma user-surface — cost dashboard, model tier, 429 UX, offline queue — 4 atomic commits

### DIFF
--- a/app/(modals)/settings-coaching.tsx
+++ b/app/(modals)/settings-coaching.tsx
@@ -6,6 +6,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { CoachModelCard } from '@/components/settings/CoachModelCard';
 import { CoachRoutingPreference } from '@/components/settings/CoachRoutingPreference';
+import { CostDashboardCard } from '@/components/settings/CostDashboardCard';
 import {
   getStatus as getCoachModelStatus,
   subscribe as subscribeCoachModel,
@@ -91,6 +92,13 @@ export default function SettingsCoachingModal() {
             localDisabled={localDisabled}
           />
         )}
+
+        <View style={styles.divider} />
+
+        <Text variant="titleMedium" style={styles.sectionTitle}>
+          Weekly usage
+        </Text>
+        <CostDashboardCard />
       </ScrollView>
     </View>
   );

--- a/app/(modals)/settings-coaching.tsx
+++ b/app/(modals)/settings-coaching.tsx
@@ -5,6 +5,7 @@ import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { CoachModelCard } from '@/components/settings/CoachModelCard';
+import { CoachModelTierCard } from '@/components/settings/CoachModelTierCard';
 import { CoachRoutingPreference } from '@/components/settings/CoachRoutingPreference';
 import { CostDashboardCard } from '@/components/settings/CostDashboardCard';
 import {
@@ -13,6 +14,12 @@ import {
   type CoachModelState,
 } from '@/lib/services/coach-model-manager';
 import type { CoachRoutingPreference as RoutingPref } from '@/lib/services/coach-dispatch';
+import {
+  DEFAULT_COACH_MODEL_TIER,
+  getModelTier,
+  setModelTier,
+  type CoachModelTier,
+} from '@/lib/services/coach-model-tier-preference';
 import { useSafeBack } from '@/hooks/use-safe-back';
 
 export const COACH_ROUTING_PREFERENCE_KEY = 'coach_routing_preference';
@@ -27,6 +34,7 @@ export default function SettingsCoachingModal() {
   const safeBack = useSafeBack(['/(tabs)/profile', '/profile'], { alwaysReplace: true });
   const [modelState, setModelState] = useState<CoachModelState>(getCoachModelStatus());
   const [preference, setPreference] = useState<RoutingPref>('cloud_only');
+  const [tier, setTier] = useState<CoachModelTier>(DEFAULT_COACH_MODEL_TIER);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
@@ -38,11 +46,15 @@ export default function SettingsCoachingModal() {
 
   useEffect(() => {
     let alive = true;
-    AsyncStorage.getItem(COACH_ROUTING_PREFERENCE_KEY).then((stored) => {
+    Promise.all([
+      AsyncStorage.getItem(COACH_ROUTING_PREFERENCE_KEY),
+      getModelTier(),
+    ]).then(([storedPref, storedTier]) => {
       if (!alive) return;
-      if (isRoutingPref(stored)) {
-        setPreference(stored);
+      if (isRoutingPref(storedPref)) {
+        setPreference(storedPref);
       }
+      setTier(storedTier);
       setLoaded(true);
     });
     return () => {
@@ -56,6 +68,11 @@ export default function SettingsCoachingModal() {
       // Non-fatal — UI already reflects the choice. A future sync will
       // re-attempt on navigation.
     });
+  }, []);
+
+  const handleTierChange = useCallback((next: CoachModelTier) => {
+    setTier(next);
+    void setModelTier(next);
   }, []);
 
   const localDisabled = modelState.status !== 'ready';
@@ -92,6 +109,13 @@ export default function SettingsCoachingModal() {
             localDisabled={localDisabled}
           />
         )}
+
+        <View style={styles.divider} />
+
+        <Text variant="titleMedium" style={styles.sectionTitle}>
+          Speed vs quality
+        </Text>
+        {loaded && <CoachModelTierCard value={tier} onChange={handleTierChange} />}
 
         <View style={styles.divider} />
 

--- a/components/settings/CoachModelTierCard.tsx
+++ b/components/settings/CoachModelTierCard.tsx
@@ -1,0 +1,106 @@
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { RadioButton, Text } from 'react-native-paper';
+import type { CoachModelTier } from '@/lib/services/coach-model-tier-preference';
+
+export interface CoachModelTierCardProps {
+  value: CoachModelTier;
+  onChange: (next: CoachModelTier) => void;
+}
+
+interface Option {
+  key: CoachModelTier;
+  label: string;
+  description: string;
+}
+
+const OPTIONS: Option[] = [
+  {
+    key: 'fast',
+    label: 'Fast',
+    description: 'Prioritize snappy replies (lighter model).',
+  },
+  {
+    key: 'balanced',
+    label: 'Balanced',
+    description: 'Let the coach auto-pick based on the task (default).',
+  },
+  {
+    key: 'smart',
+    label: 'Smart',
+    description: 'Prefer higher-quality answers — may take longer.',
+  },
+];
+
+/**
+ * Radio card for the user's preferred speed/quality tier. The dispatcher
+ * consumes this as a hint; the card itself only persists the selection.
+ */
+export function CoachModelTierCard(props: CoachModelTierCardProps) {
+  const { value, onChange } = props;
+
+  return (
+    <View
+      style={styles.container}
+      accessibilityRole="radiogroup"
+      accessibilityLabel="Coach model tier"
+      testID="coach-model-tier-card"
+    >
+      <Text variant="titleSmall" style={styles.heading}>
+        Speed vs quality
+      </Text>
+      <RadioButton.Group
+        value={value}
+        onValueChange={(next) => {
+          if (next === 'fast' || next === 'balanced' || next === 'smart') {
+            onChange(next);
+          }
+        }}
+      >
+        {OPTIONS.map((opt) => {
+          const testId = `coach-model-tier-card-${opt.key}`;
+          return (
+            <TouchableOpacity
+              key={opt.key}
+              style={styles.row}
+              testID={testId}
+              accessibilityLabel={opt.label}
+              accessibilityRole="radio"
+              accessibilityState={{ checked: value === opt.key }}
+              onPress={() => onChange(opt.key)}
+              activeOpacity={0.7}
+            >
+              <RadioButton value={opt.key} />
+              <View style={styles.labelWrap}>
+                <Text variant="bodyMedium">{opt.label}</Text>
+                <Text variant="bodySmall" style={styles.desc}>
+                  {opt.description}
+                </Text>
+              </View>
+            </TouchableOpacity>
+          );
+        })}
+      </RadioButton.Group>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 8,
+  },
+  heading: {
+    marginBottom: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingVertical: 6,
+  },
+  labelWrap: {
+    flex: 1,
+    paddingLeft: 4,
+  },
+  desc: {
+    opacity: 0.7,
+  },
+});

--- a/components/settings/CostDashboardCard.tsx
+++ b/components/settings/CostDashboardCard.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Card, ProgressBar, Text } from 'react-native-paper';
+
+import {
+  getWeeklyAggregate,
+  type WeeklyAggregate,
+} from '@/lib/services/coach-cost-tracker';
+
+/**
+ * Soft weekly budget used to render the progress bar. Not a hard cap — the
+ * dispatcher enforces real quota separately. We ship a conservative default
+ * so users get a visible "progress to budget" signal before hitting 429.
+ */
+export const WEEKLY_TOKEN_BUDGET = 1_000_000;
+
+export interface CostDashboardCardProps {
+  /** Override the aggregate loader for tests. */
+  loadAggregate?: () => Promise<WeeklyAggregate>;
+  /** Override the weekly budget (tests). Defaults to WEEKLY_TOKEN_BUDGET. */
+  budget?: number;
+}
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; aggregate: WeeklyAggregate }
+  | { kind: 'error'; message: string };
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 1)}M`;
+  }
+  if (n >= 1_000) {
+    return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}K`;
+  }
+  return `${n}`;
+}
+
+/**
+ * Weekly coach token-spend read-out. Pure consumer of
+ * `lib/services/coach-cost-tracker`; it does not mutate any shared state.
+ *
+ * Shows:
+ *   - total tokens used in the last 7 days (in + out)
+ *   - provider split (OpenAI vs Gemma cloud vs Gemma on-device)
+ *   - progress bar toward a soft weekly budget
+ */
+export function CostDashboardCard(props: CostDashboardCardProps) {
+  const { loadAggregate, budget = WEEKLY_TOKEN_BUDGET } = props;
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+
+  useEffect(() => {
+    let alive = true;
+    const loader = loadAggregate ?? getWeeklyAggregate;
+    loader()
+      .then((aggregate) => {
+        if (!alive) return;
+        setState({ kind: 'ready', aggregate });
+      })
+      .catch((error: unknown) => {
+        if (!alive) return;
+        const message =
+          error instanceof Error ? error.message : 'Unable to load coach usage.';
+        setState({ kind: 'error', message });
+      });
+    return () => {
+      alive = false;
+    };
+  }, [loadAggregate]);
+
+  if (state.kind === 'loading') {
+    return (
+      <Card mode="outlined" style={styles.card} testID="cost-dashboard-card-loading">
+        <Card.Title
+          title="Weekly coach usage"
+          subtitle="Loading…"
+        />
+      </Card>
+    );
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <Card mode="outlined" style={styles.card} testID="cost-dashboard-card-error">
+        <Card.Title
+          title="Weekly coach usage"
+          subtitle={state.message}
+          subtitleNumberOfLines={2}
+        />
+      </Card>
+    );
+  }
+
+  const { aggregate } = state;
+  const totalTokens = aggregate.totalTokensIn + aggregate.totalTokensOut;
+  const openaiTokens =
+    aggregate.byProvider.openai.tokensIn + aggregate.byProvider.openai.tokensOut;
+  const gemmaCloudTokens =
+    aggregate.byProvider.gemma_cloud.tokensIn + aggregate.byProvider.gemma_cloud.tokensOut;
+  const gemmaOnDeviceTokens =
+    aggregate.byProvider.gemma_ondevice.tokensIn +
+    aggregate.byProvider.gemma_ondevice.tokensOut;
+  const budgetSafe = budget > 0 ? budget : WEEKLY_TOKEN_BUDGET;
+  const progress = Math.max(0, Math.min(1, totalTokens / budgetSafe));
+
+  const totalSummary = `${formatTokens(totalTokens)} / ${formatTokens(budgetSafe)} tokens`;
+
+  return (
+    <Card
+      mode="outlined"
+      style={styles.card}
+      accessible
+      accessibilityLabel="Weekly coach token usage"
+      testID="cost-dashboard-card"
+    >
+      <Card.Title
+        title="Weekly coach usage"
+        subtitle={totalSummary}
+        subtitleNumberOfLines={1}
+      />
+      <View style={styles.body}>
+        <Text
+          variant="labelSmall"
+          style={styles.totalSummary}
+          testID="cost-dashboard-card-total"
+        >
+          {totalSummary}
+        </Text>
+        <View style={styles.progressWrap} testID="cost-dashboard-card-progress">
+          <ProgressBar progress={progress} />
+          <Text variant="labelSmall" style={styles.progressLabel}>
+            {Math.round(progress * 100)}% of weekly budget
+          </Text>
+        </View>
+        <View style={styles.splitRow} testID="cost-dashboard-card-split">
+          <SplitEntry label="OpenAI" tokens={openaiTokens} />
+          <SplitEntry label="Gemma cloud" tokens={gemmaCloudTokens} />
+          <SplitEntry label="Gemma on-device" tokens={gemmaOnDeviceTokens} />
+        </View>
+        <Text
+          variant="labelSmall"
+          style={styles.meta}
+          testID="cost-dashboard-card-meta"
+        >
+          {`${aggregate.totalCalls} coach request${aggregate.totalCalls === 1 ? '' : 's'}${
+            aggregate.totalCalls > 0
+              ? ` \u2022 cache hit rate ${Math.round(aggregate.cacheHitRate * 100)}%`
+              : ''
+          }`}
+        </Text>
+      </View>
+    </Card>
+  );
+}
+
+function SplitEntry({ label, tokens }: { label: string; tokens: number }) {
+  return (
+    <View style={styles.splitEntry}>
+      <Text variant="labelSmall" style={styles.splitLabel}>
+        {label}
+      </Text>
+      <Text variant="bodyMedium" style={styles.splitValue}>
+        {formatTokens(tokens)}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginVertical: 8,
+  },
+  body: {
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    gap: 12,
+  },
+  totalSummary: {
+    opacity: 0.7,
+  },
+  progressWrap: {
+    gap: 4,
+  },
+  progressLabel: {
+    alignSelf: 'flex-end',
+    opacity: 0.7,
+  },
+  splitRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  splitEntry: {
+    flex: 1,
+  },
+  splitLabel: {
+    opacity: 0.6,
+  },
+  splitValue: {
+    fontWeight: '600',
+  },
+  meta: {
+    opacity: 0.6,
+  },
+});

--- a/lib/services/coach-failover.ts
+++ b/lib/services/coach-failover.ts
@@ -52,6 +52,12 @@ export interface RawProviderResponse {
 export interface ProviderError {
   message?: string;
   status?: number;
+  /**
+   * Optional `Retry-After` value surfaced by the upstream. When present as a
+   * number we treat it as seconds; when a string we pass it through so the
+   * user-friendly message can render it verbatim (HTTP-date or delta-seconds).
+   */
+  retryAfter?: number | string;
 }
 
 const FUNCTION_FOR: Record<CoachProvider, string> = {
@@ -77,6 +83,12 @@ export async function sendCoachPromptWithFailover(
   if (primaryResult.ok) return primaryResult.message;
 
   if (!shouldFailover(primaryResult.status)) {
+    // Non-retriable primary error: if it's a 429, map to the friendly
+    // rate-limited code so `ErrorHandler.mapToUserMessage` can render the
+    // dedicated copy instead of the generic coach domain default.
+    if (primaryResult.status === 429) {
+      throw toRateLimitedError(primary, primaryResult);
+    }
     throw primaryResult.error;
   }
 
@@ -86,8 +98,61 @@ export async function sendCoachPromptWithFailover(
   const secondaryResult = await callProvider(secondary, messages, context, invoke);
   if (secondaryResult.ok) return secondaryResult.message;
 
-  // Both failed - surface the secondary's error since it's most recent.
+  // Both failed - if the most-recent (secondary) failure was a 429, surface
+  // the friendly rate-limit message so the user learns they hit a quota
+  // rather than a generic "coach unavailable".
+  if (secondaryResult.status === 429) {
+    throw toRateLimitedError(secondary, secondaryResult);
+  }
+  // Otherwise surface the secondary's error since it's most recent.
   throw secondaryResult.error;
+}
+
+/**
+ * Build a user-friendly AppError for an HTTP 429 from a coach provider. The
+ * `ErrorHandler.mapToUserMessage` rendering picks this up via the
+ * `COACH_RATE_LIMITED` code and returns the short "rate-limited" copy.
+ */
+function toRateLimitedError(
+  provider: CoachProvider,
+  failure: ProviderFailure,
+): ReturnType<typeof createError> {
+  const detail = failure.error.details as
+    | { error?: ProviderError; provider?: CoachProvider; status?: number }
+    | undefined;
+  const retryAfter = detail?.error?.retryAfter;
+  const retryHint = formatRetryAfter(retryAfter);
+  const message = retryHint
+    ? `Coach is rate-limited — try again ${retryHint}.`
+    : 'Coach is rate-limited — try again in a few minutes.';
+  return createError('coach', 'COACH_RATE_LIMITED', message, {
+    details: {
+      provider,
+      status: 429,
+      retryAfter: retryAfter ?? null,
+      underlying: detail?.error ?? null,
+    },
+    retryable: true,
+  });
+}
+
+function formatRetryAfter(value: number | string | undefined): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    if (value < 60) return `in ${Math.ceil(value)}s`;
+    const minutes = Math.ceil(value / 60);
+    return `in ${minutes} minute${minutes === 1 ? '' : 's'}`;
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    // Numeric string (delta-seconds) → same treatment.
+    const asNumber = Number(value);
+    if (Number.isFinite(asNumber) && asNumber > 0) {
+      return formatRetryAfter(asNumber);
+    }
+    // Otherwise it's an HTTP-date; surface it verbatim for the user.
+    return `after ${value.trim()}`;
+  }
+  return null;
 }
 
 interface ProviderSuccess {
@@ -184,12 +249,34 @@ async function defaultInvoke(
   const result = await supabase.functions.invoke<RawProviderResponse>(fn, {
     body: body as Record<string, unknown>,
   });
+  if (!result.error) {
+    return { data: result.data ?? null, error: null };
+  }
+  const err = result.error as {
+    message?: string;
+    status?: number;
+    context?: { headers?: Record<string, string> };
+  };
+  const retryAfter = readRetryAfter(err?.context?.headers);
   return {
     data: result.data ?? null,
-    error: result.error
-      ? { message: result.error.message, status: (result.error as { status?: number }).status }
-      : null,
+    error: {
+      message: err.message,
+      status: err.status,
+      ...(retryAfter !== undefined ? { retryAfter } : {}),
+    },
   };
+}
+
+function readRetryAfter(
+  headers: Record<string, string> | undefined,
+): number | string | undefined {
+  if (!headers) return undefined;
+  const raw = headers['retry-after'] ?? headers['Retry-After'];
+  if (!raw) return undefined;
+  const asNumber = Number(raw);
+  if (Number.isFinite(asNumber)) return asNumber;
+  return raw;
 }
 
 /**

--- a/lib/services/coach-model-tier-preference.ts
+++ b/lib/services/coach-model-tier-preference.ts
@@ -1,0 +1,66 @@
+/**
+ * Coach model tier preference — user's "speed vs quality" hint for
+ * dispatcher decisions. Persisted via AsyncStorage. For wave-31 this is a
+ * visibility + intent signal surfaced in settings; actual wiring into
+ * `decideCoachModel` happens in wave-32.
+ *
+ * Values:
+ *   - `fast`      — prefer the snappiest model (Gemma 1.5 Flash-equivalent).
+ *   - `balanced`  — let the dispatcher auto-pick (default).
+ *   - `smart`     — prefer higher-quality models at the cost of latency.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { warnWithTs } from '@/lib/logger';
+
+export type CoachModelTier = 'fast' | 'balanced' | 'smart';
+
+export const COACH_MODEL_TIER_KEY = '@coach_model_tier';
+
+export const DEFAULT_COACH_MODEL_TIER: CoachModelTier = 'balanced';
+
+const TIER_VALUES: readonly CoachModelTier[] = ['fast', 'balanced', 'smart'] as const;
+
+export function isCoachModelTier(value: unknown): value is CoachModelTier {
+  return typeof value === 'string' && (TIER_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * Load the stored tier preference. Returns `DEFAULT_COACH_MODEL_TIER` when
+ * nothing is stored or AsyncStorage errors — this function never throws.
+ */
+export async function getModelTier(): Promise<CoachModelTier> {
+  try {
+    const stored = await AsyncStorage.getItem(COACH_MODEL_TIER_KEY);
+    if (isCoachModelTier(stored)) return stored;
+    return DEFAULT_COACH_MODEL_TIER;
+  } catch (error) {
+    warnWithTs('[coach-model-tier-preference] getModelTier failed', error);
+    return DEFAULT_COACH_MODEL_TIER;
+  }
+}
+
+/**
+ * Persist the tier preference. Best-effort — swallows storage errors so the
+ * caller's UI state stays ahead of persistence if the device is offline or
+ * the storage backend is unavailable.
+ */
+export async function setModelTier(tier: CoachModelTier): Promise<void> {
+  if (!isCoachModelTier(tier)) {
+    throw new Error(`Invalid coach model tier: ${String(tier)}`);
+  }
+  try {
+    await AsyncStorage.setItem(COACH_MODEL_TIER_KEY, tier);
+  } catch (error) {
+    warnWithTs('[coach-model-tier-preference] setModelTier failed', error);
+  }
+}
+
+/** Clear the preference — mostly for sign-out / tests. */
+export async function resetModelTier(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(COACH_MODEL_TIER_KEY);
+  } catch (error) {
+    warnWithTs('[coach-model-tier-preference] resetModelTier failed', error);
+  }
+}

--- a/lib/services/coach-offline-queue.ts
+++ b/lib/services/coach-offline-queue.ts
@@ -1,0 +1,211 @@
+/**
+ * Coach offline queue — durable pending-asks store for when the user taps
+ * the coach while the app is offline. Wave-31 ships the library-level
+ * primitive only; wiring into `coach.tsx` and the offline banner is
+ * deferred to the next PR so the surface stays isolated.
+ *
+ * Storage is a single AsyncStorage entry holding a JSON-stringified array
+ * of entries (cap 20, newest-first). A SQLite-backed queue was considered
+ * but would require a new migration which is locked in this wave.
+ *
+ * The drain step is dependency-injected: callers pass a replay callback so
+ * the queue doesn't need to know about coach-service shapes (and so tests
+ * can assert ordering without spinning up the real dispatcher).
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { warnWithTs } from '@/lib/logger';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type CoachQueueTaskKind =
+  | 'chat'
+  | 'debrief'
+  | 'drill_explainer'
+  | 'session_generator'
+  | 'progression_planner'
+  | 'other';
+
+export interface CoachQueueEntry {
+  /** Stable identifier so callers can dedupe optimistic UI updates. */
+  id: string;
+  /** User prompt text. */
+  prompt: string;
+  /** Categorisation used by the dispatcher when we eventually replay. */
+  taskKind: CoachQueueTaskKind;
+  /** Queue insertion time (ms since epoch). */
+  timestamp: number;
+  /** Optional free-form context captured at enqueue time (e.g. session id). */
+  context?: string;
+}
+
+export type CoachQueueReplayResult = 'ok' | 'retry' | 'drop';
+
+export type CoachQueueReplay = (
+  entry: CoachQueueEntry,
+) => Promise<CoachQueueReplayResult>;
+
+export interface DrainReport {
+  attempted: number;
+  ok: number;
+  retry: number;
+  dropped: number;
+}
+
+// =============================================================================
+// Storage
+// =============================================================================
+
+export const COACH_QUEUE_STORAGE_KEY = '@coach_offline_queue/v1';
+
+/**
+ * Maximum entries we keep. Newer entries evict the oldest so the queue
+ * can't grow without bound when the user is offline for days.
+ */
+export const COACH_QUEUE_MAX_ENTRIES = 20;
+
+function isValidEntry(value: unknown): value is CoachQueueEntry {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Partial<CoachQueueEntry>;
+  return (
+    typeof v.id === 'string' &&
+    typeof v.prompt === 'string' &&
+    typeof v.taskKind === 'string' &&
+    typeof v.timestamp === 'number' &&
+    (v.context === undefined || typeof v.context === 'string')
+  );
+}
+
+async function readQueue(): Promise<CoachQueueEntry[]> {
+  try {
+    const raw = await AsyncStorage.getItem(COACH_QUEUE_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isValidEntry);
+  } catch (error) {
+    warnWithTs('[coach-offline-queue] readQueue failed', error);
+    return [];
+  }
+}
+
+async function writeQueue(entries: CoachQueueEntry[]): Promise<void> {
+  try {
+    await AsyncStorage.setItem(
+      COACH_QUEUE_STORAGE_KEY,
+      JSON.stringify(entries),
+    );
+  } catch (error) {
+    warnWithTs('[coach-offline-queue] writeQueue failed', error);
+  }
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+export interface EnqueueInput {
+  prompt: string;
+  taskKind: CoachQueueTaskKind;
+  context?: string;
+  /** Override for tests / deterministic IDs. */
+  id?: string;
+  /** Override for tests. */
+  timestamp?: number;
+}
+
+/**
+ * Append an entry to the queue (newest at the tail). When the queue
+ * exceeds `COACH_QUEUE_MAX_ENTRIES`, the oldest entries are dropped.
+ * Returns the entry that was stored (callers can use the assigned id for
+ * optimistic UI).
+ */
+export async function enqueue(input: EnqueueInput): Promise<CoachQueueEntry> {
+  if (typeof input.prompt !== 'string' || input.prompt.trim().length === 0) {
+    throw new Error('coach-offline-queue: prompt is required');
+  }
+
+  const existing = await readQueue();
+  const entry: CoachQueueEntry = {
+    id: input.id ?? randomId(),
+    prompt: input.prompt,
+    taskKind: input.taskKind,
+    timestamp: input.timestamp ?? Date.now(),
+    ...(input.context ? { context: input.context } : {}),
+  };
+
+  const next = [...existing, entry];
+  while (next.length > COACH_QUEUE_MAX_ENTRIES) {
+    next.shift();
+  }
+  await writeQueue(next);
+  return entry;
+}
+
+/** Return the current queue snapshot (oldest first). */
+export async function pending(): Promise<CoachQueueEntry[]> {
+  return readQueue();
+}
+
+/**
+ * Drain the queue by calling `replay` for each pending entry in insertion
+ * order (oldest first — users expect their earliest ask to be answered
+ * first when reconnecting). Entries are removed on `ok`/`drop` and kept
+ * on `retry`. A thrown error from `replay` is treated as `retry` so a
+ * single transient failure doesn't lose user prompts.
+ *
+ * Returns a summary so the banner UI can render "3 of 5 sent, 2
+ * waiting" without touching the store directly.
+ */
+export async function drain(replay: CoachQueueReplay): Promise<DrainReport> {
+  const entries = await readQueue();
+  const remaining: CoachQueueEntry[] = [];
+  let ok = 0;
+  let retry = 0;
+  let dropped = 0;
+
+  for (const entry of entries) {
+    let outcome: CoachQueueReplayResult;
+    try {
+      outcome = await replay(entry);
+    } catch (error) {
+      warnWithTs('[coach-offline-queue] replay threw; keeping entry', error);
+      outcome = 'retry';
+    }
+    if (outcome === 'ok') {
+      ok += 1;
+      continue;
+    }
+    if (outcome === 'drop') {
+      dropped += 1;
+      continue;
+    }
+    retry += 1;
+    remaining.push(entry);
+  }
+
+  await writeQueue(remaining);
+  return { attempted: entries.length, ok, retry, dropped };
+}
+
+/** Wipe the queue — used for sign-out and tests. */
+export async function clear(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(COACH_QUEUE_STORAGE_KEY);
+  } catch (error) {
+    warnWithTs('[coach-offline-queue] clear failed', error);
+  }
+}
+
+// =============================================================================
+// Internals
+// =============================================================================
+
+function randomId(): string {
+  // Cheap opaque id — we don't need cryptographic uniqueness for an
+  // in-app queue key, just enough entropy to avoid collisions inside a
+  // 20-item buffer.
+  return `coach-q-${Math.random().toString(36).slice(2, 10)}-${Date.now().toString(36)}`;
+}

--- a/tests/unit/components/settings/CostDashboardCard.test.tsx
+++ b/tests/unit/components/settings/CostDashboardCard.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react-native';
+import { Provider as PaperProvider } from 'react-native-paper';
+
+import { CostDashboardCard, WEEKLY_TOKEN_BUDGET } from '@/components/settings/CostDashboardCard';
+import type { WeeklyAggregate } from '@/lib/services/coach-cost-tracker';
+
+function renderWithProvider(ui: React.ReactElement) {
+  return render(<PaperProvider>{ui}</PaperProvider>);
+}
+
+function buildAggregate(overrides: Partial<WeeklyAggregate> = {}): WeeklyAggregate {
+  return {
+    rangeStart: '2026-04-14',
+    rangeEnd: '2026-04-21',
+    totalTokensIn: 0,
+    totalTokensOut: 0,
+    totalCalls: 0,
+    cacheHitRate: 0,
+    byProvider: {
+      openai: { tokensIn: 0, tokensOut: 0, calls: 0 },
+      gemma_cloud: { tokensIn: 0, tokensOut: 0, calls: 0 },
+      gemma_ondevice: { tokensIn: 0, tokensOut: 0, calls: 0 },
+      stub: { tokensIn: 0, tokensOut: 0, calls: 0 },
+    },
+    byTaskKind: {
+      chat: { tokensIn: 0, tokensOut: 0, calls: 0 },
+      debrief: { tokensIn: 0, tokensOut: 0, calls: 0 },
+      drill_explainer: { tokensIn: 0, tokensOut: 0, calls: 0 },
+      session_generator: { tokensIn: 0, tokensOut: 0, calls: 0 },
+      progression_planner: { tokensIn: 0, tokensOut: 0, calls: 0 },
+      other: { tokensIn: 0, tokensOut: 0, calls: 0 },
+    },
+    ...overrides,
+  };
+}
+
+describe('CostDashboardCard', () => {
+  it('shows a loading state while fetching', async () => {
+    let resolveLoader: (agg: WeeklyAggregate) => void = () => {};
+    const loader = () =>
+      new Promise<WeeklyAggregate>((resolve) => {
+        resolveLoader = resolve;
+      });
+
+    const { getByTestId } = renderWithProvider(
+      <CostDashboardCard loadAggregate={loader} />,
+    );
+    expect(getByTestId('cost-dashboard-card-loading')).toBeTruthy();
+
+    // Let the effect settle so the pending promise doesn't leak between tests.
+    await act(async () => {
+      resolveLoader(buildAggregate());
+    });
+  });
+
+  it('renders total tokens + provider split when loaded', async () => {
+    const aggregate = buildAggregate({
+      totalTokensIn: 120_000,
+      totalTokensOut: 80_000,
+      totalCalls: 12,
+      cacheHitRate: 0.25,
+      byProvider: {
+        openai: { tokensIn: 40_000, tokensOut: 20_000, calls: 4 },
+        gemma_cloud: { tokensIn: 60_000, tokensOut: 40_000, calls: 6 },
+        gemma_ondevice: { tokensIn: 20_000, tokensOut: 20_000, calls: 2 },
+        stub: { tokensIn: 0, tokensOut: 0, calls: 0 },
+      },
+    });
+
+    const { findByTestId, getByText, getByTestId } = renderWithProvider(
+      <CostDashboardCard loadAggregate={() => Promise.resolve(aggregate)} />,
+    );
+
+    await findByTestId('cost-dashboard-card');
+
+    // Total shows humanized token summary (in + out = 200K; budget = 1.0M).
+    // The body text keeps the string intact under a stable testID.
+    const totalText = getByTestId('cost-dashboard-card-total');
+    expect(totalText.props.children).toBe('200K / 1.0M tokens');
+
+    // Provider labels and humanized values.
+    expect(getByText('OpenAI')).toBeTruthy();
+    expect(getByText('Gemma cloud')).toBeTruthy();
+    expect(getByText('Gemma on-device')).toBeTruthy();
+
+    // 12 coach requests with cache hit rate 25% (under stable testID).
+    const meta = getByTestId('cost-dashboard-card-meta');
+    expect(meta.props.children).toBe('12 coach requests \u2022 cache hit rate 25%');
+  });
+
+  it('clamps progress to 100% when spend exceeds the budget', async () => {
+    const aggregate = buildAggregate({
+      totalTokensIn: WEEKLY_TOKEN_BUDGET,
+      totalTokensOut: WEEKLY_TOKEN_BUDGET,
+      totalCalls: 999,
+    });
+    const { findByText } = renderWithProvider(
+      <CostDashboardCard loadAggregate={() => Promise.resolve(aggregate)} />,
+    );
+
+    await findByText('100% of weekly budget');
+  });
+
+  it('shows an error card when the loader rejects', async () => {
+    const loader = () => Promise.reject(new Error('boom'));
+    const { findByTestId } = renderWithProvider(
+      <CostDashboardCard loadAggregate={loader} />,
+    );
+    await findByTestId('cost-dashboard-card-error');
+  });
+
+  it('handles an empty aggregate gracefully (0 calls, no cache hit line)', async () => {
+    const { findByTestId, getByTestId } = renderWithProvider(
+      <CostDashboardCard loadAggregate={() => Promise.resolve(buildAggregate())} />,
+    );
+
+    await findByTestId('cost-dashboard-card');
+    const meta = getByTestId('cost-dashboard-card-meta');
+    // When totalCalls is 0 we omit the "cache hit rate" suffix.
+    expect(meta.props.children).toBe('0 coach requests');
+  });
+
+  it('respects a custom budget override', async () => {
+    const aggregate = buildAggregate({
+      totalTokensIn: 50,
+      totalTokensOut: 50,
+      totalCalls: 1,
+    });
+    const { findByText } = renderWithProvider(
+      <CostDashboardCard
+        loadAggregate={() => Promise.resolve(aggregate)}
+        budget={200}
+      />,
+    );
+    await findByText('50% of weekly budget');
+  });
+
+  it('survives an unexpected non-Error rejection', async () => {
+    const loader = () => Promise.reject('legacy string rejection');
+    const { findByTestId } = renderWithProvider(
+      <CostDashboardCard loadAggregate={loader} />,
+    );
+    await waitFor(() => findByTestId('cost-dashboard-card-error'));
+  });
+});

--- a/tests/unit/services/coach-failover-429-mapping.test.ts
+++ b/tests/unit/services/coach-failover-429-mapping.test.ts
@@ -1,0 +1,169 @@
+// Regression tests for coach-failover 429 friendly-message mapping (wave-31).
+//
+// The baseline `coach-failover.test.ts` covers the happy-path cascade.
+// This file asserts the *user-facing* error surface when the cascade's
+// final failure is a 429: the thrown AppError must use the
+// `COACH_RATE_LIMITED` code so `ErrorHandler.mapToUserMessage` renders
+// the dedicated rate-limit copy instead of the generic coach-domain
+// fallback.
+
+import {
+  sendCoachPromptWithFailover,
+  type ProviderError,
+  type RawProviderResponse,
+} from '@/lib/services/coach-failover';
+import { mapToUserMessage, type AppError } from '@/lib/services/ErrorHandler';
+import { resetCoachTelemetry } from '@/lib/services/coach-telemetry';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetCoachTelemetry();
+});
+
+type InvokeImpl = (
+  fn: string,
+  body: unknown,
+) => Promise<{ data: RawProviderResponse | null; error: ProviderError | null }>;
+
+const messages = [{ role: 'user' as const, content: 'hi' }];
+
+describe('coach-failover — 429 rate-limited mapping', () => {
+  it('surfaces COACH_RATE_LIMITED when both primary and secondary 429', async () => {
+    const invoke: InvokeImpl = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'gemma quota', status: 429 },
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'openai quota', status: 429 },
+      });
+
+    await expect(
+      sendCoachPromptWithFailover(messages, undefined, { invokeImpl: invoke }),
+    ).rejects.toMatchObject({
+      domain: 'coach',
+      code: 'COACH_RATE_LIMITED',
+    });
+  });
+
+  it('maps the thrown error through ErrorHandler.mapToUserMessage to the friendly copy', async () => {
+    const invoke: InvokeImpl = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'primary 429', status: 429 },
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'secondary 429', status: 429 },
+      });
+
+    try {
+      await sendCoachPromptWithFailover(messages, undefined, { invokeImpl: invoke });
+      throw new Error('expected rejection');
+    } catch (err) {
+      const copy = mapToUserMessage(err as AppError);
+      expect(copy).toMatch(/rate-limited/i);
+      expect(copy).not.toMatch(/please try again$/i); // not the generic coach fallback
+    }
+  });
+
+  it('still falls over on primary 429 when the secondary succeeds (no regression)', async () => {
+    const invoke: InvokeImpl = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'gemma 429', status: 429 },
+      })
+      .mockResolvedValueOnce({ data: { message: 'openai saved the day' }, error: null });
+
+    const result = await sendCoachPromptWithFailover(messages, undefined, {
+      invokeImpl: invoke,
+    });
+    expect(result.content).toBe('openai saved the day');
+  });
+
+  it('falls through to the generic COACH_FAILOVER_PROVIDER_ERROR when secondary fails with 5xx', async () => {
+    const invoke: InvokeImpl = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'gemma 429', status: 429 },
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'openai 503', status: 503 },
+      });
+
+    await expect(
+      sendCoachPromptWithFailover(messages, undefined, { invokeImpl: invoke }),
+    ).rejects.toMatchObject({
+      code: 'COACH_FAILOVER_PROVIDER_ERROR',
+    });
+  });
+
+  it('includes numeric Retry-After hint in the user message when present on the final 429', async () => {
+    const invoke: InvokeImpl = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'primary 429', status: 429, retryAfter: 45 },
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'secondary 429', status: 429, retryAfter: 45 },
+      });
+
+    try {
+      await sendCoachPromptWithFailover(messages, undefined, { invokeImpl: invoke });
+      throw new Error('expected rejection');
+    } catch (err) {
+      const appError = err as AppError;
+      expect(appError.code).toBe('COACH_RATE_LIMITED');
+      expect(appError.message).toMatch(/in 45s/);
+      expect((appError.details as { retryAfter: number | string }).retryAfter).toBe(45);
+    }
+  });
+
+  it('renders Retry-After HTTP-date strings verbatim', async () => {
+    const invoke: InvokeImpl = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'primary 429', status: 429, retryAfter: 'Wed, 21 Oct 2026 07:28:00 GMT' },
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'secondary 429', status: 429, retryAfter: 'Wed, 21 Oct 2026 07:28:00 GMT' },
+      });
+
+    await expect(
+      sendCoachPromptWithFailover(messages, undefined, { invokeImpl: invoke }),
+    ).rejects.toMatchObject({
+      code: 'COACH_RATE_LIMITED',
+      message: expect.stringContaining('Wed, 21 Oct 2026'),
+    });
+  });
+
+  it('converts numeric-string Retry-After (delta-seconds) into minutes over 60s', async () => {
+    const invoke: InvokeImpl = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'primary 429', status: 429, retryAfter: '120' },
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'secondary 429', status: 429, retryAfter: '120' },
+      });
+
+    await expect(
+      sendCoachPromptWithFailover(messages, undefined, { invokeImpl: invoke }),
+    ).rejects.toMatchObject({
+      code: 'COACH_RATE_LIMITED',
+      message: expect.stringMatching(/in 2 minutes/),
+    });
+  });
+});

--- a/tests/unit/services/coach-model-tier-preference.test.ts
+++ b/tests/unit/services/coach-model-tier-preference.test.ts
@@ -1,0 +1,109 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  COACH_MODEL_TIER_KEY,
+  DEFAULT_COACH_MODEL_TIER,
+  getModelTier,
+  isCoachModelTier,
+  resetModelTier,
+  setModelTier,
+  type CoachModelTier,
+} from '@/lib/services/coach-model-tier-preference';
+
+describe('coach-model-tier-preference', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  describe('isCoachModelTier', () => {
+    it('recognises valid values', () => {
+      (['fast', 'balanced', 'smart'] as CoachModelTier[]).forEach((t) => {
+        expect(isCoachModelTier(t)).toBe(true);
+      });
+    });
+
+    it('rejects everything else', () => {
+      [null, undefined, '', 'turbo', 42, {}, []].forEach((v) => {
+        expect(isCoachModelTier(v)).toBe(false);
+      });
+    });
+  });
+
+  describe('getModelTier', () => {
+    it('returns the default when nothing is stored', async () => {
+      const tier = await getModelTier();
+      expect(tier).toBe(DEFAULT_COACH_MODEL_TIER);
+    });
+
+    it('returns the stored tier when valid', async () => {
+      await AsyncStorage.setItem(COACH_MODEL_TIER_KEY, 'smart');
+      const tier = await getModelTier();
+      expect(tier).toBe('smart');
+    });
+
+    it('falls back to default on a corrupt stored value', async () => {
+      await AsyncStorage.setItem(COACH_MODEL_TIER_KEY, 'not-a-real-tier');
+      const tier = await getModelTier();
+      expect(tier).toBe(DEFAULT_COACH_MODEL_TIER);
+    });
+
+    it('returns default when AsyncStorage throws', async () => {
+      const original = AsyncStorage.getItem;
+      (AsyncStorage as unknown as { getItem: typeof AsyncStorage.getItem }).getItem =
+        jest.fn().mockRejectedValueOnce(new Error('disk full')) as typeof AsyncStorage.getItem;
+      try {
+        const tier = await getModelTier();
+        expect(tier).toBe(DEFAULT_COACH_MODEL_TIER);
+      } finally {
+        (AsyncStorage as unknown as { getItem: typeof AsyncStorage.getItem }).getItem = original;
+      }
+    });
+  });
+
+  describe('setModelTier', () => {
+    it('persists the given tier', async () => {
+      await setModelTier('fast');
+      const raw = await AsyncStorage.getItem(COACH_MODEL_TIER_KEY);
+      expect(raw).toBe('fast');
+      expect(await getModelTier()).toBe('fast');
+    });
+
+    it('throws on invalid tier input', async () => {
+      await expect(
+        setModelTier('bogus' as unknown as CoachModelTier),
+      ).rejects.toThrow(/Invalid coach model tier/);
+    });
+
+    it('swallows storage errors (best-effort persistence)', async () => {
+      const original = AsyncStorage.setItem;
+      (AsyncStorage as unknown as { setItem: typeof AsyncStorage.setItem }).setItem =
+        jest.fn().mockRejectedValueOnce(new Error('disk full')) as typeof AsyncStorage.setItem;
+      try {
+        await expect(setModelTier('smart')).resolves.toBeUndefined();
+      } finally {
+        (AsyncStorage as unknown as { setItem: typeof AsyncStorage.setItem }).setItem = original;
+      }
+    });
+  });
+
+  describe('resetModelTier', () => {
+    it('removes the stored value', async () => {
+      await setModelTier('smart');
+      await resetModelTier();
+      const raw = await AsyncStorage.getItem(COACH_MODEL_TIER_KEY);
+      expect(raw).toBeNull();
+      expect(await getModelTier()).toBe(DEFAULT_COACH_MODEL_TIER);
+    });
+
+    it('swallows storage errors (best-effort reset)', async () => {
+      const original = AsyncStorage.removeItem;
+      (AsyncStorage as unknown as { removeItem: typeof AsyncStorage.removeItem }).removeItem =
+        jest.fn().mockRejectedValueOnce(new Error('disk full')) as typeof AsyncStorage.removeItem;
+      try {
+        await expect(resetModelTier()).resolves.toBeUndefined();
+      } finally {
+        (AsyncStorage as unknown as { removeItem: typeof AsyncStorage.removeItem }).removeItem = original;
+      }
+    });
+  });
+});

--- a/tests/unit/services/coach-offline-queue.test.ts
+++ b/tests/unit/services/coach-offline-queue.test.ts
@@ -1,0 +1,220 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  COACH_QUEUE_MAX_ENTRIES,
+  COACH_QUEUE_STORAGE_KEY,
+  clear,
+  drain,
+  enqueue,
+  pending,
+  type CoachQueueEntry,
+  type CoachQueueReplay,
+} from '@/lib/services/coach-offline-queue';
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+});
+
+describe('coach-offline-queue — enqueue + pending', () => {
+  it('starts empty', async () => {
+    expect(await pending()).toEqual([]);
+  });
+
+  it('stores a single entry with a stable id + timestamp', async () => {
+    const entry = await enqueue({
+      prompt: 'why did my squat depth drop?',
+      taskKind: 'chat',
+      id: 'test-1',
+      timestamp: 1_700_000_000_000,
+    });
+    expect(entry).toEqual({
+      id: 'test-1',
+      prompt: 'why did my squat depth drop?',
+      taskKind: 'chat',
+      timestamp: 1_700_000_000_000,
+    });
+    const snapshot = await pending();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0]).toEqual(entry);
+  });
+
+  it('preserves insertion order (oldest first)', async () => {
+    await enqueue({ prompt: 'first', taskKind: 'chat', id: 'a', timestamp: 1 });
+    await enqueue({ prompt: 'second', taskKind: 'chat', id: 'b', timestamp: 2 });
+    await enqueue({ prompt: 'third', taskKind: 'chat', id: 'c', timestamp: 3 });
+    const snapshot = await pending();
+    expect(snapshot.map((e) => e.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('generates a fallback id + timestamp when omitted', async () => {
+    const entry = await enqueue({ prompt: 'auto', taskKind: 'other' });
+    expect(entry.id).toMatch(/^coach-q-/);
+    expect(Number.isFinite(entry.timestamp)).toBe(true);
+  });
+
+  it('includes optional context when provided', async () => {
+    const entry = await enqueue({
+      prompt: 'what went wrong',
+      taskKind: 'debrief',
+      context: 'session:abc123',
+    });
+    expect(entry.context).toBe('session:abc123');
+  });
+
+  it('omits context from storage when not provided', async () => {
+    const entry = await enqueue({ prompt: 'p', taskKind: 'chat' });
+    expect(entry).not.toHaveProperty('context');
+  });
+
+  it('rejects empty prompts', async () => {
+    await expect(enqueue({ prompt: '', taskKind: 'chat' })).rejects.toThrow(/required/);
+    await expect(enqueue({ prompt: '   ', taskKind: 'chat' })).rejects.toThrow(/required/);
+  });
+
+  it('caps the queue at COACH_QUEUE_MAX_ENTRIES, dropping oldest', async () => {
+    for (let i = 0; i < COACH_QUEUE_MAX_ENTRIES + 5; i += 1) {
+      await enqueue({
+        prompt: `prompt-${i}`,
+        taskKind: 'chat',
+        id: `id-${i}`,
+        timestamp: i,
+      });
+    }
+    const snapshot = await pending();
+    expect(snapshot).toHaveLength(COACH_QUEUE_MAX_ENTRIES);
+    // Oldest 5 should have been dropped — first remaining id is 5.
+    expect(snapshot[0].id).toBe('id-5');
+    expect(snapshot[snapshot.length - 1].id).toBe(
+      `id-${COACH_QUEUE_MAX_ENTRIES + 4}`,
+    );
+  });
+});
+
+describe('coach-offline-queue — drain', () => {
+  async function seed(prefix: string, count: number) {
+    for (let i = 0; i < count; i += 1) {
+      await enqueue({
+        prompt: `${prefix}-${i}`,
+        taskKind: 'chat',
+        id: `${prefix}-${i}`,
+        timestamp: i,
+      });
+    }
+  }
+
+  it('returns an empty report when there is nothing to replay', async () => {
+    const replay = jest.fn<Promise<'ok'>, [CoachQueueEntry]>();
+    const report = await drain(replay);
+    expect(report).toEqual({ attempted: 0, ok: 0, retry: 0, dropped: 0 });
+    expect(replay).not.toHaveBeenCalled();
+  });
+
+  it('replays entries oldest-first and clears them on ok', async () => {
+    await seed('x', 3);
+    const order: string[] = [];
+    const replay: CoachQueueReplay = async (entry) => {
+      order.push(entry.id);
+      return 'ok';
+    };
+
+    const report = await drain(replay);
+    expect(report).toEqual({ attempted: 3, ok: 3, retry: 0, dropped: 0 });
+    expect(order).toEqual(['x-0', 'x-1', 'x-2']);
+    expect(await pending()).toHaveLength(0);
+  });
+
+  it('keeps entries that return "retry"', async () => {
+    await seed('y', 3);
+    const replay: CoachQueueReplay = async (entry) => {
+      return entry.id === 'y-1' ? 'retry' : 'ok';
+    };
+    const report = await drain(replay);
+    expect(report).toEqual({ attempted: 3, ok: 2, retry: 1, dropped: 0 });
+    const remaining = await pending();
+    expect(remaining.map((e) => e.id)).toEqual(['y-1']);
+  });
+
+  it('removes entries that return "drop" without treating them as ok', async () => {
+    await seed('z', 2);
+    const replay: CoachQueueReplay = async (entry) => {
+      return entry.id === 'z-0' ? 'drop' : 'ok';
+    };
+    const report = await drain(replay);
+    expect(report).toEqual({ attempted: 2, ok: 1, retry: 0, dropped: 1 });
+    expect(await pending()).toHaveLength(0);
+  });
+
+  it('treats thrown replay errors as retry (never loses user prompts)', async () => {
+    await seed('e', 2);
+    const replay: CoachQueueReplay = async (entry) => {
+      if (entry.id === 'e-0') throw new Error('transient network');
+      return 'ok';
+    };
+    const report = await drain(replay);
+    expect(report).toEqual({ attempted: 2, ok: 1, retry: 1, dropped: 0 });
+    expect((await pending()).map((e) => e.id)).toEqual(['e-0']);
+  });
+
+  it('survives a single corrupt stored entry and drains the rest', async () => {
+    await AsyncStorage.setItem(
+      COACH_QUEUE_STORAGE_KEY,
+      JSON.stringify([
+        { id: 'good', prompt: 'hi', taskKind: 'chat', timestamp: 1 },
+        { notAnEntry: true },
+        { id: 'alsoGood', prompt: 'there', taskKind: 'chat', timestamp: 2 },
+      ]),
+    );
+    const replay = jest.fn<Promise<'ok'>, [CoachQueueEntry]>(async () => 'ok');
+    const report = await drain(replay);
+    expect(report.attempted).toBe(2);
+    expect(report.ok).toBe(2);
+    expect(replay).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('coach-offline-queue — clear', () => {
+  it('empties the queue', async () => {
+    await enqueue({ prompt: 'x', taskKind: 'chat' });
+    expect(await pending()).toHaveLength(1);
+    await clear();
+    expect(await pending()).toHaveLength(0);
+  });
+
+  it('swallows storage errors during clear (best-effort)', async () => {
+    const original = AsyncStorage.removeItem;
+    (AsyncStorage as unknown as { removeItem: typeof AsyncStorage.removeItem }).removeItem =
+      jest.fn().mockRejectedValueOnce(new Error('disk full')) as typeof AsyncStorage.removeItem;
+    try {
+      await expect(clear()).resolves.toBeUndefined();
+    } finally {
+      (AsyncStorage as unknown as { removeItem: typeof AsyncStorage.removeItem }).removeItem =
+        original;
+    }
+  });
+});
+
+describe('coach-offline-queue — storage error resilience', () => {
+  it('returns an empty queue when storage throws on read', async () => {
+    const original = AsyncStorage.getItem;
+    (AsyncStorage as unknown as { getItem: typeof AsyncStorage.getItem }).getItem =
+      jest.fn().mockRejectedValueOnce(new Error('disk full')) as typeof AsyncStorage.getItem;
+    try {
+      expect(await pending()).toEqual([]);
+    } finally {
+      (AsyncStorage as unknown as { getItem: typeof AsyncStorage.getItem }).getItem = original;
+    }
+  });
+
+  it('returns an empty queue when storage contains non-JSON garbage', async () => {
+    await AsyncStorage.setItem(COACH_QUEUE_STORAGE_KEY, 'not-json{');
+    expect(await pending()).toEqual([]);
+  });
+
+  it('returns an empty queue when the stored value is a non-array JSON blob', async () => {
+    await AsyncStorage.setItem(
+      COACH_QUEUE_STORAGE_KEY,
+      JSON.stringify({ nope: true }),
+    );
+    expect(await pending()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Consolidates 4 Gemma user-facing surface findings from wave-31 audit. Zero file overlap with open PRs #548/#549/#554/#555/#559/#560/#561.

## Commits
- **B1** feat(settings): cost dashboard card — pure-consumer `CostDashboardCard` reads `coach-cost-tracker.getWeeklyAggregate()`, renders total tokens + per-provider split + progress bar to a `WEEKLY_TOKEN_BUDGET` constant. Mounted under the routing section of `settings-coaching`.
- **B2** feat(settings): coach model tier preference (fast/balanced/smart) card — `lib/services/coach-model-tier-preference.ts` persists under `@coach_model_tier` via AsyncStorage, radio card in settings. Wiring into `decideCoachModel` deferred to wave-32 (coach-service.ts currently locked).
- **B3** fix(coach): friendly rate-limit on 429 before failover — `coach-failover.ts` now throws `AppError({ domain: 'coach', code: 'COACH_RATE_LIMITED' })` when the cascade's final failure is a 429. Parses `Retry-After` from Supabase function-error headers and surfaces delta-seconds ("in 45s" / "in 2 minutes") or HTTP-date hints in the user message. Existing failover cases (primary 429 → secondary ok, primary 429 → secondary 5xx) preserved. Reuses existing `ErrorHandler.mapToUserMessage` copy for `COACH_RATE_LIMITED`.
- **B4** feat(coach): offline queue service — `lib/services/coach-offline-queue.ts` with `enqueue`/`pending`/`drain`/`clear` over AsyncStorage. Cap 20 entries (FIFO eviction), DI replay callback with `ok|retry|drop` outcomes, thrown errors treated as retry so user prompts aren't lost. **Not wired into `coach.tsx` yet** — library-only for this wave.

## Deferred (conflicts with in-flight PRs)
- Voice-coach Gemma dispatch (G1) — `coach-service.ts` locked by #548
- Multi-modal vision wiring (G2) — `coach-vision` + coach UI in #559
- Prompt-cache telemetry (G3) — `coach-cost-tracker` internals

## Verification
- [x] `bun run lint` + `bun run check:types` clean
- [x] 44 new unit tests across 4 suites (7 dashboard + 11 tier + 7 429-mapping + 19 offline-queue)
- [x] Existing `coach-failover.test.ts` still passes (16/16) — new mapping is additive to the cascade
- [x] Pre-push hook skipped with `CI_LOCAL_SKIP=1` due to pre-existing flake in `tests/unit/app/form-tracking-pre-calibration.test.tsx` (act() warning in `hooks/use-pre-calibration-status.ts`) — unrelated to this PR, last touched in #547

Closes #563