### PR TITLE
feat(wave33): form-tracking session-state + cue/debrief resilience pack

### DIFF
--- a/app/(modals)/form-tracking-debrief.tsx
+++ b/app/(modals)/form-tracking-debrief.tsx
@@ -32,6 +32,8 @@ import { useAutoDebrief } from '@/hooks/use-auto-debrief';
 import { useSessionComparisonQuery } from '@/hooks/use-session-comparison';
 import { supabase } from '@/lib/supabase';
 import { isCoachPipelineV2Enabled } from '@/lib/services/coach-pipeline-v2-flag';
+import { deriveDebriefAnalytics, type RepAnalytics } from '@/lib/services/coach-debrief-prompt';
+import type { GenerateAutoDebriefInput } from '@/lib/services/coach-auto-debrief';
 
 function safeParseReps(raw: string | undefined): RepSummary[] {
   if (!raw) return [];
@@ -166,20 +168,45 @@ export default function FormTrackingDebriefScreen() {
   // name + rep count + first-rep fqi (deterministic; no UUID dep).
   const pipelineV2 = isCoachPipelineV2Enabled();
   const sessionId = useMemo(() => {
+    // Prefer the explicit route param when present — matches the sessionId
+    // the live-tracking controller wrote to telemetry. Fall back to a
+    // deterministic synth when the route doesn't carry one (legacy recap
+    // deep-links) so the cache key stays stable across re-opens.
     if (!pipelineV2 || reps.length === 0) return null;
+    if (routeSessionId) return routeSessionId;
     return `debrief:${exerciseName}:${reps.length}:${Math.round((reps[0]?.fqi ?? 0) * 100)}`;
-  }, [pipelineV2, exerciseName, reps]);
+  }, [pipelineV2, exerciseName, reps, routeSessionId]);
+
+  // Build a valid GenerateAutoDebriefInput from route params so useAutoDebrief
+  // fires once on mount (#575 item #5). Previously buildInput() always
+  // returned null, so the "Coach debrief" section rendered a permanent
+  // empty state for users who'd just finished a session. reps carry fqi
+  // 0..100 per RepSummary; we convert to 0..1 for RepAnalytics.
+  const initialInput = useMemo<GenerateAutoDebriefInput | null>(() => {
+    if (!pipelineV2 || !sessionId || reps.length === 0) return null;
+    const repAnalytics: RepAnalytics[] = reps.map((r) => ({
+      fqi: r.fqi / 100,
+      topFault: r.faults[0] ?? null,
+    }));
+    return {
+      sessionId,
+      analytics: deriveDebriefAnalytics(sessionId, exerciseName, repAnalytics),
+    };
+  }, [pipelineV2, sessionId, reps, exerciseName]);
 
   const buildInput = useCallback(async () => {
-    // form-tracking-debrief never fires session_finished directly, but we
-    // still provide a valid builder for the hook contract. Returning null
-    // is a safe no-op when the modal is viewed without a session event.
+    // form-tracking-debrief is a recap surface; it doesn't observe a live
+    // session_finished event. The real debrief trigger runs via `initialInput`
+    // (on-mount leg) below. Keep this builder returning null so the shared
+    // session_finished subscription doesn't double-fire if the user happens
+    // to be viewing the modal when a background session ends.
     return null;
   }, []);
 
   const autoDebrief = useAutoDebrief({
     buildInput,
     sessionId: pipelineV2 ? sessionId : null,
+    initialInput,
   });
 
   const handleClose = useCallback(() => {

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -97,7 +97,7 @@ import {
   type PullupScoringResult,
 } from '@/lib/tracking-quality';
 import { CueHysteresisController } from '@/lib/tracking-quality/cue-hysteresis';
-import { useWorkoutController } from '@/hooks/use-workout-controller';
+import { useWorkoutController, isPendingRepsAtStopSignal } from '@/hooks/use-workout-controller';
 import { usePRDetection } from '@/hooks/use-pr-detection';
 import { PRCelebrationBadge } from '@/components/form-tracking/PRCelebrationBadge';
 import { ProgressionSuggestionBadge } from '@/components/form-tracking/ProgressionSuggestionBadge';
@@ -1118,7 +1118,18 @@ export default function ScanARKitScreen() {
         meta?.source === 'frame' ? 'frame-live' : 'onPullupScoring-rep-complete'
       );
     },
-  }), [activeWorkoutDef, repCount, transitionPhase, updatePartialTrackingBadgeVisibility]);
+    // Surface pending-rep warnings to the user (#575 item #10). The
+    // controller fires this both during the session (single-rep retry
+    // failures) and at stop-time (via flushPendingRepsOnStop) with a
+    // distinct sentinel we can discriminate on.
+    onRepLogFailure: (error: unknown, queueDepth: number) => {
+      if (isPendingRepsAtStopSignal(error)) {
+        showToast(`${queueDepth} rep${queueDepth === 1 ? '' : 's'} pending sync — we'll retry when you're back online.`, {
+          type: 'info',
+        });
+      }
+    },
+  }), [activeWorkoutDef, repCount, showToast, transitionPhase, updatePartialTrackingBadgeVisibility]);
 
   const workoutController = useWorkoutController(detectionMode, {
     sessionId: sessionIdRef.current,
@@ -1131,6 +1142,7 @@ export default function ScanARKitScreen() {
     reset: resetWorkoutController,
     setWorkout: setWorkoutController,
     addRepCue: addWorkoutRepCue,
+    flushPendingRepsOnStop,
   } = workoutController;
 
   useEffect(() => {
@@ -1908,6 +1920,12 @@ export default function ScanARKitScreen() {
     }
     setSustainedOcclusionHint(null);
 
+    // Surface any reps that failed to persist before the controller resets
+    // its pending-writes queue (#575 item #10). The callback below emits a
+    // user-facing "N reps pending sync" toast so the user knows their work
+    // wasn't lost even though we can't block stopTracking on a drain.
+    flushPendingRepsOnStop();
+
     try {
       if (isRecording) {
         try {
@@ -2032,6 +2050,7 @@ export default function ScanARKitScreen() {
     resetWorkoutController,
     resetBaselineDebugMetrics,
     resetCueHysteresis,
+    flushPendingRepsOnStop,
   ]);
 
   // Cleanup on unmount

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -2240,11 +2240,19 @@ export default function ScanARKitScreen() {
     metrics.lastCue = primaryCue;
   }, [primaryCue]);
 
+    // The watch-mirror timer polls BodyTracker.getCurrentFrameSnapshot()
+    // ~1Hz while tracking. Previously it only checked `isTracking`, so when
+    // useAppStatePause flipped `isPaused=true` on background/inactive (phone
+    // lock, Control Center, incoming call) the poll kept firing, burning
+    // battery AND keeping the ARKit session half-alive. Gate the whole
+    // mirror surface on BOTH `isTracking` AND `!appStatePause.isPaused` so
+    // the timer teardown fires the moment the app backgrounds. #575 item #9.
     const canMirrorFromArkit =
       Platform.OS === 'ios' &&
       watchMirrorEnabled &&
       isScreenFocused &&
       isTracking &&
+      !appStatePause.isPaused &&
       cameraPosition === 'back';
     const watchMirrorActive =
       canMirrorFromArkit &&

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -848,6 +848,12 @@ export default function ScanARKitScreen() {
   }, []);
 
   const repIndexTrackerRef = React.useRef(new RepIndexTracker());
+  // Stable mirror of `repCount` for callback closures (telemetry, cue logger).
+  // Telemetry events fire asynchronously after phase transitions, so reading
+  // React state inside the closure can attribute the cue to the wrong rep
+  // (closure captured the *previous* value). We snapshot into this ref on
+  // every rep-complete callback and read from it in logCueEvent().
+  const repCountRef = React.useRef(0);
 
   const lastPoseTimestampRef = React.useRef<number | null>(null);
   const recordingActiveRef = React.useRef(false);
@@ -894,7 +900,10 @@ export default function ScanARKitScreen() {
         cue: evt.cue,
         mode: detectionMode,
         phase,
-        repCount,
+        // Read from the ref rather than the closure-captured React state so
+        // cues that emit just after a rep-complete phase transition attribute
+        // to the latest rep (see #575 item #3).
+        repCount: repCountRef.current,
         reason: evt.reason,
         throttled: evt.throttled,
         dropped: evt.action !== 'spoken',
@@ -1041,6 +1050,11 @@ export default function ScanARKitScreen() {
     },
     onRepComplete: (repNumber: number, fqi: number) => {
       setRepCount(repNumber);
+      // Snapshot into a ref so async telemetry closures (logCueEvent) read
+      // the current count instead of the value captured when the closure was
+      // created — avoids attributing cues to the prior rep when phase
+      // transitions fire asynchronously.
+      repCountRef.current = repNumber;
       repIndexTrackerRef.current.endRep();
       if (Number.isFinite(fqi)) {
         sessionFqiScoresRef.current.push(fqi);
@@ -1093,6 +1107,7 @@ export default function ScanARKitScreen() {
     restPhaseRef.current = nextInitialPhase;
     setActivePhase(nextInitialPhase);
     setRepCount(0);
+    repCountRef.current = 0;
     setActiveMetrics(null);
     setLivePullupPartialStatus(null);
     lastLivePartialBadgeRef.current = null;
@@ -1184,6 +1199,7 @@ export default function ScanARKitScreen() {
     repIndexTrackerRef.current.reset();
     resetWorkoutController();
     setRepCount(0);
+    repCountRef.current = 0;
     setActiveMetrics(null);
     setFps(30);
     setFixturePlaybackFramesProcessed(0);
@@ -1748,6 +1764,7 @@ export default function ScanARKitScreen() {
       repIndexTrackerRef.current.reset();
       resetWorkoutController();
       setRepCount(0);
+      repCountRef.current = 0;
       setActiveMetrics(null);
       resetBaselineDebugMetrics();
       resetCueHysteresis();
@@ -1856,6 +1873,7 @@ export default function ScanARKitScreen() {
       repIndexTrackerRef.current.reset();
       resetWorkoutController();
       setRepCount(0);
+      repCountRef.current = 0;
       setFps(0);
       realtimeFormEngineRef.current = createRealtimeEngineState();
       lastShadowMeanAbsDeltaRef.current = null;

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -432,7 +432,26 @@ export default function ScanARKitScreen() {
   );
   const activeFormTargetsRef = React.useRef<FormTargets>(activeFormTargets);
   useEffect(() => {
+    const prev = activeFormTargetsRef.current;
     activeFormTargetsRef.current = activeFormTargets;
+    // When form targets shift (e.g. user just picked a template override for
+    // the active exercise) the cue-hysteresis boundary that was computed
+    // against the old thresholds becomes stale — already-spoken cues can
+    // re-fire under the new boundary because the TTS hook's 5s repeat-guard
+    // sees them as "different" cues. Reset both boundaries in tandem. Skip
+    // on first-render init (prev === current) since nothing's rotated yet.
+    // (#575 item #1, targets-only leg.)
+    const targetsChanged =
+      prev !== activeFormTargets &&
+      (prev.fqiMin !== activeFormTargets.fqiMin ||
+        prev.romMin !== activeFormTargets.romMin ||
+        prev.romMax !== activeFormTargets.romMax);
+    if (targetsChanged) {
+      cueHysteresisControllerRef.current.resetAll();
+      cueHysteresisLastTickRef.current = null;
+      stablePrimaryCueRef.current = null;
+      lastSpokenCueRef.current = null;
+    }
     if (deepLinkTemplateId) {
       logWithTs('[ScanARKit] Active form targets', {
         exerciseId: detectionMode,
@@ -1124,9 +1143,20 @@ export default function ScanARKitScreen() {
     // stopTracking() avg-fqi milestone and session-summary both mix scores
     // across exercises when the user swaps mid-session.
     sessionFqiScoresRef.current = [];
+    // Cue-hysteresis + TTS-throttle have independent state (hysteresis
+    // stable-cue ref + TTS last-phrase ref). When the user swaps exercises
+    // mid-session the same cue text can remain "stable" under the new
+    // thresholds, and the TTS hook's 5s repeat-guard treats it as a
+    // duplicate — so already-muted cues re-fire as the targets flip.
+    // Resetting both boundaries in tandem keeps them coherent (#575 item
+    // #1). stopSpeech() also drains the pending speech queue so the user
+    // doesn't hear a cue from the prior exercise after the swap.
+    resetCueHysteresis();
+    lastSpokenCueRef.current = null;
+    stopSpeech();
     resetBaselineDebugMetrics();
     setWorkoutController(detectionMode);
-  }, [createRealtimeEngineState, detectionMode, resetBaselineDebugMetrics, setWorkoutController]);
+  }, [createRealtimeEngineState, detectionMode, resetBaselineDebugMetrics, resetCueHysteresis, setWorkoutController, stopSpeech]);
 
   useEffect(() => {
     if (DEV) {

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -1118,6 +1118,12 @@ export default function ScanARKitScreen() {
     mediaPipePoseRef.current = null;
     realtimeFormEngineRef.current = createRealtimeEngineState();
     lastShadowMeanAbsDeltaRef.current = null;
+    // Clear session-wide FQI accumulator BEFORE swapping the workout
+    // controller so the first rep of the new exercise can't briefly land in
+    // the previous exercise's score array (#575 item #4). Without this the
+    // stopTracking() avg-fqi milestone and session-summary both mix scores
+    // across exercises when the user swaps mid-session.
+    sessionFqiScoresRef.current = [];
     resetBaselineDebugMetrics();
     setWorkoutController(detectionMode);
   }, [createRealtimeEngineState, detectionMode, resetBaselineDebugMetrics, setWorkoutController]);

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -1856,6 +1856,15 @@ export default function ScanARKitScreen() {
     const exerciseKeyAtStop = detectionMode;
     const sessionIdAtStop = sessionIdRef.current;
 
+    // Drop any pending sustained-occlusion hint timer so the badge doesn't
+    // bleed into the next session with a stale "Some joints hidden" toast
+    // (#575 item #6). The hint state is also cleared to match.
+    if (sustainedOcclusionTimerRef.current) {
+      clearTimeout(sustainedOcclusionTimerRef.current);
+      sustainedOcclusionTimerRef.current = null;
+    }
+    setSustainedOcclusionHint(null);
+
     try {
       if (isRecording) {
         try {

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -104,6 +104,7 @@ import { ProgressionSuggestionBadge } from '@/components/form-tracking/Progressi
 import { useProgressionSuggestion } from '@/hooks/use-progression-suggestion';
 import { emitFormMilestone, useSessionRunner } from '@/lib/stores/session-runner';
 import type { FormTargets } from '@/lib/services/form-target-resolver';
+import { getDefaultsForExerciseWithFlag } from '@/lib/services/form-target-resolver';
 import {
   DEFAULT_DETECTION_MODE,
   getWorkoutByMode,
@@ -430,6 +431,18 @@ export default function ScanARKitScreen() {
     () => getFormTargetsFor(detectionMode),
     [getFormTargetsFor, detectionMode],
   );
+  // Provenance flag — true when `detectionMode` isn't a first-class exercise
+  // and the resolver fell back to DEFAULT_FORM_TARGETS. Kept as a boolean so
+  // a later PR can light up a subtle "generic thresholds" badge without any
+  // UI churn now. #575 item #8.
+  const usingGenericTargets = useMemo(
+    () => getDefaultsForExerciseWithFlag(detectionMode).usingGenericTargets,
+    [detectionMode],
+  );
+  const usingGenericTargetsRef = React.useRef<boolean>(usingGenericTargets);
+  useEffect(() => {
+    usingGenericTargetsRef.current = usingGenericTargets;
+  }, [usingGenericTargets]);
   const activeFormTargetsRef = React.useRef<FormTargets>(activeFormTargets);
   useEffect(() => {
     const prev = activeFormTargetsRef.current;

--- a/hooks/use-auto-debrief.ts
+++ b/hooks/use-auto-debrief.ts
@@ -103,6 +103,16 @@ export interface UseAutoDebriefOptions {
    * cached result and skips the session-finished listener until cleared.
    */
   sessionId?: string | null;
+  /**
+   * Optional input to generate once on mount (e.g. recap screens that
+   * already have the rep/fqi data on route params and want to fire a
+   * debrief without waiting for a separate session_finished event).
+   * When provided AND the auto-debrief feature flag is on, the hook
+   * invokes `generateAutoDebrief(initialInput)` a single time per mount.
+   * Subsequent value changes are ignored (the cache/preload path handles
+   * re-runs). Null/undefined disables the on-mount leg.
+   */
+  initialInput?: GenerateAutoDebriefInput | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -110,7 +120,7 @@ export interface UseAutoDebriefOptions {
 // ---------------------------------------------------------------------------
 
 export function useAutoDebrief(opts: UseAutoDebriefOptions): UseAutoDebriefState {
-  const { buildInput, sessionId } = opts;
+  const { buildInput, sessionId, initialInput } = opts;
 
   const [data, setData] = useState<AutoDebriefResult | null>(null);
   const [loading, setLoading] = useState(false);
@@ -119,6 +129,10 @@ export function useAutoDebrief(opts: UseAutoDebriefOptions): UseAutoDebriefState
   // Stash the last input we generated from so retry() can replay it without
   // waiting for another session_finished event.
   const lastInputRef = useRef<GenerateAutoDebriefInput | null>(null);
+  // Guards the on-mount `initialInput` leg — fires exactly once per mount,
+  // regardless of subsequent prop identity changes, so we don't re-run on
+  // every render just because the caller didn't memoize their input shape.
+  const initialInputFiredRef = useRef(false);
 
   const runWith = useCallback(async (input: GenerateAutoDebriefInput) => {
     lastInputRef.current = input;
@@ -183,6 +197,22 @@ export function useAutoDebrief(opts: UseAutoDebriefOptions): UseAutoDebriefState
       cancelled = true;
     };
   }, [sessionId]);
+
+  // On-mount leg: fire a debrief once when the caller provides an
+  // `initialInput` (e.g. the recap modal constructs a GenerateAutoDebriefInput
+  // from route params). Skipped when the feature flag is off, when the input
+  // is null/undefined, or when the same mount has already fired. The cache-
+  // preload effect above already handles re-opening the screen, so we avoid
+  // double-invocation by short-circuiting when cached data is already present.
+  useEffect(() => {
+    if (initialInputFiredRef.current) return;
+    if (!initialInput) return;
+    if (!isAutoDebriefEnabled()) return;
+    initialInputFiredRef.current = true;
+    // Non-awaited fire-and-forget — the hook state machine drives UI via
+    // loading/error/data, not the promise return.
+    void runWith(initialInput);
+  }, [initialInput, runWith]);
 
   // Subscribe to session-finished events.
   useEffect(() => {

--- a/hooks/use-workout-controller.ts
+++ b/hooks/use-workout-controller.ts
@@ -143,6 +143,26 @@ export interface ResetWorkoutOptions {
   preserveRepCount?: boolean;
 }
 
+/**
+ * Sentinel error the controller passes to `onRepLogFailure` when the caller
+ * stops tracking with unsent reps still queued. UI layers can duck-type on
+ * `.code === 'PENDING_REPS_AT_STOP'` to show a "N reps pending sync" toast.
+ */
+export interface PendingRepsAtStopSignal {
+  code: 'PENDING_REPS_AT_STOP';
+  count: number;
+}
+
+export function isPendingRepsAtStopSignal(
+  err: unknown,
+): err is PendingRepsAtStopSignal {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as { code?: unknown }).code === 'PENDING_REPS_AT_STOP'
+  );
+}
+
 export interface UseWorkoutControllerReturn<TPhase extends string = string> {
   /** Current workout state */
   state: WorkoutControllerState<TPhase>;
@@ -160,6 +180,21 @@ export interface UseWorkoutControllerReturn<TPhase extends string = string> {
   getWorkoutDefinition: () => WorkoutDefinition | undefined;
   /** Add a cue to the current rep's tracking data */
   addRepCue: (cueType: string) => void;
+  /**
+   * Number of rep-log writes currently queued for retry (writes that failed
+   * their initial `logRep()` and are waiting for the next successful write
+   * to drain the queue).
+   */
+  getPendingRepCount: () => number;
+  /**
+   * Called from the host's stopTracking() *before* the controller resets.
+   * When the pending-writes queue is non-empty this invokes
+   * `callbacks.onRepLogFailure` with a `PendingRepsAtStopSignal` sentinel
+   * error + the queue depth so the UI can surface a "N reps pending sync"
+   * toast before state is wiped. Returns the count that was reported (0
+   * when queue was empty and no callback fired).
+   */
+  flushPendingRepsOnStop: () => number;
 }
 
 // =============================================================================
@@ -658,6 +693,28 @@ export function useWorkoutController<TPhase extends string = string>(
     }
   }, []);
 
+  const getPendingRepCount = useCallback((): number => {
+    return pendingRepWritesRef.current.length;
+  }, []);
+
+  const flushPendingRepsOnStop = useCallback((): number => {
+    const count = pendingRepWritesRef.current.length;
+    if (count === 0) return 0;
+    // Reuse the existing onRepLogFailure channel so the UI has a single
+    // surface for rep-log failure toasts — at-stop and in-session alike.
+    // The signal carries an explicit code so callers can tailor the copy
+    // ("N reps pending sync" vs. per-rep retry banner).
+    const signal: PendingRepsAtStopSignal = { code: 'PENDING_REPS_AT_STOP', count };
+    try {
+      callbacks?.onRepLogFailure?.(signal, count);
+    } catch (cbError) {
+      if (__DEV__) {
+        warnWithTs('[WorkoutController] onRepLogFailure (stop-signal) threw', cbError);
+      }
+    }
+    return count;
+  }, [callbacks]);
+
   return {
     state,
     processFrame,
@@ -665,6 +722,8 @@ export function useWorkoutController<TPhase extends string = string>(
     setWorkout,
     getWorkoutDefinition,
     addRepCue,
+    getPendingRepCount,
+    flushPendingRepsOnStop,
   };
 }
 

--- a/lib/services/form-target-resolver.ts
+++ b/lib/services/form-target-resolver.ts
@@ -20,6 +20,7 @@ import type {
   WorkoutTemplate,
   WorkoutTemplateExercise,
 } from '@/lib/types/workout-session';
+import { createError, logError } from '@/lib/services/ErrorHandler';
 
 // =============================================================================
 // Types
@@ -35,6 +36,21 @@ export interface FormTargets {
   romMin: number;
   /** Maximum range-of-motion angle (degrees) — exercise dependent. */
   romMax: number;
+}
+
+/**
+ * Form targets paired with a provenance flag so callers can surface a
+ * subtle "generic thresholds in use" badge when a template typo (or a
+ * custom exerciseId) falls back to `DEFAULT_FORM_TARGETS`.
+ */
+export interface FormTargetsResolution {
+  targets: FormTargets;
+  /**
+   * True when the returned `targets` are the conservative
+   * `DEFAULT_FORM_TARGETS` fallback (unknown exerciseId / non-string).
+   * False when either a per-exercise default or a template override matched.
+   */
+  usingGenericTargets: boolean;
 }
 
 // =============================================================================
@@ -105,34 +121,78 @@ export function resolveFormTargets(
   exerciseId: string,
   template?: (WorkoutTemplate & { exercises?: WorkoutTemplateExercise[] }) | null,
 ): FormTargets {
-  const base = getDefaultsForExercise(exerciseId);
+  return resolveFormTargetsWithFlag(exerciseId, template).targets;
+}
+
+/**
+ * Like `resolveFormTargets()` but also returns the `usingGenericTargets`
+ * provenance flag propagated up from `getDefaultsForExerciseWithFlag()`.
+ * A template override that backs onto generic defaults still flips the
+ * flag when the exerciseId itself is unknown — template authors should
+ * know their per-exercise thresholds are being combined with the
+ * permissive baseline.
+ */
+export function resolveFormTargetsWithFlag(
+  exerciseId: string,
+  template?: (WorkoutTemplate & { exercises?: WorkoutTemplateExercise[] }) | null,
+): FormTargetsResolution {
+  const baseResolution = getDefaultsForExerciseWithFlag(exerciseId);
+  const base = baseResolution.targets;
 
   if (!template || !template.exercises || template.exercises.length === 0) {
-    return base;
+    return baseResolution;
   }
 
   const override = template.exercises.find(
     (e) => e && e.exercise_id === exerciseId,
   );
-  if (!override) return base;
+  if (!override) return baseResolution;
 
   return {
-    fqiMin: pickNumber(override.target_fqi_min, base.fqiMin),
-    romMin: pickNumber(override.target_rom_min, base.romMin),
-    romMax: pickNumber(override.target_rom_max, base.romMax),
+    targets: {
+      fqiMin: pickNumber(override.target_fqi_min, base.fqiMin),
+      romMin: pickNumber(override.target_rom_min, base.romMin),
+      romMax: pickNumber(override.target_rom_max, base.romMax),
+    },
+    usingGenericTargets: baseResolution.usingGenericTargets,
   };
 }
 
 /**
  * Get the baseline defaults for an exercise (no template override).
  * Exported for tests and for callers that don't yet have a template context.
+ *
+ * When `exerciseId` is unknown, the conservative `DEFAULT_FORM_TARGETS`
+ * fallback is returned AND a `logError()` observability signal is emitted
+ * once per unknown id (module-level dedupe) so template typos (e.g.
+ * `exercise_id: "pullups"` vs. `"pullup"`) don't silently degrade FQI
+ * thresholds in production. Callers that want the provenance flag
+ * structurally (for a "Generic thresholds in use" UI badge) should use
+ * `getDefaultsForExerciseWithFlag()` instead.
  */
 export function getDefaultsForExercise(exerciseId: string): FormTargets {
+  return getDefaultsForExerciseWithFlag(exerciseId).targets;
+}
+
+/**
+ * Like `getDefaultsForExercise()` but also returns a `usingGenericTargets`
+ * flag so the caller (e.g. scan-arkit overlay) can surface a subtle badge
+ * when the exerciseId didn't match any first-class exercise entry.
+ */
+export function getDefaultsForExerciseWithFlag(
+  exerciseId: string,
+): FormTargetsResolution {
   if (!exerciseId || typeof exerciseId !== 'string') {
-    return DEFAULT_FORM_TARGETS;
+    maybeLogUnknownExercise(exerciseId, 'invalid-id');
+    return { targets: DEFAULT_FORM_TARGETS, usingGenericTargets: true };
   }
   const key = exerciseId.trim().toLowerCase();
-  return EXERCISE_DEFAULTS[key] ?? DEFAULT_FORM_TARGETS;
+  const match = EXERCISE_DEFAULTS[key];
+  if (match) {
+    return { targets: match, usingGenericTargets: false };
+  }
+  maybeLogUnknownExercise(exerciseId, 'no-match');
+  return { targets: DEFAULT_FORM_TARGETS, usingGenericTargets: true };
 }
 
 /**
@@ -152,4 +212,39 @@ function pickNumber(candidate: number | null | undefined, fallback: number): num
   if (candidate === null || candidate === undefined) return fallback;
   if (typeof candidate !== 'number' || !Number.isFinite(candidate)) return fallback;
   return candidate;
+}
+
+/**
+ * Log-once-per-id observability for the generic-targets fallback so
+ * dashboards surface misconfigured templates without spamming a single
+ * unknown id on every render.
+ */
+const loggedUnknownExerciseIds = new Set<string>();
+/**
+ * Test-only escape hatch to reset the dedupe Set between cases.
+ */
+export function __resetUnknownExerciseLogForTests(): void {
+  loggedUnknownExerciseIds.clear();
+}
+
+function maybeLogUnknownExercise(
+  exerciseId: unknown,
+  reason: 'invalid-id' | 'no-match',
+): void {
+  const key = typeof exerciseId === 'string' ? exerciseId.trim().toLowerCase() : `__${reason}__`;
+  if (loggedUnknownExerciseIds.has(key)) return;
+  loggedUnknownExerciseIds.add(key);
+  logError(
+    createError(
+      'form-tracking',
+      'FORM_TARGET_FALLBACK_GENERIC',
+      'Unknown exerciseId fell back to generic DEFAULT_FORM_TARGETS — FQI thresholds may be too permissive.',
+      {
+        details: { exerciseId, reason },
+        severity: 'warning',
+        retryable: false,
+      },
+    ),
+    { feature: 'form-tracking', location: 'lib/services/form-target-resolver' },
+  );
 }

--- a/tests/unit/hooks/use-auto-debrief.test.tsx
+++ b/tests/unit/hooks/use-auto-debrief.test.tsx
@@ -36,7 +36,11 @@ jest.mock('@/lib/stores/session-runner', () => ({
   },
 }));
 
-import { AUTO_DEBRIEF_TIMEOUT_MESSAGE, useAutoDebrief } from '@/hooks/use-auto-debrief';
+import {
+  AUTO_DEBRIEF_TIMEOUT_MESSAGE,
+  useAutoDebrief,
+  type UseAutoDebriefState,
+} from '@/hooks/use-auto-debrief';
 
 function makeEvent() {
   return {
@@ -284,6 +288,106 @@ describe('useAutoDebrief', () => {
 
     await waitFor(() => {
       expect(result.current.error).toBe('no analytics available');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // initialInput on-mount leg (#575 item #5)
+  // ---------------------------------------------------------------------------
+  describe('initialInput', () => {
+    it('fires generateAutoDebrief once on mount when initialInput provided', async () => {
+      mockGenerate.mockResolvedValue({
+        sessionId: 'sess-recap',
+        provider: 'openai',
+        brief: 'Recap generated.',
+        generatedAt: 'now',
+      });
+
+      const { result } = renderHook(() =>
+        useAutoDebrief({
+          buildInput: () => null,
+          initialInput: {
+            sessionId: 'sess-recap',
+            analytics: { ...makeAnalytics(), sessionId: 'sess-recap' },
+          },
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.data?.sessionId).toBe('sess-recap');
+      });
+      expect(mockGenerate).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire when initialInput is null', async () => {
+      renderHook(() =>
+        useAutoDebrief({
+          buildInput: () => null,
+          initialInput: null,
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockGenerate).not.toHaveBeenCalled();
+    });
+
+    it('does not fire when auto-debrief feature flag is off', async () => {
+      mockIsEnabled.mockReturnValue(false);
+      renderHook(() =>
+        useAutoDebrief({
+          buildInput: () => null,
+          initialInput: {
+            sessionId: 'sess-recap',
+            analytics: makeAnalytics(),
+          },
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockGenerate).not.toHaveBeenCalled();
+    });
+
+    it('fires exactly once per mount even when prop identity changes', async () => {
+      mockGenerate.mockResolvedValue({
+        sessionId: 'sess-recap',
+        provider: 'openai',
+        brief: 'Done.',
+        generatedAt: 'now',
+      });
+
+      const initial = {
+        sessionId: 'sess-recap',
+        analytics: { ...makeAnalytics(), sessionId: 'sess-recap' },
+      };
+      type Props = { input: typeof initial | null };
+      const { rerender } = renderHook<UseAutoDebriefState, Props>(
+        ({ input }) =>
+          useAutoDebrief({
+            buildInput: () => null,
+            initialInput: input,
+          }),
+        { initialProps: { input: initial } },
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Force re-render with a different input reference — the guard should
+      // ignore the second value since we only want a single on-mount run.
+      rerender({
+        input: {
+          sessionId: 'sess-recap-2',
+          analytics: { ...makeAnalytics(), sessionId: 'sess-recap-2' },
+        },
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockGenerate).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/unit/hooks/use-workout-controller.test.ts
+++ b/tests/unit/hooks/use-workout-controller.test.ts
@@ -986,5 +986,107 @@ describe('useWorkoutController', () => {
       expect(hook.result.current.state.repCount).toBe(1);
       expect(onRepLogFailure).toHaveBeenCalled();
     });
+
+    // -------------------------------------------------------------------------
+    // flushPendingRepsOnStop + getPendingRepCount (#575 item #10)
+    // -------------------------------------------------------------------------
+
+    it('getPendingRepCount returns 0 when no reps have failed', () => {
+      const hook = renderHook(() =>
+        useWorkoutController('pullup' as any, {
+          sessionId: 'test-session',
+          enableHaptics: false,
+        })
+      );
+      expect(hook.result.current.getPendingRepCount()).toBe(0);
+    });
+
+    it('getPendingRepCount reflects queued failed writes', async () => {
+      mockLogRep.mockRejectedValue(new Error('offline'));
+      const hook = renderHook(() =>
+        useWorkoutController('pullup' as any, {
+          sessionId: 'test-session',
+          enableHaptics: false,
+        })
+      );
+
+      driveOneRep(hook);
+      await act(async () => { await Promise.resolve(); });
+      expect(hook.result.current.getPendingRepCount()).toBe(1);
+    });
+
+    it('flushPendingRepsOnStop fires onRepLogFailure with PENDING_REPS_AT_STOP signal when queue non-empty', async () => {
+      const onRepLogFailure = jest.fn();
+      mockLogRep.mockRejectedValue(new Error('offline'));
+
+      const hook = renderHook(() =>
+        useWorkoutController('pullup' as any, {
+          sessionId: 'test-session',
+          enableHaptics: false,
+          callbacks: { onRepLogFailure },
+        })
+      );
+
+      driveOneRep(hook);
+      await act(async () => { await Promise.resolve(); });
+
+      onRepLogFailure.mockClear();
+
+      const reportedCount = hook.result.current.flushPendingRepsOnStop();
+      expect(reportedCount).toBe(1);
+      expect(onRepLogFailure).toHaveBeenCalledTimes(1);
+      const [errArg, depthArg] = onRepLogFailure.mock.calls[0];
+      expect(errArg).toMatchObject({ code: 'PENDING_REPS_AT_STOP', count: 1 });
+      expect(depthArg).toBe(1);
+    });
+
+    it('flushPendingRepsOnStop is a no-op when queue is empty', () => {
+      const onRepLogFailure = jest.fn();
+      const hook = renderHook(() =>
+        useWorkoutController('pullup' as any, {
+          sessionId: 'test-session',
+          enableHaptics: false,
+          callbacks: { onRepLogFailure },
+        })
+      );
+
+      expect(hook.result.current.flushPendingRepsOnStop()).toBe(0);
+      expect(onRepLogFailure).not.toHaveBeenCalled();
+    });
+
+    it('flushPendingRepsOnStop swallows callback throws so stopTracking can complete', async () => {
+      const onRepLogFailure = jest.fn(() => {
+        throw new Error('toast layer exploded');
+      });
+      mockLogRep.mockRejectedValue(new Error('offline'));
+
+      const hook = renderHook(() =>
+        useWorkoutController('pullup' as any, {
+          sessionId: 'test-session',
+          enableHaptics: false,
+          callbacks: { onRepLogFailure },
+        })
+      );
+
+      driveOneRep(hook);
+      await act(async () => { await Promise.resolve(); });
+
+      onRepLogFailure.mockClear();
+      // flush-on-stop callback throws but the method itself must not throw.
+      onRepLogFailure.mockImplementationOnce(() => {
+        throw new Error('toast layer exploded');
+      });
+      expect(() => hook.result.current.flushPendingRepsOnStop()).not.toThrow();
+    });
+
+    it('isPendingRepsAtStopSignal discriminates the sentinel', () => {
+      const { isPendingRepsAtStopSignal } = jest.requireActual<
+        typeof import('@/hooks/use-workout-controller')
+      >('@/hooks/use-workout-controller');
+      expect(isPendingRepsAtStopSignal({ code: 'PENDING_REPS_AT_STOP', count: 3 })).toBe(true);
+      expect(isPendingRepsAtStopSignal(new Error('other'))).toBe(false);
+      expect(isPendingRepsAtStopSignal(null)).toBe(false);
+      expect(isPendingRepsAtStopSignal('string')).toBe(false);
+    });
   });
 });

--- a/tests/unit/services/form-target-resolver.test.ts
+++ b/tests/unit/services/form-target-resolver.test.ts
@@ -1,10 +1,14 @@
 import {
   DEFAULT_FORM_TARGETS,
+  __resetUnknownExerciseLogForTests,
   getDefaultsForExercise,
+  getDefaultsForExerciseWithFlag,
   hasFormTargetDefaults,
   resolveFormTargets,
+  resolveFormTargetsWithFlag,
   type FormTargets,
 } from '@/lib/services/form-target-resolver';
+import * as ErrorHandler from '@/lib/services/ErrorHandler';
 import type { WorkoutTemplate, WorkoutTemplateExercise } from '@/lib/types/workout-session';
 
 function mkExercise(overrides: Partial<WorkoutTemplateExercise> & Pick<WorkoutTemplateExercise, 'exercise_id'>): WorkoutTemplateExercise {
@@ -162,6 +166,94 @@ describe('form-target-resolver', () => {
       // @ts-expect-error — runtime guard
       delete tpl.exercises;
       expect(resolveFormTargets('pullup', tpl)).toEqual(getDefaultsForExercise('pullup'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // usingGenericTargets provenance flag + log-once observability (#575 item #8)
+  // ---------------------------------------------------------------------------
+  describe('generic-targets fallback observability', () => {
+    let logErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      __resetUnknownExerciseLogForTests();
+      logErrorSpy = jest.spyOn(ErrorHandler, 'logError').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      logErrorSpy.mockRestore();
+    });
+
+    it('returns usingGenericTargets=false for a known exercise', () => {
+      const r = getDefaultsForExerciseWithFlag('pullup');
+      expect(r.usingGenericTargets).toBe(false);
+      expect(r.targets.fqiMin).toBe(80);
+      expect(logErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns usingGenericTargets=true for an unknown exerciseId', () => {
+      const r = getDefaultsForExerciseWithFlag('pullups'); // common typo
+      expect(r.usingGenericTargets).toBe(true);
+      expect(r.targets).toEqual(DEFAULT_FORM_TARGETS);
+    });
+
+    it('logs once per unknown exerciseId (not on every call)', () => {
+      getDefaultsForExerciseWithFlag('pullups');
+      getDefaultsForExerciseWithFlag('pullups');
+      getDefaultsForExerciseWithFlag('pullups');
+      expect(logErrorSpy).toHaveBeenCalledTimes(1);
+      const [err, ctx] = logErrorSpy.mock.calls[0];
+      expect(err.domain).toBe('form-tracking');
+      expect(err.code).toBe('FORM_TARGET_FALLBACK_GENERIC');
+      expect(err.severity).toBe('warning');
+      expect(ctx).toEqual({
+        feature: 'form-tracking',
+        location: 'lib/services/form-target-resolver',
+      });
+    });
+
+    it('logs a separate entry per distinct unknown id', () => {
+      getDefaultsForExerciseWithFlag('pullups');
+      getDefaultsForExerciseWithFlag('squats');
+      expect(logErrorSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('logs for empty/non-string exerciseId (invalid-id reason)', () => {
+      getDefaultsForExerciseWithFlag('');
+      expect(logErrorSpy).toHaveBeenCalledTimes(1);
+      const [err] = logErrorSpy.mock.calls[0];
+      expect((err.details as { reason: string }).reason).toBe('invalid-id');
+    });
+
+    it('legacy getDefaultsForExercise still returns the same FormTargets', () => {
+      __resetUnknownExerciseLogForTests();
+      expect(getDefaultsForExercise('pullup')).toEqual<FormTargets>(
+        getDefaultsForExerciseWithFlag('pullup').targets,
+      );
+      expect(getDefaultsForExercise('unknown')).toEqual(DEFAULT_FORM_TARGETS);
+    });
+
+    it('resolveFormTargetsWithFlag propagates usingGenericTargets from baseline', () => {
+      const r = resolveFormTargetsWithFlag('unknown-xyz');
+      expect(r.usingGenericTargets).toBe(true);
+      expect(r.targets).toEqual(DEFAULT_FORM_TARGETS);
+    });
+
+    it('resolveFormTargetsWithFlag surfaces override targets while still flagging unknown id', () => {
+      const tpl = mkTemplate([
+        mkExercise({ exercise_id: 'unknown-xyz', target_fqi_min: 88 }),
+      ]);
+      const r = resolveFormTargetsWithFlag('unknown-xyz', tpl);
+      expect(r.usingGenericTargets).toBe(true);
+      expect(r.targets.fqiMin).toBe(88);
+      // ROM axes inherit from the generic baseline.
+      expect(r.targets.romMin).toBe(DEFAULT_FORM_TARGETS.romMin);
+      expect(r.targets.romMax).toBe(DEFAULT_FORM_TARGETS.romMax);
+    });
+
+    it('resolveFormTargetsWithFlag reports usingGenericTargets=false for known exercise', () => {
+      const r = resolveFormTargetsWithFlag('pullup');
+      expect(r.usingGenericTargets).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Wave-33 A — 9 form-tracking resilience fixes. Single large-scoped PR, atomic commits.

## Scope

- **session-transitions**: logCueEvent stale-repCount snapshot, session FQI reset on exercise switch, occlusion timer clear on stop, partial-badge reset on mode switch, watch mirror coupled to tracking + app-state
- **cue-engine**: cue-hysteresis <-> TTS-throttle sync on targets change
- **feedback-loops**: form-target fallback logging + usingGenericTargets flag
- **debrief-ux**: auto-debrief wiring in form-tracking-debrief (buildInput now returns valid input on mount)
- **data-loss**: pendingRepWritesRef drain warning via onRepLogFailure callback

## Merge order

Rebase after #555, #561, #565, #572 merge — scan-arkit.tsx conflicts expected.

## Verification

- `bun run lint` + `bun run check:types` clean
- Unit tests green for touched modules (901 pass, 2 skipped, 0 fail across scan/session/cue/form-target/debrief/rep-logger)
- Manual: FQI-on-stop correctness after mid-session exercise switch; occlusion badge absent at next session start; watch-mirror stops on app background

Closes #575