### PR TITLE
test(wave31): context coverage + NetworkContext stale-closure fix — 6 atomic commits

### DIFF
--- a/contexts/NetworkContext.tsx
+++ b/contexts/NetworkContext.tsx
@@ -18,10 +18,17 @@ export const NetworkProvider = ({ children }: { children: ReactNode }) => {
   const [isConnected, setIsConnected] = useState(true);
   const [networkType, setNetworkType] = useState<string | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Guards state setters against stale-closure invocations after unmount.
+  // `expo-network`'s `getNetworkStateAsync()` is not abortable, so an
+  // in-flight poll can still resolve after cleanup — we gate every
+  // `setState` on this flag rather than let React 18 emit the
+  // "can't perform a React state update on an unmounted component" warning.
+  const mountedRef = useRef(true);
 
   const checkNetworkStatus = useCallback(async () => {
     try {
       const networkState = await Network.getNetworkStateAsync();
+      if (!mountedRef.current) return;
       setIsOnline(networkState.isInternetReachable ?? true);
       setIsConnected(networkState.isConnected ?? true);
       setNetworkType(networkState.type || null);
@@ -32,6 +39,7 @@ export const NetworkProvider = ({ children }: { children: ReactNode }) => {
         type: networkState.type,
       });
     } catch (error) {
+      if (!mountedRef.current) return;
       console.error('[NetworkContext] Error checking network status:', error);
       // Default to online if we can't determine status
       setIsOnline(true);
@@ -40,6 +48,8 @@ export const NetworkProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   useEffect(() => {
+    mountedRef.current = true;
+
     // Check initial network status
     checkNetworkStatus();
 
@@ -52,6 +62,7 @@ export const NetworkProvider = ({ children }: { children: ReactNode }) => {
     intervalRef.current = setInterval(checkNetworkStatus, 30000);
 
     return () => {
+      mountedRef.current = false;
       if (intervalRef.current !== null) {
         clearInterval(intervalRef.current);
         intervalRef.current = null;

--- a/tests/unit/contexts/FoodContext.test.tsx
+++ b/tests/unit/contexts/FoodContext.test.tsx
@@ -1,0 +1,315 @@
+/**
+ * FoodContext CRUD + sync queue regression coverage (wave-31, Pack C / C4).
+ *
+ * Complements the existing `food-context.test.tsx` (initialization / basic
+ * CRUD / refresh) with scenarios targeting the sync-queue transitions that
+ * were previously uncovered:
+ *
+ *   - add -> sync-success: syncToSupabase resolves cleanly, no toast
+ *   - add -> sync-failure: rejection is caught inside the fire-and-forget
+ *     `void syncToSupabase()` and surfaces a toast, but local write and
+ *     UI state are unaffected
+ *   - delete -> offline: no sync attempt, UI still updates, soft-delete
+ *     persists in the local DB
+ *   - delete -> online replay: deleted item stays deleted after an incoming
+ *     realtime onSyncComplete reloads from local DB
+ *   - queue recovery after failure: a later addFood re-attempts the sync
+ *     even if an earlier call failed — the failure does not "jam" the
+ *     context
+ *
+ * Uses the same localDB/syncService mocks as the sister suite to keep
+ * assumptions aligned, but under a different file path.
+ */
+
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import type * as FoodContextModule from '@/contexts/FoodContext';
+import type { FoodEntry } from '@/contexts/FoodContext';
+import { ToastProvider } from '@/contexts/ToastContext';
+
+jest.mock('expo-crypto', () => ({
+  randomUUID: jest.fn(() => 'generated-uuid-xyz'),
+}));
+
+const mockNetworkValue = { isOnline: true, isConnected: true, networkType: 'WIFI' };
+jest.mock('@/contexts/NetworkContext', () => ({
+  useNetwork: () => mockNetworkValue,
+}));
+
+const mockAuthValue = { user: { id: 'test-user-xyz' }, loading: false };
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockAuthValue,
+}));
+
+const mockLocalDB = {
+  initialize: jest.fn().mockResolvedValue(undefined),
+  getAllFoods: jest.fn().mockResolvedValue([]),
+  insertFood: jest.fn().mockResolvedValue(undefined),
+  softDeleteFood: jest.fn().mockResolvedValue(undefined),
+};
+jest.mock('@/lib/services/database/local-db', () => ({
+  localDB: mockLocalDB,
+}));
+
+const mockSyncCallbacks: (() => void)[] = [];
+const mockSyncService = {
+  fullSync: jest.fn().mockResolvedValue(undefined),
+  syncToSupabase: jest.fn().mockResolvedValue(undefined),
+  initializeRealtimeSync: jest.fn().mockResolvedValue(undefined),
+  cleanupRealtimeSync: jest.fn(),
+  onSyncComplete: jest.fn((cb: () => void) => {
+    mockSyncCallbacks.push(cb);
+    return () => {
+      const idx = mockSyncCallbacks.indexOf(cb);
+      if (idx >= 0) mockSyncCallbacks.splice(idx, 1);
+    };
+  }),
+};
+jest.mock('@/lib/services/database/sync-service', () => ({
+  syncService: mockSyncService,
+}));
+
+type FoodModule = typeof FoodContextModule;
+let FoodProvider: FoodModule['FoodProvider'];
+let useFood: FoodModule['useFood'];
+
+beforeAll(() => {
+  const mod = require('@/contexts/FoodContext') as FoodModule;
+  FoodProvider = mod.FoodProvider;
+  useFood = mod.useFood;
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ToastProvider>
+    <FoodProvider>{children}</FoodProvider>
+  </ToastProvider>
+);
+
+const makeFoodEntry = (overrides: Partial<FoodEntry> = {}): FoodEntry => ({
+  id: 'food-sync',
+  name: 'Quinoa Bowl',
+  calories: 450,
+  protein: 20,
+  carbs: 60,
+  fat: 12,
+  date: '2026-04-21',
+  ...overrides,
+});
+
+describe('FoodContext — sync queue transitions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSyncCallbacks.length = 0;
+    mockLocalDB.getAllFoods.mockResolvedValue([]);
+    mockLocalDB.initialize.mockResolvedValue(undefined);
+    mockLocalDB.insertFood.mockResolvedValue(undefined);
+    mockLocalDB.softDeleteFood.mockResolvedValue(undefined);
+    mockSyncService.fullSync.mockResolvedValue(undefined);
+    mockSyncService.syncToSupabase.mockResolvedValue(undefined);
+    mockSyncService.initializeRealtimeSync.mockResolvedValue(undefined);
+    mockNetworkValue.isOnline = true;
+  });
+
+  it('addFood -> sync-success: local write, UI update, syncToSupabase resolves cleanly', async () => {
+    const { result } = renderHook(() => useFood(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    mockSyncService.syncToSupabase.mockClear();
+
+    const newFood = makeFoodEntry();
+    await act(async () => {
+      await result.current.addFood(newFood);
+    });
+
+    // Local-first write happened.
+    expect(mockLocalDB.insertFood).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'food-sync', calories: 450 }),
+    );
+    // UI mirrored the change immediately.
+    expect(result.current.foods[0]).toMatchObject({ id: 'food-sync' });
+    // Sync was fired (fire-and-forget).
+    expect(mockSyncService.syncToSupabase).toHaveBeenCalledTimes(1);
+  });
+
+  it('addFood -> sync-failure: rejection is swallowed, local write persists, toast surfaces', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockSyncService.syncToSupabase.mockRejectedValueOnce(new Error('supabase down'));
+
+    const { result } = renderHook(() => useFood(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    mockSyncService.syncToSupabase.mockClear();
+    mockSyncService.syncToSupabase.mockRejectedValueOnce(new Error('supabase still down'));
+
+    await act(async () => {
+      await result.current.addFood(makeFoodEntry({ id: 'food-fail' }));
+      // Allow the rejected fire-and-forget promise microtask to flush.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // addFood itself did NOT reject — fire-and-forget swallowed the sync error.
+    expect(result.current.foods[0]).toMatchObject({ id: 'food-fail' });
+    expect(mockLocalDB.insertFood).toHaveBeenCalled();
+    // Warning was logged + attempt actually happened.
+    expect(mockSyncService.syncToSupabase).toHaveBeenCalledTimes(1);
+    expect(
+      warnSpy.mock.calls.some((call) =>
+        String(call[0] ?? '').includes('[FoodContext] Sync failed'),
+      ),
+    ).toBe(true);
+
+    warnSpy.mockRestore();
+  });
+
+  it('deleteFood offline: no sync attempted, UI still updates, soft-delete persists', async () => {
+    mockLocalDB.getAllFoods.mockResolvedValue([
+      { id: 'f-del', name: 'Oats', calories: 150, protein: 5, carbs: 27, fat: 3, date: '2026-04-21' },
+    ]);
+    mockNetworkValue.isOnline = false;
+
+    const { result } = renderHook(() => useFood(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.foods).toHaveLength(1);
+    });
+    mockSyncService.syncToSupabase.mockClear();
+
+    await act(async () => {
+      await result.current.deleteFood('f-del');
+    });
+
+    expect(mockLocalDB.softDeleteFood).toHaveBeenCalledWith('f-del');
+    expect(result.current.foods).toHaveLength(0);
+    expect(mockSyncService.syncToSupabase).not.toHaveBeenCalled();
+  });
+
+  it('deleteFood online: soft-delete, sync attempted, deletion survives a post-sync reload', async () => {
+    // Start online with one food, then delete while online. After deletion the
+    // sync-service realtime callback fires and reloads from the local DB —
+    // the deleted food must still be gone (soft-delete persisted).
+    mockLocalDB.getAllFoods.mockResolvedValue([
+      { id: 'f-keep', name: 'Salmon', calories: 350, protein: 40, carbs: 0, fat: 20, date: '2026-04-21' },
+    ]);
+
+    const { result } = renderHook(() => useFood(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.foods).toHaveLength(1);
+    });
+
+    // Deletion triggers a soft-delete + online sync. Before the realtime
+    // reload fires, flip the local-db response to reflect the deletion.
+    mockLocalDB.getAllFoods.mockResolvedValue([]);
+
+    await act(async () => {
+      await result.current.deleteFood('f-keep');
+    });
+
+    expect(mockLocalDB.softDeleteFood).toHaveBeenCalledWith('f-keep');
+    expect(mockSyncService.syncToSupabase).toHaveBeenCalled();
+    expect(result.current.foods).toHaveLength(0);
+
+    // Trigger the onSyncComplete callback — simulates Supabase realtime push
+    // landing locally after the user's soft-delete.
+    await act(async () => {
+      mockSyncCallbacks.forEach((cb) => cb());
+      await Promise.resolve();
+    });
+
+    // Deletion must NOT be reverted by the realtime reload.
+    expect(result.current.foods).toHaveLength(0);
+  });
+
+  it('queue recovery: after a sync-failure, a later addFood still attempts a fresh sync', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useFood(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Arrange: first add fails sync, second add succeeds.
+    mockSyncService.syncToSupabase.mockClear();
+    mockSyncService.syncToSupabase
+      .mockRejectedValueOnce(new Error('flaky supabase'))
+      .mockResolvedValueOnce(undefined);
+
+    await act(async () => {
+      await result.current.addFood(makeFoodEntry({ id: 'food-a' }));
+      // Drain the rejected fire-and-forget.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.addFood(makeFoodEntry({ id: 'food-b' }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Both adds attempted sync — the context didn't "jam" after the first failure.
+    expect(mockSyncService.syncToSupabase).toHaveBeenCalledTimes(2);
+    // Both writes landed locally.
+    expect(mockLocalDB.insertFood).toHaveBeenCalledTimes(2);
+    expect(result.current.foods.map((f) => f.id)).toEqual(
+      expect.arrayContaining(['food-a', 'food-b']),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('fetchFoods online triggers fullSync and reloads from local DB', async () => {
+    mockLocalDB.getAllFoods.mockResolvedValue([
+      { id: 'f-a', name: 'Apple', calories: 95, protein: 0.5, carbs: 25, fat: 0.3, date: '2026-04-21' },
+    ]);
+
+    const { result } = renderHook(() => useFood(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.foods).toHaveLength(1);
+    });
+
+    mockSyncService.fullSync.mockClear();
+
+    await act(async () => {
+      await result.current.refreshFoods();
+    });
+
+    // performSync fires fullSync and then re-loads via getAllFoods.
+    expect(mockSyncService.fullSync).toHaveBeenCalledTimes(1);
+    expect(result.current.foods[0].name).toBe('Apple');
+  });
+
+  it('fire-and-forget sync on delete: syncToSupabase rejection surfaces toast + warning', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockLocalDB.getAllFoods.mockResolvedValue([
+      { id: 'f-fail', name: 'Cottage Cheese', calories: 110, protein: 12, carbs: 3, fat: 5, date: '2026-04-21' },
+    ]);
+
+    const { result } = renderHook(() => useFood(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.foods).toHaveLength(1);
+    });
+
+    // Next syncToSupabase rejects — deleteFood must not throw.
+    mockSyncService.syncToSupabase.mockClear();
+    mockSyncService.syncToSupabase.mockRejectedValueOnce(new Error('rejected'));
+
+    await act(async () => {
+      await result.current.deleteFood('f-fail');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Local state reflects the delete despite the sync failure.
+    expect(result.current.foods).toHaveLength(0);
+    // Warning log fired from the fire-and-forget catch.
+    expect(
+      warnSpy.mock.calls.some((call) =>
+        String(call[0] ?? '').includes('[FoodContext] Sync failed'),
+      ),
+    ).toBe(true);
+
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/unit/contexts/NetworkContext.test.tsx
+++ b/tests/unit/contexts/NetworkContext.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * NetworkContext polling + unmount regression coverage (wave-31, Pack C / C2).
+ *
+ * Complements the existing `network-context.test.tsx` with scenarios that
+ * were previously untested:
+ *   - interval cleanup count (exactly one clearInterval per provider mount)
+ *   - rapid unmount while a poll is in flight must NOT fire setters after
+ *     the provider unmounts (mounted-ref guard from the companion fix)
+ *   - error path respects the mounted-ref guard too
+ *   - initial default-online before the first poll resolves
+ *
+ * Paired with the `fix(NetworkContext): guard async setters with mounted-ref`
+ * commit so the regression stays locked in.
+ */
+
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import type * as NetworkContextModule from '@/contexts/NetworkContext';
+
+const mockGetNetworkStateAsync = jest.fn();
+
+jest.mock('expo-network', () => ({
+  getNetworkStateAsync: (...args: any[]) => mockGetNetworkStateAsync(...args),
+  NetworkStateType: {
+    NONE: 'NONE',
+    WIFI: 'WIFI',
+    CELLULAR: 'CELLULAR',
+  },
+}));
+
+type NetworkModule = typeof NetworkContextModule;
+let NetworkProvider: NetworkModule['NetworkProvider'];
+let useNetwork: NetworkModule['useNetwork'];
+
+beforeAll(() => {
+  const mod = require('@/contexts/NetworkContext') as NetworkModule;
+  NetworkProvider = mod.NetworkProvider;
+  useNetwork = mod.useNetwork;
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <NetworkProvider>{children}</NetworkProvider>
+);
+
+/** Build a deferred promise we can resolve/reject from the test. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('NetworkContext — polling + unmount (stale-closure regression)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockGetNetworkStateAsync.mockResolvedValue({
+      isInternetReachable: true,
+      isConnected: true,
+      type: 'WIFI',
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('defaults to online before the first poll resolves', () => {
+    // Don't resolve the first poll — state should stay on its defaults.
+    mockGetNetworkStateAsync.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useNetwork(), { wrapper });
+
+    expect(result.current.isOnline).toBe(true);
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.networkType).toBeNull();
+  });
+
+  it('clears the polling interval exactly once on unmount', async () => {
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+    const setIntervalSpy = jest.spyOn(global, 'setInterval');
+
+    const { unmount } = renderHook(() => useNetwork(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockGetNetworkStateAsync).toHaveBeenCalled();
+    });
+
+    // Exactly one interval got installed on mount.
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    const installedHandle = setIntervalSpy.mock.results[0].value;
+
+    unmount();
+
+    // clearInterval was called and specifically for our handle.
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    const clearedForOurHandle = clearIntervalSpy.mock.calls.some(
+      (call) => call[0] === installedHandle,
+    );
+    expect(clearedForOurHandle).toBe(true);
+
+    setIntervalSpy.mockRestore();
+    clearIntervalSpy.mockRestore();
+  });
+
+  it('resolving the poll AFTER unmount does not produce a setState-on-unmounted warning', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const d = deferred<any>();
+    mockGetNetworkStateAsync.mockReturnValueOnce(d.promise);
+
+    const { unmount } = renderHook(() => useNetwork(), { wrapper });
+
+    // Unmount with the poll still in flight.
+    unmount();
+
+    // Now resolve the pending poll — the mounted-ref guard should swallow
+    // the setters silently.
+    await act(async () => {
+      d.resolve({ isInternetReachable: true, isConnected: true, type: 'WIFI' });
+    });
+
+    const setStateWarning = errorSpy.mock.calls.find((call) =>
+      String(call[0] ?? '').includes(
+        "can't perform a React state update on an unmounted component",
+      ),
+    );
+    expect(setStateWarning).toBeUndefined();
+
+    errorSpy.mockRestore();
+  });
+
+  it('rejecting the poll AFTER unmount does not log errors or produce warnings', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const d = deferred<any>();
+    mockGetNetworkStateAsync.mockReturnValueOnce(d.promise);
+
+    const { unmount } = renderHook(() => useNetwork(), { wrapper });
+
+    unmount();
+
+    // Reject the poll post-unmount — guard should skip both the console.error
+    // AND the setters in the catch block.
+    await act(async () => {
+      d.reject(new Error('network borked post-unmount'));
+    });
+
+    // Neither the NetworkContext error log nor a setState-on-unmounted warning.
+    const contextErrorLog = errorSpy.mock.calls.find((call) =>
+      String(call[0] ?? '').includes('[NetworkContext] Error checking network status'),
+    );
+    expect(contextErrorLog).toBeUndefined();
+
+    const setStateWarning = errorSpy.mock.calls.find((call) =>
+      String(call[0] ?? '').includes(
+        "can't perform a React state update on an unmounted component",
+      ),
+    );
+    expect(setStateWarning).toBeUndefined();
+
+    errorSpy.mockRestore();
+  });
+
+  it('error path before unmount still falls back to online=true (regression guard)', async () => {
+    mockGetNetworkStateAsync.mockRejectedValueOnce(new Error('boom'));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useNetwork(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockGetNetworkStateAsync).toHaveBeenCalledTimes(1);
+    });
+
+    expect(result.current.isOnline).toBe(true);
+    expect(result.current.isConnected).toBe(true);
+
+    // The context DID log the error pre-unmount.
+    const contextErrorLog = errorSpy.mock.calls.find((call) =>
+      String(call[0] ?? '').includes('[NetworkContext] Error checking network status'),
+    );
+    expect(contextErrorLog).toBeDefined();
+
+    errorSpy.mockRestore();
+  });
+
+  it('updates state across subsequent polls while mounted (mounted-ref does not short-circuit)', async () => {
+    mockGetNetworkStateAsync.mockResolvedValueOnce({
+      isInternetReachable: true,
+      isConnected: true,
+      type: 'WIFI',
+    });
+
+    const { result } = renderHook(() => useNetwork(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.networkType).toBe('WIFI');
+    });
+
+    // Swap to offline state for the next poll.
+    mockGetNetworkStateAsync.mockResolvedValueOnce({
+      isInternetReachable: false,
+      isConnected: false,
+      type: 'NONE',
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isOnline).toBe(false);
+      expect(result.current.networkType).toBe('NONE');
+    });
+
+    expect(mockGetNetworkStateAsync).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/contexts/ToastContext.test.tsx
+++ b/tests/unit/contexts/ToastContext.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * ToastContext animation lifecycle coverage (wave-31, Pack C / C1).
+ *
+ * Targets the untested branches around `show()`:
+ *   - single show → fade-in → auto-dismiss timeout → fade-out → state clear
+ *   - rapid double-show: second call must cancel the first timer cleanly
+ *     and replace the message without leaking state
+ *   - unmount during animation: the timeout + Animated callbacks must not
+ *     trigger `setState` on an unmounted provider
+ *   - empty message is a no-op (guard branch in `show`)
+ *   - custom duration + type plumb through to the rendered toast
+ *
+ * Uses fake timers so we can deterministically flush both the dismissal
+ * timeout and the short Animated.timing durations without real waits.
+ */
+
+import React from 'react';
+import { Text, View } from 'react-native';
+import { act, render } from '@testing-library/react-native';
+import { ToastProvider, useToast } from '@/contexts/ToastContext';
+
+type ToastOptions = { type?: 'info' | 'success' | 'error'; duration?: number };
+
+function Harness({
+  onReady,
+}: {
+  onReady: (api: { show: (msg: string, opts?: ToastOptions) => void }) => void;
+}) {
+  const { show } = useToast();
+  React.useEffect(() => {
+    onReady({ show });
+  }, [onReady, show]);
+  return <View testID="harness" />;
+}
+
+describe('ToastContext', () => {
+  let show: (msg: string, opts?: ToastOptions) => void;
+  // Capture the `show` function via a ref exposed from Harness.
+  const captureShow = (api: { show: (msg: string, opts?: ToastOptions) => void }) => {
+    show = api.show;
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // Flush any pending animation frames and timers, then swap back.
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('shows a toast with the given message and auto-dismisses after the duration', () => {
+    const { queryByText } = render(
+      <ToastProvider>
+        <Harness onReady={captureShow} />
+      </ToastProvider>,
+    );
+
+    expect(queryByText('Saved')).toBeNull();
+
+    act(() => {
+      show('Saved', { duration: 1500 });
+    });
+
+    // Fade-in (180ms) runs, then the dismiss-timer (~duration) fires.
+    expect(queryByText('Saved')).not.toBeNull();
+
+    // Advance past dismiss timer + fade-out (200ms) plus some slack.
+    act(() => {
+      jest.advanceTimersByTime(1500 + 250);
+    });
+
+    // After fade-out finishes, toast state clears.
+    expect(queryByText('Saved')).toBeNull();
+  });
+
+  it('rapid double-show: the second call cancels the first timer and replaces the message', () => {
+    const { queryByText } = render(
+      <ToastProvider>
+        <Harness onReady={captureShow} />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      show('First toast', { duration: 3000 });
+    });
+    expect(queryByText('First toast')).not.toBeNull();
+
+    // Before the first timer fires, show a second toast. This should
+    // `clearTimeout` the pending dismiss for `First toast` and render
+    // `Second toast` without leaking — no lingering first message, no
+    // premature dismissal.
+    act(() => {
+      jest.advanceTimersByTime(500);
+      show('Second toast', { duration: 3000 });
+    });
+
+    expect(queryByText('First toast')).toBeNull();
+    expect(queryByText('Second toast')).not.toBeNull();
+
+    // Second toast must live a full 3000ms from the re-show (not 2500 left
+    // on the original timer). Advance 2500 — still visible.
+    act(() => {
+      jest.advanceTimersByTime(2500);
+    });
+    expect(queryByText('Second toast')).not.toBeNull();
+
+    // Now advance past its dismissal + fade-out.
+    act(() => {
+      jest.advanceTimersByTime(500 + 250);
+    });
+    expect(queryByText('Second toast')).toBeNull();
+  });
+
+  it('unmount during animation: no state-update warnings and no throws', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { unmount } = render(
+      <ToastProvider>
+        <Harness onReady={captureShow} />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      show('Hold on', { duration: 5000 });
+    });
+
+    // Unmount while fade-in is in flight and long before the dismiss timer.
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+    expect(() => unmount()).not.toThrow();
+
+    // Advance past everything — the timeout + animation callback must not
+    // touch state on the unmounted provider. If the cleanup is correct,
+    // console.error stays clean (React-18 warns about setState on
+    // unmounted components on console.error).
+    act(() => {
+      jest.advanceTimersByTime(10_000);
+    });
+
+    const unmountedSetStateWarning = errorSpy.mock.calls.find((call) =>
+      String(call[0] ?? '').includes("can't perform a React state update on an unmounted component"),
+    );
+    expect(unmountedSetStateWarning).toBeUndefined();
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('ignores empty messages (guard branch in show)', () => {
+    const { queryByText } = render(
+      <ToastProvider>
+        <Harness onReady={captureShow} />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      show('');
+    });
+
+    // No toast element should have rendered — no text nodes present.
+    expect(queryByText(/.+/)).toBeNull();
+  });
+
+  it('respects custom duration and type options', () => {
+    const { queryByText, UNSAFE_root } = render(
+      <ToastProvider>
+        <Harness onReady={captureShow} />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      show('Error!', { type: 'error', duration: 100 });
+    });
+    expect(queryByText('Error!')).not.toBeNull();
+
+    // Still visible before duration elapses.
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+    expect(queryByText('Error!')).not.toBeNull();
+
+    // After the short duration + fade-out window, it clears.
+    act(() => {
+      jest.advanceTimersByTime(100 + 250);
+    });
+    expect(queryByText('Error!')).toBeNull();
+
+    // Sanity: the tree accepted our render at all.
+    expect(UNSAFE_root).toBeTruthy();
+  });
+
+  it('useToast throws when used outside a ToastProvider', () => {
+    const BadConsumer = () => {
+      useToast();
+      return <Text>should not render</Text>;
+    };
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(<BadConsumer />)).toThrow(/useToast must be used within a ToastProvider/);
+    errorSpy.mockRestore();
+  });
+});

--- a/tests/unit/hooks/use-streaming-tts.test.ts
+++ b/tests/unit/hooks/use-streaming-tts.test.ts
@@ -1,0 +1,280 @@
+/**
+ * use-streaming-tts fallback + re-entrancy coverage (wave-31, Pack C / C5).
+ *
+ * Targets the untested branches around the TTS fallback chain:
+ *   - ElevenLabs success: audio buffer -> Audio.Sound.createAsync -> playAsync
+ *   - ElevenLabs returns null: hook falls back to expo-speech Speech.speak
+ *   - ElevenLabs throws: catch-branch unloads any stale sound + falls back
+ *     to expo-speech Speech.speak
+ *   - processQueue re-entrancy guard: speak() can't kick off a parallel
+ *     sentence synthesis while the previous one is still playing
+ *   - speakStream accumulates chunks and only flushes complete sentences;
+ *     an incomplete tail stays buffered
+ *   - stop() drains queue + stops in-flight sound + silences Speech
+ */
+
+import { renderHook, act } from '@testing-library/react-native';
+
+// ---- expo-av mock -------------------------------------------------------
+const mockPlayAsync = jest.fn().mockResolvedValue(undefined);
+const mockStopAsync = jest.fn().mockResolvedValue(undefined);
+const mockUnloadAsync = jest.fn().mockResolvedValue(undefined);
+const mockSetOnPlaybackStatusUpdate = jest.fn();
+
+const makeSound = () => ({
+  playAsync: mockPlayAsync,
+  stopAsync: mockStopAsync,
+  unloadAsync: mockUnloadAsync,
+  setOnPlaybackStatusUpdate: mockSetOnPlaybackStatusUpdate,
+});
+
+const mockCreateAsync: jest.Mock = jest.fn(async (_source: unknown) => ({
+  sound: makeSound(),
+}));
+
+jest.mock('expo-av', () => ({
+  Audio: {
+    Sound: {
+      createAsync: (source: unknown) => mockCreateAsync(source),
+    },
+  },
+}));
+
+// ---- expo-speech mock ---------------------------------------------------
+const mockSpeak = jest.fn();
+const mockSpeechStop = jest.fn();
+jest.mock('expo-speech', () => ({
+  speak: (...args: any[]) => mockSpeak(...args),
+  stop: (...args: any[]) => mockSpeechStop(...args),
+}));
+
+// ---- elevenlabs-service mock --------------------------------------------
+const mockGenerateSpeech = jest.fn();
+jest.mock('@/lib/services/elevenlabs-service', () => ({
+  generateSpeech: (...args: any[]) => mockGenerateSpeech(...args),
+}));
+
+// `btoa` is a browser global but jest-expo's environment exposes it via
+// Node 20. If it isn't present, polyfill for the ArrayBuffer->base64 helper.
+if (typeof (globalThis as any).btoa !== 'function') {
+  (globalThis as any).btoa = (str: string) =>
+    Buffer.from(str, 'binary').toString('base64');
+}
+
+import { useStreamingTts } from '@/hooks/use-streaming-tts';
+
+function oneByteBuffer(): ArrayBuffer {
+  return new Uint8Array([0x42]).buffer;
+}
+
+async function flushMicrotasks() {
+  // 4 flushes is enough to drain the processQueue chain.
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('use-streaming-tts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGenerateSpeech.mockReset();
+    mockCreateAsync.mockImplementation(async () => ({ sound: makeSound() }));
+  });
+
+  it('ElevenLabs success: synthesizes, creates a sound, and plays it', async () => {
+    mockGenerateSpeech.mockResolvedValue(oneByteBuffer());
+
+    const { result } = renderHook(() => useStreamingTts());
+
+    await act(async () => {
+      result.current.speak('Hello there.');
+      await flushMicrotasks();
+    });
+
+    expect(mockGenerateSpeech).toHaveBeenCalledTimes(1);
+    expect(mockGenerateSpeech).toHaveBeenCalledWith('Hello there.');
+    expect(mockCreateAsync).toHaveBeenCalledTimes(1);
+    // The constructed sound had a data URI for mpeg/base64.
+    const createArgs = mockCreateAsync.mock.calls[0]?.[0] as { uri: string } | undefined;
+    expect(createArgs?.uri).toMatch(/^data:audio\/mpeg;base64,/);
+    expect(mockPlayAsync).toHaveBeenCalledTimes(1);
+    // Did NOT fall back to system TTS.
+    expect(mockSpeak).not.toHaveBeenCalled();
+  });
+
+  it('ElevenLabs returns null -> falls back to expo-speech', async () => {
+    mockGenerateSpeech.mockResolvedValue(null);
+    // The system TTS invokes onDone to signal completion of the single
+    // sentence so the queue drains.
+    mockSpeak.mockImplementation((_text: string, opts: { onDone?: () => void }) => {
+      opts.onDone?.();
+    });
+
+    const { result } = renderHook(() => useStreamingTts());
+
+    await act(async () => {
+      result.current.speak('Back to system speech.');
+      await flushMicrotasks();
+    });
+
+    expect(mockGenerateSpeech).toHaveBeenCalled();
+    expect(mockCreateAsync).not.toHaveBeenCalled();
+    expect(mockSpeak).toHaveBeenCalledTimes(1);
+    expect(mockSpeak.mock.calls[0][0]).toBe('Back to system speech.');
+  });
+
+  it('ElevenLabs throws -> logs warn and falls back to expo-speech', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockGenerateSpeech.mockRejectedValue(new Error('11labs 500'));
+    mockSpeak.mockImplementation((_text: string, opts: { onDone?: () => void }) => {
+      opts.onDone?.();
+    });
+
+    const { result } = renderHook(() => useStreamingTts());
+
+    await act(async () => {
+      result.current.speak('Will survive.');
+      await flushMicrotasks();
+    });
+
+    expect(
+      warnSpy.mock.calls.some((call) =>
+        String(call[0] ?? '').includes('[StreamingTTS] ElevenLabs playback error'),
+      ),
+    ).toBe(true);
+    expect(mockSpeak).toHaveBeenCalledTimes(1);
+    expect(mockSpeak.mock.calls[0][0]).toBe('Will survive.');
+
+    warnSpy.mockRestore();
+  });
+
+  it('processQueue re-entrancy: a second speak() while one sentence is still playing does not double-synthesize in parallel', async () => {
+    // Set up a long-running first synthesis: resolve with a buffer, but
+    // hold the subsequent Audio.Sound.createAsync off so the hook gets
+    // stuck in "processing" state mid-sentence.
+    let unblockCreate!: () => void;
+    const createBlock = new Promise<void>((resolve) => {
+      unblockCreate = resolve;
+    });
+    mockGenerateSpeech.mockResolvedValue(oneByteBuffer());
+    mockCreateAsync.mockImplementationOnce(async () => {
+      await createBlock;
+      return { sound: makeSound() };
+    });
+
+    const { result } = renderHook(() => useStreamingTts());
+
+    await act(async () => {
+      result.current.speak('Sentence one. Sentence two.');
+      await flushMicrotasks();
+    });
+
+    // Only the first sentence is being synthesized; the second one sits
+    // on the queue until the currently-playing sound signals didJustFinish.
+    expect(mockGenerateSpeech).toHaveBeenCalledTimes(1);
+    expect(mockGenerateSpeech).toHaveBeenCalledWith('Sentence one.');
+
+    // Now speak() again — but speak() resets the processingRef to false and
+    // rewrites the queue. The re-entrancy guard inside processQueue means
+    // only ONE processor chain is active at a time. Unblock the first sound
+    // afterwards and confirm the second-speak queue ran.
+    mockGenerateSpeech.mockResolvedValueOnce(oneByteBuffer());
+    await act(async () => {
+      result.current.speak('Third. Fourth.');
+      await flushMicrotasks();
+    });
+
+    // speak() reset the queue — total generateSpeech calls should reflect
+    // the reset (new queue drained in order without the original queue
+    // continuing in parallel).
+    expect(mockGenerateSpeech.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // The most recent call picked up the NEW queue's first sentence.
+    expect(mockGenerateSpeech).toHaveBeenLastCalledWith('Third.');
+
+    // Unblock the original createAsync so jest doesn't leave a dangling
+    // microtask that pollutes later tests.
+    unblockCreate();
+    await act(async () => {
+      await flushMicrotasks();
+    });
+  });
+
+  it('speakStream: accumulates chunks and only flushes complete sentences', async () => {
+    mockGenerateSpeech.mockResolvedValue(oneByteBuffer());
+
+    const { result } = renderHook(() => useStreamingTts());
+
+    await act(async () => {
+      result.current.speakStream('Hello ');
+      await flushMicrotasks();
+    });
+    // Incomplete sentence — nothing synthesized yet.
+    expect(mockGenerateSpeech).not.toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.speakStream('there. Keep going');
+      await flushMicrotasks();
+    });
+    // "Hello there." is complete and got flushed; "Keep going" is buffered.
+    expect(mockGenerateSpeech).toHaveBeenCalledTimes(1);
+    expect(mockGenerateSpeech).toHaveBeenCalledWith('Hello there.');
+
+    // The splitter only recognises a complete sentence when a terminator is
+    // followed by whitespace — i.e. the NEXT sentence starts. Deliver the
+    // terminator plus the start of a following sentence, and simulate the
+    // in-flight sound finishing so the queue can process the next entry.
+    const statusCb = mockSetOnPlaybackStatusUpdate.mock.calls[0]?.[0];
+    expect(typeof statusCb).toBe('function');
+    await act(async () => {
+      statusCb({ isLoaded: true, didJustFinish: true });
+      await flushMicrotasks();
+    });
+
+    await act(async () => {
+      result.current.speakStream(' strong. Done');
+      await flushMicrotasks();
+    });
+
+    // "Keep going strong." gets flushed once the terminator + next-sentence
+    // lead ("Done") arrive. "Done" stays buffered until a further terminator.
+    expect(mockGenerateSpeech).toHaveBeenCalledWith('Keep going strong.');
+    expect(mockGenerateSpeech).not.toHaveBeenCalledWith('Done');
+  });
+
+  it('stop(): clears queue, calls Speech.stop, stops and unloads current sound', async () => {
+    mockGenerateSpeech.mockResolvedValue(oneByteBuffer());
+
+    const { result } = renderHook(() => useStreamingTts());
+
+    await act(async () => {
+      result.current.speak('One. Two. Three.');
+      await flushMicrotasks();
+    });
+
+    // A sound was created for "One."
+    expect(mockCreateAsync).toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.stop();
+      await flushMicrotasks();
+    });
+
+    expect(mockSpeechStop).toHaveBeenCalledTimes(1);
+    expect(mockStopAsync).toHaveBeenCalledTimes(1);
+    expect(mockUnloadAsync).toHaveBeenCalled();
+    expect(result.current.isSpeaking).toBe(false);
+  });
+
+  it('empty stream chunks never synthesize', async () => {
+    const { result } = renderHook(() => useStreamingTts());
+
+    await act(async () => {
+      result.current.speakStream('');
+      result.current.speakStream('   ');
+      await flushMicrotasks();
+    });
+
+    expect(mockGenerateSpeech).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/ErrorHandler.test.ts
+++ b/tests/unit/services/ErrorHandler.test.ts
@@ -1,0 +1,256 @@
+/**
+ * ErrorHandler domain-to-user-message + sanitizeDetails coverage
+ * (wave-31, Pack C / C3).
+ *
+ * Complements `error-handler-form-tracking.test.ts` (which deep-dives the
+ * form-tracking codes) with table-driven coverage over every other
+ * domain, the `default`/`unknown` fallback, `sanitizeDetails` branches
+ * (Error instance, JSON-cyclic, null/undefined, primitives), and both
+ * `withErrorHandling` success + failure paths.
+ *
+ * Ships under a different filename to avoid overlap with the existing
+ * form-tracking suite and in-flight test PRs.
+ */
+
+const mockErrorWithTs = jest.fn();
+jest.mock('@/lib/logger', () => ({
+  logWithTs: jest.fn(),
+  infoWithTs: jest.fn(),
+  warnWithTs: jest.fn(),
+  errorWithTs: (...args: unknown[]) => mockErrorWithTs(...args),
+}));
+
+import {
+  AppError,
+  createError,
+  mapToUserMessage,
+  logError,
+  shouldRetry,
+  withErrorHandling,
+} from '@/lib/services/ErrorHandler';
+
+describe('ErrorHandler — createError defaults', () => {
+  test('retryable defaults to false and severity to error', () => {
+    const err = createError('network', 'UNREACHABLE', 'no route to host');
+    expect(err.domain).toBe('network');
+    expect(err.code).toBe('UNREACHABLE');
+    expect(err.message).toBe('no route to host');
+    expect(err.retryable).toBe(false);
+    expect(err.severity).toBe('error');
+    expect(err.details).toBeUndefined();
+  });
+
+  test('severity + retryable overrides plumb through', () => {
+    const err = createError('sync', 'QUEUE_DRAIN_FAILED', 'retry later', {
+      retryable: true,
+      severity: 'warning',
+      details: { attempts: 3 },
+    });
+    expect(err.retryable).toBe(true);
+    expect(err.severity).toBe('warning');
+    expect(err.details).toEqual({ attempts: 3 });
+  });
+});
+
+describe('ErrorHandler — mapToUserMessage domain coverage', () => {
+  // Table covers every non-form-tracking domain. The form-tracking domain
+  // has its own dedicated suite in error-handler-form-tracking.test.ts.
+  type DomainCase = {
+    domain: AppError['domain'];
+    code?: string;
+    expectedContains: string;
+  };
+
+  const cases: DomainCase[] = [
+    { domain: 'network', expectedContains: 'Connection issue' },
+    { domain: 'session', expectedContains: 'session could not be validated' },
+    { domain: 'validation', expectedContains: 'configuration is incomplete' },
+    { domain: 'camera', expectedContains: 'Camera is unavailable' },
+    { domain: 'ml', expectedContains: 'Processing issue' },
+    { domain: 'storage', expectedContains: 'trouble saving your data' },
+    { domain: 'sync', expectedContains: 'Sync issue' },
+    { domain: 'auth', expectedContains: 'Authentication error' },
+    { domain: 'coach', expectedContains: 'Coach service hit an issue' },
+  ];
+
+  test.each(cases)('maps domain=$domain to user-facing copy', ({ domain, expectedContains }) => {
+    const msg = mapToUserMessage(createError(domain, 'SOME_CODE', 'internal'));
+    expect(msg).toContain(expectedContains);
+    // Generic fallback must never leak when the domain is known.
+    expect(msg).not.toBe('Something went wrong. Please try again.');
+  });
+
+  test('unknown domain (via the `default` branch) falls back to generic copy', () => {
+    // Cast because the union rejects arbitrary strings; the default branch
+    // is only reachable from non-exhaustive inputs in practice.
+    const err = createError('unknown' as AppError['domain'], 'X', 'internal');
+    const msg = mapToUserMessage(err);
+    expect(msg).toBe('Something went wrong. Please try again.');
+  });
+
+  test('oauth: base domain copy vs OAUTH_CANCELLED vs OAUTH_DISMISSED are distinct', () => {
+    const cancelled = mapToUserMessage(createError('oauth', 'OAUTH_CANCELLED', 'user back'));
+    const dismissed = mapToUserMessage(createError('oauth', 'OAUTH_DISMISSED', 'user swiped'));
+    const generic = mapToUserMessage(createError('oauth', 'OAUTH_UNKNOWN', 'other'));
+
+    expect(cancelled.toLowerCase()).toContain('cancelled');
+    expect(dismissed.toLowerCase()).toContain('dismissed');
+    expect(generic.toLowerCase()).toContain('authentication failed');
+    expect(new Set([cancelled, dismissed, generic]).size).toBe(3);
+  });
+
+  test('coach: COACH_RATE_LIMITED overrides the domain-default copy', () => {
+    const rate = mapToUserMessage(createError('coach', 'COACH_RATE_LIMITED', 'too many'));
+    const generic = mapToUserMessage(createError('coach', 'COACH_OTHER', 'other'));
+
+    expect(rate.toLowerCase()).toContain('rate-limited');
+    expect(generic.toLowerCase()).toContain('coach service');
+    expect(rate).not.toBe(generic);
+  });
+});
+
+describe('ErrorHandler — shouldRetry', () => {
+  test('honors explicit retryable=true', () => {
+    const err = createError('validation', 'X', 'y', { retryable: true });
+    expect(shouldRetry(err)).toBe(true);
+  });
+
+  test('honors explicit retryable=false on a domain that would default-true', () => {
+    // NB: the implementation returns `err.retryable` when it's a boolean.
+    // That means retryable:false on a network error short-circuits the
+    // domain-default true; lock that in.
+    const err = createError('network', 'X', 'y', { retryable: false });
+    expect(shouldRetry(err)).toBe(false);
+  });
+
+  test('network + sync domains are retryable even without explicit override when not set', () => {
+    // createError always sets a boolean (defaults false), so to reach the
+    // "typeof err.retryable !== 'boolean'" branch we have to build the
+    // object by hand.
+    const network = { ...createError('network', 'X', 'y'), retryable: undefined as any };
+    const sync = { ...createError('sync', 'X', 'y'), retryable: undefined as any };
+    const auth = { ...createError('auth', 'X', 'y'), retryable: undefined as any };
+
+    expect(shouldRetry(network)).toBe(true);
+    expect(shouldRetry(sync)).toBe(true);
+    expect(shouldRetry(auth)).toBe(false);
+  });
+});
+
+describe('ErrorHandler — logError + sanitizeDetails branches', () => {
+  beforeEach(() => {
+    mockErrorWithTs.mockClear();
+  });
+
+  // errorWithTs is called as (tag, payload) — our mock records args as-is,
+  // so the structured payload lives at mock.calls[0][1].
+  test('Error instance details are captured as { name, message, stack }', () => {
+    const cause = new TypeError('bad thing');
+    logError(createError('ml', 'BOOM', 'explode', { details: cause }), { feature: 'ui' });
+    expect(mockErrorWithTs).toHaveBeenCalled();
+    const payload = mockErrorWithTs.mock.calls[0][1];
+    expect(payload.details).toEqual(
+      expect.objectContaining({
+        name: 'TypeError',
+        message: 'bad thing',
+        stack: expect.any(String),
+      }),
+    );
+    // Stack is preserved (not swallowed), so ops can triage post-mortem.
+    expect(String(payload.details.stack)).toContain('bad thing');
+  });
+
+  test('plain JSON-safe details pass through untouched', () => {
+    logError(createError('storage', 'SAVE_FAIL', 'disk', { details: { size: 42 } }));
+    const payload = mockErrorWithTs.mock.calls[0][1];
+    expect(payload.details).toEqual({ size: 42 });
+  });
+
+  test('undefined details resolve to undefined in the payload', () => {
+    logError(createError('network', 'N', 'oops'));
+    const payload = mockErrorWithTs.mock.calls[0][1];
+    expect(payload.details).toBeUndefined();
+  });
+
+  test('cyclic details are coerced to their String() representation', () => {
+    const cyclic: any = { name: 'cyclic' };
+    cyclic.self = cyclic;
+    logError(createError('sync', 'CYCLIC', 'boom', { details: cyclic }));
+    const payload = mockErrorWithTs.mock.calls[0][1];
+    // JSON.stringify throws for cycles → catch-branch returns String(details).
+    expect(typeof payload.details).toBe('string');
+    expect(payload.details).toMatch(/object/);
+  });
+
+  test('payload includes structured fields for downstream dashboards', () => {
+    logError(
+      createError('coach', 'C1', 'hi', { severity: 'warning', retryable: true }),
+      { feature: 'coach', location: 'coach-service', meta: { traceId: 'abc' } },
+    );
+    const payload = mockErrorWithTs.mock.calls[0][1];
+    expect(payload).toEqual(
+      expect.objectContaining({
+        domain: 'coach',
+        code: 'C1',
+        message: 'hi',
+        severity: 'warning',
+        retryable: true,
+        ctx: expect.objectContaining({ feature: 'coach', location: 'coach-service' }),
+        platform: expect.any(String),
+      }),
+    );
+  });
+});
+
+describe('ErrorHandler — withErrorHandling', () => {
+  test('returns ok=true with data on successful promise', async () => {
+    const result = await withErrorHandling(
+      async () => ({ greeting: 'hi' }),
+      () => createError('unknown', 'UNUSED', 'never'),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toEqual({ greeting: 'hi' });
+  });
+
+  test('returns ok=false with the built AppError on throw', async () => {
+    mockErrorWithTs.mockClear();
+    const result = await withErrorHandling(
+      async () => {
+        throw new Error('boom');
+      },
+      (cause) =>
+        createError('network', 'REQUEST_FAILED', 'failed to fetch', { details: cause }),
+      { feature: 'app', location: 'withErrorHandling.test' },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.domain).toBe('network');
+      expect(result.error.code).toBe('REQUEST_FAILED');
+      // Original Error is captured in the sanitized payload via logError.
+      const payload = mockErrorWithTs.mock.calls[0][1];
+      expect(payload.details).toEqual(
+        expect.objectContaining({ name: 'Error', message: 'boom' }),
+      );
+    }
+  });
+
+  test('builder can inspect thrown value to classify the error', async () => {
+    const result = await withErrorHandling(
+      async () => {
+        throw new Error('rate limited');
+      },
+      (cause) =>
+        createError(
+          'coach',
+          (cause as Error).message.includes('rate') ? 'COACH_RATE_LIMITED' : 'COACH_OTHER',
+          'service',
+        ),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('COACH_RATE_LIMITED');
+      // Maps to the dedicated rate-limit copy, not the generic coach fallback.
+      expect(mapToUserMessage(result.error).toLowerCase()).toContain('rate-limited');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
5 test-coverage gaps + 1 source fix from wave-31 audit. Zero file overlap with open test PRs #549/#554/#560 (different test paths) or source PRs #548/#555/#559/#561 (different surfaces).

## Commits
- C1 ToastContext lifecycle tests — single show, rapid re-show replacement, unmount-during-animation, empty-message guard, custom duration/type, useToast provider-absent throw
- C2a NetworkContext mounted-ref source fix — stale-closure memory leak when a poll resolves after unmount (expo-network has no AbortController)
- C2b NetworkContext polling + cleanup tests — interval count, resolve-after-unmount, reject-after-unmount, pre-unmount fallback, continued-polling regression
- C3 ErrorHandler mapping coverage — table-driven over every non-form-tracking domain, COACH_RATE_LIMITED + OAUTH code overrides, sanitizeDetails branches (Error/plain/cyclic/undefined), withErrorHandling happy/error paths
- C4 FoodContext CRUD + sync tests — add→sync-success, add→sync-failure, delete offline, delete online + realtime reload survival, queue recovery after failure, fire-and-forget warn path
- C5 use-streaming-tts fallback chain tests — ElevenLabs success, null → system TTS, throw → warn + system TTS, processQueue re-entrancy, speakStream buffered accumulation contract, stop() drain + silence

Total: 51 new tests + 1 source fix.

## Source-fix rationale (C2a)
`expo-network`'s `getNetworkStateAsync()` is not abortable. If the `NetworkProvider` unmounts (fast tab switch, sign-out, hot reload) while a 30s poll is in flight, the async callback fires `setIsOnline` / `setIsConnected` / `setNetworkType` on an unmounted component — React 18 emits "can't perform a React state update on an unmounted component" and long-lived sessions accumulate closure retention. The fix gates every setState call (success + error paths) on a `mountedRef` that's flipped to `false` in the effect cleanup. The interval still cleans up as before; the new guard specifically protects against the still-in-flight poll.

## File overlap audit
- `contexts/NetworkContext.tsx` — **modified by this PR only**; not touched by open PRs #548/#555/#559/#561 (per issue #564 excluded list).
- New test files all use PascalCase paths (`ToastContext.test.tsx`, `NetworkContext.test.tsx`, `FoodContext.test.tsx`, `ErrorHandler.test.ts`) so they don't collide with the existing kebab-case test files (`network-context.test.tsx`, `food-context.test.tsx`, `error-handler-form-tracking.test.ts`) owned by other PRs. Both old and new test files pass together (verified locally).

## Verification
- [x] `bun run lint` — clean
- [x] `bun run check:types` — clean
- [x] All 5 new test files pass (51 tests)
- [x] Pre-existing sibling tests (`network-context.test.tsx`, `food-context.test.tsx`, `error-handler-form-tracking.test.ts`) still pass (30 tests)
- [x] Full suite `bun run test` — 5059 pass, 0 fail (pre-push hook hit a known flaky `reset-password.test.tsx` interleaving issue on one run; re-ran twice clean — unrelated to this change, confirmed pre-existing)

Closes #564