### PR TITLE
feat(wave33): Gemma surface expansion — session/warmup/pre-set taskKind + voice NLU

### DIFF
--- a/lib/services/coach-cost-tracker.ts
+++ b/lib/services/coach-cost-tracker.ts
@@ -25,6 +25,8 @@ export type CoachTaskKind =
   | 'drill_explainer'
   | 'session_generator'
   | 'progression_planner'
+  | 'form_check'
+  | 'voice_debrief'
   | 'other';
 
 export interface CoachUsageEvent {
@@ -281,6 +283,8 @@ function emptyTaskKindMap(): WeeklyAggregate['byTaskKind'] {
     drill_explainer: { tokensIn: 0, tokensOut: 0, calls: 0 },
     session_generator: { tokensIn: 0, tokensOut: 0, calls: 0 },
     progression_planner: { tokensIn: 0, tokensOut: 0, calls: 0 },
+    form_check: { tokensIn: 0, tokensOut: 0, calls: 0 },
+    voice_debrief: { tokensIn: 0, tokensOut: 0, calls: 0 },
     other: { tokensIn: 0, tokensOut: 0, calls: 0 },
   };
 }

--- a/lib/services/coach-model-dispatch.ts
+++ b/lib/services/coach-model-dispatch.ts
@@ -48,6 +48,9 @@ export type CoachTaskKind =
   | 'nutrition_balance'
   | 'multi_turn_debrief'
   | 'session_generator'
+  | 'progression_planner'
+  | 'form_check'
+  | 'voice_debrief'
   | 'general_chat';
 
 export type CoachModelId =

--- a/lib/services/pre-set-preview.ts
+++ b/lib/services/pre-set-preview.ts
@@ -17,6 +17,8 @@
 import type { FrameSnapshot, JointAngles } from '@/lib/arkit/ARKitBodyTracker';
 import { sendCoachPrompt, type CoachMessage } from './coach-service';
 import { sendCoachGemmaPrompt } from './coach-gemma-service';
+import { recordCoachUsage } from './coach-cost-tracker';
+import { warnWithTs } from '@/lib/logger';
 
 export type PreSetPreviewProvider = 'gemma' | 'openai';
 
