### PR TITLE
feat(wave32): form-UX polish pack — FQI a11y, pre-cal guidance, hook stability, router hardening

### DIFF
--- a/app/(modals)/form-tracking-debrief.tsx
+++ b/app/(modals)/form-tracking-debrief.tsx
@@ -31,6 +31,7 @@ import { resolveExerciseKey } from '@/lib/services/form-session-history-lookup';
 import { useAutoDebrief } from '@/hooks/use-auto-debrief';
 import { useSessionComparisonQuery } from '@/hooks/use-session-comparison';
 import { supabase } from '@/lib/supabase';
+import { warnWithTs } from '@/lib/logger';
 import { isCoachPipelineV2Enabled } from '@/lib/services/coach-pipeline-v2-flag';
 
 function safeParseReps(raw: string | undefined): RepSummary[] {
@@ -158,7 +159,14 @@ export default function FormTrackingDebriefScreen() {
       exerciseId: comparisonExerciseId,
       priorSessionId: comparison.priorSessionId,
     }).toString();
-    router.push(`/(modals)/form-comparison?${qs}` as `/${string}`);
+    // Defensive try/catch: router.push throws synchronously on bad routes
+    // (registry mismatch after a refactor) and the user would otherwise see
+    // a red-screen crash instead of an inert chip.
+    try {
+      router.push(`/(modals)/form-comparison?${qs}` as `/${string}`);
+    } catch (err) {
+      warnWithTs('[form-tracking-debrief] router.push to form-comparison failed', err);
+    }
   }, [router, comparison?.priorSessionId, comparisonExerciseId, routeSessionId]);
 
   // Pipeline v2: synthesize a stable sessionId from the recap payload so the

--- a/app/(modals)/form-tracking-pre-calibration.tsx
+++ b/app/(modals)/form-tracking-pre-calibration.tsx
@@ -150,6 +150,13 @@ interface PreviewStepProps {
   onCancel: () => void;
 }
 
