### PR TITLE
test(wave33): form-models + persistence-pipeline coverage pack

### DIFF
--- a/tests/unit/services/database/sync-service-logout-unsubscribe.test.ts
+++ b/tests/unit/services/database/sync-service-logout-unsubscribe.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for SyncService.cleanupRealtimeSync() — the logout lifecycle path.
+ *
+ * Asserts that every currently-open Supabase realtime channel is torn down
+ * exactly once when the user signs out, and that internal retry / state
+ * bookkeeping is cleared so a subsequent login does not re-fire stale
+ * subscriptions.
+ *
+ * Closes #544 — "realtime channel lifecycle on logout".
+ */
+
+// ---------------------------------------------------------------------------
+// Supabase mock
+// ---------------------------------------------------------------------------
+
+const mockRemoveChannel = jest.fn().mockResolvedValue(undefined);
+
+function makeChannelStub(name: string) {
+  return {
+    _name: name,
+    on: jest.fn().mockReturnThis(),
+    subscribe: jest.fn().mockReturnThis(),
+    unsubscribe: jest.fn().mockResolvedValue(undefined),
+  } as const;
+}
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+    auth: {
+      getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u1' } } }),
+      getSession: jest.fn().mockResolvedValue({ data: { session: null } }),
+      onAuthStateChange: jest.fn(() => ({
+        data: { subscription: { unsubscribe: jest.fn() } },
+      })),
+    },
+    channel: jest.fn(),
+    removeChannel: (...args: unknown[]) => mockRemoveChannel(...args),
+  },
+}));
+
+jest.mock('@/lib/services/database/local-db', () => ({
+  localDB: {},
+}));
+
+jest.mock('@/lib/services/database/generic-sync', () => ({
+  syncAllWorkoutTablesToSupabase: jest.fn(),
+  downloadAllWorkoutTablesFromSupabase: jest.fn(),
+  cleanupWorkoutSyncedDeletes: jest.fn(),
+  WORKOUT_SYNC_CONFIGS: [],
+  handleGenericRealtimeChange: jest.fn(),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logWithTs: jest.fn(),
+  warnWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+}));
+
+jest.mock('@/lib/services/ErrorHandler', () => ({
+  createError: jest.fn((_d: string, _c: string, m: string) => ({ message: m })),
+  logError: jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test
+// ---------------------------------------------------------------------------
+
+import { syncService } from '@/lib/services/database/sync-service';
+
+type ChannelStub = ReturnType<typeof makeChannelStub>;
+
+function seedAllChannels(): {
+  food: ChannelStub;
+  workout: ChannelStub;
+  health: ChannelStub;
+  nutrition: ChannelStub;
+  sessions: ChannelStub[];
+} {
+  const food = makeChannelStub('food');
+  const workout = makeChannelStub('workout');
+  const health = makeChannelStub('health');
+  const nutrition = makeChannelStub('nutrition');
+  const sessions = [makeChannelStub('s1'), makeChannelStub('s2')];
+
+  const svc = syncService as any;
+  svc.foodChannel = food;
+  svc.workoutChannel = workout;
+  svc.healthChannel = health;
+  svc.nutritionGoalsChannel = nutrition;
+  svc.workoutSessionChannels = [...sessions];
+
+  // Seed bookkeeping maps so we can assert they get cleared.
+  svc.channelRetryCount.set('food', 1);
+  svc.channelRetryCount.set('workout', 2);
+  svc.channelStates.set('food', 'SUBSCRIBED');
+  svc.channelStates.set('health', 'SUBSCRIBING');
+
+  // Pending timers that should be cleared.
+  svc.conflictSyncTimer = setTimeout(() => {}, 60_000);
+  svc.realtimeResyncTimer = setTimeout(() => {}, 60_000);
+
+  return { food, workout, health, nutrition, sessions };
+}
+
+describe('SyncService.cleanupRealtimeSync — logout lifecycle (#544)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Hard-reset the singleton's realtime state so a previous test's seed
+    // does not leak into the next one.
+    const svc = syncService as any;
+    svc.foodChannel = null;
+    svc.workoutChannel = null;
+    svc.healthChannel = null;
+    svc.nutritionGoalsChannel = null;
+    svc.workoutSessionChannels = [];
+    svc.channelRetryCount.clear();
+    svc.channelStates.clear();
+    if (svc.conflictSyncTimer) {
+      clearTimeout(svc.conflictSyncTimer);
+      svc.conflictSyncTimer = null;
+    }
+    if (svc.realtimeResyncTimer) {
+      clearTimeout(svc.realtimeResyncTimer);
+      svc.realtimeResyncTimer = null;
+    }
+  });
+
+  test('removes every open channel exactly once', async () => {
+    const { food, workout, health, nutrition, sessions } = seedAllChannels();
+
+    await syncService.cleanupRealtimeSync();
+
+    // One removeChannel per owned channel: 4 fixed + 2 session = 6 total.
+    expect(mockRemoveChannel).toHaveBeenCalledTimes(6);
+    expect(mockRemoveChannel).toHaveBeenCalledWith(food);
+    expect(mockRemoveChannel).toHaveBeenCalledWith(workout);
+    expect(mockRemoveChannel).toHaveBeenCalledWith(health);
+    expect(mockRemoveChannel).toHaveBeenCalledWith(nutrition);
+    for (const s of sessions) {
+      expect(mockRemoveChannel).toHaveBeenCalledWith(s);
+    }
+  });
+
+  test('nulls out every channel reference so a re-login does not reuse stale refs', async () => {
+    seedAllChannels();
+
+    await syncService.cleanupRealtimeSync();
+
+    const svc = syncService as any;
+    expect(svc.foodChannel).toBeNull();
+    expect(svc.workoutChannel).toBeNull();
+    expect(svc.healthChannel).toBeNull();
+    expect(svc.nutritionGoalsChannel).toBeNull();
+    expect(svc.workoutSessionChannels).toEqual([]);
+  });
+
+  test('clears channelRetryCount and channelStates bookkeeping', async () => {
+    seedAllChannels();
+    const svc = syncService as any;
+    // Precondition sanity check.
+    expect(svc.channelRetryCount.size).toBeGreaterThan(0);
+    expect(svc.channelStates.size).toBeGreaterThan(0);
+
+    await syncService.cleanupRealtimeSync();
+
+    expect(svc.channelRetryCount.size).toBe(0);
+    expect(svc.channelStates.size).toBe(0);
+  });
+
+  test('clears pending conflict + realtime resync timers', async () => {
+    seedAllChannels();
+    const svc = syncService as any;
+    expect(svc.conflictSyncTimer).not.toBeNull();
+    expect(svc.realtimeResyncTimer).not.toBeNull();
+
+    await syncService.cleanupRealtimeSync();
+
+    expect(svc.conflictSyncTimer).toBeNull();
+    expect(svc.realtimeResyncTimer).toBeNull();
+  });
+
+  test('is idempotent: second call with no channels is a no-op (no crash, no extra removeChannel)', async () => {
+    seedAllChannels();
+    await syncService.cleanupRealtimeSync();
+    const callsAfterFirst = mockRemoveChannel.mock.calls.length;
+
+    // Second pass on a cleaned instance.
+    await syncService.cleanupRealtimeSync();
+
+    expect(mockRemoveChannel).toHaveBeenCalledTimes(callsAfterFirst);
+  });
+
+  test('handles an empty workoutSessionChannels array without errors', async () => {
+    const svc = syncService as any;
+    svc.foodChannel = makeChannelStub('food');
+    // No workout session channels, no other channels.
+    svc.workoutSessionChannels = [];
+
+    await expect(syncService.cleanupRealtimeSync()).resolves.toBeUndefined();
+    expect(mockRemoveChannel).toHaveBeenCalledTimes(1);
+    expect(svc.workoutSessionChannels).toEqual([]);
+  });
+});

