### PR TITLE
fix(wave32): Gemma/coach reliability + telemetry pack — 7 atomic commits

### DIFF
--- a/lib/services/coach-auto-debrief.ts
+++ b/lib/services/coach-auto-debrief.ts
@@ -229,7 +229,11 @@ async function dispatch(
   // transient Gemma outage doesn't break the auto-debrief.
   if (provider === 'gemma') {
     try {
-      return await sendCoachGemmaPrompt(messages, context);
+      return await sendCoachGemmaPrompt(
+        messages,
+        context,
+        v2Opts ? { taskKind: v2Opts.taskKind } : undefined,
+      );
     } catch (err) {
       warnWithTs('[coach-auto-debrief] gemma dispatch failed, falling back to openai', err);
       return sendCoachPrompt(messages, { ...context, focus: 'post_session_debrief' }, v2Opts);

--- a/lib/services/coach-auto-debrief.ts
+++ b/lib/services/coach-auto-debrief.ts
@@ -214,6 +214,14 @@ async function dispatch(
   messages: CoachMessage[],
   context: CoachContext,
 ): Promise<CoachMessage> {
+  // Pipeline-v2: pass taskKind so the cost-aware dispatcher recognises
+  // this as a complex task (multi_turn_debrief → GPT, not the default
+  // general_chat fallback) and so downstream telemetry (#537) can label
+  // the usage. Flag-off preserves the prior two-arg call shape.
+  const v2Opts = isCoachPipelineV2Enabled()
+    ? ({ taskKind: 'multi_turn_debrief' as const })
+    : undefined;
+
   // Direct-call routing: the gemma branch now targets the coach-gemma edge
   // function directly so Gemma-specific parameters (model, etc.) flow
   // through without going through the generic `coach` function. Failures
@@ -224,8 +232,8 @@ async function dispatch(
       return await sendCoachGemmaPrompt(messages, context);
     } catch (err) {
       warnWithTs('[coach-auto-debrief] gemma dispatch failed, falling back to openai', err);
-      return sendCoachPrompt(messages, { ...context, focus: 'post_session_debrief' });
+      return sendCoachPrompt(messages, { ...context, focus: 'post_session_debrief' }, v2Opts);
     }
   }
-  return sendCoachPrompt(messages, context);
+  return sendCoachPrompt(messages, context, v2Opts);
 }

--- a/lib/services/coach-cost-tracker.ts
+++ b/lib/services/coach-cost-tracker.ts
@@ -152,12 +152,35 @@ function isValidBucket(b: unknown): b is StoredBucket {
 }
 
 async function persist(): Promise<void> {
+  const payload = JSON.stringify({ buckets: state.buckets });
   try {
-    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ buckets: state.buckets }));
-  } catch (error) {
-    warnWithTs('[coach-cost-tracker] failed to persist to AsyncStorage', error);
+    await AsyncStorage.setItem(STORAGE_KEY, payload);
+    return;
+  } catch (firstError) {
+    // Transient backgrounding / memory-pressure failures happen — retry once
+    // with a brief delay before giving up. In-memory state remains valid for
+    // subsequent reads even if both attempts fail, so the tracker degrades
+    // to in-memory-only without crashing the coach path.
+    try {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, PERSIST_RETRY_DELAY_MS);
+      });
+      await AsyncStorage.setItem(STORAGE_KEY, payload);
+    } catch (secondError) {
+      warnWithTs(
+        '[coach-cost-tracker] failed to persist to AsyncStorage after retry',
+        secondError,
+      );
+    }
   }
 }
+
+/**
+ * Retry delay between the first AsyncStorage failure and the second attempt.
+ * Short enough that a blocked app-background transition can settle; small
+ * enough that a genuinely broken store surfaces in under a second.
+ */
+const PERSIST_RETRY_DELAY_MS = 120;
 
 // =============================================================================
 // Public API

--- a/lib/services/coach-cost-tracker.ts
+++ b/lib/services/coach-cost-tracker.ts
@@ -248,6 +248,93 @@ export async function getWeeklyAggregate(
   };
 }
 
