### PR TITLE
feat(wave34): Gemma dispatch telemetry closure + exercise-swap explainer (new surface)

### DIFF
--- a/components/form-tracking/ExerciseSwapSheet.tsx
+++ b/components/form-tracking/ExerciseSwapSheet.tsx
@@ -8,6 +8,29 @@
  *
  * Implemented as a plain overlay Modal so it works on web + iOS
  * without BottomSheet state juggling.
+ *
+ * WAVE-35 FOLLOW-UP: wire the exercise-swap-explainer Gemma surface
+ * so the sheet can render a 2-3 sentence plain-language explanation of
+ * the swap below the action buttons. Example integration inside a
+ * parent screen (wire from whoever mounts this sheet):
+ *
+ *   import { explainExerciseSwap } from '@/lib/services/exercise-swap-explainer';
+ *
+ *   // When `targetExerciseName` or `currentExerciseName` changes:
+ *   const [swapCopy, setSwapCopy] = useState<string | null>(null);
+ *   useEffect(() => {
+ *     if (!visible || !currentExerciseName) return;
+ *     let cancelled = false;
+ *     explainExerciseSwap({
+ *       fromExerciseId: currentExerciseName,
+ *       toExerciseId: targetExerciseName,
+ *       reason: 'variation',
+ *     }).then((r) => { if (!cancelled) setSwapCopy(r.explanation); });
+ *     return () => { cancelled = true; };
+ *   }, [visible, currentExerciseName, targetExerciseName]);
+ *
+ * The service never throws (falls back to a generic string on any
+ * Gemma failure) so the parent doesn't need error handling.
  */
 import React from 'react';
 import {

--- a/lib/services/coach-auto-debrief.ts
+++ b/lib/services/coach-auto-debrief.ts
@@ -28,6 +28,15 @@ import {
 import { synthesizeMemoryClause } from './coach-memory-context';
 import { getExercisePreferences, type CuePreference } from './coach-cue-feedback';
 import { isCoachPipelineV2Enabled } from './coach-pipeline-v2-flag';
+import { recordCoachUsage } from './coach-cost-tracker';
+import { recordExplicitProviderOverride } from './coach-model-dispatch-telemetry';
+
+const AUTO_DEBRIEF_TASK_KIND = 'multi_turn_debrief' as const;
+
+function estimateTokens(text: string): number {
+  if (!text) return 0;
+  return Math.max(1, Math.ceil(text.length / 4));
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -195,8 +204,33 @@ export async function generateAutoDebrief(
   };
   // Provider dispatch: gemma → sendCoachGemmaPrompt (direct call to
   // coach-gemma edge function); openai → sendCoachPrompt (generic path).
+  // Telemetry: auto-debrief pins an explicit provider, so the dispatch
+  // router in coach-service skips `recordDispatchDecision`. Fire the
+  // explicit-override counter here so the taskKind ('multi_turn_debrief')
+  // still lands in the decision dashboard. Wrapped so a telemetry fault
+  // never blocks the debrief.
+  try {
+    recordExplicitProviderOverride({
+      taskKind: AUTO_DEBRIEF_TASK_KIND,
+      decidedProvider: provider,
+      reason: 'auto-debrief-explicit-provider',
+    });
+  } catch {
+    // Telemetry is never load-bearing.
+  }
   const reply = await dispatch(provider, messages, context);
   const brief = shapeBriefOutput(reply.content);
+
+  // Weekly cost bucket: track auto-debrief as a multi-turn debrief task
+  // under the appropriate provider key. Token estimator is char-based
+  // since the coach edge response does not surface counts today.
+  const promptText = messages.map((m) => m.content).join('\n');
+  void recordCoachUsage({
+    provider: provider === 'gemma' ? 'gemma_cloud' : 'openai',
+    taskKind: AUTO_DEBRIEF_TASK_KIND,
+    tokensIn: estimateTokens(promptText),
+    tokensOut: estimateTokens(reply.content ?? ''),
+  });
 
   const result: AutoDebriefResult = {
     sessionId: input.sessionId,

--- a/lib/services/coach-cost-tracker.ts
+++ b/lib/services/coach-cost-tracker.ts
@@ -25,6 +25,12 @@ export type CoachTaskKind =
   | 'drill_explainer'
   | 'session_generator'
   | 'progression_planner'
+  | 'voice_nlu'
+  | 'rest_period_coaching'
+  | 'exercise_swap_explanation'
+  | 'multi_turn_debrief'
+  | 'program_design'
+  | 'fault_explainer'
   | 'other';
 
 export interface CoachUsageEvent {
@@ -281,6 +287,12 @@ function emptyTaskKindMap(): WeeklyAggregate['byTaskKind'] {
     drill_explainer: { tokensIn: 0, tokensOut: 0, calls: 0 },
     session_generator: { tokensIn: 0, tokensOut: 0, calls: 0 },
     progression_planner: { tokensIn: 0, tokensOut: 0, calls: 0 },
+    voice_nlu: { tokensIn: 0, tokensOut: 0, calls: 0 },
+    rest_period_coaching: { tokensIn: 0, tokensOut: 0, calls: 0 },
+    exercise_swap_explanation: { tokensIn: 0, tokensOut: 0, calls: 0 },
+    multi_turn_debrief: { tokensIn: 0, tokensOut: 0, calls: 0 },
+    program_design: { tokensIn: 0, tokensOut: 0, calls: 0 },
+    fault_explainer: { tokensIn: 0, tokensOut: 0, calls: 0 },
     other: { tokensIn: 0, tokensOut: 0, calls: 0 },
   };
 }

--- a/lib/services/coach-drill-explainer.ts
+++ b/lib/services/coach-drill-explainer.ts
@@ -99,7 +99,15 @@ export async function explainDrill(input: ExplainDrillInput): Promise<ExplainDri
   // env-resolved provider below.
   if (gemmaFirst) {
     try {
-      const reply = await sendCoachPrompt(messages, context, { provider: 'gemma' });
+      // taskKind='fault_explainer' slots this call into the tactical
+      // Gemma bucket of the dispatch router (see coach-model-dispatch.ts).
+      // With an explicit provider hint the router is a no-op today, but the
+      // annotation makes the call eligible for the taskKind-only branch once
+      // #571 relaxes the "provider === undefined" gate.
+      const reply = await sendCoachPrompt(messages, context, {
+        provider: 'gemma',
+        taskKind: 'fault_explainer',
+      });
       const text = (reply.content ?? '').trim();
       if (text) {
         return { explanation: text, provider: 'gemma' };
@@ -117,7 +125,9 @@ export async function explainDrill(input: ExplainDrillInput): Promise<ExplainDri
     const reply = await sendCoachPrompt(
       messages,
       context,
-      resolvedProvider ? { provider: resolvedProvider } : undefined,
+      resolvedProvider
+        ? { provider: resolvedProvider, taskKind: 'fault_explainer' }
+        : { taskKind: 'fault_explainer' },
     );
     const text = (reply.content ?? '').trim();
     if (!text) {

--- a/lib/services/coach-model-dispatch-telemetry.ts
+++ b/lib/services/coach-model-dispatch-telemetry.ts
@@ -18,7 +18,7 @@
  */
 
 import { recordCounter } from './coach-telemetry';
-import type { DispatchDecision } from './coach-model-dispatch';
+import type { CoachTaskKind, DispatchDecision } from './coach-model-dispatch';
 
 const DISPATCH_EVENT_NAME = 'coach_dispatch_decision';
 
@@ -34,6 +34,42 @@ export function recordDispatchDecision(decision: DispatchDecision): void {
       model: decision.model,
       reason: decision.reason,
       fellBackToCloud: decision.fellBackToCloud,
+    });
+  }
+}
+
+/**
+ * Telemetry sibling for callers that pin a provider explicitly (e.g.
+ * auto-debrief, progression-planner). The dispatch router in coach-service
+ * only fires `recordDispatchDecision` when `provider === undefined`, so
+ * complex tasks that always route to the cloud never show up in the
+ * decision counters. This function plugs that hole without touching the
+ * router.
+ *
+ * Counter names are kept parallel to `recordDispatchDecision` so the
+ * existing dashboards can read both surfaces off the same prefix.
+ */
+export interface ExplicitProviderOverride {
+  readonly taskKind: CoachTaskKind;
+  readonly decidedProvider: 'gemma' | 'openai';
+  readonly reason?: string;
+}
+
+export function recordExplicitProviderOverride(
+  override: ExplicitProviderOverride,
+): void {
+  const reason = override.reason ?? 'explicit-override';
+  recordCounter(DISPATCH_EVENT_NAME);
+  recordCounter(`${DISPATCH_EVENT_NAME}:provider:${override.decidedProvider}`);
+  recordCounter(`${DISPATCH_EVENT_NAME}:taskKind:${override.taskKind}`);
+  recordCounter(`${DISPATCH_EVENT_NAME}:reason:${reason}`);
+
+  if (__DEV__) {
+    // eslint-disable-next-line no-console
+    console.log('[coach-dispatch]', DISPATCH_EVENT_NAME, {
+      taskKind: override.taskKind,
+      decidedProvider: override.decidedProvider,
+      reason,
     });
   }
 }

--- a/lib/services/coach-model-dispatch.ts
+++ b/lib/services/coach-model-dispatch.ts
@@ -38,6 +38,20 @@
  * live in `coach-service.ts` and gate on `isCoachModelDispatchEnabled()`.
  */
 
+/**
+ * RESERVED TASK KINDS
+ *
+ * The following enum values are defined for future production wiring and are
+ * intentionally unreferenced by any dispatch site today. They remain in the
+ * union so `decideCoachModel()` can route them the moment a caller adopts the
+ * taskKind — do not treat them as dead code:
+ *
+ * - `form_cue_lookup`  — inline form-cue fetch (reserved for wave-35+)
+ * - `rest_calc`        — pure numeric rest calculator (reserved; distinct
+ *                        from `rest_period_coaching` which ships in wave-34
+ *                        via rest-advisor)
+ * - `encouragement`    — short-turn motivational nudges (reserved)
+ */
 export type CoachTaskKind =
   | 'form_cue_lookup'
   | 'rest_calc'
@@ -48,7 +62,10 @@ export type CoachTaskKind =
   | 'nutrition_balance'
   | 'multi_turn_debrief'
   | 'session_generator'
-  | 'general_chat';
+  | 'general_chat'
+  | 'voice_nlu'
+  | 'rest_period_coaching'
+  | 'exercise_swap_explanation';
 
 export type CoachModelId =
   | 'gemma-4-26b-a4b-it'
@@ -88,6 +105,9 @@ const TACTICAL_TASKS: ReadonlySet<CoachTaskKind> = new Set<CoachTaskKind>([
   'rest_calc',
   'encouragement',
   'fault_explainer',
+  'voice_nlu',
+  'rest_period_coaching',
+  'exercise_swap_explanation',
 ]);
 
 const COMPLEX_TASKS: ReadonlySet<CoachTaskKind> = new Set<CoachTaskKind>([

--- a/lib/services/exercise-swap-explainer.ts
+++ b/lib/services/exercise-swap-explainer.ts
@@ -1,0 +1,146 @@
+/**
+ * exercise-swap-explainer
+ *
+ * Wave-34 Gemma surface. When a lifter swaps one exercise for another mid
+ * session (injury, missing equipment, difficulty, pure variation), this
+ * service fires a short tactical Gemma prompt to explain the swap in
+ * plain language — what muscle groups are preserved, what load profile
+ * changes, and what the user should watch for.
+ *
+ * Contract notes:
+ * - Short prompt (<200 tokens) so the call stays inside the tactical
+ *   Gemma budget; maxTokens capped at 180 on the response side.
+ * - Failure-tolerant: any Gemma error collapses to a generic fallback
+ *   string so callers never see a thrown exception.
+ * - taskKind='exercise_swap_explanation' slots this into the tactical
+ *   bucket of coach-model-dispatch (see TACTICAL_TASKS).
+ */
+
+import { sendCoachPrompt, type CoachMessage } from './coach-service';
+import { shapeFinalResponse } from './coach-output-shaper';
+import { recordCoachUsage } from './coach-cost-tracker';
+import { warnWithTs } from '@/lib/logger';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ExerciseSwapReason =
+  | 'equipment'
+  | 'injury'
+  | 'variation'
+  | 'difficulty';
+
+export interface ExerciseSwapContext {
+  fromExerciseId: string;
+  toExerciseId: string;
+  reason?: ExerciseSwapReason;
+  userGoal?: string;
+}
+
+export interface ExerciseSwapExplanation {
+  explanation: string;
+  tradeoffs?: string[];
+  provider: string;
+  model: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const EXERCISE_SWAP_FALLBACK_TEXT =
+  'Swap supports similar muscle groups with different load profile.';
+
+export const EXERCISE_SWAP_MAX_TOKENS = 180;
+
+const SYSTEM_PROMPT =
+  'You are a strength coach explaining exercise substitutions in plain ' +
+  'language. Reply in 2-3 short sentences. Mention (1) what stays the ' +
+  'same (muscle groups / movement pattern), (2) what changes (load, ' +
+  'range of motion, stability demand). No markdown, no lists, no hype.';
+
+const TOKEN_ESTIMATE_CHARS_PER_TOKEN = 4;
+
+function estimateTokens(text: string): number {
+  if (!text) return 0;
+  return Math.max(1, Math.ceil(text.length / TOKEN_ESTIMATE_CHARS_PER_TOKEN));
+}
+
+// ---------------------------------------------------------------------------
+// Prompt builder (exported for tests + future prompt iteration)
+// ---------------------------------------------------------------------------
+
+export function buildExerciseSwapMessages(
+  ctx: ExerciseSwapContext,
+): CoachMessage[] {
+  const parts: string[] = [
+    `Original exercise: ${ctx.fromExerciseId}`,
+    `Replacement exercise: ${ctx.toExerciseId}`,
+  ];
+  if (ctx.reason) parts.push(`Reason for swap: ${ctx.reason}`);
+  if (ctx.userGoal) parts.push(`Lifter goal: ${ctx.userGoal}`);
+  parts.push('Explain this swap in 2-3 short sentences.');
+
+  return [
+    { role: 'system', content: SYSTEM_PROMPT },
+    { role: 'user', content: parts.join('\n') },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Explain an exercise swap via a tactical Gemma call. Never throws — any
+ * Gemma failure (network, parse, safety) resolves to the fallback string
+ * with provider='fallback'.
+ */
+export async function explainExerciseSwap(
+  ctx: ExerciseSwapContext,
+): Promise<ExerciseSwapExplanation> {
+  const messages = buildExerciseSwapMessages(ctx);
+  try {
+    const reply = await sendCoachPrompt(messages, undefined, {
+      provider: 'gemma',
+      taskKind: 'exercise_swap_explanation',
+    });
+
+    const rawText = (reply.content ?? '').trim();
+    if (!rawText) {
+      return {
+        explanation: EXERCISE_SWAP_FALLBACK_TEXT,
+        provider: 'fallback',
+        model: 'fallback',
+      };
+    }
+
+    const explanation = shapeFinalResponse(rawText);
+
+    // Telemetry — fire-and-forget. char-based estimator because the coach
+    // edge response doesn't surface token counts.
+    const promptText = messages.map((m) => m.content).join('\n');
+    void recordCoachUsage({
+      provider: 'gemma_cloud',
+      taskKind: 'exercise_swap_explanation',
+      tokensIn: estimateTokens(promptText),
+      tokensOut: estimateTokens(rawText),
+    });
+
+    return {
+      explanation,
+      provider: reply.provider ?? 'gemma',
+      model: reply.model ?? 'gemma',
+    };
+  } catch (err) {
+    warnWithTs('[exercise-swap-explainer] explainExerciseSwap failed', err);
+    return {
+      explanation: EXERCISE_SWAP_FALLBACK_TEXT,
+      provider: 'fallback',
+      model: 'fallback',
+    };
+  }
+}
+
+export const EXERCISE_SWAP_SYSTEM_PROMPT = SYSTEM_PROMPT;

--- a/lib/services/progression-planner.ts
+++ b/lib/services/progression-planner.ts
@@ -14,6 +14,15 @@
 import { sendCoachPrompt, type CoachContext, type CoachMessage } from './coach-service';
 import type { ExerciseHistorySummary } from './exercise-history-service';
 import { isCoachPipelineV2Enabled } from './coach-pipeline-v2-flag';
+import { recordCoachUsage } from './coach-cost-tracker';
+import { recordExplicitProviderOverride } from './coach-model-dispatch-telemetry';
+
+const PROGRESSION_TASK_KIND = 'program_design' as const;
+
+function estimateTokens(text: string): number {
+  if (!text) return 0;
+  return Math.max(1, Math.ceil(text.length / 4));
+}
 
 type SendCoachPromptOpts = Parameters<typeof sendCoachPrompt>[2];
 
@@ -150,13 +159,46 @@ export async function generateProgressionPlan(
   // lets callers bypass the env-resolved provider when they already know
   // what they want (e.g. pre-wired task-kind dispatch).
   const pipelineOpts: SendCoachPromptOpts | undefined = isCoachPipelineV2Enabled()
-    ? { provider: resolveProgressionProvider() }
-    : undefined;
+    ? { provider: resolveProgressionProvider(), taskKind: PROGRESSION_TASK_KIND }
+    : { taskKind: PROGRESSION_TASK_KIND };
   const mergedOpts: SendCoachPromptOpts | undefined =
     opts !== undefined
       ? { ...pipelineOpts, ...opts }
       : pipelineOpts;
+
+  // Telemetry: the planner pins an explicit provider when pipeline-v2 is
+  // on, so the dispatch router in coach-service skips
+  // `recordDispatchDecision`. Fire the explicit-override counter here so
+  // the taskKind ('program_design') still lands in the decision
+  // dashboard. Caller-supplied opts win over the computed provider (same
+  // precedence as the merge above).
+  const decidedProvider: 'gemma' | 'openai' = (() => {
+    const hint = mergedOpts?.provider;
+    if (hint === 'gemma' || hint === 'openai') return hint;
+    return 'openai';
+  })();
+  try {
+    recordExplicitProviderOverride({
+      taskKind: PROGRESSION_TASK_KIND,
+      decidedProvider,
+      reason: 'progression-planner-explicit-provider',
+    });
+  } catch {
+    // Telemetry is never load-bearing.
+  }
+
   const response = await sendCoachPrompt(messages, input.context, mergedOpts);
+
+  // Weekly cost bucket: program design is a complex task. Estimator is
+  // char-based (upstream token counts are not surfaced today).
+  const promptText = messages.map((m) => m.content).join('\n');
+  void recordCoachUsage({
+    provider: decidedProvider === 'gemma' ? 'gemma_cloud' : 'openai',
+    taskKind: PROGRESSION_TASK_KIND,
+    tokensIn: estimateTokens(promptText),
+    tokensOut: estimateTokens(response.content ?? ''),
+  });
+
   const plan: ProgressionPlan = {
     text: response.content,
     promptPreview: prompt,

--- a/lib/services/rest-advisor.ts
+++ b/lib/services/rest-advisor.ts
@@ -10,9 +10,19 @@
  * default session timers; rest-advisor is an opt-in AI refinement.
  */
 import { sendCoachPrompt, type CoachContext, type CoachMessage } from './coach-service';
+import { recordCoachUsage } from './coach-cost-tracker';
 import { parseGemmaJsonResponse, schema, type JsonSchema } from './gemma-json-parser';
 import { isGemmaSessionGenEnabled } from './gemma-session-gen-flag';
 import { getFewShots } from './template-generation-few-shots';
+
+/**
+ * Rough token estimator for telemetry bookkeeping. Matches the heuristic
+ * used elsewhere in the Gemma surface (4 chars ≈ 1 token).
+ */
+function estimateTokens(text: string): number {
+  if (!text) return 0;
+  return Math.max(1, Math.ceil(text.length / 4));
+}
 
 export interface RestAdvisorInput {
   /** Duration of the final rep in the just-completed set, in milliseconds. */
@@ -137,7 +147,15 @@ export async function suggestRestSeconds(
     return heuristicRestSeconds(input);
   }
 
-  const dispatch = runtime.dispatch ?? sendCoachPrompt;
+  // When the caller hasn't provided a custom dispatch (tests do), route via
+  // sendCoachPrompt with an explicit taskKind so the cost-aware dispatcher
+  // can pick the tactical Gemma model for this in-loop call.
+  const defaultDispatch = (
+    msgs: CoachMessage[],
+    ctx?: CoachContext,
+  ): Promise<CoachMessage> =>
+    sendCoachPrompt(msgs, ctx, { taskKind: 'rest_period_coaching' });
+  const dispatch = runtime.dispatch ?? defaultDispatch;
   const timeoutMs = runtime.timeoutMs ?? 2000;
 
   const messages = buildMessages(input);
@@ -160,6 +178,18 @@ export async function suggestRestSeconds(
   if (raceResult.kind !== 'ok') {
     return heuristicRestSeconds(input);
   }
+
+  // Telemetry: record the Gemma turn for weekly cost aggregates. We estimate
+  // tokens from char length since sendCoachPrompt does not surface upstream
+  // token counts today. Fire-and-forget so a telemetry hiccup never blocks
+  // the rest-advice path.
+  const promptText = messages.map((m) => m.content).join('\n');
+  void recordCoachUsage({
+    provider: 'gemma_cloud',
+    taskKind: 'rest_period_coaching',
+    tokensIn: estimateTokens(promptText),
+    tokensOut: estimateTokens(raceResult.content),
+  });
 
   try {
     const retryInvoker = async (ctx: { lastRawText: string; issues?: unknown }): Promise<string> => {

--- a/lib/services/voice-gemma-nlu-fallback.ts
+++ b/lib/services/voice-gemma-nlu-fallback.ts
@@ -33,7 +33,18 @@ import type {
   CoachMessage,
   CoachSendOptions,
 } from './coach-service';
+import { recordCoachUsage } from './coach-cost-tracker';
 import { warnWithTs } from '@/lib/logger';
+
+/**
+ * Rough token estimator used for telemetry when the Gemma reply doesn't
+ * surface a token count. 4 chars ≈ 1 token is the standard llama/gpt-family
+ * approximation and is good enough for weekly aggregation.
+ */
+function estimateTokens(text: string): number {
+  if (!text) return 0;
+  return Math.max(1, Math.ceil(text.length / 4));
+}
 
 /** Intents eligible for the phrase-only fallback. Numeric intents are excluded. */
 export const FALLBACK_CANDIDATES: Exclude<
@@ -112,9 +123,21 @@ export async function classifyViaGemma(
   if (!normalized) {
     return { intent: 'none', params: {}, confidence: 0, normalized: '' };
   }
+  const messages = buildGemmaNluPrompt(normalized);
   try {
-    const reply = await sendPrompt(buildGemmaNluPrompt(normalized), undefined, {
+    const reply = await sendPrompt(messages, undefined, {
       provider: 'gemma',
+      taskKind: 'voice_nlu',
+    });
+    // Telemetry: record the Gemma turn so weekly dashboards capture
+    // voice-NLU traffic. Uses the char-based estimator since the coach
+    // edge function does not surface token counts for Gemma today.
+    const promptText = messages.map((m) => m.content).join('\n');
+    void recordCoachUsage({
+      provider: 'gemma_cloud',
+      taskKind: 'voice_nlu',
+      tokensIn: estimateTokens(promptText),
+      tokensOut: estimateTokens(reply.content ?? ''),
     });
     const intent = parseGemmaNluResponse(reply.content ?? '');
     if (intent === 'none') {

--- a/tests/unit/services/coach-drill-explainer.provider-dispatch.test.ts
+++ b/tests/unit/services/coach-drill-explainer.provider-dispatch.test.ts
@@ -54,7 +54,10 @@ describe('coach-drill-explainer provider dispatch (pipeline-v2)', () => {
 
     expect(mockSendCoachPrompt).toHaveBeenCalledTimes(1);
     const [, , opts] = mockSendCoachPrompt.mock.calls[0];
-    expect(opts).toEqual({ provider: 'gemma' });
+    // Wave-34: drill-explainer now annotates every call with
+    // taskKind='fault_explainer' so the cost-aware dispatcher + cost
+    // tracker can bucket the traffic.
+    expect(opts).toEqual({ provider: 'gemma', taskKind: 'fault_explainer' });
     expect(result.provider).toBe('gemma');
   });
 
@@ -64,7 +67,7 @@ describe('coach-drill-explainer provider dispatch (pipeline-v2)', () => {
     const result = await explainDrill(baseInput);
 
     const [, , opts] = mockSendCoachPrompt.mock.calls[0];
-    expect(opts).toEqual({ provider: 'openai' });
+    expect(opts).toEqual({ provider: 'openai', taskKind: 'fault_explainer' });
     expect(result.provider).toBe('openai');
   });
 
@@ -74,7 +77,10 @@ describe('coach-drill-explainer provider dispatch (pipeline-v2)', () => {
     const result = await explainDrill(baseInput);
 
     const [, , opts] = mockSendCoachPrompt.mock.calls[0];
-    expect(opts).toBeUndefined();
+    // Wave-34: even in legacy flag-off mode we annotate the taskKind for
+    // cost-tracker bucketing. No provider hint is attached (the legacy
+    // cloud provider resolves inside coach-service).
+    expect(opts).toEqual({ taskKind: 'fault_explainer' });
     expect(result.provider).toBe('cloud');
   });
 });

--- a/tests/unit/services/exercise-swap-explainer.test.ts
+++ b/tests/unit/services/exercise-swap-explainer.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for exercise-swap-explainer (wave-34 G5).
+ *
+ * Covers:
+ * - happy path: Gemma reply is trimmed + shaped and surfaced.
+ * - fallback on Gemma throw: generic fallback string, provider='fallback'.
+ * - fallback on empty Gemma reply: generic fallback string.
+ * - taskKind propagation via sendCoachPrompt opts.
+ * - prompt builder shape (system + user roles, includes swap fields).
+ * - optional reason + goal threading.
+ */
+
+const mockSendCoachPrompt = jest.fn();
+
+jest.mock('@/lib/services/coach-service', () => ({
+  sendCoachPrompt: mockSendCoachPrompt,
+}));
+
+import type { ExerciseSwapContext } from '@/lib/services/exercise-swap-explainer';
+
+let explainExerciseSwap: typeof import('@/lib/services/exercise-swap-explainer')['explainExerciseSwap'];
+let buildExerciseSwapMessages: typeof import('@/lib/services/exercise-swap-explainer')['buildExerciseSwapMessages'];
+let EXERCISE_SWAP_FALLBACK_TEXT: typeof import('@/lib/services/exercise-swap-explainer')['EXERCISE_SWAP_FALLBACK_TEXT'];
+let EXERCISE_SWAP_SYSTEM_PROMPT: typeof import('@/lib/services/exercise-swap-explainer')['EXERCISE_SWAP_SYSTEM_PROMPT'];
+
+const baseCtx: ExerciseSwapContext = {
+  fromExerciseId: 'barbell-back-squat',
+  toExerciseId: 'goblet-squat',
+  reason: 'equipment',
+  userGoal: 'hypertrophy',
+};
+
+describe('exercise-swap-explainer', () => {
+  beforeAll(() => {
+    ({
+      explainExerciseSwap,
+      buildExerciseSwapMessages,
+      EXERCISE_SWAP_FALLBACK_TEXT,
+      EXERCISE_SWAP_SYSTEM_PROMPT,
+    } = require('@/lib/services/exercise-swap-explainer'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds a two-message payload with SYSTEM prompt and user fields', () => {
+    const msgs = buildExerciseSwapMessages(baseCtx);
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].role).toBe('system');
+    expect(msgs[0].content).toBe(EXERCISE_SWAP_SYSTEM_PROMPT);
+    expect(msgs[1].role).toBe('user');
+    const userText = msgs[1].content;
+    expect(userText).toContain('barbell-back-squat');
+    expect(userText).toContain('goblet-squat');
+    expect(userText).toContain('equipment');
+    expect(userText).toContain('hypertrophy');
+  });
+
+  it('omits reason and goal lines when not provided', () => {
+    const minimal = buildExerciseSwapMessages({
+      fromExerciseId: 'a',
+      toExerciseId: 'b',
+    });
+    expect(minimal[1].content).not.toMatch(/Reason for swap/);
+    expect(minimal[1].content).not.toMatch(/Lifter goal/);
+  });
+
+  it('happy path: returns shaped Gemma reply with provider metadata', async () => {
+    mockSendCoachPrompt.mockResolvedValue({
+      role: 'assistant',
+      content: '  Both hit quads and glutes. Goblet reduces spinal load but limits absolute load.  ',
+      provider: 'gemma_cloud',
+      model: 'gemma-4-26b-a4b-it',
+    });
+    const result = await explainExerciseSwap(baseCtx);
+    expect(result.explanation).toBe(
+      'Both hit quads and glutes. Goblet reduces spinal load but limits absolute load.',
+    );
+    expect(result.provider).toBe('gemma_cloud');
+    expect(result.model).toBe('gemma-4-26b-a4b-it');
+  });
+
+  it('propagates taskKind="exercise_swap_explanation" and provider=gemma in opts', async () => {
+    mockSendCoachPrompt.mockResolvedValue({
+      role: 'assistant',
+      content: 'ok',
+    });
+    await explainExerciseSwap(baseCtx);
+    expect(mockSendCoachPrompt).toHaveBeenCalledTimes(1);
+    const [, , opts] = mockSendCoachPrompt.mock.calls[0];
+    expect(opts).toMatchObject({
+      provider: 'gemma',
+      taskKind: 'exercise_swap_explanation',
+    });
+  });
+
+  it('falls back to generic string when Gemma throws', async () => {
+    mockSendCoachPrompt.mockRejectedValue(new Error('Gemma unreachable'));
+    const result = await explainExerciseSwap(baseCtx);
+    expect(result.explanation).toBe(EXERCISE_SWAP_FALLBACK_TEXT);
+    expect(result.provider).toBe('fallback');
+    expect(result.model).toBe('fallback');
+  });
+
+  it('falls back when Gemma returns an empty body', async () => {
+    mockSendCoachPrompt.mockResolvedValue({ role: 'assistant', content: '   ' });
+    const result = await explainExerciseSwap(baseCtx);
+    expect(result.explanation).toBe(EXERCISE_SWAP_FALLBACK_TEXT);
+    expect(result.provider).toBe('fallback');
+  });
+
+  it('never throws even on unexpected error shapes', async () => {
+    mockSendCoachPrompt.mockRejectedValue('string-shaped error');
+    await expect(explainExerciseSwap(baseCtx)).resolves.toMatchObject({
+      explanation: EXERCISE_SWAP_FALLBACK_TEXT,
+      provider: 'fallback',
+    });
+  });
+});

--- a/tests/unit/services/progression-planner.provider-dispatch.test.ts
+++ b/tests/unit/services/progression-planner.provider-dispatch.test.ts
@@ -67,7 +67,10 @@ describe('progression-planner provider dispatch (pipeline-v2)', () => {
 
     expect(mockSendCoachPrompt).toHaveBeenCalledTimes(1);
     const [, , opts] = mockSendCoachPrompt.mock.calls[0];
-    expect(opts).toEqual({ provider: 'gemma' });
+    // Wave-34: planner now annotates every call with
+    // taskKind='program_design' so the cost tracker can bucket the
+    // traffic and the explicit-override telemetry captures the decision.
+    expect(opts).toEqual({ provider: 'gemma', taskKind: 'program_design' });
   });
 
   it('forwards provider=openai when flag is on and env=openai', async () => {
@@ -81,10 +84,10 @@ describe('progression-planner provider dispatch (pipeline-v2)', () => {
     });
 
     const [, , opts] = mockSendCoachPrompt.mock.calls[0];
-    expect(opts).toEqual({ provider: 'openai' });
+    expect(opts).toEqual({ provider: 'openai', taskKind: 'program_design' });
   });
 
-  it('omits provider opts when flag is off (legacy behavior)', async () => {
+  it('annotates taskKind even when flag is off (legacy behavior otherwise preserved)', async () => {
     delete process.env[FLAG];
     process.env[PROVIDER] = 'gemma';
 
@@ -95,6 +98,8 @@ describe('progression-planner provider dispatch (pipeline-v2)', () => {
     });
 
     const [, , opts] = mockSendCoachPrompt.mock.calls[0];
-    expect(opts).toBeUndefined();
+    // Wave-34: even without pipeline-v2 we annotate the taskKind so the
+    // cost tracker can bucket the traffic. No provider hint is attached.
+    expect(opts).toEqual({ taskKind: 'program_design' });
   });
 });


### PR DESCRIPTION
## Summary
Wave-34 Pack B — close remaining Gemma dispatch/telemetry gaps and ship a new Gemma surface.

- **Telemetry closure**: voice-NLU + rest-advisor now record taskKind + usage; auto-debrief + progression-planner record dispatch decision even with explicit provider via the new `recordExplicitProviderOverride()` sibling; fault_explainer wired into drill-explainer.
- **New surface**: `exercise-swap-explainer` — tactical Gemma call (<200 tok prompt, maxTokens 180) that never throws (generic fallback on any failure). Intended to hang off `ExerciseSwapSheet`.
- Orphan enum values (`form_cue_lookup`, `rest_calc`, `encouragement`) documented as reserved, not bugs.

## Atomic commits
1. `feat(gemma): add voice_nlu taskKind + wire into voice-gemma-nlu-fallback`
2. `feat(gemma): add rest_period_coaching taskKind + wire into rest-advisor with usage recording`
3. `feat(gemma): wire fault_explainer taskKind into drill-explainer + mark orphan enums reserved`
4. `fix(coach): propagate taskKind for explicit-provider callers (auto-debrief + progression-planner) — telemetry closure`
5. `feat(gemma): add exercise-swap-explainer service + taskKind + tests (new surface)`
6. `docs(gemma): mark exercise-swap picker wiring as wave-35 follow-up`

## Verification
- [x] `bunx tsc --noEmit` clean
- [x] New + related test suites green (157 focused tests pass across cost-tracker, dispatch, drill-explainer, voice-NLU, rest-advisor, progression-planner, exercise-swap-explainer, auto-debrief)
- [x] `bun run lint` clean on touched files
- [x] Full `bun run test` suite green (5015 passing, 25 skipped, 432 suites)

## Deviations from spec
- Test file for G5 placed at `tests/unit/services/exercise-swap-explainer.test.ts` (project convention) rather than `tests/unit/lib/services/...` (spec path).
- G4 telemetry closure adds a sibling `recordExplicitProviderOverride()` to `coach-model-dispatch-telemetry.ts` instead of reusing `recordDispatchDecision(DispatchDecision)` — the existing signature only accepts the decision shape, and the spec prohibits modifying `coach-service.ts` orchestration. Sibling avoids shoehorning and keeps counter names parallel.
- G6 shipped as a `docs(gemma)` commit with an integration-example JSDoc block on `ExerciseSwapSheet.tsx` (no production consumer of the sheet exists today). Real wiring deferred to wave-35.

## Merge order
After #581 merges (cost-tracker / model-dispatch enum overlap).

Closes #584