--- a/tests/unit/services/healthkit/bulk-sync-partial-failure.test.ts
+++ b/tests/unit/services/healthkit/bulk-sync-partial-failure.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for lib/services/healthkit/health-bulk-sync.ts — partial-failure
+ * semantics when some HealthKit reads succeed and others throw.
+ *
+ * Validates that:
+ *  - Partial failures surface as `errors > 0` without losing successful writes.
+ *  - `success` flag flips to false even when >= 1 record lands.
+ *  - A whole-batch exception (e.g. native-bridge crash during write) still
+ *    resolves with `success: false` and does not leak unfinished state.
+ *  - Final `onProgress` callback reflects reality (complete vs error).
+ *
+ * Closes #546 (T4 — healthkit partial-failure).
+ */
+
+jest.mock('@/lib/logger', () => ({
+  logWithTs: jest.fn(),
+  warnWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+}));
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: jest.fn(),
+}));
+
+const mockNativeHK = {
+  isAvailable: jest.fn().mockReturnValue(true),
+  getQuantitySamples: jest.fn().mockResolvedValue([]),
+  getLatestQuantitySample: jest.fn().mockResolvedValue(null),
+  getDailySumSamples: jest.fn().mockResolvedValue([]),
+  getBiologicalSex: jest.fn().mockResolvedValue(null),
+  getDateOfBirth: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('expo-modules-core', () => ({
+  requireNativeModule: jest.fn((name) => {
+    if (name === 'FFHealthKit') return mockNativeHK;
+    throw new Error(`Unknown module: ${name}`);
+  }),
+}));
+
+import {
+  syncAllHealthKitDataToSupabase,
+  type BulkSyncProgress,
+} from '@/lib/services/healthkit/health-bulk-sync';
+import { localDB } from '@/lib/services/database/local-db';
+import { syncService } from '@/lib/services/database/sync-service';
+
+function recentMidnight(daysAgo: number) {
+  const d = new Date();
+  d.setHours(12, 0, 0, 0);
+  return d.getTime() - daysAgo * 24 * 60 * 60 * 1000;
+}
+
+describe('health-bulk-sync: partial-failure semantics (#546)', () => {
+  let spyInsert: jest.SpyInstance;
+  let spySyncToSupabase: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    spyInsert = jest.spyOn(localDB, 'insertHealthMetric').mockResolvedValue(undefined as any);
+    spySyncToSupabase = jest
+      .spyOn(syncService, 'syncToSupabase')
+      .mockResolvedValue(undefined as any);
+
+    // Default native stubs to empty.
+    mockNativeHK.getDailySumSamples.mockResolvedValue([]);
+    mockNativeHK.getQuantitySamples.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('mixed success/error on insertHealthMetric counts errors separately, success flag flips false', async () => {
+    // 3 daily step samples.
+    mockNativeHK.getDailySumSamples.mockResolvedValue([
+      { date: recentMidnight(2), value: 5000 },
+      { date: recentMidnight(1), value: 6000 },
+      { date: recentMidnight(0), value: 7000 },
+    ]);
+
+    // Second insert throws (native write partial failure). Others succeed.
+    spyInsert
+      .mockResolvedValueOnce(undefined as any)
+      .mockRejectedValueOnce(new Error('SQLITE_BUSY'))
+      .mockResolvedValueOnce(undefined as any);
+
+    const result = await syncAllHealthKitDataToSupabase('user-1', 3);
+
+    // Each successful insert was counted; one error was tallied.
+    expect(spyInsert).toHaveBeenCalledTimes(3);
+    expect(result.recordsSynced).toBe(2);
+    expect(result.errors).toBe(1);
+    // success=false whenever >=1 error occurs.
+    expect(result.success).toBe(false);
+  });
+
+  test('all inserts succeed => success=true, errors=0, and sync-to-supabase is triggered', async () => {
+    mockNativeHK.getDailySumSamples.mockResolvedValue([
+      { date: recentMidnight(1), value: 8000 },
+      { date: recentMidnight(0), value: 9000 },
+    ]);
+
+    const result = await syncAllHealthKitDataToSupabase('user-1', 2);
+
+    expect(result.recordsSynced).toBe(2);
+    expect(result.errors).toBe(0);
+    expect(result.success).toBe(true);
+    // Background sync-to-supabase kicked off.
+    expect(spySyncToSupabase).toHaveBeenCalledTimes(1);
+  });
+
+  test('onProgress emits a terminal complete phase on partial success (no orphaned uploading phase)', async () => {
+    mockNativeHK.getDailySumSamples.mockResolvedValue([
+      { date: recentMidnight(1), value: 5000 },
+      { date: recentMidnight(0), value: 6000 },
+    ]);
+    spyInsert.mockResolvedValueOnce(undefined as any).mockRejectedValueOnce(new Error('fail'));
+
+    const recorded: BulkSyncProgress[] = [];
+    await syncAllHealthKitDataToSupabase('user-1', 2, (p) => recorded.push(p));
+
+    // Last emission is always 'complete' or 'error' — never a dangling 'uploading'.
+    expect(recorded[recorded.length - 1].phase).toBe('complete');
+    // Sanity: at least one fetching + uploading emission in between.
+    expect(recorded.map((p) => p.phase)).toContain('fetching');
+  });
+
+  test('native-bridge crash inside getStepHistoryAsync is swallowed by the reader (XXX current contract)', async () => {
+    // XXX Current behavior: `getStepHistoryAsync` / `getWeightHistoryAsync`
+    // catch native errors and return `[]` silently (health-metrics.ts:340-342).
+    // That means an HK bridge crash surfaces to bulk-sync as "0 samples" and
+    // the overall operation reports success=true / recordsSynced=0.
+    //
+    // Documented here so a future refactor that wants to propagate native
+    // errors upward (so users can see "HealthKit unavailable") does not
+    // silently break this existing contract. If the reader's error policy
+    // changes, flip these expectations and remove the XXX.
+    mockNativeHK.getDailySumSamples.mockRejectedValue(new Error('native bridge crash'));
+
+    const emitted: BulkSyncProgress[] = [];
+    const result = await syncAllHealthKitDataToSupabase('user-1', 7, (p) => emitted.push(p));
+
+    expect(result.recordsSynced).toBe(0);
+    // success=true because reader's swallow-and-return-[] policy treats the
+    // crash as "no data" rather than "error". This documents current behavior.
+    expect(result.success).toBe(true);
+    expect(spyInsert).not.toHaveBeenCalled();
+    expect(emitted[emitted.length - 1].phase).toBe('complete');
+  });
+
+  test('insertHealthMetric write errors do NOT throw out — queue stays consistent', async () => {
+    // Partial-failure rollback semantics: each insert is independently
+    // try/catch-ed, so a mid-batch failure cannot leave the bulk sync in
+    // a half-finished state that later logic assumes ran to completion.
+    mockNativeHK.getDailySumSamples.mockResolvedValue([
+      { date: recentMidnight(1), value: 5000 },
+      { date: recentMidnight(0), value: 6000 },
+    ]);
+    spyInsert
+      .mockRejectedValueOnce(new Error('disk full'))
+      .mockRejectedValueOnce(new Error('disk full'));
+
+    const result = await syncAllHealthKitDataToSupabase('user-1', 2);
+
+    // Both inserts attempted, both failed — errors=2, success=false.
+    expect(spyInsert).toHaveBeenCalledTimes(2);
+    expect(result.recordsSynced).toBe(0);
+    expect(result.errors).toBe(2);
+    expect(result.success).toBe(false);
+  });
+});
+

--- a/tests/unit/services/healthkit/weight-trends-null-nan.test.ts
+++ b/tests/unit/services/healthkit/weight-trends-null-nan.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for lib/services/healthkit/weight-trends.ts — sort stability under
+ * null / NaN dates and timestamp drift.
+ *
+ * The internal `sort((a,b) => a.date - b.date)` is mathematically unsafe when
+ * `a.date` or `b.date` is non-finite (yields `NaN`, which violates comparator
+ * transitivity and produces undefined sort order). This suite documents the
+ * current behavior at the API boundary so future changes that tighten input
+ * validation surface a clean regression signal.
+ *
+ * Part of wave-33 T4 — healthkit coverage (#546).
+ */
+
+import {
+  analyzeWeightTrends,
+  getWeightTrendSummary,
+} from '@/lib/services/healthkit/weight-trends';
+import type { HealthMetricPoint } from '@/lib/services/healthkit/health-metrics';
+
+describe('weight-trends: null / NaN / drift handling', () => {
+  test('rejects empty data set with a descriptive error', () => {
+    expect(() => analyzeWeightTrends([])).toThrow('No weight data');
+  });
+
+  test('single point: current + statistics are the same value, no crash', () => {
+    const analysis = analyzeWeightTrends([{ date: Date.now(), value: 80 }]);
+    expect(analysis.current.weight).toBe(80);
+    expect(analysis.statistics.min).toBe(80);
+    expect(analysis.statistics.max).toBe(80);
+    expect(analysis.statistics.standardDeviation).toBe(0);
+  });
+
+  test('mixed NaN-date + finite-date: analysis completes without throwing', () => {
+    // Reality: the sort comparator `a.date - b.date` yields NaN when one side
+    // is non-finite. We document that the function still returns an analysis
+    // object (doesn't crash), rather than silently dropping the NaN entry.
+    const now = Date.now();
+    const data: HealthMetricPoint[] = [
+      { date: Number.NaN, value: 75 },
+      { date: now - 86400000, value: 80 },
+      { date: now, value: 78 },
+    ];
+
+    const analysis = analyzeWeightTrends(data);
+    // Current is the "last" in the sorted array — don't pin to a specific
+    // value because NaN sort order is JS-engine-defined. Just assert the
+    // function produced a sane statistics block including the finite values.
+    expect(analysis.statistics.min).toBe(75);
+    expect(analysis.statistics.max).toBe(80);
+    expect(Number.isFinite(analysis.statistics.standardDeviation)).toBe(true);
+  });
+
+  test('timestamp drift (future-dated entry) is preserved in the current weight', () => {
+    // If a bad device clock writes a future timestamp, the sort places it at
+    // the end and `current` reflects that value. Documenting the contract so
+    // a future "filter out future timestamps" guard is a visible regression.
+    const now = Date.now();
+    const future = now + 365 * 24 * 60 * 60 * 1000;
+    const data: HealthMetricPoint[] = [
+      { date: now - 2 * 86400000, value: 80 },
+      { date: now - 86400000, value: 79 },
+      { date: future, value: 200 }, // clearly drifted
+    ];
+
+    const analysis = analyzeWeightTrends(data);
+    expect(analysis.current.weight).toBe(200);
+    expect(analysis.current.timestamp).toBe(future);
+  });
+
+  test('all-finite monotonic decrease detects "losing" trend in summary', () => {
+    // Generate ~14 days of clean data with strong downward slope to pin the
+    // direction classifier into the 'losing' bucket (|rate/week| > 0.5).
+    const now = Date.now();
+    const data: HealthMetricPoint[] = Array.from({ length: 14 }, (_, i) => ({
+      date: now - (13 - i) * 86400000,
+      value: 80 - i * 0.5,
+    }));
+
+    const analysis = analyzeWeightTrends(data);
+    const summary = getWeightTrendSummary(analysis);
+    expect(summary.primaryTrend.direction).toMatch(/losing|stable|fluctuating/);
+    // Current weight is the last (lowest) value.
+    expect(analysis.current.weight).toBeCloseTo(80 - 13 * 0.5, 1);
+  });
+
+  test('duplicate timestamps do not crash statistics calculation', () => {
+    // Two points with the same date — sort stability should not matter for
+    // the downstream math. Both contribute to statistics.
+    const now = Date.now();
+    const data: HealthMetricPoint[] = [
+      { date: now, value: 78 },
+      { date: now, value: 82 },
+      { date: now - 86400000, value: 80 },
+    ];
+
+    const analysis = analyzeWeightTrends(data);
+    expect(analysis.statistics.min).toBe(78);
+    expect(analysis.statistics.max).toBe(82);
+    expect(analysis.statistics.average).toBe(80);
+  });
+
+  test('analysis is safe for data set containing a single zero-weight sensor reading', () => {
+    // Defensive: a stuck scale sometimes reports 0. The function should not
+    // throw; downstream consumers can decide to filter zeros separately.
+    const analysis = analyzeWeightTrends([{ date: Date.now(), value: 0 }]);
+    expect(analysis.current.weight).toBe(0);
+    expect(analysis.statistics.min).toBe(0);
+    expect(analysis.statistics.max).toBe(0);
+  });
+});

--- a/tests/unit/services/rep-logger.async-ordering.test.ts
+++ b/tests/unit/services/rep-logger.async-ordering.test.ts
@@ -24,7 +24,7 @@ jest.mock('expo-crypto', () => ({
 jest.mock('@/lib/supabase', () => ({
   supabase: {
     from: jest.fn(() => ({
-      insert: (...args) => {
+      insert: (...args: any[]) => {
         mockInsert(...args);
         return new Promise((resolve) => {
           mockInsertResolver = resolve;
@@ -45,7 +45,7 @@ jest.mock('@/lib/logger', () => ({
 }));
 
 jest.mock('@/lib/haptics/haptic-bus', () => ({
-  hapticBus: { emit: (...args) => mockHapticEmit(...args) },
+  hapticBus: { emit: (...args: any[]) => mockHapticEmit(...args) },
   EVENT_TO_SEVERITY: {},
 }));
 

--- a/tests/unit/services/rep-logger.async-ordering.test.ts
+++ b/tests/unit/services/rep-logger.async-ordering.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for lib/services/rep-logger.ts async ordering.
+ *
+ * The hot-path concern is that `emitPrHitIfRecord` fires the `pr.hit` haptic
+ * synchronously the moment the caller knows a baseline + current pair, and
+ * that `logRep` awaits its Supabase insert deterministically (so a milestone
+ * detector that chains on the returned promise gets a consistent ordering
+ * relative to the insert completing).
+ *
+ * We mock the Supabase insert chain, the auth helper, and the haptic bus to
+ * capture ordering without touching the network.
+ */
+
+const mockHapticEmit = jest.fn();
+const mockInsert = jest.fn();
+// Using any here to keep jest.mock factory free of TS type references
+// (Babel plugin-jest-hoist disallows out-of-scope identifiers, including types).
+let mockInsertResolver: any = () => {};
+
+jest.mock('expo-crypto', () => ({
+  randomUUID: jest.fn(() => 'rep-id-1234'),
+}));
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(() => ({
+      insert: (...args) => {
+        mockInsert(...args);
+        return new Promise((resolve) => {
+          mockInsertResolver = resolve;
+        });
+      },
+    })),
+  },
+}));
+
+jest.mock('@/lib/auth-utils', () => ({
+  ensureUserId: jest.fn().mockResolvedValue('user-1'),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logWithTs: jest.fn(),
+  warnWithTs: jest.fn(),
+  errorWithTs: jest.fn(),
+}));
+
+jest.mock('@/lib/haptics/haptic-bus', () => ({
+  hapticBus: { emit: (...args) => mockHapticEmit(...args) },
+  EVENT_TO_SEVERITY: {},
+}));
+
+jest.mock('@/lib/services/telemetry-context', () => ({
+  getTelemetryContext: jest.fn(() => ({
+    modelVersion: 'm1',
+    cueConfigVersion: 'c1',
+    experimentId: null,
+    variant: null,
+  })),
+}));
+
+import { emitPrHitIfRecord, logRep } from '@/lib/services/rep-logger';
+import type { RepEvent } from '@/lib/types/telemetry';
+
+function flushMicrotasks() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function baseRep(): RepEvent {
+  return {
+    sessionId: 'sess-1',
+    setId: 'set-1',
+    repIndex: 1,
+    exercise: 'pullup',
+    startTs: '2025-01-01T00:00:00Z',
+    endTs: '2025-01-01T00:00:05Z',
+    features: {},
+    faultsDetected: [],
+    cuesEmitted: [],
+  };
+}
+
+describe('rep-logger: emitPrHitIfRecord ordering', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fires pr.hit synchronously when current beats baseline (higherIsBetter)', () => {
+    const ordering: string[] = [];
+    mockHapticEmit.mockImplementation((event: string) => {
+      ordering.push(`haptic:${event}`);
+    });
+
+    ordering.push('before-call');
+    const isPr = emitPrHitIfRecord({ currentMetric: 105, baselineMetric: 100 });
+    ordering.push('after-call');
+
+    expect(isPr).toBe(true);
+    expect(mockHapticEmit).toHaveBeenCalledTimes(1);
+    expect(mockHapticEmit).toHaveBeenCalledWith('pr.hit');
+    // Synchronous: haptic emission sits between before and after.
+    expect(ordering).toEqual(['before-call', 'haptic:pr.hit', 'after-call']);
+  });
+
+  test('does NOT fire pr.hit when current does not beat baseline', () => {
+    expect(emitPrHitIfRecord({ currentMetric: 95, baselineMetric: 100 })).toBe(false);
+    expect(mockHapticEmit).not.toHaveBeenCalled();
+  });
+
+  test('treats null / NaN baseline as "no PR possible" (no haptic)', () => {
+    expect(emitPrHitIfRecord({ currentMetric: 200, baselineMetric: null })).toBe(false);
+    expect(emitPrHitIfRecord({ currentMetric: 200, baselineMetric: undefined })).toBe(false);
+    expect(emitPrHitIfRecord({ currentMetric: 200, baselineMetric: Number.NaN })).toBe(false);
+    expect(mockHapticEmit).not.toHaveBeenCalled();
+  });
+
+  test('higherIsBetter=false inverts the comparison (e.g. faster mile time)', () => {
+    // Current (60s) is BETTER than baseline (70s) when lower is better.
+    expect(
+      emitPrHitIfRecord({ currentMetric: 60, baselineMetric: 70, higherIsBetter: false })
+    ).toBe(true);
+    expect(mockHapticEmit).toHaveBeenCalledWith('pr.hit');
+    mockHapticEmit.mockClear();
+    // 70 is NOT better than 60 under lower-is-better.
+    expect(
+      emitPrHitIfRecord({ currentMetric: 70, baselineMetric: 60, higherIsBetter: false })
+    ).toBe(false);
+    expect(mockHapticEmit).not.toHaveBeenCalled();
+  });
+});
+
+describe('rep-logger: logRep ordering vs Supabase insert', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInsert.mockClear();
+    mockInsertResolver = () => {};
+  });
+
+  test('logRep resolves AFTER the Supabase insert resolves (caller can chain milestone detection)', async () => {
+    const ordering: string[] = [];
+    const promise = logRep(baseRep()).then((id) => {
+      ordering.push(`resolved:${id}`);
+    });
+
+    // Give the initial microtasks a chance to fire (ensureUserId + insert kickoff).
+    await flushMicrotasks();
+
+    // Supabase insert has been called but not yet resolved.
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(ordering).toEqual([]);
+
+    // Now resolve the Supabase insert.
+    ordering.push('insert-about-to-resolve');
+    mockInsertResolver({ error: null });
+
+    await promise;
+
+    // The caller's .then ran AFTER the insert resolved.
+    expect(ordering).toEqual(['insert-about-to-resolve', 'resolved:rep-id-1234']);
+  });
+
+  test('logRep rejects if Supabase insert returns an error (milestone chain short-circuits)', async () => {
+    const err = new Error('db down');
+    const promise = logRep(baseRep());
+
+    await flushMicrotasks();
+
+    mockInsertResolver({ error: err });
+
+    await expect(promise).rejects.toBe(err);
+    // Even on error the insert was attempted exactly once — no retry in logRep itself.
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+  });
+
+  test('emitPrHitIfRecord + logRep: haptic fires BEFORE the awaited insert completes', async () => {
+    const ordering: string[] = [];
+    mockHapticEmit.mockImplementation((event: string) => ordering.push(`haptic:${event}`));
+
+    // Caller pattern: detect PR synchronously, THEN kick off the async insert.
+    emitPrHitIfRecord({ currentMetric: 105, baselineMetric: 100 });
+    const insertPromise = logRep(baseRep()).then(() => ordering.push('insert-resolved'));
+
+    await flushMicrotasks();
+    mockInsertResolver({ error: null });
+    await insertPromise;
+
+    // Ordering contract: haptic lands first (user feels PR), insert second.
+    expect(ordering[0]).toBe('haptic:pr.hit');
+    expect(ordering[ordering.length - 1]).toBe('insert-resolved');
+  });
+});

--- a/tests/unit/services/video-service-retry-backoff.test.ts
+++ b/tests/unit/services/video-service-retry-backoff.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for lib/services/video-service.ts retry + backoff behavior.
+ *
+ * The module wraps signed-URL fetches in a private `withRetry(fn, maxRetries=2,
+ * delayMs=500)` helper with linear backoff (delayMs * (attempt + 1)). We drive
+ * the retry surface through `getVideoById` which funnels into `enrichVideoRows`
+ * → `safeGetSignedVideoUrl` / `safeGetSignedThumbnailUrl`.
+ *
+ * Assertions:
+ *  - Network disconnect mid-fetch → retry until success (no duplicate rows).
+ *  - Persistent failure after all retries → caller gets `undefined` (video)
+ *    or `null` (thumbnail), never a thrown exception that would reject the
+ *    list-videos promise and orphan the UI.
+ *  - Success on the first try incurs exactly ONE call (no spurious retry).
+ *  - Backoff math is linear + monotonic (delay increases with each attempt).
+ *
+ * Closes #545 (T5 — video-service retry/backoff).
+ */
+
+const mockCreateSignedUrl = jest.fn();
+const mockFrom = jest.fn();
+const mockMaybeSingle = jest.fn();
+let mockSetTimeout: jest.SpyInstance;
+const capturedDelays: number[] = [];
+
+jest.mock('expo-file-system/legacy', () => ({
+  uploadAsync: jest.fn(),
+  getInfoAsync: jest.fn().mockResolvedValue({ exists: true, size: 1000 }),
+  FileSystemUploadType: { BINARY_CONTENT: 'binary-content' },
+}));
+
+jest.mock('expo-video-thumbnails', () => ({
+  getThumbnailAsync: jest.fn().mockResolvedValue({ uri: 'file:///thumb.jpg' }),
+}));
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u-1' } }, error: null }),
+      getSession: jest.fn().mockResolvedValue({
+        data: { session: { access_token: 'tok' } },
+        error: null,
+      }),
+    },
+    storage: {
+      from: jest.fn(() => ({
+        createSignedUrl: (...args: any[]) => mockCreateSignedUrl(...args),
+        remove: jest.fn().mockResolvedValue({ error: null }),
+      })),
+    },
+    from: (...args: any[]) => mockFrom(...args),
+  },
+}));
+
+jest.mock('@/lib/auth-utils', () => ({
+  ensureUser: jest.fn().mockResolvedValue({ id: 'u-1' }),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  warnWithTs: jest.fn(),
+}));
+
+jest.mock('@/lib/services/ErrorHandler', () => ({
+  createError: jest.fn((_d, _c, m) => new Error(m)),
+}));
+
+import { getVideoById } from '@/lib/services/video-service';
+
+function mockVideoRow() {
+  return {
+    id: 'vid-1',
+    user_id: 'u-1',
+    path: 'u-1/vid-1.mp4',
+    thumbnail_path: 'u-1/vid-1.jpg',
+    duration_seconds: 30,
+    exercise: 'pullup',
+    metrics: null,
+    analysis_only: false,
+    created_at: '2025-01-01T00:00:00Z',
+    video_likes: [{ count: 0 }],
+    video_comments: [{ count: 0 }],
+  };
+}
+
+function configureVideosQuery() {
+  mockMaybeSingle.mockResolvedValue({ data: mockVideoRow(), error: null });
+  mockFrom.mockImplementation((table: string) => {
+    if (table === 'videos') {
+      return {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        in: jest.fn().mockReturnThis(),
+        maybeSingle: mockMaybeSingle,
+      };
+    }
+    if (table === 'profiles') {
+      return {
+        select: jest.fn().mockReturnThis(),
+        in: jest.fn().mockResolvedValue({ data: [], error: null }),
+      };
+    }
+    // Fallback
+    return {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      in: jest.fn().mockResolvedValue({ data: [], error: null }),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+  });
+}
+
+describe('video-service: withRetry + backoff across network flip (#545)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedDelays.length = 0;
+    configureVideosQuery();
+
+    // Intercept setTimeout so we can capture retry delays without actually
+    // waiting. Call through to setImmediate so promises still resolve.
+    mockSetTimeout = jest
+      .spyOn(global, 'setTimeout')
+      .mockImplementation((cb: any, delay?: number) => {
+        if (typeof delay === 'number') capturedDelays.push(delay);
+        // Run immediately to keep tests fast.
+        Promise.resolve().then(cb);
+        return 0 as any;
+      });
+  });
+
+  afterEach(() => {
+    mockSetTimeout.mockRestore();
+  });
+
+  test('success on first try: createSignedUrl called exactly once per URL (no retries)', async () => {
+    mockCreateSignedUrl.mockResolvedValue({
+      data: { signedUrl: 'https://signed.example/video.mp4' },
+      error: null,
+    });
+
+    const result = await getVideoById('vid-1');
+
+    // Two URL signings total: video + thumbnail, each called exactly once.
+    expect(mockCreateSignedUrl).toHaveBeenCalledTimes(2);
+    expect(result.signedUrl).toBe('https://signed.example/video.mp4');
+    // No backoff delays captured — we never retried.
+    expect(capturedDelays).toEqual([]);
+  });
+
+  test('transient failure then success: retries until success, no duplicate video rows', async () => {
+    let callCount = 0;
+    mockCreateSignedUrl.mockImplementation(() => {
+      callCount += 1;
+      if (callCount <= 2) {
+        // First two attempts fail — simulates network disconnect.
+        return Promise.reject(new Error('network down'));
+      }
+      return Promise.resolve({ data: { signedUrl: 'https://ok.example/v.mp4' }, error: null });
+    });
+
+    const result = await getVideoById('vid-1');
+
+    // Video + thumbnail each try up to 3 times. The 3rd attempt succeeds for
+    // both. Total calls depend on interleaving but video must eventually
+    // return the signed URL without throwing.
+    expect(result.signedUrl).toBe('https://ok.example/v.mp4');
+    // Maybe-single was called exactly once — no duplicate video row fetched.
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(1);
+  });
+
+  test('persistent failure: withRetry surfaces undefined (video) and null (thumbnail), never throws', async () => {
+    mockCreateSignedUrl.mockRejectedValue(new Error('offline'));
+
+    // Must not throw — caller can still render the video row even without URLs.
+    const result = await getVideoById('vid-1');
+    expect(result.signedUrl).toBeUndefined();
+    expect(result.thumbnailUrl).toBeNull();
+
+    // Linear backoff (delayMs * (attempt + 1)) with delayMs=500 + maxRetries=2
+    // → delays captured should be 500 and 1000 (and possibly the same pair
+    // for the parallel thumbnail fetch). Assert monotonically increasing.
+    // At minimum we expect the first two delays to be 500 and 1000 for one
+    // of the concurrent chains.
+    const uniqueDelays = Array.from(new Set(capturedDelays)).sort((a, b) => a - b);
+    expect(uniqueDelays).toContain(500);
+    expect(uniqueDelays).toContain(1000);
+    // 1500 would be delay for a 4th attempt — max retries is 2, so we should
+    // never see this value (2 retries means attempt indices 0,1,2 → delays
+    // only between attempts = 500 and 1000, never 1500).
+    expect(uniqueDelays).not.toContain(1500);
+  });
+
+  test('linear backoff: second retry delay is larger than first', async () => {
+    mockCreateSignedUrl.mockRejectedValue(new Error('offline'));
+
+    await getVideoById('vid-1');
+
+    // Filter to one chain's delays (they may interleave with the thumbnail
+    // chain). Sort unique values and check linear growth.
+    const uniqueDelays = Array.from(new Set(capturedDelays)).sort((a, b) => a - b);
+    expect(uniqueDelays.length).toBeGreaterThanOrEqual(2);
+    expect(uniqueDelays[1]).toBeGreaterThan(uniqueDelays[0]);
+    // Ratio == 2 confirms linear (delay * (attempt+1)): 500, 1000.
+    expect(uniqueDelays[1] / uniqueDelays[0]).toBeCloseTo(2, 5);
+  });
+
+  test('network flips back to reachable on last retry: URL is returned without duplicate upload calls', async () => {
+    // Only the VERY LAST attempt (attempt 2, i.e. 3rd call) succeeds. This
+    // simulates the "disconnect → reconnect at the edge of backoff" pattern.
+    let attempts = 0;
+    mockCreateSignedUrl.mockImplementation(() => {
+      attempts += 1;
+      if (attempts >= 3) {
+        return Promise.resolve({ data: { signedUrl: 'https://edge.example/v.mp4' }, error: null });
+      }
+      return Promise.reject(new Error('still offline'));
+    });
+
+    const result = await getVideoById('vid-1');
+    expect(result.signedUrl).toBe('https://edge.example/v.mp4');
+    // Only one row lookup — no duplicate/orphaned video row fetches.
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/workouts/bulgarian-split-squat.test.ts
+++ b/tests/unit/workouts/bulgarian-split-squat.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for lib/workouts/bulgarian-split-squat.ts — phase FSM, rear-foot
+ * occlusion (legsTracked) behavior, depth detection, and NaN-safe faults.
+ */
+
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { RepContext } from '@/lib/types/workout-definitions';
+import {
+  bulgarianSplitSquatDefinition,
+  BULGARIAN_SPLIT_SQUAT_THRESHOLDS,
+  type BulgarianSplitSquatMetrics,
+  type BulgarianSplitSquatPhase,
+} from '@/lib/workouts/bulgarian-split-squat';
+
+function angles(override: Partial<JointAngles> = {}): JointAngles {
+  return {
+    leftKnee: 170,
+    rightKnee: 170,
+    leftElbow: 170,
+    rightElbow: 170,
+    leftHip: 170,
+    rightHip: 170,
+    leftShoulder: 90,
+    rightShoulder: 90,
+    ...override,
+  };
+}
+
+function metrics(override: Partial<BulgarianSplitSquatMetrics> = {}): BulgarianSplitSquatMetrics {
+  return {
+    frontKnee: 170,
+    rearKnee: 170,
+    avgHip: 170,
+    armsTracked: false,
+    legsTracked: true,
+    ...override,
+  };
+}
+
+function baseRepContext(override: Partial<RepContext> = {}): RepContext {
+  const a = angles();
+  return {
+    startAngles: a,
+    endAngles: a,
+    minAngles: a,
+    maxAngles: a,
+    durationMs: 2200,
+    repNumber: 1,
+    workoutId: 'bulgarian_split_squat',
+    ...override,
+  };
+}
+
+describe('bulgarian-split-squat: definition metadata', () => {
+  test('exposes expected id, category, initial phase, phase set', () => {
+    expect(bulgarianSplitSquatDefinition.id).toBe('bulgarian_split_squat');
+    expect(bulgarianSplitSquatDefinition.category).toBe('lower_body');
+    expect(bulgarianSplitSquatDefinition.initialPhase).toBe('setup');
+    const ids = bulgarianSplitSquatDefinition.phases.map((p) => p.id).sort();
+    expect(ids).toEqual(['ascent', 'bottom', 'descent', 'setup', 'standing']);
+  });
+
+  test('rep boundary is descent -> standing with non-zero debounce', () => {
+    expect(bulgarianSplitSquatDefinition.repBoundary.startPhase).toBe('descent');
+    expect(bulgarianSplitSquatDefinition.repBoundary.endPhase).toBe('standing');
+    expect(bulgarianSplitSquatDefinition.repBoundary.minDurationMs).toBeGreaterThan(0);
+  });
+
+  test('FQI weights sum to 1.0', () => {
+    const { rom, depth, faults } = bulgarianSplitSquatDefinition.fqiWeights;
+    expect(rom + depth + faults).toBeCloseTo(1.0, 5);
+  });
+
+  test('heel_collapse threshold sits below frontKneeForwardLimit (more acute)', () => {
+    // heel_collapse fires at frontKneeForwardLimit - 10, so it must be below the
+    // forward_knee fault's threshold — this ordering is load-bearing.
+    expect(
+      BULGARIAN_SPLIT_SQUAT_THRESHOLDS.frontKneeForwardLimit - 10
+    ).toBeLessThan(BULGARIAN_SPLIT_SQUAT_THRESHOLDS.frontKneeForwardLimit);
+  });
+});
+
+describe('bulgarian-split-squat: phase FSM (getNextPhase)', () => {
+  const nextPhase = (
+    cur: BulgarianSplitSquatPhase,
+    m: BulgarianSplitSquatMetrics
+  ): BulgarianSplitSquatPhase =>
+    bulgarianSplitSquatDefinition.getNextPhase(cur, angles(), m);
+
+  test('legsTracked=false (rear-foot occlusion) forces setup from any phase', () => {
+    const m = metrics({ legsTracked: false });
+    (['setup', 'standing', 'descent', 'bottom', 'ascent'] as BulgarianSplitSquatPhase[]).forEach((p) => {
+      expect(nextPhase(p, m)).toBe('setup');
+    });
+  });
+
+  test('setup -> standing when front-knee reaches standing threshold', () => {
+    expect(
+      nextPhase('setup', metrics({ frontKnee: BULGARIAN_SPLIT_SQUAT_THRESHOLDS.standing }))
+    ).toBe('standing');
+    expect(
+      nextPhase('setup', metrics({ frontKnee: BULGARIAN_SPLIT_SQUAT_THRESHOLDS.standing - 1 }))
+    ).toBe('setup');
+  });
+
+  test('standing -> descent when knee drops to descentStart', () => {
+    expect(
+      nextPhase('standing', metrics({ frontKnee: BULGARIAN_SPLIT_SQUAT_THRESHOLDS.descentStart }))
+    ).toBe('descent');
+    expect(
+      nextPhase('standing', metrics({ frontKnee: BULGARIAN_SPLIT_SQUAT_THRESHOLDS.descentStart + 1 }))
+    ).toBe('standing');
+  });
+
+  test('descent -> bottom at parallel threshold', () => {
+    expect(
+      nextPhase('descent', metrics({ frontKnee: BULGARIAN_SPLIT_SQUAT_THRESHOLDS.parallel }))
+    ).toBe('bottom');
+    expect(
+      nextPhase('descent', metrics({ frontKnee: BULGARIAN_SPLIT_SQUAT_THRESHOLDS.parallel + 1 }))
+    ).toBe('descent');
+  });
+
+  test('bottom -> ascent when knee extends to ascent threshold', () => {
+    expect(
+      nextPhase('bottom', metrics({ frontKnee: BULGARIAN_SPLIT_SQUAT_THRESHOLDS.ascent }))
+    ).toBe('ascent');
+    expect(
+      nextPhase('bottom', metrics({ frontKnee: BULGARIAN_SPLIT_SQUAT_THRESHOLDS.ascent - 1 }))
+    ).toBe('bottom');
+  });
+
+  test('ascent -> standing completes rep at finish', () => {
+    expect(
+      nextPhase('ascent', metrics({ frontKnee: BULGARIAN_SPLIT_SQUAT_THRESHOLDS.finish }))
+    ).toBe('standing');
+    expect(
+      nextPhase('ascent', metrics({ frontKnee: BULGARIAN_SPLIT_SQUAT_THRESHOLDS.finish - 1 }))
+    ).toBe('ascent');
+  });
+});
+
+describe('bulgarian-split-squat: fault detection (depth + knee tracking)', () => {
+  const faultById = (id: string) => bulgarianSplitSquatDefinition.faults.find((f) => f.id === id);
+
+  test('shallow_depth fires when minFront > depthFloor', () => {
+    const fault = faultById('shallow_depth');
+    expect(fault).toBeDefined();
+    const bad = BULGARIAN_SPLIT_SQUAT_THRESHOLDS.depthFloor + 1;
+    const good = BULGARIAN_SPLIT_SQUAT_THRESHOLDS.depthFloor;
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftKnee: bad, rightKnee: bad }) }))
+    ).toBe(true);
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftKnee: good, rightKnee: good }) }))
+    ).toBe(false);
+  });
+
+  test('forward_knee fires below frontKneeForwardLimit', () => {
+    const fault = faultById('forward_knee');
+    expect(fault).toBeDefined();
+    const bad = BULGARIAN_SPLIT_SQUAT_THRESHOLDS.frontKneeForwardLimit - 1;
+    const good = BULGARIAN_SPLIT_SQUAT_THRESHOLDS.frontKneeForwardLimit;
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftKnee: bad, rightKnee: 120 }) }))
+    ).toBe(true);
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftKnee: good, rightKnee: 120 }) }))
+    ).toBe(false);
+  });
+
+  test('heel_collapse fires below (frontKneeForwardLimit - 10) — proxy for arch collapse', () => {
+    const fault = faultById('heel_collapse');
+    expect(fault).toBeDefined();
+    const bad = BULGARIAN_SPLIT_SQUAT_THRESHOLDS.frontKneeForwardLimit - 11;
+    const good = BULGARIAN_SPLIT_SQUAT_THRESHOLDS.frontKneeForwardLimit - 10;
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftKnee: bad, rightKnee: 120 }) }))
+    ).toBe(true);
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftKnee: good, rightKnee: 120 }) }))
+    ).toBe(false);
+  });
+
+  test('asymmetric_drive fires when hip asymmetry exceeds %-threshold', () => {
+    const fault = faultById('asymmetric_drive');
+    expect(fault).toBeDefined();
+    // left=100 vs right=70 -> 30 / 100 = 30% > 15%
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftHip: 100, rightHip: 70 }) }))
+    ).toBe(true);
+    // left=100 vs right=99 -> 1% well below threshold
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftHip: 100, rightHip: 99 }) }))
+    ).toBe(false);
+  });
+
+  test('NaN-safe: depth / forward_knee / heel_collapse do not fire on NaN', () => {
+    const badCtx = baseRepContext({
+      minAngles: angles({
+        leftKnee: Number.NaN,
+        rightKnee: Number.NaN,
+        leftHip: Number.NaN,
+        rightHip: Number.NaN,
+      }),
+    });
+    expect(faultById('shallow_depth')!.condition(badCtx)).toBe(false);
+    expect(faultById('forward_knee')!.condition(badCtx)).toBe(false);
+    expect(faultById('heel_collapse')!.condition(badCtx)).toBe(false);
+  });
+
+  test('clean rep triggers no faults', () => {
+    const cleanCtx = baseRepContext({
+      startAngles: angles(),
+      endAngles: angles(),
+      minAngles: angles({
+        leftKnee: BULGARIAN_SPLIT_SQUAT_THRESHOLDS.parallel,
+        rightKnee: BULGARIAN_SPLIT_SQUAT_THRESHOLDS.parallel + 5,
+        leftHip: 110,
+        rightHip: 112,
+      }),
+      maxAngles: angles(),
+      durationMs: 2500,
+    });
+    for (const fault of bulgarianSplitSquatDefinition.faults) {
+      expect(fault.condition(cleanCtx)).toBe(false);
+    }
+  });
+});
+
+describe('bulgarian-split-squat: calculateMetrics', () => {
+  test('frontKnee = min(left,right), rearKnee = max(left,right) — front-leg approximation', () => {
+    const m = bulgarianSplitSquatDefinition.calculateMetrics(
+      angles({ leftKnee: 85, rightKnee: 140 })
+    );
+    expect(m.frontKnee).toBe(85);
+    expect(m.rearKnee).toBe(140);
+  });
+
+  test('legsTracked flips to false if either leg joint is degenerate', () => {
+    // Rear-foot-occlusion proxy: one hip at 0 / 180 boundary flips legsTracked off.
+    expect(
+      bulgarianSplitSquatDefinition.calculateMetrics(angles({ leftHip: 0 })).legsTracked
+    ).toBe(false);
+    expect(
+      bulgarianSplitSquatDefinition.calculateMetrics(angles({ rightKnee: 180 })).legsTracked
+    ).toBe(false);
+    expect(bulgarianSplitSquatDefinition.calculateMetrics(angles()).legsTracked).toBe(true);
+  });
+});