+/**
+ * Low-confidence frame window after which we surface a remediation tip.
+ * Matches the auditor recommendation (≈15 frames ~1.5s @ 100ms cadence);
+ * keeps the tip suppressed during the normal short settling window.
+ */
+const LOW_CONFIDENCE_HINT_THRESHOLD = 15;
+
 function PreviewStep({
   confidencePercent,
   framesPercent,
@@ -159,6 +166,13 @@ function PreviewStep({
   onCancel,
 }: PreviewStepProps) {
   const isReady = statusLabel === 'success' || confidencePercent >= 75;
+  // After ~15 frames of sub-50% confidence, the settling window is over and
+  // low confidence is usually an environment problem. Surface an actionable
+  // hint rather than leaving the user staring at a spinning baseline.
+  const showLowConfidenceHint =
+    !isReady &&
+    framesObserved >= LOW_CONFIDENCE_HINT_THRESHOLD &&
+    confidencePercent < 50;
   return (
     <>
       <View style={styles.iconWrap}>
@@ -169,7 +183,10 @@ function PreviewStep({
         )}
       </View>
       <Text style={styles.title}>Calibrating tracker</Text>
-      <Text style={styles.subtitle}>Hold still — building a confidence baseline.</Text>
+      <Text style={styles.subtitle}>
+        Hold still — building a confidence baseline. Low confidence usually
+        means low light, occlusion, or a partial-body frame.
+      </Text>
       <View style={styles.metricRow}>
         <Metric label="Confidence" value={`${confidencePercent}%`} />
         <Metric label="Frames" value={`${framesObserved}`} />
@@ -177,6 +194,15 @@ function PreviewStep({
       <View style={styles.progressTrack} accessibilityLabel={`Calibration ${framesPercent}% complete`}>
         <View style={[styles.progressFill, { width: `${Math.max(2, framesPercent)}%` }]} />
       </View>
+      {showLowConfidenceHint ? (
+        <View style={styles.hintCallout} accessibilityLiveRegion="polite">
+          <Ionicons name="bulb-outline" size={16} color="#FFC244" />
+          <Text style={styles.hintText}>
+            Try more light, stepping back, or clearing the background — your
+            full body should fit the frame.
+          </Text>
+        </View>
+      ) : null}
       <View style={styles.actions}>
         <TouchableOpacity style={styles.secondaryButton} onPress={onCancel} testID="pre-calibration-cancel">
           <Text style={styles.secondaryButtonText}>Cancel</Text>
@@ -342,5 +368,24 @@ const styles = StyleSheet.create({
   progressFill: {
     height: '100%',
     backgroundColor: '#4C8CFF',
+  },
+  hintCallout: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+    marginTop: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: 'rgba(255, 194, 68, 0.12)',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 194, 68, 0.25)',
+    width: '100%',
+  },
+  hintText: {
+    flex: 1,
+    color: '#F5E7C3',
+    fontSize: 12,
+    lineHeight: 16,
   },
 });

--- a/components/form-tracking/FqiExplainerModal.tsx
+++ b/components/form-tracking/FqiExplainerModal.tsx
@@ -30,6 +30,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 
+import { warnWithTs } from '@/lib/logger';
 import { getFqiColor } from './FqiGauge';
 
 export interface FqiExplainerModalProps {
@@ -92,7 +93,14 @@ export function FqiExplainerModal({
     if (!exerciseId) return;
     onDismiss();
     const encoded = encodeURIComponent(exerciseId);
-    router.push(`/(modals)/form-quality-recovery?exerciseId=${encoded}` as `/${string}`);
+    // Guard against a bad route (e.g. registry out-of-sync after a refactor)
+    // so the crash doesn't propagate past the dismissed modal. router.push
+    // throws synchronously for invalid routes in expo-router.
+    try {
+      router.push(`/(modals)/form-quality-recovery?exerciseId=${encoded}` as `/${string}`);
+    } catch (err) {
+      warnWithTs('[FqiExplainerModal] router.push to form-quality-recovery failed', err);
+    }
   };
 
   return (

--- a/components/form-tracking/FqiGauge.tsx
+++ b/components/form-tracking/FqiGauge.tsx
@@ -16,8 +16,15 @@
  * `score = null` to render the idle state ("--").
  */
 
-import React, { useEffect, useMemo } from 'react';
-import { View, Text, StyleSheet, type ViewStyle, type StyleProp } from 'react-native';
+import React, { useEffect, useMemo, useRef } from 'react';
+import {
+  AccessibilityInfo,
+  View,
+  Text,
+  StyleSheet,
+  type ViewStyle,
+  type StyleProp,
+} from 'react-native';
 import Svg, { Circle } from 'react-native-svg';
 import { MotiView } from 'moti';
 
@@ -41,6 +48,23 @@ const SIZE_MAP: Record<FqiGaugeSize, { diameter: number; strokeWidth: number; fo
   md: { diameter: 72, strokeWidth: 6, fontSize: 22, labelSize: 10 },
   lg: { diameter: 96, strokeWidth: 8, fontSize: 30, labelSize: 12 },
 };
+
+type FqiBucket = 'poor' | 'acceptable' | 'good';
+
+function toBucket(score: number | null): FqiBucket | null {
+  if (score == null || Number.isNaN(score)) return null;
+  if (score < 40) return 'poor';
+  if (score < 70) return 'acceptable';
+  return 'good';
+}
+
+function bucketLabel(bucket: FqiBucket): string {
+  return bucket === 'poor'
+    ? 'poor'
+    : bucket === 'acceptable'
+      ? 'acceptable'
+      : 'good';
+}
 
 /** Map an FQI score 0-100 into a semantic color bucket. */
 export function getFqiColor(score: number | null): { fill: string; track: string; text: string } {
@@ -81,6 +105,30 @@ export default function FqiGauge({
   useEffect(() => {
     if (score != null) setPulseKey((k) => k + 1);
   }, [score]);
+
+  // Screen-reader announcement on FQI bucket changes (poor → ok → good).
+  // accessibilityValue updates alone aren't reliably re-announced by
+  // VoiceOver during live sessions; firing an explicit announcement when
+  // the semantic bucket crosses a threshold gives a vision-impaired user
+  // audible confirmation that form quality shifted. We debounce on bucket
+  // rather than raw score so announcements don't stack every frame.
+  const lastBucketRef = useRef<FqiBucket | null>(null);
+  useEffect(() => {
+    const bucket = toBucket(score);
+    if (bucket === null) {
+      lastBucketRef.current = null;
+      return;
+    }
+    if (lastBucketRef.current === bucket) return;
+    const prev = lastBucketRef.current;
+    lastBucketRef.current = bucket;
+    // Skip the first transition when there was no prior reading — the
+    // accessibilityValue on mount already communicates the initial state.
+    if (prev === null) return;
+    AccessibilityInfo.announceForAccessibility(
+      `Form quality ${bucketLabel(bucket)} — ${Math.round(clamped)} of 100`,
+    );
+  }, [score, clamped]);
 
   const displayScore = score == null ? '--' : Math.round(clamped).toString();
   const label =

--- a/hooks/use-auto-debrief.ts
+++ b/hooks/use-auto-debrief.ts
@@ -120,6 +120,16 @@ export function useAutoDebrief(opts: UseAutoDebriefOptions): UseAutoDebriefState
   // waiting for another session_finished event.
   const lastInputRef = useRef<GenerateAutoDebriefInput | null>(null);
 
+  // Keep a stable reference to buildInput so the session-finished subscribe
+  // effect doesn't re-subscribe on every parent re-render when the caller
+  // passes a fresh closure (common: inline `() => ...`). Without this ref,
+  // the effect unsubscribes + resubscribes every render, which can drop a
+  // session-finished event fired mid-transition.
+  const buildInputRef = useRef(buildInput);
+  useEffect(() => {
+    buildInputRef.current = buildInput;
+  });
+
   const runWith = useCallback(async (input: GenerateAutoDebriefInput) => {
     lastInputRef.current = input;
     setLoading(true);
@@ -184,12 +194,14 @@ export function useAutoDebrief(opts: UseAutoDebriefOptions): UseAutoDebriefState
     };
   }, [sessionId]);
 
-  // Subscribe to session-finished events.
+  // Subscribe to session-finished events. Reads buildInput from a ref so
+  // the subscription is stable across parent re-renders that pass a fresh
+  // inline closure.
   useEffect(() => {
     if (!isAutoDebriefEnabled()) return;
     const unsubscribe = onSessionFinished(async (event) => {
       try {
-        const input = await buildInput(event);
+        const input = await buildInputRef.current(event);
         if (!input) return;
         await runWith(input);
       } catch (err) {
@@ -199,7 +211,7 @@ export function useAutoDebrief(opts: UseAutoDebriefOptions): UseAutoDebriefState
       }
     });
     return unsubscribe;
-  }, [buildInput, runWith]);
+  }, [runWith]);
 
   return { data, loading, error, retry };
 }


### PR DESCRIPTION
Wave-32 A — focused form-tracking UX + correctness pack. Single PR, atomic commits.

## What changes

- **U4** `FqiGauge.tsx`: VoiceOver announcement on FQI semantic-bucket changes (poor/acceptable/good) via `AccessibilityInfo.announceForAccessibility`. Debounced on bucket (not raw score) so announcements only fire when the meaning changes. accessibilityValue updates alone are not reliably re-announced by screen readers during a live session.
- **U2** `form-tracking-pre-calibration.tsx`: subtitle now explains what low confidence means (low light / occlusion / partial frame); after 15 frames at <50% an accessibility-live tip surfaces concrete remediation ("more light, step back, clear the background"). Normal fast-converging sessions stay clean.
- **F1** `hooks/use-auto-debrief.ts`: `buildInput` is routed through a ref so the `onSessionFinished` subscribe effect doesn't thrash every render when the caller passes a fresh inline closure. No more unsubscribe→resubscribe window where a mid-transition event can be missed.
- **F3/F7** `FqiExplainerModal.tsx` + `form-tracking-debrief.tsx`: wrap both `router.push` call sites in try/catch with `warnWithTs`. Route-registry drift now surfaces as a warn log instead of a red-screen crash.

## Findings deferred out of scope

Several audit findings didn't pan out on verification:
- F2 userId race — `useSessionComparisonQuery` already guards `!userId` at the effect entry.
- F4 haptic unmount guard — timeout is already cleared on unmount cleanup.
- F6 cancelled guard — already in place.
- U6 tracking-recovered announcement — `TrackingLossBanner` isn't yet imported from any `app/` file on main (wiring lives in in-flight PRs); adding a hook here would be dead code until that lands.
- U1/U7 MediaPipe fallback copy + provider badge — requires touching `scan-arkit.tsx` (~3000 LOC); deferred to avoid merge-conflict surface with in-flight PRs that also edit it.
- U5 destructive-action confirmation — same scope constraint as U1/U7; deferred.

## Closes

- Part of #568 — wave-32 form-UX umbrella (F1/F3/F7/U2/U4 checklist boxes)

## Verification

- ✅ `bun run lint` clean
- ✅ `bun run check:types` clean
- ✅ `bun run test` 5008 pass / 25 skipped / 0 fail — 431 suites
- ✅ Pre-push policy + lint + types + audit green
- ✅ No file overlap with open PRs: PR #571 (wave-32 B) touches `lib/services/coach-*`; PRs #565/#566/#567 (wave-31) touch different components. This PR touches `components/form-tracking/FqiGauge` + `FqiExplainerModal`, `app/(modals)/form-tracking-pre-calibration` + `form-tracking-debrief`, and `hooks/use-auto-debrief`.

## Commits

1. `feat(form-tracking): FQI gauge announces bucket changes to VoiceOver`
2. `feat(form-tracking): pre-calibration explains low-confidence + surfaces tip`
3. `fix(use-auto-debrief): stable session-finished subscription via ref`
4. `fix(form-tracking): catch router.push failures in debrief + FQI explainer`