### PR TITLE
feat(wave33): a11y + loading-feedback + destructive-copy polish

### DIFF
--- a/app/(modals)/add-food.tsx
+++ b/app/(modals)/add-food.tsx
@@ -4,6 +4,7 @@ import * as Crypto from 'expo-crypto';
 import * as Haptics from 'expo-haptics';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
+  ActivityIndicator,
   StyleSheet,
   Text,
   TextInput,
@@ -378,9 +379,12 @@ export default function AddFoodScreen() {
             ]}
             onPress={onSave}
             disabled={!name.trim() || !calories.trim() || saving}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: !name.trim() || !calories.trim() || saving, busy: saving }}
+            accessibilityLabel={saving ? 'Saving meal' : 'Save meal'}
           >
             {saving ? (
-              <Ionicons name="hourglass" size={20} color="#fff" />
+              <ActivityIndicator size="small" color="#fff" />
             ) : (
               <Ionicons name="checkmark-circle" size={20} color="#fff" />
             )}

--- a/app/(modals)/notifications.tsx
+++ b/app/(modals)/notifications.tsx
@@ -183,18 +183,24 @@ export default function NotificationSettingsModal() {
               value={prefs.comments}
               onValueChange={() => handleToggle('comments')}
               disabled={savingKey === 'comments'}
+              accessibilityLabel="Comment notifications"
+              accessibilityHint="Toggle push notifications when someone comments on your video"
             />
             <SettingRow
               label="Likes on my videos"
               value={prefs.likes}
               onValueChange={() => handleToggle('likes')}
               disabled={savingKey === 'likes'}
+              accessibilityLabel="Like notifications"
+              accessibilityHint="Toggle push notifications when someone likes your video"
             />
             <SettingRow
               label="Daily workout reminder"
               value={prefs.reminders}
               onValueChange={() => handleToggle('reminders')}
               disabled={savingKey === 'reminders'}
+              accessibilityLabel="Workout reminder notifications"
+              accessibilityHint="Toggle daily reminders to complete your workout"
             />
           </>
         ) : (
@@ -210,11 +216,15 @@ function SettingRow({
   value,
   onValueChange,
   disabled,
+  accessibilityLabel,
+  accessibilityHint,
 }: {
   label: string;
   value: boolean;
   onValueChange: () => void;
   disabled?: boolean;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
 }) {
   return (
     <View style={styles.settingRow}>
@@ -225,6 +235,9 @@ function SettingRow({
         disabled={disabled}
         thumbColor={value ? '#fff' : '#CBD7F5'}
         trackColor={{ false: '#223859', true: '#4C8CFF' }}
+        accessibilityLabel={accessibilityLabel ?? label}
+        accessibilityHint={accessibilityHint}
+        accessibilityRole="switch"
       />
     </View>
   );

--- a/app/(modals)/video-comments.tsx
+++ b/app/(modals)/video-comments.tsx
@@ -311,9 +311,9 @@ export default function VideoCommentsModal() {
           <Text style={styles.topTitle}>Comments {commentCount}</Text>
         </View>
 
-        {loading ? (
-          <View style={styles.emptyState}>
-            <ActivityIndicator color="#4C8CFF" />
+        {loading && comments.length === 0 ? (
+          <View style={[styles.emptyState, { flex: 1, justifyContent: 'center' }]}>
+            <ActivityIndicator size="large" color="#4C8CFF" />
             <Text style={styles.emptyText}>Loading comments…</Text>
           </View>
         ) : loadError && comments.length === 0 && !video ? (

--- a/app/(onboarding)/arkit-usage.tsx
+++ b/app/(onboarding)/arkit-usage.tsx
@@ -213,7 +213,13 @@ export default function ARKitUsageScreen() {
               <Ionicons name="arrow-back" size={24} color="#007AFF" />
             </TouchableOpacity>
             <Text style={styles.headerTitle}>Get Started</Text>
-            <OnboardingProgress current={2} total={3} />
+            <View
+              accessible
+              accessibilityRole="progressbar"
+              accessibilityLabel="Step 2 of 3: Get Started for Form Tracking"
+            >
+              <OnboardingProgress current={2} total={3} />
+            </View>
           </Animated.View>
 
           {/* Hero Section */}

--- a/app/(onboarding)/welcome.tsx
+++ b/app/(onboarding)/welcome.tsx
@@ -112,6 +112,8 @@ export default function WelcomeScreen() {
             onPress={handleGetStarted}
             activeOpacity={0.7}
             accessibilityRole="button"
+            accessibilityLabel="Sign in to existing account"
+            accessibilityHint="Opens login screen"
           >
             <Text style={styles.secondaryButtonText}>I already have an account</Text>
           </TouchableOpacity>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1095,7 +1095,20 @@ Generated: ${new Date().toISOString()}
           />
           <View style={styles.modalContent}>
             <View style={styles.modalHandle} />
-            <Text style={styles.modalTitle}>Edit Profile</Text>
+            <View style={styles.modalTitleRow}>
+              <Text style={styles.modalTitle}>Edit Profile</Text>
+              <TouchableOpacity
+                style={styles.modalCloseButton}
+                onPress={() => (!isSavingName ? setIsEditProfileVisible(false) : null)}
+                disabled={isSavingName}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                accessibilityRole="button"
+                accessibilityLabel="Close profile edit"
+                accessibilityHint="Discard changes and close the edit profile sheet"
+              >
+                <Ionicons name="close" size={22} color="#9AACD1" />
+              </TouchableOpacity>
+            </View>
             <Text style={styles.modalLabel}>Full Name</Text>
             <TextInput
               value={fullName}
@@ -1127,6 +1140,8 @@ Generated: ${new Date().toISOString()}
                 style={[styles.modalButton, styles.modalButtonSecondary]}
                 onPress={() => setIsEditProfileVisible(false)}
                 disabled={isSavingName}
+                accessibilityRole="button"
+                accessibilityLabel="Cancel profile edit"
               >
                 <Text style={[styles.modalButtonText, styles.modalButtonTextSecondary]}>Cancel</Text>
               </TouchableOpacity>
@@ -1134,6 +1149,8 @@ Generated: ${new Date().toISOString()}
                 style={[styles.modalButton, styles.modalButtonPrimary]}
                 onPress={handleSaveProfile}
                 disabled={isSavingName}
+                accessibilityRole="button"
+                accessibilityLabel="Save profile changes"
               >
                 {isSavingName ? (
                   <ActivityIndicator color="#0F2339" />
@@ -1155,7 +1172,20 @@ Generated: ${new Date().toISOString()}
           />
           <View style={styles.modalContent}>
             <View style={styles.modalHandle} />
-            <Text style={styles.modalTitle}>Edit Nutrition Goals</Text>
+            <View style={styles.modalTitleRow}>
+              <Text style={styles.modalTitle}>Edit Nutrition Goals</Text>
+              <TouchableOpacity
+                style={styles.modalCloseButton}
+                onPress={() => (!isSavingGoals ? setIsEditGoalsVisible(false) : null)}
+                disabled={isSavingGoals}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                accessibilityRole="button"
+                accessibilityLabel="Close nutrition goals edit"
+                accessibilityHint="Discard changes and close the nutrition goals sheet"
+              >
+                <Ionicons name="close" size={22} color="#9AACD1" />
+              </TouchableOpacity>
+            </View>
 
             <View style={styles.inputContainer}>
               <Text style={styles.modalLabel}>Daily Calories *</Text>
@@ -1220,6 +1250,8 @@ Generated: ${new Date().toISOString()}
                 style={[styles.modalButton, styles.modalButtonSecondary]}
                 onPress={() => setIsEditGoalsVisible(false)}
                 disabled={isSavingGoals}
+                accessibilityRole="button"
+                accessibilityLabel="Cancel nutrition goals edit"
               >
                 <Text style={[styles.modalButtonText, styles.modalButtonTextSecondary]}>Cancel</Text>
               </TouchableOpacity>
@@ -1227,6 +1259,8 @@ Generated: ${new Date().toISOString()}
                 style={[styles.modalButton, styles.modalButtonPrimary]}
                 onPress={handleSaveGoals}
                 disabled={isSavingGoals}
+                accessibilityRole="button"
+                accessibilityLabel="Save nutrition goals"
               >
                 {isSavingGoals ? (
                   <ActivityIndicator color="#0F2339" />

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -385,7 +385,7 @@ export default function ProfileScreen() {
               onPress: () => {
                 Alert.alert(
                   'Delete video?',
-                  'This removes the clip and metrics permanently.',
+                  'Delete video and all metrics permanently? This cannot be undone.',
                   [
                     { text: 'Cancel', style: 'cancel' },
                     { text: 'Delete', style: 'destructive', onPress: () => handleDeleteVideo(video.id) },

--- a/styles/tabs/_profile.styles.ts
+++ b/styles/tabs/_profile.styles.ts
@@ -286,11 +286,27 @@ export const styles = StyleSheet.create({
     alignSelf: 'center',
     marginBottom: spacing.md,
   },
+  modalTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.sm + spacing.xs,
+  },
   modalTitle: {
     fontSize: 20,
     fontWeight: '700',
     color: tabColors.textPrimary,
     marginBottom: spacing.sm + spacing.xs,
+    flex: 1,
+  },
+  modalCloseButton: {
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: borderRadius.md,
+    backgroundColor: 'rgba(154, 172, 209, 0.1)',
+    marginLeft: spacing.sm,
   },
   modalLabel: {
     fontSize: 14,
@@ -340,6 +356,9 @@ export const styles = StyleSheet.create({
     paddingHorizontal: 18,
     borderRadius: borderRadius.md,
     borderWidth: 1,
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   modalButtonSecondary: {
     borderColor: tabColors.border,


### PR DESCRIPTION
Wave-33 D — net-new UX/a11y polish outside form-tracking core. Non-duplicates of wave-31 #565 and wave-32 #572.

## Scope

- **a11y**: notifications Switch labels, profile modal close button + nutrition touch targets, onboarding progress screen-reader, welcome CTA role/hint
- **loading**: add-food save spinner, video-comments fetch skeleton
- **destructive copy**: video delete alert context

## Verification

- `bun run lint` + `bun run check:types` clean (ran via pre-commit hook on each of the 7 atomic commits)
- Manual screen-reader smoke passed on onboarding + notifications
- No changes to `settings-coaching.tsx` (deferred — open #566 holds it)

Closes #578