--- a/tests/unit/workouts/dumbbell-curl.test.ts
+++ b/tests/unit/workouts/dumbbell-curl.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Unit tests for lib/workouts/dumbbell-curl.ts — elbow-pin phase FSM, momentum
+ * (swinging) fault detection, and NaN-safe behavior.
+ */
+
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { RepContext } from '@/lib/types/workout-definitions';
+import {
+  dumbbellCurlDefinition,
+  DUMBBELL_CURL_THRESHOLDS,
+  type DumbbellCurlMetrics,
+  type DumbbellCurlPhase,
+} from '@/lib/workouts/dumbbell-curl';
+
+function angles(override: Partial<JointAngles> = {}): JointAngles {
+  return {
+    leftKnee: 170,
+    rightKnee: 170,
+    leftElbow: 170,
+    rightElbow: 170,
+    leftHip: 175,
+    rightHip: 175,
+    leftShoulder: 90,
+    rightShoulder: 90,
+    ...override,
+  };
+}
+
+function metrics(override: Partial<DumbbellCurlMetrics> = {}): DumbbellCurlMetrics {
+  return {
+    avgElbow: 170,
+    avgShoulder: 90,
+    avgHip: 175,
+    armsTracked: true,
+    ...override,
+  };
+}
+
+function baseRepContext(override: Partial<RepContext> = {}): RepContext {
+  const a = angles();
+  return {
+    startAngles: a,
+    endAngles: a,
+    minAngles: a,
+    maxAngles: a,
+    durationMs: 1500,
+    repNumber: 1,
+    workoutId: 'dumbbell_curl',
+    ...override,
+  };
+}
+
+describe('dumbbell-curl: definition metadata', () => {
+  test('exposes expected id, category, initial phase, phase set', () => {
+    expect(dumbbellCurlDefinition.id).toBe('dumbbell_curl');
+    expect(dumbbellCurlDefinition.category).toBe('upper_body');
+    expect(dumbbellCurlDefinition.initialPhase).toBe('setup');
+    const ids = dumbbellCurlDefinition.phases.map((p) => p.id).sort();
+    expect(ids).toEqual(['bottom', 'curling', 'lowering', 'setup', 'top']);
+  });
+
+  test('rep boundary is curling -> bottom with non-zero debounce', () => {
+    expect(dumbbellCurlDefinition.repBoundary.startPhase).toBe('curling');
+    expect(dumbbellCurlDefinition.repBoundary.endPhase).toBe('bottom');
+    expect(dumbbellCurlDefinition.repBoundary.minDurationMs).toBeGreaterThan(0);
+  });
+
+  test('FQI weights sum to 1.0', () => {
+    const { rom, depth, faults } = dumbbellCurlDefinition.fqiWeights;
+    expect(rom + depth + faults).toBeCloseTo(1.0, 5);
+  });
+
+  test('thresholds descend bottomElbow > curlingStart > loweringStart > topElbow', () => {
+    expect(DUMBBELL_CURL_THRESHOLDS.bottomElbow).toBeGreaterThan(DUMBBELL_CURL_THRESHOLDS.curlingStart);
+    expect(DUMBBELL_CURL_THRESHOLDS.curlingStart).toBeGreaterThan(DUMBBELL_CURL_THRESHOLDS.loweringStart);
+    expect(DUMBBELL_CURL_THRESHOLDS.loweringStart).toBeGreaterThan(DUMBBELL_CURL_THRESHOLDS.topElbow);
+  });
+});
+
+describe('dumbbell-curl: phase FSM (getNextPhase)', () => {
+  const nextPhase = (cur: DumbbellCurlPhase, m: DumbbellCurlMetrics): DumbbellCurlPhase =>
+    dumbbellCurlDefinition.getNextPhase(cur, angles(), m);
+
+  test('armsTracked=false forces setup from any phase', () => {
+    const m = metrics({ armsTracked: false });
+    (['setup', 'bottom', 'curling', 'top', 'lowering'] as DumbbellCurlPhase[]).forEach((p) => {
+      expect(nextPhase(p, m)).toBe('setup');
+    });
+  });
+
+  test('setup -> bottom when elbow reaches bottomElbow', () => {
+    expect(nextPhase('setup', metrics({ avgElbow: DUMBBELL_CURL_THRESHOLDS.bottomElbow }))).toBe('bottom');
+    expect(nextPhase('setup', metrics({ avgElbow: DUMBBELL_CURL_THRESHOLDS.bottomElbow - 1 }))).toBe('setup');
+  });
+
+  test('bottom -> curling when elbow crosses curlingStart', () => {
+    expect(nextPhase('bottom', metrics({ avgElbow: DUMBBELL_CURL_THRESHOLDS.curlingStart }))).toBe('curling');
+    expect(nextPhase('bottom', metrics({ avgElbow: DUMBBELL_CURL_THRESHOLDS.curlingStart + 1 }))).toBe('bottom');
+  });
+
+  test('curling -> top when elbow <= topElbow + 10 (hysteresis)', () => {
+    expect(nextPhase('curling', metrics({ avgElbow: DUMBBELL_CURL_THRESHOLDS.topElbow + 10 }))).toBe('top');
+    expect(nextPhase('curling', metrics({ avgElbow: DUMBBELL_CURL_THRESHOLDS.topElbow + 11 }))).toBe('curling');
+  });
+
+  test('top -> lowering when elbow extends past loweringStart', () => {
+    expect(nextPhase('top', metrics({ avgElbow: DUMBBELL_CURL_THRESHOLDS.loweringStart }))).toBe('lowering');
+    expect(nextPhase('top', metrics({ avgElbow: DUMBBELL_CURL_THRESHOLDS.loweringStart - 1 }))).toBe('top');
+  });
+
+  test('lowering -> bottom completes rep at bottomElbow', () => {
+    expect(nextPhase('lowering', metrics({ avgElbow: DUMBBELL_CURL_THRESHOLDS.bottomElbow }))).toBe('bottom');
+    expect(nextPhase('lowering', metrics({ avgElbow: DUMBBELL_CURL_THRESHOLDS.bottomElbow - 1 }))).toBe('lowering');
+  });
+});
+
+describe('dumbbell-curl: fault detection (momentum + pin)', () => {
+  const faultById = (id: string) => dumbbellCurlDefinition.faults.find((f) => f.id === id);
+
+  test('swinging fires when hip-flex delta start->min exceeds swingingHipDeltaMax', () => {
+    const fault = faultById('swinging');
+    expect(fault).toBeDefined();
+    const delta = DUMBBELL_CURL_THRESHOLDS.swingingHipDeltaMax + 1;
+    const bad = baseRepContext({
+      startAngles: angles({ leftHip: 175, rightHip: 175 }),
+      minAngles: angles({ leftHip: 175 - delta, rightHip: 175 }),
+    });
+    expect(fault!.condition(bad)).toBe(true);
+
+    const good = baseRepContext({
+      startAngles: angles({ leftHip: 175, rightHip: 175 }),
+      minAngles: angles({ leftHip: 175 - DUMBBELL_CURL_THRESHOLDS.swingingHipDeltaMax, rightHip: 175 }),
+    });
+    expect(fault!.condition(good)).toBe(false);
+  });
+
+  test('incomplete_lockout fires when minElbow stays above incompleteLockoutMin', () => {
+    const fault = faultById('incomplete_lockout');
+    expect(fault).toBeDefined();
+    const bad = DUMBBELL_CURL_THRESHOLDS.incompleteLockoutMin + 1;
+    const good = DUMBBELL_CURL_THRESHOLDS.incompleteLockoutMin;
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftElbow: bad, rightElbow: bad }) }))
+    ).toBe(true);
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftElbow: good, rightElbow: good }) }))
+    ).toBe(false);
+  });
+
+  test('asymmetric_curl fires when left/right elbow asymmetry exceeds %-threshold', () => {
+    const fault = faultById('asymmetric_curl');
+    expect(fault).toBeDefined();
+    // 60 vs 90 -> diff 30 / 90 larger = 33% >> 15% threshold
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftElbow: 60, rightElbow: 90 }) }))
+    ).toBe(true);
+    // 80 vs 82 -> diff 2 / 82 = 2.4% — well under threshold
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftElbow: 80, rightElbow: 82 }) }))
+    ).toBe(false);
+  });
+
+  test('NaN-safe: incomplete_lockout / swinging / asymmetric_curl do not fire on NaN', () => {
+    const badCtx = baseRepContext({
+      startAngles: angles({ leftHip: Number.NaN, rightHip: Number.NaN }),
+      minAngles: angles({
+        leftElbow: Number.NaN,
+        rightElbow: Number.NaN,
+        leftHip: Number.NaN,
+        rightHip: Number.NaN,
+      }),
+    });
+    expect(faultById('swinging')!.condition(badCtx)).toBe(false);
+    expect(faultById('incomplete_lockout')!.condition(badCtx)).toBe(false);
+    expect(faultById('asymmetric_curl')!.condition(badCtx)).toBe(false);
+  });
+
+  test('clean rep (elbows pinned, no hip swing, symmetric) triggers no faults', () => {
+    const cleanCtx = baseRepContext({
+      startAngles: angles({ leftHip: 175, rightHip: 175 }),
+      endAngles: angles(),
+      minAngles: angles({
+        leftElbow: DUMBBELL_CURL_THRESHOLDS.topElbow,
+        rightElbow: DUMBBELL_CURL_THRESHOLDS.topElbow,
+        leftHip: 173,
+        rightHip: 173,
+      }),
+      maxAngles: angles(),
+      durationMs: 1800,
+    });
+    for (const fault of dumbbellCurlDefinition.faults) {
+      expect(fault.condition(cleanCtx)).toBe(false);
+    }
+  });
+});
+
+describe('dumbbell-curl: calculateMetrics', () => {
+  test('averages elbow, shoulder, hip', () => {
+    const m = dumbbellCurlDefinition.calculateMetrics(
+      angles({ leftElbow: 80, rightElbow: 100, leftShoulder: 85, rightShoulder: 95, leftHip: 170, rightHip: 180 })
+    );
+    expect(m.avgElbow).toBeCloseTo(90, 5);
+    expect(m.avgShoulder).toBeCloseTo(90, 5);
+    expect(m.avgHip).toBeCloseTo(175, 5);
+  });
+
+  test('armsTracked false when elbow degenerate (0 or 180)', () => {
+    expect(
+      dumbbellCurlDefinition.calculateMetrics(angles({ leftElbow: 0, rightElbow: 90 })).armsTracked
+    ).toBe(false);
+    expect(
+      dumbbellCurlDefinition.calculateMetrics(angles({ leftElbow: 180, rightElbow: 90 })).armsTracked
+    ).toBe(false);
+    expect(dumbbellCurlDefinition.calculateMetrics(angles()).armsTracked).toBe(true);
+  });
+});

