### PR TITLE
feat(wave34): auth + onboarding + coach-chat a11y/keyboard polish pack

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -331,6 +331,9 @@ export default function SignInScreen() {
               style={[styles.socialButton, isSigningIn && styles.buttonDisabled]}
               onPress={() => handleSocialAuth('google')}
               disabled={isSigningIn}
+              accessibilityRole="button"
+              accessibilityLabel="Sign in with Google"
+              accessibilityHint="Double-tap to authenticate"
             >
               <Text style={styles.socialButtonText}>
                 Continue with Google
@@ -342,6 +345,9 @@ export default function SignInScreen() {
                 style={[styles.socialButton, isSigningIn && styles.buttonDisabled]}
                 onPress={() => handleSocialAuth('apple')}
                 disabled={isSigningIn}
+                accessibilityRole="button"
+                accessibilityLabel="Sign in with Apple"
+                accessibilityHint="Double-tap to authenticate"
               >
                 <Text style={styles.socialButtonText}>
                   Continue with Apple

--- a/app/(modals)/shared-inbox.tsx
+++ b/app/(modals)/shared-inbox.tsx
@@ -156,16 +156,22 @@ export default function SharedInboxModal() {
         </TouchableOpacity>
       </View>
 
-      <View style={styles.tabRow}>
+      <View style={styles.tabRow} accessibilityRole="tablist">
         <TouchableOpacity
           style={[styles.tabButton, activeTab === 'inbox' && styles.tabButtonActive]}
           onPress={() => setActiveTab('inbox')}
+          accessibilityRole="tab"
+          accessibilityLabel="Inbox"
+          accessibilityState={{ selected: activeTab === 'inbox' }}
         >
           <Text style={[styles.tabText, activeTab === 'inbox' && styles.tabTextActive]}>Inbox</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={[styles.tabButton, activeTab === 'sent' && styles.tabButtonActive]}
           onPress={() => setActiveTab('sent')}
+          accessibilityRole="tab"
+          accessibilityLabel="Sent"
+          accessibilityState={{ selected: activeTab === 'sent' }}
         >
           <Text style={[styles.tabText, activeTab === 'sent' && styles.tabTextActive]}>Sent</Text>
         </TouchableOpacity>

--- a/app/(onboarding)/nutrition-goals.tsx
+++ b/app/(onboarding)/nutrition-goals.tsx
@@ -1,5 +1,5 @@
 import { Ionicons } from '@expo/vector-icons';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   Alert,
   KeyboardAvoidingView,
@@ -33,6 +33,10 @@ export default function NutritionGoalsScreen() {
   const [carbs, setCarbs] = useState(goals?.carbs?.toString() || '');
   const [fat, setFat] = useState(goals?.fat?.toString() || '');
   const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const proteinRef = useRef<TextInput>(null);
+  const carbsRef = useRef<TextInput>(null);
+  const fatRef = useRef<TextInput>(null);
 
   function normalizeDecimal(value: string): string {
     const cleaned = value.replace(/[^0-9.]/g, '');
@@ -226,6 +230,9 @@ export default function NutritionGoalsScreen() {
               placeholder="e.g., 2000"
               placeholderTextColor="#8CA5C6"
               editable={!isSyncing}
+              accessibilityLabel="Daily calorie target in kilocalories"
+              returnKeyType="next"
+              onSubmitEditing={() => proteinRef.current?.focus()}
             />
             {errors.calories ? <Text style={styles.errorText}>{errors.calories}</Text> : null}
           </View>
@@ -234,6 +241,7 @@ export default function NutritionGoalsScreen() {
             <View style={[styles.inputContainer, styles.thirdWidth]}>
               <Text style={styles.label}>Protein (g)</Text>
               <TextInput
+                ref={proteinRef}
                 style={[styles.input, errors.protein && styles.inputError]}
                 value={protein}
                 onChangeText={(t: string) => handleFieldChange('protein', t)}
@@ -243,6 +251,9 @@ export default function NutritionGoalsScreen() {
                 placeholder="Optional"
                 placeholderTextColor="#8CA5C6"
                 editable={!isSyncing}
+                accessibilityLabel="Daily protein target in grams"
+                returnKeyType="next"
+                onSubmitEditing={() => carbsRef.current?.focus()}
               />
               {errors.protein ? <Text style={styles.errorText}>{errors.protein}</Text> : null}
             </View>
@@ -250,6 +261,7 @@ export default function NutritionGoalsScreen() {
             <View style={[styles.inputContainer, styles.thirdWidth]}>
               <Text style={styles.label}>Carbs (g)</Text>
               <TextInput
+                ref={carbsRef}
                 style={[styles.input, errors.carbs && styles.inputError]}
                 value={carbs}
                 onChangeText={(t: string) => handleFieldChange('carbs', t)}
@@ -259,6 +271,9 @@ export default function NutritionGoalsScreen() {
                 placeholder="Optional"
                 placeholderTextColor="#8CA5C6"
                 editable={!isSyncing}
+                accessibilityLabel="Daily carbohydrate target in grams"
+                returnKeyType="next"
+                onSubmitEditing={() => fatRef.current?.focus()}
               />
               {errors.carbs ? <Text style={styles.errorText}>{errors.carbs}</Text> : null}
             </View>
@@ -266,6 +281,7 @@ export default function NutritionGoalsScreen() {
             <View style={[styles.inputContainer, styles.thirdWidth]}>
               <Text style={styles.label}>Fat (g)</Text>
               <TextInput
+                ref={fatRef}
                 style={[styles.input, errors.fat && styles.inputError]}
                 value={fat}
                 onChangeText={(t: string) => handleFieldChange('fat', t)}
@@ -275,6 +291,8 @@ export default function NutritionGoalsScreen() {
                 placeholder="Optional"
                 placeholderTextColor="#8CA5C6"
                 editable={!isSyncing}
+                accessibilityLabel="Daily fat target in grams"
+                returnKeyType="done"
               />
               {errors.fat ? <Text style={styles.errorText}>{errors.fat}</Text> : null}
             </View>

--- a/app/(onboarding)/profile-setup.tsx
+++ b/app/(onboarding)/profile-setup.tsx
@@ -110,7 +110,11 @@ export default function ProfileSetupScreen() {
           {/* Fitness Goal */}
           <View style={styles.inputContainer}>
             <Text style={styles.label}>Fitness Goal</Text>
-            <View style={styles.goalGrid}>
+            <View
+              style={styles.goalGrid}
+              accessibilityRole="radiogroup"
+              accessibilityLabel="Fitness goal"
+            >
               {goalOptions.map((option) => (
                 <TouchableOpacity
                   key={option.value}
@@ -120,6 +124,9 @@ export default function ProfileSetupScreen() {
                   ]}
                   onPress={() => setFitnessGoal(option.value)}
                   activeOpacity={0.7}
+                  accessibilityRole="radio"
+                  accessibilityLabel={option.label}
+                  accessibilityState={{ checked: fitnessGoal === option.value }}
                 >
                   <Ionicons
                     name={option.icon}

--- a/app/(tabs)/coach.tsx
+++ b/app/(tabs)/coach.tsx
@@ -429,6 +429,10 @@ export default function CoachScreen() {
             value={coachInput}
             onChangeText={setCoachInput}
             multiline
+            accessibilityLabel="Coach message input"
+            returnKeyType="send"
+            onSubmitEditing={() => handleCoachSend()}
+            editable={!coachSending}
           />
 
           {voiceEnabled && !coachSending && (
@@ -451,6 +455,10 @@ export default function CoachScreen() {
             style={[styles.coachSend, (!coachInput.trim() || coachSending) && styles.coachSendDisabled]}
             onPress={() => handleCoachSend()}
             disabled={!coachInput.trim() || coachSending}
+            accessibilityRole="button"
+            accessibilityLabel={coachSending ? 'Sending message' : 'Send message'}
+            accessibilityHint="Double-tap to send your prompt to the coach"
+            accessibilityState={{ busy: coachSending, disabled: coachSending || !coachInput.trim() }}
           >
             {coachSending ? (
               <ActivityIndicator color="#ffffff" />

--- a/app/(tabs)/form.tsx
+++ b/app/(tabs)/form.tsx
@@ -4,6 +4,7 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  TouchableOpacity,
   View,
 } from 'react-native';
 import { useRouter } from 'expo-router';
@@ -70,6 +71,18 @@ export default function FormHomeScreen() {
             <Text style={styles.errorText}>
               Could not load form data: {formHome.error.message}
             </Text>
+            <TouchableOpacity
+              onPress={() => {
+                void formHome.refresh();
+              }}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityRole="button"
+              accessibilityLabel="Retry loading form data"
+              accessibilityHint="Double-tap to reload your form metrics"
+              style={styles.retryButton}
+            >
+              <Text style={styles.retryText}>Retry</Text>
+            </TouchableOpacity>
           </View>
         ) : null}
 
@@ -134,9 +147,22 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 12,
     padding: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
   },
   errorText: {
     color: '#F5F7FF',
     fontSize: 13,
+    flex: 1,
+  },
+  retryButton: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  retryText: {
+    color: '#4C8CFF',
+    fontSize: 14,
+    fontWeight: '600',
   },
 });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -874,11 +874,19 @@ export default function HomeScreen() {
           value={coachInput}
           onChangeText={setCoachInput}
           multiline
+          accessibilityLabel="Coach message input"
+          returnKeyType="send"
+          onSubmitEditing={() => handleCoachSend()}
+          editable={!coachSending}
         />
         <TouchableOpacity
           style={[styles.coachSend, (!coachInput.trim() || coachSending) && styles.coachSendDisabled]}
           onPress={() => handleCoachSend()}
           disabled={!coachInput.trim() || coachSending}
+          accessibilityRole="button"
+          accessibilityLabel={coachSending ? 'Sending message' : 'Send message'}
+          accessibilityHint="Double-tap to send your prompt to the coach"
+          accessibilityState={{ busy: coachSending, disabled: coachSending || !coachInput.trim() }}
         >
           {coachSending ? (
             <ActivityIndicator color="#ffffff" />


### PR DESCRIPTION
## Summary
Wave-34 Pack D — a11y + keyboard polish on screens NOT touched by #580 (wave-33) or earlier polish waves.

- Coach chat inputs + send buttons (2 locations): a11y labels, return-key send, editable guard, busy state
- Sign-in social login buttons: role + labels + hint
- Profile-setup goal cards: radio role + checked state, wrapped in radiogroup
- Shared-inbox tabs: tab role + selected state, wrapped in tablist
- Nutrition-goals inputs: labels + next/done return-key progression (calories -> protein -> carbs -> fat)
- Form tab error: inline Retry button wired to `useFormHomeData().refresh()`

## Verification
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` clean on touched files
- [x] Pre-commit hook (lint + types + supabase-shared + cue-variants) green on every commit
- [x] No file overlap with open PRs (#580 touched notifications/profile/video-comments/welcome/arkit-usage/add-food)

## Commits
- `feat(coach): a11y labels + keyboard submit on coach TextInputs + send buttons`
- `feat(sign-in): a11y role + labels on social login buttons`
- `feat(profile-setup): a11y radio role + checked state on goal cards`
- `feat(shared-inbox): a11y tab role + selected state on tab switcher`
- `feat(nutrition-goals): a11y labels + return-key progression on inputs`
- `feat(form): retry CTA on tab error state`

Closes #586