@@ -28,6 +30,34 @@ export interface PreSetPreviewResult {
 
 const GEMMA_PROVIDER_ENV = 'EXPO_PUBLIC_COACH_CLOUD_PROVIDER';
 const MAX_VERDICT_LENGTH = 160;
+
+/**
+ * Task-kind hint for pre-set stance previews. Recorded against the coach
+ * cost-tracker so weekly aggregates surface form-check spend separately from
+ * general chat / debrief. Exported so tests + call sites can assert on the
+ * exact string literal.
+ */
+export const PRE_SET_PREVIEW_TASK_KIND = 'form_check' as const;
+
+/**
+ * Best-effort usage recorder. Fires after each call-site resolution so the
+ * cost-tracker can attribute pre-set spend to the `form_check` bucket. Token
+ * counts aren't available from the edge function response here (tracked at
+ * the edge level), so we log call-count-only with zero tokens. A follow-up
+ * can plumb actual token usage when the edge function starts returning it.
+ */
+function recordPreSetUsage(provider: 'gemma_cloud' | 'openai'): void {
+  void recordCoachUsage({
+    provider,
+    taskKind: PRE_SET_PREVIEW_TASK_KIND,
+    tokensIn: 0,
+    tokensOut: 0,
+  }).catch((err) => {
+    // recordCoachUsage already swallows AsyncStorage faults; this is a last
+    // line of defence so a telemetry bug never breaks the form-check path.
+    warnWithTs('[pre-set-preview] recordCoachUsage failed', err);
+  });
+}
 
 /**
  * Inline replacement for coach-live-snapshot.buildLiveSessionSnapshot().
@@ -124,6 +154,7 @@ export async function checkPreSetStance(
     try {
       const reply = await callGemma(prompt);
       const interpreted = interpretVerdict(reply);
+      recordPreSetUsage('gemma_cloud');
       return { ...interpreted, provider: 'gemma' };
     } catch {
       // Fall through to OpenAI — Gemma path is best-effort.
@@ -132,5 +163,6 @@ export async function checkPreSetStance(
 
   const reply = await callOpenAI(prompt);
   const interpreted = interpretVerdict(reply);
+  recordPreSetUsage('openai');
   return { ...interpreted, provider: 'openai' };
 }

--- a/lib/services/session-generator.ts
+++ b/lib/services/session-generator.ts
@@ -13,7 +13,12 @@
  *      Crypto.randomUUID() ids.
  */
 import * as Crypto from 'expo-crypto';
-import { sendCoachPrompt, type CoachContext, type CoachMessage } from './coach-service';
+import {
+  sendCoachPrompt,
+  type CoachContext,
+  type CoachMessage,
+  type CoachSendOptions,
+} from './coach-service';
 import { parseGemmaJsonResponse, schema, type JsonSchema } from './gemma-json-parser';
 import { assertGemmaSessionGenEnabled } from './gemma-session-gen-flag';
 import {
@@ -93,8 +98,17 @@ export interface HydratedTemplate {
 export interface SessionGeneratorRuntime {
   userId: string;
   coachContext?: CoachContext;
-  /** Override dispatcher for tests. */
-  dispatch?: (messages: CoachMessage[], ctx?: CoachContext) => Promise<CoachMessage>;
+  /**
+   * Override dispatcher for tests. When production uses the default
+   * (`sendCoachPrompt`), taskKind is threaded through via the third arg so
+   * the cost-tracker + dispatch router can attribute spend to
+   * `session_generator`.
+   */
+  dispatch?: (
+    messages: CoachMessage[],
+    ctx?: CoachContext,
+    opts?: CoachSendOptions,
+  ) => Promise<CoachMessage>;
   /** Override uuid for tests. */
   uuid?: () => string;
   /** Retry count passed to gemma-json-parser. Default 1. */
@@ -107,6 +121,13 @@ export interface SessionGeneratorRuntime {
    */
   skipFlagCheck?: boolean;
 }
+
+/**
+ * Task-kind hint passed to `sendCoachPrompt` so the cost-tracker can attribute
+ * spend + the dispatch router can pick Gemma when the flag is on. Kept as a
+ * module-level constant so tests can reference it.
+ */
+export const SESSION_GENERATOR_TASK_KIND = 'session_generator' as const;
 
 /**
  * Generate a workout template from a natural-language intent.
@@ -128,8 +149,9 @@ export async function generateSession(
 
   const messages = buildSessionGeneratorMessages(input);
   const dispatch = runtime.dispatch ?? sendCoachPrompt;
+  const dispatchOpts: CoachSendOptions = { taskKind: SESSION_GENERATOR_TASK_KIND };
 
-  const assistantMessage = await dispatch(messages, runtime.coachContext);
+  const assistantMessage = await dispatch(messages, runtime.coachContext, dispatchOpts);
 
   const retryInvoker = async (ctx: { lastRawText: string; issues?: unknown }): Promise<string> => {
     const retryMessages: CoachMessage[] = [
@@ -140,7 +162,7 @@ export async function generateSession(
         content: `The previous response was not valid JSON or did not match the schema. Issues: ${JSON.stringify(ctx.issues ?? 'syntax error')}. Respond ONLY with corrected JSON.`,
       },
     ];
-    const retryResponse = await dispatch(retryMessages, runtime.coachContext);
+    const retryResponse = await dispatch(retryMessages, runtime.coachContext, dispatchOpts);
     return retryResponse.content;
   };
 

--- a/lib/services/voice-gemma-nlu-fallback.ts
+++ b/lib/services/voice-gemma-nlu-fallback.ts
@@ -45,6 +45,13 @@ export const FALLBACK_CANDIDATES: Exclude<
 export const GEMMA_FALLBACK_CONFIDENCE = 0.8;
 
 /**
+ * Task-kind hint forwarded to `sendCoachPrompt` so the cost-tracker attributes
+ * voice-NLU spend to the new `voice_debrief` bucket. Exported so tests can
+ * assert on the literal string.
+ */
+export const VOICE_NLU_TASK_KIND = 'voice_debrief' as const;
+
+/**
  * Builds the zero-shot Gemma prompt. Kept in its own function for unit
  * testing + future prompt iteration without touching call sites.
  */
@@ -115,6 +122,7 @@ export async function classifyViaGemma(
   try {
     const reply = await sendPrompt(buildGemmaNluPrompt(normalized), undefined, {
       provider: 'gemma',
+      taskKind: VOICE_NLU_TASK_KIND,
     });
     const intent = parseGemmaNluResponse(reply.content ?? '');
     if (intent === 'none') {

--- a/lib/services/warmup-generator.ts
+++ b/lib/services/warmup-generator.ts
@@ -5,7 +5,12 @@
  * from session-generator but returns a lighter `WarmupPlan` tree (no template
  * row materialization — callers consume directly as a checklist).
  */
-import { sendCoachPrompt, type CoachContext, type CoachMessage } from './coach-service';
+import {
+  sendCoachPrompt,
+  type CoachContext,
+  type CoachMessage,
+  type CoachSendOptions,
+} from './coach-service';
 import { parseGemmaJsonResponse, schema, type JsonSchema } from './gemma-json-parser';
 import { assertGemmaSessionGenEnabled } from './gemma-session-gen-flag';
 import {
@@ -59,7 +64,16 @@ export const WARMUP_PLAN_SCHEMA: JsonSchema<WarmupPlan> = schema.object({
 
 export interface WarmupGeneratorRuntime {
   coachContext?: CoachContext;
-  dispatch?: (messages: CoachMessage[], ctx?: CoachContext) => Promise<CoachMessage>;
+  /**
+   * Dispatcher override for tests. When production uses the default
+   * (`sendCoachPrompt`), taskKind is threaded through via the third arg so the
+   * cost-tracker can attribute spend to `progression_planner`.
+   */
+  dispatch?: (
+    messages: CoachMessage[],
+    ctx?: CoachContext,
+    opts?: CoachSendOptions,
+  ) => Promise<CoachMessage>;
   maxRetries?: number;
   /**
    * Bypass the EXPO_PUBLIC_GEMMA_SESSION_GEN gate. Intended for integration
@@ -67,6 +81,12 @@ export interface WarmupGeneratorRuntime {
    */
   skipFlagCheck?: boolean;
 }
+
+/**
+ * Task-kind hint passed to `sendCoachPrompt` so the cost-tracker attributes
+ * warmup-generator spend and the dispatch router can pick Gemma when enabled.
+ */
+export const WARMUP_GENERATOR_TASK_KIND = 'progression_planner' as const;
 
 export async function generateWarmup(
   input: WarmupGeneratorInput,
@@ -78,8 +98,9 @@ export async function generateWarmup(
 
   const messages = buildWarmupGeneratorMessages(input);
   const dispatch = runtime.dispatch ?? sendCoachPrompt;
+  const dispatchOpts: CoachSendOptions = { taskKind: WARMUP_GENERATOR_TASK_KIND };
 
-  const response = await dispatch(messages, runtime.coachContext);
+  const response = await dispatch(messages, runtime.coachContext, dispatchOpts);
 
   const retryInvoker = async (ctx: { lastRawText: string; issues?: unknown }): Promise<string> => {
     const retryMessages: CoachMessage[] = [
@@ -90,7 +111,7 @@ export async function generateWarmup(
         content: `The previous response did not match the warmup schema. Issues: ${JSON.stringify(ctx.issues ?? 'syntax error')}. Respond ONLY with corrected JSON.`,
       },
     ];
-    const retry = await dispatch(retryMessages, runtime.coachContext);
+    const retry = await dispatch(retryMessages, runtime.coachContext, dispatchOpts);
     return retry.content;
   };
 

--- a/tests/unit/pre-set-preview.test.ts
+++ b/tests/unit/pre-set-preview.test.ts
@@ -1,5 +1,6 @@
 const mockSendCoachPrompt = jest.fn();
 const mockSendCoachGemmaPrompt = jest.fn();
+const mockRecordCoachUsage = jest.fn<Promise<void>, unknown[]>();
 
 jest.mock('@/lib/services/coach-service', () => ({
   sendCoachPrompt: (...args: unknown[]) => mockSendCoachPrompt(...args),
@@ -7,6 +8,10 @@ jest.mock('@/lib/services/coach-service', () => ({
 
 jest.mock('@/lib/services/coach-gemma-service', () => ({
   sendCoachGemmaPrompt: (...args: unknown[]) => mockSendCoachGemmaPrompt(...args),
+}));
+
+jest.mock('@/lib/services/coach-cost-tracker', () => ({
+  recordCoachUsage: (...args: unknown[]) => mockRecordCoachUsage(...args),
 }));
 
 // The service imports FrameSnapshot + JointAngles from the ARKit tracker
@@ -17,6 +22,7 @@ import type { FrameSnapshot, JointAngles } from '@/lib/arkit/ARKitBodyTracker';
 import {
   buildPreSetPrompt,
   checkPreSetStance,
+  PRE_SET_PREVIEW_TASK_KIND,
 } from '@/lib/services/pre-set-preview';
 
 const snapshot: FrameSnapshot = {
@@ -55,6 +61,8 @@ describe('checkPreSetStance', () => {
   beforeEach(() => {
     mockSendCoachPrompt.mockReset();
     mockSendCoachGemmaPrompt.mockReset();
+    mockRecordCoachUsage.mockReset();
+    mockRecordCoachUsage.mockResolvedValue(undefined);
     delete process.env.EXPO_PUBLIC_COACH_CLOUD_PROVIDER;
   });
 
@@ -140,5 +148,62 @@ describe('checkPreSetStance', () => {
     await expect(
       checkPreSetStance(snapshot, 'pushup', angles)
     ).rejects.toThrow('coach-invoke-failed');
+  });
+
+  it("records usage with taskKind: 'form_check' on the OpenAI path", async () => {
+    mockSendCoachPrompt.mockResolvedValueOnce({
+      role: 'assistant',
+      content: '✓ Good',
+    });
+
+    await checkPreSetStance(snapshot, 'deadlift', angles);
+
+    expect(mockRecordCoachUsage).toHaveBeenCalledTimes(1);
+    const event = mockRecordCoachUsage.mock.calls[0][0] as {
+      provider: string;
+      taskKind: string;
+    };
+    expect(event.taskKind).toBe(PRE_SET_PREVIEW_TASK_KIND);
+    expect(event.taskKind).toBe('form_check');
+    expect(event.provider).toBe('openai');
+  });
+
+  it("records usage with provider 'gemma_cloud' when Gemma path succeeds", async () => {
+    process.env.EXPO_PUBLIC_COACH_CLOUD_PROVIDER = 'gemma';
+    mockSendCoachGemmaPrompt.mockResolvedValueOnce({
+      role: 'assistant',
+      content: '✓ Good',
+    });
+
+    await checkPreSetStance(snapshot, 'squat', angles);
+
+    expect(mockRecordCoachUsage).toHaveBeenCalledTimes(1);
+    const event = mockRecordCoachUsage.mock.calls[0][0] as {
+      provider: string;
+      taskKind: string;
+    };
+    expect(event.taskKind).toBe('form_check');
+    expect(event.provider).toBe('gemma_cloud');
+  });
+
+  it('records usage against OpenAI when Gemma throws and OpenAI fallback succeeds', async () => {
+    process.env.EXPO_PUBLIC_COACH_CLOUD_PROVIDER = 'gemma';
+    mockSendCoachGemmaPrompt.mockRejectedValueOnce(new Error('gemma-offline'));
+    mockSendCoachPrompt.mockResolvedValueOnce({
+      role: 'assistant',
+      content: '✓ Good',
+    });
+
+    await checkPreSetStance(snapshot, 'squat', angles);
+
+    // Exactly one record per completed call; Gemma attempt produced no usage event
+    // since it failed before the interpret/record step.
+    expect(mockRecordCoachUsage).toHaveBeenCalledTimes(1);
+    const event = mockRecordCoachUsage.mock.calls[0][0] as {
+      provider: string;
+      taskKind: string;
+    };
+    expect(event.provider).toBe('openai');
+    expect(event.taskKind).toBe('form_check');
   });
 });

--- a/tests/unit/services/session-generator.test.ts
+++ b/tests/unit/services/session-generator.test.ts
@@ -9,13 +9,14 @@ import {
   generateSession,
   hydrateTemplate,
   SESSION_GENERATOR_SCHEMA,
+  SESSION_GENERATOR_TASK_KIND,
   type GeneratedTemplateShape,
 } from '@/lib/services/session-generator';
 import {
   buildSessionGeneratorMessages,
   SESSION_GENERATOR_SYSTEM_PROMPT,
 } from '@/lib/services/session-generator-prompt';
-import type { CoachMessage } from '@/lib/services/coach-service';
+import type { CoachMessage, CoachSendOptions } from '@/lib/services/coach-service';
 
 describe('session-generator-prompt', () => {
   it('builds a message sequence with system + few-shots + user', () => {
@@ -173,6 +174,50 @@ describe('generateSession', () => {
     await expect(
       generateSession({ intent: 'x' }, { userId: 'u1', dispatch }),
     ).rejects.toThrow('network down');
+  });
+
+  it("forwards taskKind: 'session_generator' to the dispatcher", async () => {
+    const dispatch = jest
+      .fn<
+        Promise<CoachMessage>,
+        [CoachMessage[], unknown?, CoachSendOptions?]
+      >()
+      .mockResolvedValue({
+        role: 'assistant',
+        content: JSON.stringify(validResponse),
+      });
+
+    await generateSession(
+      { intent: 'quick push' },
+      { userId: 'u1', dispatch, uuid: () => 'fixed-uuid' },
+    );
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const [, , opts] = dispatch.mock.calls[0];
+    expect(opts?.taskKind).toBe(SESSION_GENERATOR_TASK_KIND);
+    expect(opts?.taskKind).toBe('session_generator');
+  });
+
+  it('passes the same taskKind on retry turns so both calls are attributed', async () => {
+    const dispatch = jest
+      .fn<
+        Promise<CoachMessage>,
+        [CoachMessage[], unknown?, CoachSendOptions?]
+      >()
+      .mockResolvedValueOnce({ role: 'assistant', content: 'not json!' })
+      .mockResolvedValueOnce({
+        role: 'assistant',
+        content: JSON.stringify(validResponse),
+      });
+
+    await generateSession(
+      { intent: 'quick push' },
+      { userId: 'u1', dispatch, maxRetries: 1 },
+    );
+
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch.mock.calls[0][2]?.taskKind).toBe('session_generator');
+    expect(dispatch.mock.calls[1][2]?.taskKind).toBe('session_generator');
   });
 
   describe('EXPO_PUBLIC_GEMMA_SESSION_GEN gate', () => {

--- a/tests/unit/services/voice-gemma-nlu-fallback.test.ts
+++ b/tests/unit/services/voice-gemma-nlu-fallback.test.ts
@@ -9,6 +9,7 @@
 import {
   FALLBACK_CANDIDATES,
   GEMMA_FALLBACK_CONFIDENCE,
+  VOICE_NLU_TASK_KIND,
   buildGemmaNluPrompt,
   classifyViaGemma,
   parseGemmaNluResponse,
@@ -100,6 +101,19 @@ describe('classifyViaGemma', () => {
       .mockResolvedValue({ role: 'assistant', content: 'next' });
     await classifyViaGemma('keep going mate', sendPrompt);
     const opts = sendPrompt.mock.calls[0]?.[2] as { provider?: string } | undefined;
+    expect(opts?.provider).toBe('gemma');
+  });
+
+  it("forwards taskKind: 'voice_debrief' so cost-tracker can attribute voice spend", async () => {
+    const sendPrompt = jest
+      .fn<Promise<CoachMessage>, unknown[]>()
+      .mockResolvedValue({ role: 'assistant', content: 'skip_rest' });
+    await classifyViaGemma('skip the rest please', sendPrompt);
+    const opts = sendPrompt.mock.calls[0]?.[2] as
+      | { taskKind?: string; provider?: string }
+      | undefined;
+    expect(opts?.taskKind).toBe(VOICE_NLU_TASK_KIND);
+    expect(opts?.taskKind).toBe('voice_debrief');
     expect(opts?.provider).toBe('gemma');
   });
 

--- a/tests/unit/services/warmup-generator.test.ts
+++ b/tests/unit/services/warmup-generator.test.ts
@@ -1,5 +1,6 @@
 import {
   generateWarmup,
+  WARMUP_GENERATOR_TASK_KIND,
   WARMUP_PLAN_SCHEMA,
   type WarmupPlan,
 } from '@/lib/services/warmup-generator';
@@ -7,7 +8,7 @@ import {
   buildWarmupGeneratorMessages,
   WARMUP_GENERATOR_SYSTEM_PROMPT,
 } from '@/lib/services/warmup-generator-prompt';
-import type { CoachMessage } from '@/lib/services/coach-service';
+import type { CoachMessage, CoachSendOptions } from '@/lib/services/coach-service';
 
 const VALID_PLAN: WarmupPlan = {
   name: 'Test Warmup',
@@ -92,6 +93,22 @@ describe('generateWarmup', () => {
     await expect(
       generateWarmup({ exerciseSlugs: ['x'] }, { dispatch, maxRetries: 1 }),
     ).rejects.toMatchObject({ code: 'GEMMA_JSON_RETRY_EXHAUSTED' });
+  });
+
+  it("forwards taskKind: 'progression_planner' to the dispatcher", async () => {
+    const dispatch = jest
+      .fn<
+        Promise<CoachMessage>,
+        [CoachMessage[], unknown?, CoachSendOptions?]
+      >()
+      .mockResolvedValue({ role: 'assistant', content: JSON.stringify(VALID_PLAN) });
+
+    await generateWarmup({ exerciseSlugs: ['squat'] }, { dispatch });
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const [, , opts] = dispatch.mock.calls[0];
+    expect(opts?.taskKind).toBe(WARMUP_GENERATOR_TASK_KIND);
+    expect(opts?.taskKind).toBe('progression_planner');
   });
 
   describe('EXPO_PUBLIC_GEMMA_SESSION_GEN gate', () => {


### PR DESCRIPTION
Wave-33 B — push Gemma into more product surfaces + close the taskKind/telemetry gaps wave-32 #571 didn't cover.

Aligns with user mandate "see if we can get gemma by google" — more services go through cost-aware Gemma-first dispatch.

## Scope

- G1 session-generator → `taskKind: 'session_generator'` forwarded on primary + retry dispatch
- G2 warmup-generator → `taskKind: 'progression_planner'` forwarded on primary + retry dispatch
- G3 pre-set-preview → new `form_check` enum + `recordCoachUsage` on both Gemma and OpenAI verdict paths
- G6 voice-NLU Gemma surface — new `voice_debrief` enum + `classifyViaGemma` now forwards it alongside the `gemma` provider hint (already wired into the voice pipeline via `classifyIntentWithFallback` — no additional call-site surgery needed)

## Files touched

- `lib/services/coach-cost-tracker.ts` — `form_check` + `voice_debrief` added to `CoachTaskKind` + empty bucket map
- `lib/services/coach-model-dispatch.ts` — mirror literals so `CoachSendOptions.taskKind` accepts them (fall through to `general_chat_default` for now)
- `lib/services/session-generator.ts` — dispatcher widened to `(messages, ctx?, opts?)`; forwards `SESSION_GENERATOR_TASK_KIND`
- `lib/services/warmup-generator.ts` — same treatment, `WARMUP_GENERATOR_TASK_KIND`
- `lib/services/pre-set-preview.ts` — `PRE_SET_PREVIEW_TASK_KIND` + best-effort `recordPreSetUsage` on both providers
- `lib/services/voice-gemma-nlu-fallback.ts` — forwards `VOICE_NLU_TASK_KIND` + `provider: 'gemma'`

## Deferred (conflict with open #571)

- G4 `coach-service.ts` cache-hit telemetry — lands after #571 merges
- G5 `coach-service.ts` streaming safety rollback — lands after #571 merges

## Verification

- `bun run lint` + `bun run check:types` clean
- 7 new unit tests (session-gen × 2, warmup-gen × 1, pre-set × 3, voice-nlu × 1) — all green
- Broader sweep: 231 tests across 9 related suites all pass

Closes #576