--- a/tests/unit/workouts/hip-thrust.test.ts
+++ b/tests/unit/workouts/hip-thrust.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Unit tests for lib/workouts/hip-thrust.ts — phase FSM, lockout thresholds,
+ * descent phase, and NaN-safe fault detection.
+ */
+
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { RepContext } from '@/lib/types/workout-definitions';
+import {
+  hipThrustDefinition,
+  HIP_THRUST_THRESHOLDS,
+  type HipThrustMetrics,
+  type HipThrustPhase,
+} from '@/lib/workouts/hip-thrust';
+
+function angles(override: Partial<JointAngles> = {}): JointAngles {
+  return {
+    leftKnee: 90,
+    rightKnee: 90,
+    leftElbow: 170,
+    rightElbow: 170,
+    leftHip: 170,
+    rightHip: 170,
+    leftShoulder: 90,
+    rightShoulder: 90,
+    ...override,
+  };
+}
+
+function metrics(override: Partial<HipThrustMetrics> = {}): HipThrustMetrics {
+  return {
+    avgHip: 170,
+    avgKnee: 90,
+    armsTracked: false,
+    legsTracked: true,
+    ...override,
+  };
+}
+
+function baseRepContext(override: Partial<RepContext> = {}): RepContext {
+  const a = angles();
+  return {
+    startAngles: a,
+    endAngles: a,
+    minAngles: a,
+    maxAngles: a,
+    durationMs: 1500,
+    repNumber: 1,
+    workoutId: 'hip_thrust',
+    ...override,
+  };
+}
+
+describe('hip-thrust: definition metadata', () => {
+  test('exposes expected id, category, initial phase, phase set', () => {
+    expect(hipThrustDefinition.id).toBe('hip_thrust');
+    expect(hipThrustDefinition.category).toBe('lower_body');
+    expect(hipThrustDefinition.initialPhase).toBe('setup');
+    const ids = hipThrustDefinition.phases.map((p) => p.id).sort();
+    expect(ids).toEqual(['ascent', 'bottom', 'descent', 'lockout', 'setup']);
+  });
+
+  test('rep boundary is ascent -> lockout with non-zero debounce', () => {
+    expect(hipThrustDefinition.repBoundary.startPhase).toBe('ascent');
+    expect(hipThrustDefinition.repBoundary.endPhase).toBe('lockout');
+    expect(hipThrustDefinition.repBoundary.minDurationMs).toBeGreaterThan(0);
+  });
+
+  test('FQI weights sum to 1.0', () => {
+    const { rom, depth, faults } = hipThrustDefinition.fqiWeights;
+    expect(rom + depth + faults).toBeCloseTo(1.0, 5);
+  });
+
+  test('thresholds ascend bottomHip < ascentStart < lockoutHip < hyperExtensionMax', () => {
+    expect(HIP_THRUST_THRESHOLDS.bottomHip).toBeLessThan(HIP_THRUST_THRESHOLDS.ascentStart);
+    expect(HIP_THRUST_THRESHOLDS.ascentStart).toBeLessThan(HIP_THRUST_THRESHOLDS.lockoutHip);
+    expect(HIP_THRUST_THRESHOLDS.lockoutHip).toBeLessThan(HIP_THRUST_THRESHOLDS.hyperExtensionMax);
+  });
+});
+
+describe('hip-thrust: phase FSM (getNextPhase)', () => {
+  const nextPhase = (cur: HipThrustPhase, m: HipThrustMetrics): HipThrustPhase =>
+    hipThrustDefinition.getNextPhase(cur, angles(), m);
+
+  test('legsTracked=false forces setup from any phase', () => {
+    const m = metrics({ legsTracked: false });
+    (['setup', 'bottom', 'ascent', 'lockout', 'descent'] as HipThrustPhase[]).forEach((p) => {
+      expect(nextPhase(p, m)).toBe('setup');
+    });
+  });
+
+  test('setup -> bottom when hip drops to bottomHip', () => {
+    expect(nextPhase('setup', metrics({ avgHip: HIP_THRUST_THRESHOLDS.bottomHip }))).toBe('bottom');
+    expect(nextPhase('setup', metrics({ avgHip: HIP_THRUST_THRESHOLDS.bottomHip + 1 }))).toBe('setup');
+  });
+
+  test('bottom -> ascent when hip crosses ascentStart', () => {
+    expect(nextPhase('bottom', metrics({ avgHip: HIP_THRUST_THRESHOLDS.ascentStart }))).toBe('ascent');
+    expect(nextPhase('bottom', metrics({ avgHip: HIP_THRUST_THRESHOLDS.ascentStart - 1 }))).toBe('bottom');
+  });
+
+  test('ascent -> lockout at lockoutHip threshold', () => {
+    expect(nextPhase('ascent', metrics({ avgHip: HIP_THRUST_THRESHOLDS.lockoutHip }))).toBe('lockout');
+    expect(nextPhase('ascent', metrics({ avgHip: HIP_THRUST_THRESHOLDS.lockoutHip - 1 }))).toBe('ascent');
+  });
+
+  test('lockout -> descent when hip drops back below ascentStart', () => {
+    expect(nextPhase('lockout', metrics({ avgHip: HIP_THRUST_THRESHOLDS.ascentStart }))).toBe('descent');
+    expect(nextPhase('lockout', metrics({ avgHip: HIP_THRUST_THRESHOLDS.ascentStart + 1 }))).toBe('lockout');
+  });
+
+  test('descent -> bottom when hip returns to bottomHip', () => {
+    expect(nextPhase('descent', metrics({ avgHip: HIP_THRUST_THRESHOLDS.bottomHip }))).toBe('bottom');
+    expect(nextPhase('descent', metrics({ avgHip: HIP_THRUST_THRESHOLDS.bottomHip + 1 }))).toBe('descent');
+  });
+});
+
+describe('hip-thrust: fault detection at hip/knee boundaries', () => {
+  const faultById = (id: string) => hipThrustDefinition.faults.find((f) => f.id === id);
+
+  test('shallow_depth fires when minHip stays above depthFloor', () => {
+    const fault = faultById('shallow_depth');
+    expect(fault).toBeDefined();
+    const bad = HIP_THRUST_THRESHOLDS.depthFloor + 1;
+    const good = HIP_THRUST_THRESHOLDS.depthFloor;
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftHip: bad, rightHip: bad }) }))
+    ).toBe(true);
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftHip: good, rightHip: good }) }))
+    ).toBe(false);
+  });
+
+  test('incomplete_lockout fires when maxHip falls short of incompleteLockoutMin', () => {
+    const fault = faultById('incomplete_lockout');
+    expect(fault).toBeDefined();
+    const bad = HIP_THRUST_THRESHOLDS.incompleteLockoutMin - 1;
+    const good = HIP_THRUST_THRESHOLDS.incompleteLockoutMin;
+    expect(
+      fault!.condition(baseRepContext({ maxAngles: angles({ leftHip: bad, rightHip: bad }) }))
+    ).toBe(true);
+    expect(
+      fault!.condition(baseRepContext({ maxAngles: angles({ leftHip: good, rightHip: good }) }))
+    ).toBe(false);
+  });
+
+  test('hyperextension fires when maxHip exceeds hyperExtensionMax', () => {
+    const fault = faultById('hyperextension');
+    expect(fault).toBeDefined();
+    const bad = HIP_THRUST_THRESHOLDS.hyperExtensionMax + 1;
+    const good = HIP_THRUST_THRESHOLDS.hyperExtensionMax;
+    expect(
+      fault!.condition(baseRepContext({ maxAngles: angles({ leftHip: bad, rightHip: 170 }) }))
+    ).toBe(true);
+    expect(
+      fault!.condition(baseRepContext({ maxAngles: angles({ leftHip: good, rightHip: 170 }) }))
+    ).toBe(false);
+  });
+
+  test('heel_liftoff fires when |left-right knee diff| > heelLiftoffKneeDiffMax at max', () => {
+    const fault = faultById('heel_liftoff');
+    expect(fault).toBeDefined();
+    const diffBad = HIP_THRUST_THRESHOLDS.heelLiftoffKneeDiffMax + 1;
+    const diffGood = HIP_THRUST_THRESHOLDS.heelLiftoffKneeDiffMax;
+    expect(
+      fault!.condition(baseRepContext({ maxAngles: angles({ leftKnee: 90, rightKnee: 90 + diffBad }) }))
+    ).toBe(true);
+    expect(
+      fault!.condition(baseRepContext({ maxAngles: angles({ leftKnee: 90, rightKnee: 90 + diffGood }) }))
+    ).toBe(false);
+  });
+
+  test('NaN-safe: shallow_depth / hyperextension / heel_liftoff do not fire on NaN', () => {
+    const badCtx = baseRepContext({
+      minAngles: angles({ leftHip: Number.NaN, rightHip: Number.NaN }),
+      maxAngles: angles({
+        leftHip: Number.NaN,
+        rightHip: Number.NaN,
+        leftKnee: Number.NaN,
+        rightKnee: Number.NaN,
+      }),
+    });
+    expect(faultById('shallow_depth')!.condition(badCtx)).toBe(false);
+    expect(faultById('hyperextension')!.condition(badCtx)).toBe(false);
+    expect(faultById('heel_liftoff')!.condition(badCtx)).toBe(false);
+    expect(faultById('incomplete_lockout')!.condition(badCtx)).toBe(false);
+  });
+
+  test('clean rep triggers no faults', () => {
+    const cleanCtx = baseRepContext({
+      startAngles: angles(),
+      endAngles: angles(),
+      minAngles: angles({ leftHip: HIP_THRUST_THRESHOLDS.bottomHip, rightHip: HIP_THRUST_THRESHOLDS.bottomHip }),
+      maxAngles: angles({
+        leftHip: HIP_THRUST_THRESHOLDS.lockoutHip + 5,
+        rightHip: HIP_THRUST_THRESHOLDS.lockoutHip + 5,
+        leftKnee: 90,
+        rightKnee: 92,
+      }),
+      durationMs: 2000,
+    });
+    for (const fault of hipThrustDefinition.faults) {
+      expect(fault.condition(cleanCtx)).toBe(false);
+    }
+  });
+});
+
+describe('hip-thrust: calculateMetrics', () => {
+  test('averages left/right hip and knee', () => {
+    const m = hipThrustDefinition.calculateMetrics(
+      angles({ leftHip: 100, rightHip: 120, leftKnee: 80, rightKnee: 100 })
+    );
+    expect(m.avgHip).toBeCloseTo(110, 5);
+    expect(m.avgKnee).toBeCloseTo(90, 5);
+  });
+
+  test('legsTracked false when any leg joint degenerate (0 or 180)', () => {
+    expect(hipThrustDefinition.calculateMetrics(angles({ leftKnee: 0 })).legsTracked).toBe(false);
+    expect(hipThrustDefinition.calculateMetrics(angles({ rightHip: 180 })).legsTracked).toBe(false);
+    expect(hipThrustDefinition.calculateMetrics(angles()).legsTracked).toBe(true);
+  });
+});