+/**
+ * Rough char-count → token estimator. ~4 characters per token is a standard
+ * approximation for English-plus-code prompts; accurate enough for weekly
+ * aggregate budgeting / provider comparison. Replace with a real tokenizer
+ * (tiktoken / gemini-equivalent) when the edge functions start surfacing real
+ * token counts in their responses (#537 follow-up).
+ */
+export function estimateTokens(text: string | undefined | null): number {
+  if (!text) return 0;
+  return Math.max(0, Math.round(text.length / 4));
+}
+
+/** Sum estimated tokens across the input-side messages of a coach call. */
+export function estimateMessageTokens(
+  messages: ReadonlyArray<{ content: string }>,
+): number {
+  let total = 0;
+  for (const m of messages) total += estimateTokens(m.content);
+  return total;
+}
+
+/**
+ * Map the coach dispatcher's task-kind enum (see coach-model-dispatch.ts)
+ * onto the cost-tracker's narrower taxonomy. Unmapped tactical kinds
+ * collapse to 'chat' (closest fit) so new kinds introduced by the dispatcher
+ * don't spray into the 'other' bucket before the UI decides how to surface
+ * them.
+ */
+const DISPATCH_TO_COST_TASK_KIND: Readonly<Record<string, CoachTaskKind>> = {
+  multi_turn_debrief: 'debrief',
+  fault_explainer: 'drill_explainer',
+  session_generator: 'session_generator',
+  program_design: 'progression_planner',
+  form_cue_lookup: 'chat',
+  rest_calc: 'chat',
+  encouragement: 'chat',
+  nutrition_balance: 'chat',
+  form_vision_check: 'chat',
+  general_chat: 'chat',
+};
+
+export function mapDispatchTaskKindForCost(kind: string | undefined): CoachTaskKind {
+  if (!kind) return 'chat';
+  return DISPATCH_TO_COST_TASK_KIND[kind] ?? 'other';
+}
+
+/**
+ * Translate the coach UI provider tag (dash-cased, e.g. `gemma-cloud` in
+ * `coach-provider-types.ts`) into the cost-tracker provider enum
+ * (underscore-cased here). Returns null for paths that do not represent a
+ * billable LLM call (cache, local fallback, or an unknown tag) so callers
+ * skip recording.
+ */
+export function mapCoachProviderForCost(
+  provider: string | undefined,
+): CoachProvider | null {
+  if (!provider) return null;
+  if (provider === 'openai') return 'openai';
+  if (provider === 'gemma-cloud' || provider === 'gemma_cloud') return 'gemma_cloud';
+  if (provider === 'gemma-on-device' || provider === 'gemma_ondevice') return 'gemma_ondevice';
+  return null;
+}
+
+/**
+ * High-level convenience: record usage for a coach reply. Collapses the
+ * plumbing (provider mapping, task-kind mapping, token estimation) so
+ * call sites stay one-liners. Never throws — persistence errors are swallowed
+ * inside `recordCoachUsage`. Returns a promise callers can fire-and-forget.
+ */
+export async function recordCoachReplyUsage(input: {
+  provider: string | undefined;
+  taskKind: string | undefined;
+  inputMessages: ReadonlyArray<{ content: string }>;
+  replyText: string;
+  cacheHit?: boolean;
+}): Promise<void> {
+  const provider = mapCoachProviderForCost(input.provider);
+  if (!provider) return;
+  await recordCoachUsage({
+    provider,
+    taskKind: mapDispatchTaskKindForCost(input.taskKind),
+    tokensIn: estimateMessageTokens(input.inputMessages),
+    tokensOut: estimateTokens(input.replyText),
+    cacheHit: input.cacheHit,
+  });
+}
+
 /** Reset the tracker. Intended for tests and sign-out. */
 export async function resetCoachCostTracker(): Promise<void> {
   state.buckets = [];

--- a/lib/services/coach-drill-explainer.ts
+++ b/lib/services/coach-drill-explainer.ts
@@ -95,11 +95,23 @@ export async function explainDrill(input: ExplainDrillInput): Promise<ExplainDri
 
   const context = { focus: 'drill-explainer', sessionId: undefined };
 
+  // Pipeline-v2: pass taskKind so the dispatcher recognises this as a
+  // tactical `fault_explainer` (→ Gemma tier) rather than falling back to
+  // general_chat, and so cost-tracker telemetry (#537) labels correctly.
+  // When V2 is off we omit opts entirely to preserve the two-arg call
+  // shape that existing tests assert against.
+  const taskKindOpts = pipelineV2
+    ? ({ taskKind: 'fault_explainer' as const })
+    : null;
+
   // Gemma-first attempt (both flags on). On any error we fall through to the
   // env-resolved provider below.
   if (gemmaFirst) {
     try {
-      const reply = await sendCoachPrompt(messages, context, { provider: 'gemma' });
+      const reply = await sendCoachPrompt(messages, context, {
+        ...(taskKindOpts ?? {}),
+        provider: 'gemma',
+      });
       const text = (reply.content ?? '').trim();
       if (text) {
         return { explanation: text, provider: 'gemma' };
@@ -114,11 +126,11 @@ export async function explainDrill(input: ExplainDrillInput): Promise<ExplainDri
   }
 
   try {
-    const reply = await sendCoachPrompt(
-      messages,
-      context,
-      resolvedProvider ? { provider: resolvedProvider } : undefined,
-    );
+    const cloudOpts =
+      resolvedProvider
+        ? { ...(taskKindOpts ?? {}), provider: resolvedProvider }
+        : taskKindOpts ?? undefined;
+    const reply = await sendCoachPrompt(messages, context, cloudOpts);
     const text = (reply.content ?? '').trim();
     if (!text) {
       return { explanation: '', provider: returnedProvider, error: 'Empty response from coach.' };

--- a/lib/services/coach-drill-explainer.ts
+++ b/lib/services/coach-drill-explainer.ts
@@ -1,9 +1,23 @@
 import { sendCoachPrompt } from '@/lib/services/coach-service';
 import type { CoachMessage } from '@/lib/services/coach-service';
+import type { CoachProvider } from '@/lib/services/coach-provider-types';
 import { isCoachPipelineV2Enabled } from '@/lib/services/coach-pipeline-v2-flag';
 import { isDispatchEnabled } from '@/lib/services/coach-model-dispatch-flag';
 
 export type DrillExplainerProvider = 'cloud' | 'gemma' | 'openai';
+
+/**
+ * Narrow the coach service's CoachProvider tag into the drill-explainer's
+ * three-way enum so callers see the actual producer (not the env-resolved
+ * default). Unknown / cache / local-fallback collapse to 'cloud' so existing
+ * UI branches that only handle the three primary values keep working.
+ */
+function mapToDrillProvider(cp: CoachProvider | undefined): DrillExplainerProvider | null {
+  if (!cp) return null;
+  if (cp === 'openai') return 'openai';
+  if (cp === 'gemma-cloud' || cp === 'gemma-on-device') return 'gemma';
+  return 'cloud';
+}
 
 /**
  * Pipeline-v2 provider resolution. Reads `EXPO_PUBLIC_COACH_CLOUD_PROVIDER`
@@ -132,10 +146,11 @@ export async function explainDrill(input: ExplainDrillInput): Promise<ExplainDri
         : taskKindOpts ?? undefined;
     const reply = await sendCoachPrompt(messages, context, cloudOpts);
     const text = (reply.content ?? '').trim();
+    const actualProvider = mapToDrillProvider(reply.provider) ?? returnedProvider;
     if (!text) {
-      return { explanation: '', provider: returnedProvider, error: 'Empty response from coach.' };
+      return { explanation: '', provider: actualProvider, error: 'Empty response from coach.' };
     }
-    return { explanation: text, provider: returnedProvider };
+    return { explanation: text, provider: actualProvider };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown coach error';
     return {

--- a/lib/services/coach-gemma-service.ts
+++ b/lib/services/coach-gemma-service.ts
@@ -2,6 +2,7 @@ import { supabase } from '@/lib/supabase';
 import { createError } from './ErrorHandler';
 import type { CoachContext, CoachMessage } from './coach-service';
 import type { CoachProvider } from './coach-provider-types';
+import { recordCoachReplyUsage } from './coach-cost-tracker';
 
 interface RawCoachGemmaResponse {
   message?: string;
@@ -29,7 +30,7 @@ function functionName(): string {
 export async function sendCoachGemmaPrompt(
   messages: CoachMessage[],
   context?: CoachContext,
-  opts?: { model?: string },
+  opts?: { model?: string; taskKind?: string },
 ): Promise<CoachMessage> {
   try {
     const body: Record<string, unknown> = { messages, context };
@@ -130,6 +131,15 @@ export async function sendCoachGemmaPrompt(
         writable: true,
       });
     }
+    // Cost-tracker wiring (#537): fire-and-forget usage record. Recording
+    // lives at the leaf so every Gemma call site (direct dispatcher, coach-
+    // service routing, auto-debrief direct dispatch) gets tracked uniformly.
+    recordCoachReplyUsage({
+      provider: 'gemma-cloud',
+      taskKind: opts?.taskKind,
+      inputMessages: messages,
+      replyText: responseText,
+    }).catch(() => undefined);
     return reply;
   } catch (err) {
     if (err && typeof err === 'object' && 'domain' in err) {

--- a/lib/services/coach-model-dispatch-flag.ts
+++ b/lib/services/coach-model-dispatch-flag.ts
@@ -14,12 +14,43 @@
  *
  * Intentionally strict string matching: we only flip on for the literal
  * `'on'` value, not "true" / "1" / "yes". Keeps the knob unambiguous.
+ *
+ * Observability: the first call logs the resolved state exactly once.
+ * When the env var is set to a non-empty non-canonical value (typos like
+ * `On`, `1`, `true`) we warn so ops catches config drift; when it's set
+ * to the canonical `on` we info-log confirmation so it's obvious dispatch
+ * is live. Calls after the first are pure — the log-once guard keeps the
+ * hot path free of I/O.
  */
+
+import { warnWithTs } from '@/lib/logger';
 
 const FLAG_ENV_VAR = 'EXPO_PUBLIC_COACH_DISPATCH';
 
+let loggedOnce = false;
+
 export function isDispatchEnabled(): boolean {
   const raw = process.env[FLAG_ENV_VAR];
-  if (typeof raw !== 'string') return false;
-  return raw === 'on';
+  const enabled = typeof raw === 'string' && raw === 'on';
+  if (!loggedOnce) {
+    loggedOnce = true;
+    if (enabled) {
+      // eslint-disable-next-line no-console
+      console.info(`[coach-dispatch-flag] ${FLAG_ENV_VAR}=on — dispatch ENABLED`);
+    } else if (typeof raw === 'string' && raw.trim().length > 0) {
+      warnWithTs(
+        `[coach-dispatch-flag] ${FLAG_ENV_VAR}=${JSON.stringify(raw)} ` +
+          `— expected literal "on" (lowercase). Dispatch remains OFF.`,
+      );
+    }
+  }
+  return enabled;
+}
+
+/**
+ * Reset the one-shot log guard. Test-only: lets suites assert the
+ * warn/info path fires without leaking flag state across tests.
+ */
+export function __resetDispatchFlagLogForTests(): void {
+  loggedOnce = false;
 }

--- a/lib/services/coach-service.ts
+++ b/lib/services/coach-service.ts
@@ -298,9 +298,39 @@ async function sendCoachPromptStreaming(
         }
       );
     }
-    return { role: 'assistant', content: shapeFinalResponse(safety.output) };
+    return attachStreamingProvenance({ role: 'assistant', content: shapeFinalResponse(safety.output) }, result);
   }
-  return { role: 'assistant', content: result.text };
+  return attachStreamingProvenance({ role: 'assistant', content: result.text }, result);
+}
+
+/**
+ * Mirror `sendCoachPromptInner`'s non-enumerable provider/model annotation
+ * so streamed replies carry the same provenance the sync path exposes.
+ * The streaming result may or may not include these fields — only the Gemma
+ * non-streaming fallback populates them today (see `coach-streaming.ts`);
+ * server-side NDJSON frames do not yet emit provider metadata. Closes #538.
+ */
+function attachStreamingProvenance(
+  reply: CoachMessage,
+  result: { provider?: CoachProvider | string; model?: string },
+): CoachMessage {
+  if (result.provider) {
+    Object.defineProperty(reply, 'provider', {
+      value: result.provider,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+  }
+  if (result.model) {
+    Object.defineProperty(reply, 'model', {
+      value: result.model,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return reply;
 }
 
 async function sendCoachPromptInner(

--- a/lib/services/coach-service.ts
+++ b/lib/services/coach-service.ts
@@ -20,6 +20,7 @@ import {
 } from './coach-model-dispatch';
 import { isDispatchEnabled } from './coach-model-dispatch-flag';
 import { recordDispatchDecision } from './coach-model-dispatch-telemetry';
+import { recordCoachReplyUsage } from './coach-cost-tracker';
 
 export type { CoachProvider } from './coach-provider-types';
 import type { LiveSessionSnapshot } from './coach-live-snapshot';
@@ -214,7 +215,7 @@ export async function sendCoachPrompt(
       messages,
       context,
       opts.cacheMs,
-      () => sendCoachPromptInner(messages, context),
+      () => sendCoachPromptInner(messages, context, opts),
       { shaper: opts.shaper }
     );
   }
@@ -249,9 +250,9 @@ export async function sendCoachPrompt(
   // No advanced opts: pick cloud provider (explicit hint, dispatcher, user pref, env, or openai default).
   const provider = opts?.provider ?? routedProvider ?? (await resolveCloudProvider());
   if (provider === 'gemma') {
-    return sendCoachGemmaPrompt(messages, context);
+    return sendCoachGemmaPrompt(messages, context, { taskKind: opts?.taskKind });
   }
-  return sendCoachPromptInner(messages, context);
+  return sendCoachPromptInner(messages, context, opts);
 }
 
 async function sendCoachPromptStreaming(
@@ -266,6 +267,14 @@ async function sendCoachPromptStreaming(
   const result = await streamCoachPrompt(messages, context, onChunk, {
     provider: opts.provider,
   });
+  // Fire-and-forget: persistence errors are swallowed inside the tracker,
+  // and we never want a usage-record hiccup to block the reply.
+  recordCoachReplyUsage({
+    provider: result.provider ?? opts.provider,
+    taskKind: opts.taskKind,
+    inputMessages: messages,
+    replyText: result.text,
+  }).catch(() => undefined);
 
   // Pipeline v2: apply the post-generation safety filter to the resolved
   // full-buffer text. Mirrors the non-stream path in sendCoachPromptInner.
@@ -335,7 +344,8 @@ function attachStreamingProvenance(
 
 async function sendCoachPromptInner(
   messages: CoachMessage[],
-  context?: CoachContext
+  context?: CoachContext,
+  opts?: CoachSendOptions,
 ): Promise<CoachMessage> {
   try {
     const memoryClause = await resolveMemoryClause(context);
@@ -542,6 +552,15 @@ async function sendCoachPromptInner(
       configurable: true,
       writable: true,
     });
+    // Cost-tracker wiring (#537): record usage for this turn. Fire-and-forget
+    // so persistence never blocks the reply; mapping failures silently skip.
+    recordCoachReplyUsage({
+      provider,
+      taskKind: opts?.taskKind,
+      inputMessages: messages,
+      replyText: responseText,
+      cacheHit: data?.source === 'cache',
+    }).catch(() => undefined);
     return reply;
   } catch (err) {
     if (err && typeof err === 'object' && 'domain' in err) {

--- a/lib/services/coach-streaming.ts
+++ b/lib/services/coach-streaming.ts
@@ -10,6 +10,7 @@ import { supabase } from '@/lib/supabase';
 import { createError } from './ErrorHandler';
 import { sendCoachGemmaPrompt } from './coach-gemma-service';
 import type { CoachContext, CoachMessage } from './coach-service';
+import type { CoachProvider } from './coach-provider-types';
 
 export interface StreamCoachOptions {
   /** Provider hint forwarded as `?provider=` (gemma|openai). */
@@ -53,6 +54,19 @@ export interface StreamCoachResult {
   durationMs: number;
   /** finishReason from the upstream provider, when present. */
   finishReason?: string;
+  /**
+   * Coach provider that produced the stream. Populated when the producer
+   * emits a provider annotation (e.g. the Gemma non-streaming fallback
+   * preserves `gemma-cloud`); otherwise undefined so the synchronous paths'
+   * `inferCoachProvider()` remains the single source of truth for
+   * unannotated cases. Closes #538.
+   */
+  provider?: CoachProvider;
+  /**
+   * Model identifier returned by the upstream producer (e.g. `gemma-3-4b-it`).
+   * Same policy as `provider` — only set when the producer annotates the reply.
+   */
+  model?: string;
 }
 
 interface StreamFrame {
@@ -299,10 +313,17 @@ async function streamGemmaViaNonStreamingFallback(
     onChunk(text);
   }
 
+  // The coach-gemma service attaches `provider` + `model` as non-enumerable
+  // properties on the reply (see coach-gemma-service.ts:119). Forward them
+  // onto the StreamCoachResult so the streaming caller can annotate its
+  // final CoachMessage with the same provenance the sync path surfaces.
+  // Closes #538.
   return {
     text,
     chunkCount: text.length > 0 ? 1 : 0,
     ttftMs,
     durationMs: Date.now() - startedAt,
+    ...(reply.provider ? { provider: reply.provider } : {}),
+    ...(reply.model ? { model: reply.model } : {}),
   };
 }

--- a/tests/unit/services/coach-drill-explainer.provider-dispatch.test.ts
+++ b/tests/unit/services/coach-drill-explainer.provider-dispatch.test.ts
@@ -47,24 +47,26 @@ describe('coach-drill-explainer provider dispatch (pipeline-v2)', () => {
     }
   });
 
-  it('passes provider=gemma through sendCoachPrompt when flag is on and env=gemma', async () => {
+  it('passes provider=gemma and taskKind=fault_explainer when flag is on and env=gemma', async () => {
     process.env[FLAG] = 'on';
     process.env[PROVIDER] = 'gemma';
     const result = await explainDrill(baseInput);
 
     expect(mockSendCoachPrompt).toHaveBeenCalledTimes(1);
     const [, , opts] = mockSendCoachPrompt.mock.calls[0];
-    expect(opts).toEqual({ provider: 'gemma' });
+    // V2 adds the fault_explainer taskKind so the dispatcher can pick the
+    // tactical tier and cost-tracker (#537) records the right bucket.
+    expect(opts).toEqual({ taskKind: 'fault_explainer', provider: 'gemma' });
     expect(result.provider).toBe('gemma');
   });
 
-  it('passes provider=openai through sendCoachPrompt when flag is on and env=openai', async () => {
+  it('passes provider=openai and taskKind=fault_explainer when flag is on and env=openai', async () => {
     process.env[FLAG] = 'on';
     process.env[PROVIDER] = 'openai';
     const result = await explainDrill(baseInput);
 
     const [, , opts] = mockSendCoachPrompt.mock.calls[0];
-    expect(opts).toEqual({ provider: 'openai' });
+    expect(opts).toEqual({ taskKind: 'fault_explainer', provider: 'openai' });
     expect(result.provider).toBe('openai');
   });
 

--- a/tests/unit/services/coach-service.provider-dispatch.test.ts
+++ b/tests/unit/services/coach-service.provider-dispatch.test.ts
@@ -90,7 +90,14 @@ describe('coach-service provider dispatch', () => {
 
     expect(result.content).toBe('Drive through the floor.');
     expect(mockSendCoachGemmaPrompt).toHaveBeenCalledTimes(1);
-    expect(mockSendCoachGemmaPrompt).toHaveBeenCalledWith(baseMessages, undefined);
+    // sendCoachPrompt forwards taskKind onto the Gemma leaf so cost-tracker
+    // labels telemetry correctly (#537). Unset taskKind flows through as
+    // `{ taskKind: undefined }` which is indistinguishable from omitted.
+    expect(mockSendCoachGemmaPrompt).toHaveBeenCalledWith(
+      baseMessages,
+      undefined,
+      { taskKind: undefined },
+    );
     expect(mockInvoke).not.toHaveBeenCalled();
     expect(mockResolveCloudProvider).not.toHaveBeenCalled();
   });
@@ -99,7 +106,11 @@ describe('coach-service provider dispatch', () => {
     const context = { profile: { id: 'u1', name: 'Pat' }, focus: 'squat' };
     await sendCoachPrompt(baseMessages, context, { provider: 'gemma' });
 
-    expect(mockSendCoachGemmaPrompt).toHaveBeenCalledWith(baseMessages, context);
+    expect(mockSendCoachGemmaPrompt).toHaveBeenCalledWith(
+      baseMessages,
+      context,
+      { taskKind: undefined },
+    );
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Wave-32 B — Gemma/coach service-layer reliability + telemetry correctness. Single large-scoped PR with atomic commits.

## What changes

- **B1** `coach-auto-debrief.ts` + `coach-drill-explainer.ts`: propagate `taskKind` (`multi_turn_debrief` / `fault_explainer`) to `sendCoachPrompt` when pipeline-v2 flag is on → dispatcher picks the right tier, cost-tracker (#537) labels telemetry correctly.
- **B5** `coach-drill-explainer.ts`: return the actual producer instead of the env-resolved default (`mapToDrillProvider(reply.provider) ?? returnedProvider`). Gemma wins are no longer misattributed as 'cloud'.
- **B2 + B6** `coach-streaming.ts` + `coach-service.ts`: `StreamCoachResult` gains optional `provider` + `model` fields; `streamGemmaViaNonStreamingFallback` forwards the non-enumerable annotations already attached by `sendCoachGemmaPrompt`; `sendCoachPromptStreaming` attaches them on the final `CoachMessage` using the same non-enumerable pattern as the sync path.
- **B3** `coach-cost-tracker.ts` gains `recordCoachReplyUsage` / `estimateTokens` / `mapDispatchTaskKindForCost` / `mapCoachProviderForCost` helpers; `sendCoachPromptInner`, `sendCoachPromptStreaming`, and `sendCoachGemmaPrompt` each fire-and-forget a usage record so every coach turn (direct, cached, streamed, Gemma-direct, fallback) is captured exactly once.
- **B7** `coach-cost-tracker.ts` `persist()` retries once after 120ms on transient AsyncStorage failure; in-memory state remains valid for reads if both attempts fail.
- **B8** `coach-model-dispatch-flag.ts` one-shot log on first evaluation: info-log when `=on` (confirmation), warn when set to a non-empty non-canonical value (e.g. `On`, `1`, `true`) to catch config typos.

Deferred to post-#566 follow-up:
- **B4** `coach-offline-queue.ts` drain-with-taskKind — the file is introduced by #566 (wave-31) and doesn't exist on main yet.

## Closes

- Closes #537 — coach-cost-tracker module had zero production call sites
- Closes #538 — StreamCoachResult discards provider/model fields
- Closes #539 — coach-drill-explainer always returns provider:'cloud'
- Partial #553 — taskKind propagation half (the 429 half is already fixed upstream)
- Closes #569 — wave-32 Gemma reliability umbrella

## Verification

- ✅ `bun run lint` clean
- ✅ `bun run check:types` clean
- ✅ `bun run test` 5008 pass / 25 skipped / 0 fail — 431 suites (coach + progression sweep: 674 pass across 51 suites)
- ✅ Pre-push policy + lint + types + audit green
- ✅ No file overlap with open PRs #565/#566/#567 (those touch form-UX screens + contexts; this one touches `lib/services/coach-*`)
- ✅ Fixture updates for existing provider-dispatch tests bundled as a separate atomic commit (asserts new call shapes)

## Commits

1. `fix(coach): propagate taskKind from auto-debrief + drill-explainer to dispatcher`
2. `fix(coach): drill-explainer attributes reply to actual producer`
3. `fix(coach): attach provider/model provenance to streaming replies`
4. `feat(coach): wire cost-tracker into service-layer call sites`
5. `fix(coach-cost-tracker): retry AsyncStorage persist once before giving up`
6. `feat(coach-dispatch-flag): one-shot log on first evaluation`
7. `test(coach): update provider-dispatch fixtures for wave-32 B1 + B5`