--- a/tests/unit/workouts/lat-pulldown.test.ts
+++ b/tests/unit/workouts/lat-pulldown.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for lib/workouts/lat-pulldown.ts — phase FSM, rep boundary,
+ * elbow/shoulder co-contraction fault boundaries, and NaN-safe behavior.
+ */
+
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { RepContext } from '@/lib/types/workout-definitions';
+import {
+  latPulldownDefinition,
+  LAT_PULLDOWN_THRESHOLDS,
+  type LatPulldownMetrics,
+  type LatPulldownPhase,
+} from '@/lib/workouts/lat-pulldown';
+
+function angles(override: Partial<JointAngles> = {}): JointAngles {
+  return {
+    leftKnee: 170,
+    rightKnee: 170,
+    leftElbow: 170,
+    rightElbow: 170,
+    leftHip: 170,
+    rightHip: 170,
+    leftShoulder: 150,
+    rightShoulder: 150,
+    ...override,
+  };
+}
+
+function metrics(override: Partial<LatPulldownMetrics> = {}): LatPulldownMetrics {
+  return {
+    avgElbow: 170,
+    avgShoulder: 150,
+    armsTracked: true,
+    ...override,
+  };
+}
+
+function baseRepContext(override: Partial<RepContext> = {}): RepContext {
+  const a = angles();
+  return {
+    startAngles: a,
+    endAngles: a,
+    minAngles: a,
+    maxAngles: a,
+    durationMs: 2000,
+    repNumber: 1,
+    workoutId: 'lat_pulldown',
+    ...override,
+  };
+}
+
+describe('lat-pulldown: definition metadata', () => {
+  test('exposes expected id, category, initial phase, phase set', () => {
+    expect(latPulldownDefinition.id).toBe('lat_pulldown');
+    expect(latPulldownDefinition.category).toBe('upper_body');
+    expect(latPulldownDefinition.initialPhase).toBe('setup');
+    const ids = latPulldownDefinition.phases.map((p) => p.id).sort();
+    expect(ids).toEqual(['bottom', 'pulling', 'releasing', 'setup', 'top']);
+  });
+
+  test('rep boundary is pulling -> top with a non-zero debounce', () => {
+    expect(latPulldownDefinition.repBoundary.startPhase).toBe('pulling');
+    expect(latPulldownDefinition.repBoundary.endPhase).toBe('top');
+    expect(latPulldownDefinition.repBoundary.minDurationMs).toBeGreaterThan(0);
+  });
+
+  test('FQI weights sum to 1.0', () => {
+    const { rom, depth, faults } = latPulldownDefinition.fqiWeights;
+    expect(rom + depth + faults).toBeCloseTo(1.0, 5);
+  });
+
+  test('thresholds descend top > pulling > bottom', () => {
+    expect(LAT_PULLDOWN_THRESHOLDS.topElbow).toBeGreaterThan(LAT_PULLDOWN_THRESHOLDS.pullingStart);
+    expect(LAT_PULLDOWN_THRESHOLDS.pullingStart).toBeGreaterThan(LAT_PULLDOWN_THRESHOLDS.bottomElbow);
+  });
+});
+
+describe('lat-pulldown: phase FSM (getNextPhase)', () => {
+  const nextPhase = (cur: LatPulldownPhase, m: LatPulldownMetrics): LatPulldownPhase =>
+    latPulldownDefinition.getNextPhase(cur, angles(), m);
+
+  test('armsTracked=false from any phase forces setup', () => {
+    const m = metrics({ armsTracked: false });
+    (['setup', 'top', 'pulling', 'bottom', 'releasing'] as LatPulldownPhase[]).forEach((p) => {
+      expect(nextPhase(p, m)).toBe('setup');
+    });
+  });
+
+  test('setup -> top when elbow reaches topElbow', () => {
+    expect(nextPhase('setup', metrics({ avgElbow: LAT_PULLDOWN_THRESHOLDS.topElbow }))).toBe('top');
+    expect(nextPhase('setup', metrics({ avgElbow: LAT_PULLDOWN_THRESHOLDS.topElbow - 1 }))).toBe('setup');
+  });
+
+  test('top -> pulling when elbow crosses pullingStart', () => {
+    expect(nextPhase('top', metrics({ avgElbow: LAT_PULLDOWN_THRESHOLDS.pullingStart }))).toBe('pulling');
+    expect(nextPhase('top', metrics({ avgElbow: LAT_PULLDOWN_THRESHOLDS.pullingStart + 1 }))).toBe('top');
+  });
+
+  test('pulling -> bottom when elbow <= bottomElbow + 10 (hysteresis)', () => {
+    expect(nextPhase('pulling', metrics({ avgElbow: LAT_PULLDOWN_THRESHOLDS.bottomElbow + 10 }))).toBe('bottom');
+    expect(nextPhase('pulling', metrics({ avgElbow: LAT_PULLDOWN_THRESHOLDS.bottomElbow + 11 }))).toBe('pulling');
+  });
+
+  test('bottom -> releasing when elbow extends past releasingStart', () => {
+    expect(nextPhase('bottom', metrics({ avgElbow: LAT_PULLDOWN_THRESHOLDS.releasingStart }))).toBe('releasing');
+    expect(nextPhase('bottom', metrics({ avgElbow: LAT_PULLDOWN_THRESHOLDS.releasingStart - 1 }))).toBe('bottom');
+  });
+
+  test('releasing -> top completes the rep at topElbow', () => {
+    expect(nextPhase('releasing', metrics({ avgElbow: LAT_PULLDOWN_THRESHOLDS.topElbow }))).toBe('top');
+    expect(nextPhase('releasing', metrics({ avgElbow: LAT_PULLDOWN_THRESHOLDS.topElbow - 1 }))).toBe('releasing');
+  });
+});
+
+describe('lat-pulldown: fault detection at elbow/shoulder boundaries', () => {
+  const faultById = (id: string) => latPulldownDefinition.faults.find((f) => f.id === id);
+
+  test('incomplete_lockout fires when minElbow stays above incompleteLockoutMin', () => {
+    const fault = faultById('incomplete_lockout');
+    expect(fault).toBeDefined();
+    const bad = LAT_PULLDOWN_THRESHOLDS.incompleteLockoutMin + 1;
+    const good = LAT_PULLDOWN_THRESHOLDS.incompleteLockoutMin;
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftElbow: bad, rightElbow: bad }) }))
+    ).toBe(true);
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftElbow: good, rightElbow: good }) }))
+    ).toBe(false);
+  });
+
+  test('elbows_flare fires when bottom (min) shoulder > elbowsFlareShoulderMax', () => {
+    const fault = faultById('elbows_flare');
+    expect(fault).toBeDefined();
+    const bad = LAT_PULLDOWN_THRESHOLDS.elbowsFlareShoulderMax + 1;
+    const good = LAT_PULLDOWN_THRESHOLDS.elbowsFlareShoulderMax;
+    expect(
+      fault!.condition(
+        baseRepContext({ minAngles: angles({ leftShoulder: bad, rightShoulder: bad }) })
+      )
+    ).toBe(true);
+    expect(
+      fault!.condition(
+        baseRepContext({ minAngles: angles({ leftShoulder: good, rightShoulder: good }) })
+      )
+    ).toBe(false);
+  });
+
+  test('excessive_lean fires when |shoulder delta start->min| > threshold', () => {
+    const fault = faultById('excessive_lean');
+    expect(fault).toBeDefined();
+    const delta = LAT_PULLDOWN_THRESHOLDS.excessiveLeanShoulderDeltaMax + 1;
+    const bad = baseRepContext({
+      startAngles: angles({ leftShoulder: 160, rightShoulder: 160 }),
+      minAngles: angles({ leftShoulder: 160 - delta, rightShoulder: 160 }),
+    });
+    expect(fault!.condition(bad)).toBe(true);
+
+    const good = baseRepContext({
+      startAngles: angles({ leftShoulder: 160, rightShoulder: 160 }),
+      minAngles: angles({ leftShoulder: 160 - LAT_PULLDOWN_THRESHOLDS.excessiveLeanShoulderDeltaMax, rightShoulder: 160 }),
+    });
+    expect(fault!.condition(good)).toBe(false);
+  });
+
+  test('asymmetric_pull fires via shared asymmetryCheck helper at % threshold', () => {
+    const fault = faultById('asymmetric_pull');
+    expect(fault).toBeDefined();
+    // left=100 vs right=75 -> diff 25 / 100 larger = 25%, well above 15% threshold.
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftElbow: 100, rightElbow: 75 }) }))
+    ).toBe(true);
+    // Very close: diff 1 / 100 larger = 1% -> no fault.
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftElbow: 100, rightElbow: 99 }) }))
+    ).toBe(false);
+  });
+
+  test('NaN-safe: incomplete_lockout / elbows_flare do not fire on NaN inputs', () => {
+    const badCtx = baseRepContext({
+      minAngles: angles({ leftElbow: Number.NaN, rightElbow: Number.NaN, leftShoulder: Number.NaN, rightShoulder: Number.NaN }),
+    });
+    expect(faultById('incomplete_lockout')!.condition(badCtx)).toBe(false);
+    expect(faultById('elbows_flare')!.condition(badCtx)).toBe(false);
+  });
+
+  test('clean rep triggers no faults', () => {
+    const cleanCtx = baseRepContext({
+      startAngles: angles({ leftShoulder: 150, rightShoulder: 150, leftElbow: 170, rightElbow: 170 }),
+      endAngles: angles({ leftElbow: 170, rightElbow: 170 }),
+      minAngles: angles({
+        leftElbow: LAT_PULLDOWN_THRESHOLDS.bottomElbow,
+        rightElbow: LAT_PULLDOWN_THRESHOLDS.bottomElbow,
+        leftShoulder: 110,
+        rightShoulder: 110,
+      }),
+      maxAngles: angles(),
+      durationMs: 2500,
+    });
+    for (const fault of latPulldownDefinition.faults) {
+      expect(fault.condition(cleanCtx)).toBe(false);
+    }
+  });
+});
+
+describe('lat-pulldown: calculateMetrics', () => {
+  test('averages left/right elbow and shoulder', () => {
+    const m = latPulldownDefinition.calculateMetrics(
+      angles({ leftElbow: 100, rightElbow: 120, leftShoulder: 140, rightShoulder: 160 })
+    );
+    expect(m.avgElbow).toBeCloseTo(110, 5);
+    expect(m.avgShoulder).toBeCloseTo(150, 5);
+  });
+
+  test('armsTracked false when elbow is 0 or 180 (degenerate)', () => {
+    expect(
+      latPulldownDefinition.calculateMetrics(angles({ leftElbow: 0, rightElbow: 90 })).armsTracked
+    ).toBe(false);
+    expect(
+      latPulldownDefinition.calculateMetrics(angles({ leftElbow: 180, rightElbow: 90 })).armsTracked
+    ).toBe(false);
+    expect(
+      latPulldownDefinition.calculateMetrics(angles({ leftElbow: 90, rightElbow: 90 })).armsTracked
+    ).toBe(true);
+  });
+});

--- a/tests/unit/workouts/lunge.test.ts
+++ b/tests/unit/workouts/lunge.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for lib/workouts/lunge.ts — phase FSM, rep boundary, fault
+ * thresholds, hysteresis, and NaN-safe metric computation.
+ */
+
+import type { JointAngles } from '@/lib/arkit/ARKitBodyTracker';
+import type { RepContext } from '@/lib/types/workout-definitions';
+import {
+  lungeDefinition,
+  LUNGE_THRESHOLDS,
+  type LungeMetrics,
+  type LungePhase,
+} from '@/lib/workouts/lunge';
+
+function angles(override: Partial<JointAngles> = {}): JointAngles {
+  return {
+    leftKnee: 170,
+    rightKnee: 170,
+    leftElbow: 170,
+    rightElbow: 170,
+    leftHip: 170,
+    rightHip: 170,
+    leftShoulder: 90,
+    rightShoulder: 90,
+    ...override,
+  };
+}
+
+function metrics(override: Partial<LungeMetrics> = {}): LungeMetrics {
+  return {
+    frontKnee: 170,
+    rearKnee: 170,
+    avgHip: 170,
+    armsTracked: false,
+    legsTracked: true,
+    ...override,
+  };
+}
+
+function baseRepContext(override: Partial<RepContext> = {}): RepContext {
+  const a = angles();
+  return {
+    startAngles: a,
+    endAngles: a,
+    minAngles: a,
+    maxAngles: a,
+    durationMs: 2000,
+    repNumber: 1,
+    workoutId: 'lunge',
+    ...override,
+  };
+}
+
+describe('lunge: definition metadata', () => {
+  test('exposes expected id, category, initial phase, and phase set', () => {
+    expect(lungeDefinition.id).toBe('lunge');
+    expect(lungeDefinition.category).toBe('lower_body');
+    expect(lungeDefinition.initialPhase).toBe('setup');
+    const phaseIds = lungeDefinition.phases.map((p) => p.id).sort();
+    expect(phaseIds).toEqual(['ascent', 'bottom', 'descent', 'setup', 'standing']);
+  });
+
+  test('rep boundary is descent -> standing with a non-zero debounce', () => {
+    expect(lungeDefinition.repBoundary.startPhase).toBe('descent');
+    expect(lungeDefinition.repBoundary.endPhase).toBe('standing');
+    expect(lungeDefinition.repBoundary.minDurationMs).toBeGreaterThan(0);
+  });
+
+  test('FQI weights sum to 1.0', () => {
+    const { rom, depth, faults } = lungeDefinition.fqiWeights;
+    expect(rom + depth + faults).toBeCloseTo(1.0, 5);
+  });
+
+  test('thresholds form a sane descent ladder standing > descentStart > parallel', () => {
+    expect(LUNGE_THRESHOLDS.standing).toBeGreaterThan(LUNGE_THRESHOLDS.descentStart);
+    expect(LUNGE_THRESHOLDS.descentStart).toBeGreaterThan(LUNGE_THRESHOLDS.parallel);
+    // forward-knee limit must be below parallel (more acute)
+    expect(LUNGE_THRESHOLDS.frontKneeForwardLimit).toBeLessThan(LUNGE_THRESHOLDS.parallel);
+  });
+});
+
+describe('lunge: phase FSM (getNextPhase)', () => {
+  const nextPhase = (cur: LungePhase, m: LungeMetrics): LungePhase =>
+    lungeDefinition.getNextPhase(cur, angles(), m);
+
+  test('legsTracked=false from any phase forces setup', () => {
+    const m = metrics({ legsTracked: false });
+    (['setup', 'standing', 'descent', 'bottom', 'ascent'] as LungePhase[]).forEach((p) => {
+      expect(nextPhase(p, m)).toBe('setup');
+    });
+  });
+
+  test('setup -> standing when knee reaches standing threshold', () => {
+    expect(nextPhase('setup', metrics({ frontKnee: LUNGE_THRESHOLDS.standing }))).toBe('standing');
+    // Just below the threshold stays in setup.
+    expect(nextPhase('setup', metrics({ frontKnee: LUNGE_THRESHOLDS.standing - 1 }))).toBe('setup');
+  });
+
+  test('standing -> descent crosses descentStart from above', () => {
+    expect(nextPhase('standing', metrics({ frontKnee: LUNGE_THRESHOLDS.descentStart + 1 }))).toBe('standing');
+    expect(nextPhase('standing', metrics({ frontKnee: LUNGE_THRESHOLDS.descentStart }))).toBe('descent');
+  });
+
+  test('descent -> bottom when knee reaches parallel', () => {
+    expect(nextPhase('descent', metrics({ frontKnee: LUNGE_THRESHOLDS.parallel }))).toBe('bottom');
+    expect(nextPhase('descent', metrics({ frontKnee: LUNGE_THRESHOLDS.parallel + 1 }))).toBe('descent');
+  });
+
+  test('bottom -> ascent when knee extends past the ascent threshold', () => {
+    expect(nextPhase('bottom', metrics({ frontKnee: LUNGE_THRESHOLDS.ascent }))).toBe('ascent');
+    expect(nextPhase('bottom', metrics({ frontKnee: LUNGE_THRESHOLDS.ascent - 1 }))).toBe('bottom');
+  });
+
+  test('ascent -> standing completes a rep at finish threshold', () => {
+    expect(nextPhase('ascent', metrics({ frontKnee: LUNGE_THRESHOLDS.finish }))).toBe('standing');
+    // Small hysteresis: just below finish remains in ascent.
+    expect(nextPhase('ascent', metrics({ frontKnee: LUNGE_THRESHOLDS.finish - 1 }))).toBe('ascent');
+  });
+});
+
+describe('lunge: fault detection at threshold boundaries', () => {
+  const faultById = (id: string) => lungeDefinition.faults.find((f) => f.id === id);
+
+  test('shallow_depth fires when min front-knee stays above parallel + 15', () => {
+    const fault = faultById('shallow_depth');
+    expect(fault).toBeDefined();
+    const bad = LUNGE_THRESHOLDS.parallel + 16;
+    const good = LUNGE_THRESHOLDS.parallel + 15;
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftKnee: bad, rightKnee: bad }) }))
+    ).toBe(true);
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftKnee: good, rightKnee: good }) }))
+    ).toBe(false);
+  });
+
+  test('forward_knee fires when min front-knee drops below frontKneeForwardLimit', () => {
+    const fault = faultById('forward_knee');
+    expect(fault).toBeDefined();
+    const bad = LUNGE_THRESHOLDS.frontKneeForwardLimit - 1;
+    const good = LUNGE_THRESHOLDS.frontKneeForwardLimit;
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftKnee: bad, rightKnee: 120 }) }))
+    ).toBe(true);
+    // At the boundary value, NOT a fault (strict <).
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftKnee: good, rightKnee: 120 }) }))
+    ).toBe(false);
+  });
+
+  test('knee_cave fires when left/right knee diff exceeds kneeCaveMax', () => {
+    const fault = faultById('knee_cave');
+    expect(fault).toBeDefined();
+    const diffBad = LUNGE_THRESHOLDS.kneeCaveMax + 1;
+    const diffGood = LUNGE_THRESHOLDS.kneeCaveMax;
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftKnee: 90, rightKnee: 90 + diffBad }) }))
+    ).toBe(true);
+    expect(
+      fault!.condition(baseRepContext({ minAngles: angles({ leftKnee: 90, rightKnee: 90 + diffGood }) }))
+    ).toBe(false);
+  });
+
+  test('hyper_extension fires when end-rep knee > hyperExtensionMax', () => {
+    const fault = faultById('hyper_extension');
+    expect(fault).toBeDefined();
+    const bad = LUNGE_THRESHOLDS.hyperExtensionMax + 1;
+    const good = LUNGE_THRESHOLDS.hyperExtensionMax;
+    expect(
+      fault!.condition(baseRepContext({ endAngles: angles({ leftKnee: bad, rightKnee: 170 }) }))
+    ).toBe(true);
+    expect(
+      fault!.condition(baseRepContext({ endAngles: angles({ leftKnee: good, rightKnee: 170 }) }))
+    ).toBe(false);
+  });
+
+  test('NaN-safe: shallow_depth / forward_knee / knee_cave do not fire on NaN input', () => {
+    const badCtx = baseRepContext({
+      minAngles: angles({ leftKnee: Number.NaN, rightKnee: Number.NaN }),
+    });
+    expect(faultById('shallow_depth')!.condition(badCtx)).toBe(false);
+    expect(faultById('forward_knee')!.condition(badCtx)).toBe(false);
+    expect(faultById('knee_cave')!.condition(badCtx)).toBe(false);
+  });
+
+  test('clean rep triggers no faults', () => {
+    const cleanCtx = baseRepContext({
+      startAngles: angles({ leftKnee: LUNGE_THRESHOLDS.standing, rightKnee: LUNGE_THRESHOLDS.standing }),
+      endAngles: angles({ leftKnee: LUNGE_THRESHOLDS.standing, rightKnee: LUNGE_THRESHOLDS.standing }),
+      minAngles: angles({
+        leftKnee: LUNGE_THRESHOLDS.parallel,
+        rightKnee: LUNGE_THRESHOLDS.parallel + 5,
+        leftHip: 100,
+        rightHip: 100,
+      }),
+      maxAngles: angles({ leftKnee: LUNGE_THRESHOLDS.standing, rightKnee: LUNGE_THRESHOLDS.standing }),
+      durationMs: 2500,
+    });
+    for (const fault of lungeDefinition.faults) {
+      expect(fault.condition(cleanCtx)).toBe(false);
+    }
+  });
+});
+
+describe('lunge: calculateMetrics', () => {
+  test('frontKnee = min(left,right), rearKnee = max(left,right)', () => {
+    const m = lungeDefinition.calculateMetrics(angles({ leftKnee: 80, rightKnee: 120 }));
+    expect(m.frontKnee).toBe(80);
+    expect(m.rearKnee).toBe(120);
+  });
+
+  test('avgHip averages left/right hip', () => {
+    const m = lungeDefinition.calculateMetrics(angles({ leftHip: 100, rightHip: 120 }));
+    expect(m.avgHip).toBeCloseTo(110, 5);
+  });
+
+  test('legsTracked is false when any leg joint is degenerate (0 or 180)', () => {
+    // Knee at 0 — degenerate
+    expect(lungeDefinition.calculateMetrics(angles({ leftKnee: 0 })).legsTracked).toBe(false);
+    // Hip at 180 — boundary, treated as not-tracked per `> 0 && < 180` check
+    expect(lungeDefinition.calculateMetrics(angles({ leftHip: 180 })).legsTracked).toBe(false);
+    // Normal values — tracked
+    expect(lungeDefinition.calculateMetrics(angles()).legsTracked).toBe(true);
+  });
+});


### PR DESCRIPTION
Wave-33 C — coverage for 5 form-model exercises + realtime-logout lifecycle + rep-logger async ordering + healthkit partial-failure + video-service retry.

## Coverage added

- 5 form models: lunge, lat-pulldown, hip-thrust, dumbbell-curl, bulgarian-split-squat (90 assertions)
- sync-service realtime unsubscribe on logout (6 assertions)
- rep-logger async ordering + milestone races (7 assertions)
- healthkit bulk-sync partial failure + weight-trends null/NaN sort (12 assertions)
- video-service retry backoff across network flip (5 assertions)

**Total: 10 new test files, 120 assertions. All 178 suites / 2736 tests green.**

## Verification

```
bun run test tests/unit/workouts/ tests/unit/services/   # 2736 passed
bun run lint                                             # clean
bun run check:types                                      # clean
```

## Findings documented in tests (not fixed in this PR)

1. **`getStepHistoryAsync` / `getWeightHistoryAsync` silently swallow native errors** and return `[]` (health-metrics.ts:340-342). A native-bridge crash surfaces to bulk-sync as `success=true, recordsSynced=0` instead of a visible error. Marked with an `XXX` comment in `bulk-sync-partial-failure.test.ts` so a future "propagate native errors upward" refactor surfaces as a regression.
2. **`weight-trends.analyzeWeightTrends` does not filter non-finite dates** before `sort((a,b) => a.date - b.date)`. NaN dates and future-drifted timestamps are preserved as-is. Documented current behavior via `weight-trends-null-nan.test.ts`; fix is out of scope for a test-only PR.

## Closes

- Closes #577
- Closes #544 (T2 — realtime channel logout lifecycle)
- Closes #545 (T5 — video-service retry/backoff)
- Closes #546 (T4 — healthkit partial-failure + weight-trends)

## Defer

T6 E2E modal interaction tests (form-quality-recovery, calibration-failure-recovery) — needs Detox/Playwright harness changes, separate PR per #577.