### PR TITLE
test(wave35): coverage pack — cue-hysteresis, Social/Units contexts, tracking-quality guards

### DIFF
--- a/lib/tracking-quality/cue-hysteresis.test.ts
+++ b/lib/tracking-quality/cue-hysteresis.test.ts
@@ -1,0 +1,224 @@
+import { CueHysteresisController } from './cue-hysteresis';
+
+describe('CueHysteresisController', () => {
+  describe('constructor assertions', () => {
+    it('throws when showFrames is zero', () => {
+      expect(() => new CueHysteresisController({ showFrames: 0, hideFrames: 2 })).toThrow(
+        /showFrames must be a positive integer/,
+      );
+    });
+
+    it('throws when hideFrames is zero', () => {
+      expect(() => new CueHysteresisController({ showFrames: 2, hideFrames: 0 })).toThrow(
+        /hideFrames must be a positive integer/,
+      );
+    });
+
+    it('throws when showFrames is negative', () => {
+      expect(() => new CueHysteresisController({ showFrames: -1, hideFrames: 2 })).toThrow(
+        /showFrames must be a positive integer/,
+      );
+    });
+
+    it('throws when showFrames is a non-integer', () => {
+      expect(() => new CueHysteresisController({ showFrames: 1.5, hideFrames: 2 })).toThrow(
+        /showFrames must be a positive integer/,
+      );
+    });
+
+    it('throws when hideFrames is a non-integer', () => {
+      expect(() => new CueHysteresisController({ showFrames: 2, hideFrames: 2.7 })).toThrow(
+        /hideFrames must be a positive integer/,
+      );
+    });
+
+    it('throws when showFrames is NaN', () => {
+      expect(() => new CueHysteresisController({ showFrames: NaN, hideFrames: 2 })).toThrow(
+        /showFrames must be a positive integer/,
+      );
+    });
+  });
+
+  describe('stepActive empty input', () => {
+    it('handles empty array without crashing', () => {
+      const ctrl = new CueHysteresisController<'a' | 'b'>({ showFrames: 2, hideFrames: 2 });
+      expect(() => ctrl.stepActive([])).not.toThrow();
+      expect(ctrl.isActive('a')).toBe(false);
+    });
+
+    it('handles empty Set without crashing', () => {
+      const ctrl = new CueHysteresisController<'a' | 'b'>({ showFrames: 2, hideFrames: 2 });
+      expect(() => ctrl.stepActive(new Set<'a' | 'b'>())).not.toThrow();
+    });
+
+    it('preserves existing runtime state when empty input is passed', () => {
+      const ctrl = new CueHysteresisController<'a'>({ showFrames: 2, hideFrames: 3 });
+      ctrl.stepActive(['a']);
+      ctrl.stepActive(['a']); // activate
+      expect(ctrl.isActive('a')).toBe(true);
+
+      // Empty input: nothing is active, but state for 'a' should still exist
+      // and be transitioning off (hideCount increments)
+      ctrl.stepActive([]);
+      const state = ctrl.getRuntimeState('a');
+      expect(state).not.toBeNull();
+      // Cue was active; one empty frame bumps hideCount to 1 (< hideFrames=3), still active
+      expect(state?.active).toBe(true);
+    });
+  });
+
+  describe('Set vs Array input equivalence', () => {
+    it('produces identical results for Set and Array with same cues', () => {
+      const ctrlA = new CueHysteresisController<'x' | 'y'>({ showFrames: 2, hideFrames: 2 });
+      const ctrlB = new CueHysteresisController<'x' | 'y'>({ showFrames: 2, hideFrames: 2 });
+
+      const frames: ('x' | 'y')[][] = [
+        ['x'],
+        ['x', 'y'],
+        ['y'],
+        [],
+        ['x'],
+      ];
+
+      for (const frame of frames) {
+        ctrlA.stepActive(frame);
+        ctrlB.stepActive(new Set(frame));
+      }
+
+      expect(ctrlA.isActive('x')).toBe(ctrlB.isActive('x'));
+      expect(ctrlA.isActive('y')).toBe(ctrlB.isActive('y'));
+      expect(ctrlA.getRuntimeState('x')).toEqual(ctrlB.getRuntimeState('x'));
+      expect(ctrlA.getRuntimeState('y')).toEqual(ctrlB.getRuntimeState('y'));
+    });
+  });
+
+  describe('nextStableCueFromOrderedActive multi-cue precedence', () => {
+    it('returns the first cue in declared order when multiple cross threshold same frame', () => {
+      const ctrl = new CueHysteresisController<'first' | 'second' | 'third'>({
+        showFrames: 2,
+        hideFrames: 2,
+      });
+      // Activate all three simultaneously across two frames.
+      ctrl.stepActive(['first', 'second', 'third']);
+      const result = ctrl.nextStableCueFromOrderedActive({
+        orderedActiveCues: ['first', 'second', 'third'],
+        previousStableCue: null,
+      });
+      expect(result).toBe('first');
+    });
+
+    it('respects given order even when cues arrive in different registration order', () => {
+      const ctrl = new CueHysteresisController<'a' | 'b' | 'c'>({ showFrames: 1, hideFrames: 2 });
+      // Register in 'c','a','b' order
+      ctrl.stepActive(['c', 'a', 'b']);
+      // Now query with priority order
+      const result = ctrl.nextStableCueFromOrderedActive({
+        orderedActiveCues: ['b', 'a', 'c'],
+        previousStableCue: null,
+      });
+      expect(result).toBe('b');
+    });
+  });
+
+  describe('previous stable cue persistence', () => {
+    it('keeps previousStableCue when still active (nextStableSelectedCue)', () => {
+      const ctrl = new CueHysteresisController<'a' | 'b'>({ showFrames: 1, hideFrames: 3 });
+      // Activate 'a'
+      ctrl.stepSelected('a');
+      expect(ctrl.isActive('a')).toBe(true);
+
+      // Raw now says 'b', but 'a' is still within hide window
+      const result = ctrl.nextStableSelectedCue({ rawCue: 'b', previousStableCue: 'a' });
+      expect(result).toBe('a');
+    });
+
+    it('keeps previousStableCue when still active (nextStableCueFromOrderedActive)', () => {
+      const ctrl = new CueHysteresisController<'a' | 'b'>({ showFrames: 1, hideFrames: 3 });
+      ctrl.stepActive(['a']);
+      expect(ctrl.isActive('a')).toBe(true);
+
+      // 'b' alone cannot become stable in one frame, but 'a' persists from prior
+      const result = ctrl.nextStableCueFromOrderedActive({
+        orderedActiveCues: ['b'],
+        previousStableCue: 'a',
+      });
+      expect(result).toBe('a');
+    });
+
+    it('returns null when neither previous nor raw cue is stable', () => {
+      const ctrl = new CueHysteresisController<'a' | 'b'>({ showFrames: 5, hideFrames: 2 });
+      const result = ctrl.nextStableSelectedCue({ rawCue: 'a', previousStableCue: null });
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('state reset on boundary crossing (flicker)', () => {
+    it('resets hideCount when cue re-appears before hide threshold', () => {
+      const ctrl = new CueHysteresisController<'a'>({ showFrames: 1, hideFrames: 4 });
+      // Activate 'a'
+      ctrl.stepActive(['a']);
+      expect(ctrl.isActive('a')).toBe(true);
+
+      // Miss 2 frames
+      ctrl.stepActive([]);
+      ctrl.stepActive([]);
+      let state = ctrl.getRuntimeState('a');
+      expect(state?.hideCount).toBe(2);
+      expect(state?.active).toBe(true);
+
+      // Re-appear: hideCount should reset to 0
+      ctrl.stepActive(['a']);
+      state = ctrl.getRuntimeState('a');
+      expect(state?.hideCount).toBe(0);
+      expect(state?.showCount).toBe(0);
+      expect(state?.active).toBe(true);
+
+      // Miss again: counter restarts from 0
+      ctrl.stepActive([]);
+      state = ctrl.getRuntimeState('a');
+      expect(state?.hideCount).toBe(1);
+    });
+
+    it('resets showCount when cue disappears before show threshold', () => {
+      const ctrl = new CueHysteresisController<'a'>({ showFrames: 3, hideFrames: 2 });
+      // Partial show progress
+      ctrl.stepActive(['a']);
+      ctrl.stepActive(['a']);
+      let state = ctrl.getRuntimeState('a');
+      expect(state?.showCount).toBe(2);
+      expect(state?.active).toBe(false);
+
+      // Flicker off: showCount must reset to 0
+      ctrl.stepActive([]);
+      state = ctrl.getRuntimeState('a');
+      expect(state?.showCount).toBe(0);
+      expect(state?.active).toBe(false);
+
+      // Need 3 more consecutive frames to activate, not 1
+      ctrl.stepActive(['a']);
+      ctrl.stepActive(['a']);
+      expect(ctrl.isActive('a')).toBe(false);
+      ctrl.stepActive(['a']);
+      expect(ctrl.isActive('a')).toBe(true);
+    });
+  });
+
+  describe('resetCue and resetAll', () => {
+    it('resetCue clears per-cue state', () => {
+      const ctrl = new CueHysteresisController<'a' | 'b'>({ showFrames: 1, hideFrames: 2 });
+      ctrl.stepActive(['a', 'b']);
+      expect(ctrl.isActive('a')).toBe(true);
+      ctrl.resetCue('a');
+      expect(ctrl.getRuntimeState('a')).toBeNull();
+      expect(ctrl.isActive('b')).toBe(true);
+    });
+
+    it('resetAll clears all runtime state', () => {
+      const ctrl = new CueHysteresisController<'a' | 'b'>({ showFrames: 1, hideFrames: 2 });
+      ctrl.stepActive(['a', 'b']);
+      ctrl.resetAll();
+      expect(ctrl.getRuntimeState('a')).toBeNull();
+      expect(ctrl.getRuntimeState('b')).toBeNull();
+    });
+  });
+});

--- a/lib/tracking-quality/occlusion.test.ts
+++ b/lib/tracking-quality/occlusion.test.ts
@@ -1,0 +1,180 @@
+import { OcclusionHoldManager } from './occlusion';
+import { HOLD_FRAMES } from './config';
+import type { CanonicalJoint2D, CanonicalJointMap } from '@/lib/pose/types';
+
+const makeJoint = (overrides: Partial<CanonicalJoint2D> = {}): CanonicalJoint2D => ({
+  x: 0.5,
+  y: 0.5,
+  isTracked: true,
+  confidence: 0.9,
+  ...overrides,
+});
+
+describe('OcclusionHoldManager', () => {
+  describe('defaults', () => {
+    it('constructs with default options', () => {
+      const mgr = new OcclusionHoldManager();
+      const out = mgr.update({ head: makeJoint() });
+      expect(out.head).toBeDefined();
+    });
+
+    it('honors custom holdFrames option', () => {
+      const mgr = new OcclusionHoldManager({ holdFrames: 2 });
+      mgr.update({ head: makeJoint() });
+      // Missing frame #1
+      let result = mgr.update({});
+      expect(result.head).toBeTruthy();
+      // Missing frame #2
+      result = mgr.update({});
+      expect(result.head).toBeTruthy();
+      // Missing frame #3 — exceeds holdFrames, should drop
+      result = mgr.update({});
+      expect(result.head).toBeNull();
+    });
+  });
+
+  describe('Record (plain object) input', () => {
+    it('passes through visible joints unchanged (apart from confidence clamp)', () => {
+      const mgr = new OcclusionHoldManager();
+      const out = mgr.update({
+        head: makeJoint({ x: 0.1, y: 0.2, confidence: 0.95 }),
+      });
+      expect(out.head).toEqual({ x: 0.1, y: 0.2, isTracked: true, confidence: 0.95 });
+    });
+
+    it('clamps confidence > 1 to 1', () => {
+      const mgr = new OcclusionHoldManager();
+      const out = mgr.update({ head: makeJoint({ confidence: 1.5 }) });
+      expect(out.head?.confidence).toBe(1);
+    });
+
+    it('returns null for a never-seen missing joint', () => {
+      const mgr = new OcclusionHoldManager();
+      const out = mgr.update({ head: null });
+      expect(out.head).toBeNull();
+    });
+
+    it('holds last good position when joint becomes untracked mid-session', () => {
+      const mgr = new OcclusionHoldManager({ holdFrames: 5, decayFactorPerFrame: 0.9 });
+      mgr.update({ head: makeJoint({ x: 0.4, y: 0.4, confidence: 0.9 }) });
+      const out = mgr.update({ head: null });
+      expect(out.head).toEqual({
+        x: 0.4,
+        y: 0.4,
+        isTracked: true,
+        confidence: expect.any(Number),
+      });
+      // confidence should have decayed by factor 0.9
+      expect(out.head!.confidence).toBeCloseTo(0.9 * 0.9, 5);
+    });
+
+    it('decays confidence geometrically per missing frame', () => {
+      const mgr = new OcclusionHoldManager({ holdFrames: 10, decayFactorPerFrame: 0.5 });
+      mgr.update({ head: makeJoint({ confidence: 1 }) });
+      const r1 = mgr.update({});
+      const r2 = mgr.update({});
+      const r3 = mgr.update({});
+      expect(r1.head!.confidence).toBeCloseTo(0.5, 5);
+      expect(r2.head!.confidence).toBeCloseTo(0.25, 5);
+      expect(r3.head!.confidence).toBeCloseTo(0.125, 5);
+    });
+
+    it('drops joint after holdFrames exceeded', () => {
+      const mgr = new OcclusionHoldManager({ holdFrames: 2 });
+      mgr.update({ head: makeJoint() });
+      mgr.update({});
+      mgr.update({});
+      const out = mgr.update({});
+      expect(out.head).toBeNull();
+
+      // Subsequent update should confirm joint is fully gone (no key emitted)
+      const out2 = mgr.update({});
+      expect(out2.head).toBeUndefined();
+    });
+
+    it('resets hold when joint reappears visible', () => {
+      const mgr = new OcclusionHoldManager({ holdFrames: 5 });
+      mgr.update({ head: makeJoint({ x: 0.1, y: 0.1 }) });
+      mgr.update({});
+      mgr.update({});
+      const r = mgr.update({ head: makeJoint({ x: 0.5, y: 0.5 }) });
+      expect(r.head!.x).toBe(0.5);
+
+      // Now miss one frame — confidence reflects fresh start, not cumulative
+      const missing = mgr.update({});
+      expect(missing.head!.x).toBe(0.5);
+      expect(missing.head!.confidence).toBeCloseTo(0.9 * 0.85, 5);
+    });
+  });
+
+  describe('CanonicalJointMap input', () => {
+    it('returns a Map when given a Map', () => {
+      const mgr = new OcclusionHoldManager();
+      const joints: CanonicalJointMap = new Map([['head', makeJoint()]]);
+      const out = mgr.update(joints);
+      expect(out).toBeInstanceOf(Map);
+      expect((out as CanonicalJointMap).get('head')).toBeDefined();
+    });
+
+    it('omits never-seen missing joints from the output Map', () => {
+      const mgr = new OcclusionHoldManager();
+      const out = mgr.update(new Map()) as CanonicalJointMap;
+      expect(out.size).toBe(0);
+    });
+
+    it('holds last-good for missing Map joints until holdFrames', () => {
+      const mgr = new OcclusionHoldManager({ holdFrames: 2 });
+      const initial: CanonicalJointMap = new Map([['head', makeJoint({ x: 0.2, y: 0.3, confidence: 0.8 })]]);
+      mgr.update(initial);
+
+      const out = mgr.update(new Map()) as CanonicalJointMap;
+      expect(out.get('head')).toMatchObject({ x: 0.2, y: 0.3, isTracked: true });
+
+      mgr.update(new Map());
+      const out2 = mgr.update(new Map()) as CanonicalJointMap;
+      // exceeded holdFrames → dropped
+      expect(out2.has('head')).toBe(false);
+    });
+  });
+
+  describe('visibility thresholding', () => {
+    it('treats joint below minConfidence as missing', () => {
+      const mgr = new OcclusionHoldManager({ minConfidence: 0.5 });
+      mgr.update({ head: makeJoint({ confidence: 0.9 }) });
+      // Next frame joint exists but confidence too low
+      const out = mgr.update({ head: makeJoint({ confidence: 0.2 }) });
+      // Treated as missing → hold kicks in
+      expect(out.head).toBeTruthy();
+      expect(out.head!.confidence).toBeLessThan(0.9);
+    });
+
+    it('treats untracked joint as missing', () => {
+      const mgr = new OcclusionHoldManager();
+      mgr.update({ head: makeJoint({ confidence: 0.9 }) });
+      const out = mgr.update({ head: makeJoint({ isTracked: false, confidence: 0.9 }) });
+      // Not tracked → hold kicks in
+      expect(out.head).toBeTruthy();
+      expect(out.head!.confidence).toBeLessThan(0.9);
+    });
+  });
+
+  describe('reset()', () => {
+    it('clears all held joints', () => {
+      const mgr = new OcclusionHoldManager({ holdFrames: 5 });
+      mgr.update({ head: makeJoint(), shoulder: makeJoint() });
+      mgr.update({}); // now in hold
+      mgr.reset();
+      const out = mgr.update({});
+      // With no holds and no incoming keys, output is empty
+      expect(out.head).toBeUndefined();
+      expect(out.shoulder).toBeUndefined();
+    });
+  });
+
+  describe('default HOLD_FRAMES constant', () => {
+    it('matches config export', () => {
+      expect(typeof HOLD_FRAMES).toBe('number');
+      expect(HOLD_FRAMES).toBeGreaterThan(0);
+    });
+  });
+});

--- a/lib/tracking-quality/visibility.test.ts
+++ b/lib/tracking-quality/visibility.test.ts
@@ -1,0 +1,194 @@
+import {
+  getConfidenceTier,
+  getVisibilityTier,
+  isJointVisible,
+  areRequiredJointsVisible,
+  PULLUP_CRITICAL_JOINTS,
+  is_joint_visible,
+  required_joints_visible,
+} from './visibility';
+import { CONFIDENCE_TIER_THRESHOLDS } from './config';
+import type { CanonicalJoint2D, CanonicalJointMap } from '@/lib/pose/types';
+
+const makeJoint = (overrides: Partial<CanonicalJoint2D> = {}): CanonicalJoint2D => ({
+  x: 0.5,
+  y: 0.5,
+  isTracked: true,
+  confidence: 0.9,
+  ...overrides,
+});
+
+describe('visibility tier helpers', () => {
+  describe('getConfidenceTier boundary precision', () => {
+    it('returns "low" below the low threshold', () => {
+      expect(getConfidenceTier(0)).toBe('low');
+      expect(getConfidenceTier(CONFIDENCE_TIER_THRESHOLDS.low - 0.0001)).toBe('low');
+    });
+
+    it('returns "medium" at the low threshold (inclusive)', () => {
+      expect(getConfidenceTier(CONFIDENCE_TIER_THRESHOLDS.low)).toBe('medium');
+    });
+
+    it('returns "medium" below the medium threshold', () => {
+      expect(getConfidenceTier(CONFIDENCE_TIER_THRESHOLDS.medium - 0.0001)).toBe('medium');
+    });
+
+    it('returns "high" at the medium threshold (inclusive)', () => {
+      expect(getConfidenceTier(CONFIDENCE_TIER_THRESHOLDS.medium)).toBe('high');
+    });
+
+    it('returns "high" at and above 1', () => {
+      expect(getConfidenceTier(1)).toBe('high');
+      expect(getConfidenceTier(5)).toBe('high'); // clamp01 clamps above 1
+    });
+
+    it('treats negative / NaN as 0 (low)', () => {
+      expect(getConfidenceTier(-1)).toBe('low');
+      expect(getConfidenceTier(NaN)).toBe('low');
+    });
+  });
+
+  describe('getVisibilityTier', () => {
+    it('maps high → trusted', () => {
+      expect(getVisibilityTier(1)).toBe('trusted');
+    });
+    it('maps medium → weak', () => {
+      expect(getVisibilityTier((CONFIDENCE_TIER_THRESHOLDS.low + CONFIDENCE_TIER_THRESHOLDS.medium) / 2)).toBe('weak');
+    });
+    it('maps low → missing', () => {
+      expect(getVisibilityTier(0.1)).toBe('missing');
+    });
+  });
+});
+
+describe('isJointVisible', () => {
+  it('returns false for null or undefined joints', () => {
+    expect(isJointVisible(null)).toBe(false);
+    expect(isJointVisible(undefined)).toBe(false);
+  });
+
+  it('returns false when isTracked is false', () => {
+    expect(isJointVisible(makeJoint({ isTracked: false }))).toBe(false);
+  });
+
+  it('returns true when tracked and confidence >= min', () => {
+    expect(isJointVisible(makeJoint({ confidence: 0.5 }), 0.3)).toBe(true);
+  });
+
+  it('returns false when tracked but confidence below min', () => {
+    expect(isJointVisible(makeJoint({ confidence: 0.1 }), 0.5)).toBe(false);
+  });
+
+  it('returns true when tracked with no confidence field', () => {
+    expect(isJointVisible({ x: 0, y: 0, isTracked: true })).toBe(true);
+  });
+
+  it('uses default min threshold from config', () => {
+    // confidence equal to the default min → visible (>= comparison)
+    expect(isJointVisible(makeJoint({ confidence: CONFIDENCE_TIER_THRESHOLDS.low }))).toBe(true);
+    expect(
+      isJointVisible(makeJoint({ confidence: CONFIDENCE_TIER_THRESHOLDS.low - 0.01 })),
+    ).toBe(false);
+  });
+
+  it('is exported as snake_case alias', () => {
+    expect(is_joint_visible).toBe(isJointVisible);
+  });
+});
+
+describe('areRequiredJointsVisible', () => {
+  describe('null inputs', () => {
+    it('returns false for null joints', () => {
+      expect(areRequiredJointsVisible(null, ['head'])).toBe(false);
+    });
+    it('returns false for undefined joints', () => {
+      expect(areRequiredJointsVisible(undefined, ['head'])).toBe(false);
+    });
+  });
+
+  describe('single-key required', () => {
+    it('returns true when single required joint is visible', () => {
+      expect(
+        areRequiredJointsVisible({ head: makeJoint() }, ['head']),
+      ).toBe(true);
+    });
+    it('returns false when single required joint is missing', () => {
+      expect(
+        areRequiredJointsVisible({ head: null }, ['head']),
+      ).toBe(false);
+    });
+  });
+
+  describe('alternative-joint OR list', () => {
+    it('passes when ANY alternative joint is visible (first option present)', () => {
+      expect(
+        areRequiredJointsVisible(
+          { left_shoulder: makeJoint() },
+          [['left_shoulder', 'left_shoulder_1_joint']],
+        ),
+      ).toBe(true);
+    });
+
+    it('passes when first alternative missing but second present', () => {
+      expect(
+        areRequiredJointsVisible(
+          { left_shoulder: null, left_shoulder_1_joint: makeJoint() },
+          [['left_shoulder', 'left_shoulder_1_joint']],
+        ),
+      ).toBe(true);
+    });
+
+    it('fails when all alternatives are missing', () => {
+      expect(
+        areRequiredJointsVisible(
+          { left_shoulder: null, left_shoulder_1_joint: null },
+          [['left_shoulder', 'left_shoulder_1_joint']],
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('Map vs object input', () => {
+    it('produces identical result for Map and Record with same data', () => {
+      const record = {
+        head: makeJoint({ confidence: 0.7 }),
+        left_shoulder_1_joint: makeJoint({ confidence: 0.4 }),
+      };
+      const map: CanonicalJointMap = new Map<string, CanonicalJoint2D>([
+        ['head', record.head],
+        ['left_shoulder_1_joint', record.left_shoulder_1_joint!],
+      ]);
+
+      const spec = ['head', ['left_shoulder', 'left_shoulder_1_joint']] as Parameters<typeof areRequiredJointsVisible>[1];
+      expect(areRequiredJointsVisible(record, spec)).toBe(areRequiredJointsVisible(map, spec));
+    });
+  });
+
+  describe('PULLUP_CRITICAL_JOINTS preset', () => {
+    it('passes when all four groups have at least one member visible', () => {
+      const joints = {
+        left_shoulder: makeJoint(),
+        right_shoulder_1_joint: makeJoint(),
+        left_forearm: makeJoint(),
+        right_elbow: makeJoint(),
+      };
+      expect(areRequiredJointsVisible(joints, PULLUP_CRITICAL_JOINTS)).toBe(true);
+    });
+
+    it('fails when a required elbow group has no visible joint', () => {
+      const joints = {
+        left_shoulder: makeJoint(),
+        right_shoulder: makeJoint(),
+        left_elbow: null,
+        left_forearm: null,
+        left_forearm_joint: null,
+        right_elbow: makeJoint(),
+      };
+      expect(areRequiredJointsVisible(joints, PULLUP_CRITICAL_JOINTS)).toBe(false);
+    });
+  });
+
+  it('exports snake_case alias', () => {
+    expect(required_joints_visible).toBe(areRequiredJointsVisible);
+  });
+});

--- a/tests/unit/contexts/SocialContext.test.tsx
+++ b/tests/unit/contexts/SocialContext.test.tsx
@@ -1,0 +1,291 @@
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import type * as SocialContextModule from '@/contexts/SocialContext';
+
+// AuthContext mock — toggled per-test via this object
+const mockAuthValue: { user: { id: string } | null; loading: boolean } = {
+  user: { id: 'user-abc' },
+  loading: false,
+};
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockAuthValue,
+}));
+
+// social-service mock — gives us control over every network call
+const mockSocial = {
+  getFollowStatus: jest.fn(),
+  getPendingRequestCount: jest.fn(),
+  getUnreadShareCount: jest.fn(),
+  followUser: jest.fn(),
+  unfollowUser: jest.fn(),
+  acceptFollow: jest.fn(),
+  rejectFollow: jest.fn(),
+  blockUser: jest.fn(),
+  unblockUser: jest.fn(),
+};
+jest.mock('@/lib/services/social-service', () => ({
+  getFollowStatus: (...args: any[]) => mockSocial.getFollowStatus(...args),
+  getPendingRequestCount: (...args: any[]) => mockSocial.getPendingRequestCount(...args),
+  getUnreadShareCount: (...args: any[]) => mockSocial.getUnreadShareCount(...args),
+  followUser: (...args: any[]) => mockSocial.followUser(...args),
+  unfollowUser: (...args: any[]) => mockSocial.unfollowUser(...args),
+  acceptFollow: (...args: any[]) => mockSocial.acceptFollow(...args),
+  rejectFollow: (...args: any[]) => mockSocial.rejectFollow(...args),
+  blockUser: (...args: any[]) => mockSocial.blockUser(...args),
+  unblockUser: (...args: any[]) => mockSocial.unblockUser(...args),
+}));
+
+// Supabase realtime channel stub
+const makeChannel = () => {
+  const channel: any = {
+    on: jest.fn(() => channel),
+    subscribe: jest.fn(() => channel),
+  };
+  return channel;
+};
+
+const mockChannel = jest.fn((..._args: any[]) => makeChannel());
+const mockRemoveChannel = jest.fn((..._args: any[]) => Promise.resolve(undefined));
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: (global as any).__mockSupabaseAuth,
+    channel: (...args: any[]) => mockChannel(...args),
+    removeChannel: (...args: any[]) => mockRemoveChannel(...args),
+  },
+}));
+
+// Silence warnWithTs
+jest.mock('@/lib/logger', () => ({
+  warnWithTs: jest.fn(),
+}));
+
+type SocialModule = typeof SocialContextModule;
+let SocialProvider: SocialModule['SocialProvider'];
+let useSocial: SocialModule['useSocial'];
+
+beforeAll(() => {
+  const mod = require('@/contexts/SocialContext') as SocialModule;
+  SocialProvider = mod.SocialProvider;
+  useSocial = mod.useSocial;
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <SocialProvider>{children}</SocialProvider>
+);
+
+const buildStatus = (overrides: Partial<any> = {}) => ({
+  is_self: false,
+  outgoing_status: null,
+  incoming_status: null,
+  follows: false,
+  requested: false,
+  followed_by: false,
+  blocked_by_me: false,
+  blocked_between: false,
+  ...overrides,
+});
+
+describe('SocialContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthValue.user = { id: 'user-abc' };
+    mockSocial.getPendingRequestCount.mockResolvedValue(0);
+    mockSocial.getUnreadShareCount.mockResolvedValue(0);
+    mockSocial.getFollowStatus.mockResolvedValue(buildStatus());
+  });
+
+  describe('initial state', () => {
+    it('returns zero counts and an empty cache after init', async () => {
+      const { result } = renderHook(() => useSocial(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.loadingCounts).toBe(false);
+      });
+
+      expect(result.current.pendingRequestCount).toBe(0);
+      expect(result.current.unreadSharesCount).toBe(0);
+      expect(result.current.followStatusCache).toEqual({});
+    });
+
+    it('throws when used outside the provider', () => {
+      // suppress the thrown-error console output
+      const prevError = console.error;
+      console.error = jest.fn();
+      try {
+        expect(() => renderHook(() => useSocial()).result.current).toThrow(
+          /useSocial must be used within a SocialProvider/,
+        );
+      } finally {
+        console.error = prevError;
+      }
+    });
+  });
+
+  describe('refreshCounts', () => {
+    it('calls both count services when signed in', async () => {
+      mockSocial.getPendingRequestCount.mockResolvedValue(3);
+      mockSocial.getUnreadShareCount.mockResolvedValue(7);
+
+      const { result } = renderHook(() => useSocial(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.pendingRequestCount).toBe(3);
+      });
+      expect(result.current.unreadSharesCount).toBe(7);
+
+      // manual call
+      mockSocial.getPendingRequestCount.mockResolvedValue(5);
+      mockSocial.getUnreadShareCount.mockResolvedValue(9);
+
+      await act(async () => {
+        await result.current.refreshCounts();
+      });
+
+      expect(result.current.pendingRequestCount).toBe(5);
+      expect(result.current.unreadSharesCount).toBe(9);
+    });
+
+    it('zeroes counts when no user is signed in', async () => {
+      mockAuthValue.user = null;
+      const { result } = renderHook(() => useSocial(), { wrapper });
+
+      await act(async () => {
+        await result.current.refreshCounts();
+      });
+
+      expect(result.current.pendingRequestCount).toBe(0);
+      expect(result.current.unreadSharesCount).toBe(0);
+      expect(mockSocial.getPendingRequestCount).not.toHaveBeenCalled();
+      expect(mockSocial.getUnreadShareCount).not.toHaveBeenCalled();
+    });
+
+    it('swallows errors and preserves previous pending-count value', async () => {
+      mockSocial.getPendingRequestCount.mockResolvedValueOnce(4);
+      const { result } = renderHook(() => useSocial(), { wrapper });
+      await waitFor(() => expect(result.current.pendingRequestCount).toBe(4));
+
+      mockSocial.getPendingRequestCount.mockRejectedValueOnce(new Error('network down'));
+      await act(async () => {
+        const count = await result.current.refreshPendingRequestCount();
+        expect(count).toBe(4);
+      });
+      // error swallowed; count preserved
+      expect(result.current.pendingRequestCount).toBe(4);
+    });
+
+    it('swallows errors and preserves previous unread-share value', async () => {
+      mockSocial.getUnreadShareCount.mockResolvedValueOnce(2);
+      const { result } = renderHook(() => useSocial(), { wrapper });
+      await waitFor(() => expect(result.current.unreadSharesCount).toBe(2));
+
+      mockSocial.getUnreadShareCount.mockRejectedValueOnce(new Error('boom'));
+      await act(async () => {
+        const count = await result.current.refreshUnreadShareCount();
+        expect(count).toBe(2);
+      });
+      expect(result.current.unreadSharesCount).toBe(2);
+    });
+  });
+
+  describe('followStatusCache read/write', () => {
+    it('caches result of first getFollowStatus call', async () => {
+      const summary = buildStatus({ follows: true });
+      mockSocial.getFollowStatus.mockResolvedValueOnce(summary);
+
+      const { result } = renderHook(() => useSocial(), { wrapper });
+      await waitFor(() => expect(result.current.loadingCounts).toBe(false));
+
+      await act(async () => {
+        await result.current.getFollowStatus('target-1');
+      });
+
+      expect(result.current.followStatusCache['target-1']).toEqual(summary);
+
+      // Second call — should NOT hit network (cache hit)
+      mockSocial.getFollowStatus.mockClear();
+      await act(async () => {
+        await result.current.getFollowStatus('target-1');
+      });
+      expect(mockSocial.getFollowStatus).not.toHaveBeenCalled();
+    });
+
+    it('refreshes cache when opts.refresh is true', async () => {
+      mockSocial.getFollowStatus.mockResolvedValueOnce(buildStatus({ follows: false }));
+      const { result } = renderHook(() => useSocial(), { wrapper });
+      await waitFor(() => expect(result.current.loadingCounts).toBe(false));
+
+      await act(async () => {
+        await result.current.getFollowStatus('target-1');
+      });
+
+      mockSocial.getFollowStatus.mockResolvedValueOnce(buildStatus({ follows: true }));
+      await act(async () => {
+        await result.current.getFollowStatus('target-1', { refresh: true });
+      });
+      expect(result.current.followStatusCache['target-1'].follows).toBe(true);
+    });
+
+    it('returns self-status for own userId without hitting network', async () => {
+      const { result } = renderHook(() => useSocial(), { wrapper });
+      await waitFor(() => expect(result.current.loadingCounts).toBe(false));
+
+      mockSocial.getFollowStatus.mockClear();
+      let returned: any;
+      await act(async () => {
+        returned = await result.current.getFollowStatus('user-abc');
+      });
+
+      expect(returned.is_self).toBe(true);
+      expect(mockSocial.getFollowStatus).not.toHaveBeenCalled();
+    });
+
+    it('clearFollowStatusCache empties the cache', async () => {
+      mockSocial.getFollowStatus.mockResolvedValueOnce(buildStatus({ follows: true }));
+      const { result } = renderHook(() => useSocial(), { wrapper });
+      await waitFor(() => expect(result.current.loadingCounts).toBe(false));
+
+      await act(async () => {
+        await result.current.getFollowStatus('target-1');
+      });
+      expect(Object.keys(result.current.followStatusCache)).toHaveLength(1);
+
+      act(() => {
+        result.current.clearFollowStatusCache();
+      });
+      expect(result.current.followStatusCache).toEqual({});
+    });
+  });
+
+  describe('realtime channel lifecycle', () => {
+    it('subscribes to follows and shares channels when user is signed in', async () => {
+      renderHook(() => useSocial(), { wrapper });
+
+      await waitFor(() => {
+        expect(mockChannel).toHaveBeenCalledWith(expect.stringMatching(/^social-follows-/));
+      });
+      expect(mockChannel).toHaveBeenCalledWith(expect.stringMatching(/^social-shares-/));
+    });
+
+    it('does not subscribe when no user is present', async () => {
+      mockAuthValue.user = null;
+      renderHook(() => useSocial(), { wrapper });
+
+      // allow microtasks
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockChannel).not.toHaveBeenCalled();
+    });
+
+    it('tears down channels on unmount', async () => {
+      const { unmount } = renderHook(() => useSocial(), { wrapper });
+      await waitFor(() => {
+        expect(mockChannel).toHaveBeenCalled();
+      });
+
+      unmount();
+      expect(mockRemoveChannel).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/tests/unit/contexts/UnitsContext.test.tsx
+++ b/tests/unit/contexts/UnitsContext.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type * as UnitsContextModule from '@/contexts/UnitsContext';
+
+type UnitsModule = typeof UnitsContextModule;
+let UnitsProvider: UnitsModule['UnitsProvider'];
+let useUnits: UnitsModule['useUnits'];
+
+const STORAGE_KEY = '@weight_unit';
+
+beforeAll(() => {
+  const mod = require('@/contexts/UnitsContext') as UnitsModule;
+  UnitsProvider = mod.UnitsProvider;
+  useUnits = mod.useUnits;
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <UnitsProvider>{children}</UnitsProvider>
+);
+
+describe('UnitsContext', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('initial load', () => {
+    it('defaults to lbs when AsyncStorage is empty', async () => {
+      const { result } = renderHook(() => useUnits(), { wrapper });
+
+      // Wait for the initial effect to settle
+      await waitFor(() => {
+        expect(result.current.weightUnit).toBe('lbs');
+      });
+      expect(result.current.getWeightLabel()).toBe('lbs');
+    });
+
+    it('loads saved unit "kg" from AsyncStorage', async () => {
+      await AsyncStorage.setItem(STORAGE_KEY, 'kg');
+
+      const { result } = renderHook(() => useUnits(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.weightUnit).toBe('kg');
+      });
+      expect(result.current.getWeightLabel()).toBe('kg');
+    });
+
+    it('loads saved unit "lbs" from AsyncStorage', async () => {
+      await AsyncStorage.setItem(STORAGE_KEY, 'lbs');
+
+      const { result } = renderHook(() => useUnits(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.weightUnit).toBe('lbs');
+      });
+    });
+
+    it('ignores unexpected values in AsyncStorage and keeps default', async () => {
+      await AsyncStorage.setItem(STORAGE_KEY, 'stones');
+
+      const { result } = renderHook(() => useUnits(), { wrapper });
+
+      // Give the load effect a tick
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(result.current.weightUnit).toBe('lbs');
+    });
+
+    it('throws when useUnits is called outside provider', () => {
+      const prevError = console.error;
+      console.error = jest.fn();
+      try {
+        expect(() => renderHook(() => useUnits()).result.current).toThrow(
+          /useUnits must be used within a UnitsProvider/,
+        );
+      } finally {
+        console.error = prevError;
+      }
+    });
+  });
+
+  describe('toggleWeightUnit', () => {
+    it('switches lbs → kg and persists', async () => {
+      const { result } = renderHook(() => useUnits(), { wrapper });
+      await waitFor(() => expect(result.current.weightUnit).toBe('lbs'));
+
+      await act(async () => {
+        await result.current.toggleWeightUnit();
+      });
+
+      expect(result.current.weightUnit).toBe('kg');
+      await waitFor(async () => {
+        expect(await AsyncStorage.getItem(STORAGE_KEY)).toBe('kg');
+      });
+    });
+
+    it('switches kg → lbs and persists', async () => {
+      await AsyncStorage.setItem(STORAGE_KEY, 'kg');
+      const { result } = renderHook(() => useUnits(), { wrapper });
+      await waitFor(() => expect(result.current.weightUnit).toBe('kg'));
+
+      await act(async () => {
+        await result.current.toggleWeightUnit();
+      });
+
+      expect(result.current.weightUnit).toBe('lbs');
+      await waitFor(async () => {
+        expect(await AsyncStorage.getItem(STORAGE_KEY)).toBe('lbs');
+      });
+    });
+  });
+
+  describe('convertWeight', () => {
+    it('returns kg unchanged when unit is kg', async () => {
+      await AsyncStorage.setItem(STORAGE_KEY, 'kg');
+      const { result } = renderHook(() => useUnits(), { wrapper });
+      await waitFor(() => expect(result.current.weightUnit).toBe('kg'));
+
+      expect(result.current.convertWeight(100)).toBe(100);
+      expect(result.current.convertWeight(0)).toBe(0);
+      expect(result.current.convertWeight(72.5)).toBe(72.5);
+    });
+
+    it('converts kg → lbs using 2.20462 ratio', async () => {
+      // default is lbs
+      const { result } = renderHook(() => useUnits(), { wrapper });
+      await waitFor(() => expect(result.current.weightUnit).toBe('lbs'));
+
+      expect(result.current.convertWeight(0)).toBe(0);
+      expect(result.current.convertWeight(1)).toBeCloseTo(2.20462, 5);
+      expect(result.current.convertWeight(100)).toBeCloseTo(220.462, 3);
+      expect(result.current.convertWeight(45.36)).toBeCloseTo(100.001563, 3);
+    });
+
+    it('handles negative inputs (treats as valid signed kg)', async () => {
+      const { result } = renderHook(() => useUnits(), { wrapper });
+      await waitFor(() => expect(result.current.weightUnit).toBe('lbs'));
+
+      expect(result.current.convertWeight(-10)).toBeCloseTo(-22.0462, 3);
+    });
+
+    it('propagates NaN when input is NaN', async () => {
+      const { result } = renderHook(() => useUnits(), { wrapper });
+      await waitFor(() => expect(result.current.weightUnit).toBe('lbs'));
+
+      expect(result.current.convertWeight(NaN)).toBeNaN();
+    });
+
+    it('propagates Infinity when input is Infinity', async () => {
+      const { result } = renderHook(() => useUnits(), { wrapper });
+      await waitFor(() => expect(result.current.weightUnit).toBe('lbs'));
+
+      expect(result.current.convertWeight(Infinity)).toBe(Infinity);
+      expect(result.current.convertWeight(-Infinity)).toBe(-Infinity);
+    });
+  });
+
+  describe('getWeightLabel', () => {
+    it('returns "kg" when unit is kg', async () => {
+      await AsyncStorage.setItem(STORAGE_KEY, 'kg');
+      const { result } = renderHook(() => useUnits(), { wrapper });
+      await waitFor(() => expect(result.current.getWeightLabel()).toBe('kg'));
+    });
+
+    it('returns "lbs" when unit is lbs', async () => {
+      const { result } = renderHook(() => useUnits(), { wrapper });
+      await waitFor(() => expect(result.current.getWeightLabel()).toBe('lbs'));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Wave-35 pack C (test coverage). Adds five atomic test files covering edge cases and guards across the cue/visibility/occlusion pipeline and the Social / Units context providers. 89 new tests, all green, no production code changes.

Closes #593.

## Atomic commits

- `test(cue-hysteresis): cover edge cases + multi-cue precedence` — empty input (array + Set), Set/Array equivalence, ordered precedence in `nextStableCueFromOrderedActive`, previous-stable persistence across both `nextStable*` APIs, flicker reset (show/hide), assertion guards (zero/negative/non-integer/NaN), resetCue/resetAll.
- `test(social-context): cover provider, cache, realtime lifecycle` — zero-count init, error-swallowing for both count refreshers (preserves previous value), `followStatusCache` cache-hit + `opts.refresh`, self-status short-circuit, `clearFollowStatusCache`, realtime channel subscribe/unsubscribe on user presence transitions.
- `test(units-context): cover AsyncStorage load + conversion edge cases` — default (lbs), load persisted `kg`/`lbs`, rejection of unexpected persisted values, provider guard, `toggleWeightUnit` round-trip + persistence, `convertWeight` kg passthrough + lbs conversion, NaN/Infinity/negative passthrough.
- `test(occlusion): cover OcclusionHoldManager hold + decay lifecycle` — default + custom `holdFrames`, geometric decay per missing frame, confidence clamp, last-good position retention, hold drop after exceeded frames, re-visibility resets hold, Map + Record input parity, minConfidence + isTracked gate visibility, `reset()` clears all holds.
- `test(visibility): cover tier boundaries + alternative-joint OR lists` — `getConfidenceTier` boundary precision at each threshold (inclusive low/medium), clamping for negative/NaN/above-1, `getVisibilityTier` mapping, `isJointVisible` gating on isTracked + minConfidence + undefined-confidence passthrough, `areRequiredJointsVisible` single-key and OR-list alternatives (first/second visible), Map vs Record parity, `PULLUP_CRITICAL_JOINTS` preset.

## Skipped from original pack (source not on main)

These were in the request but reference source files that live only on unmerged feature branches. Landing these tests on main without the source they exercise would fail or drift. They are parked for a follow-up pack once each source lands:

- `test(coach-provider-types)` — `lib/services/coach-provider-types.ts` is only on `feat/wave15b-coach-provider-badge` etc.
- `test(use-form-tracking-settings)` — `hooks/use-form-tracking-settings.ts` is only on `feat/overnight-wave12-ft-settings-cue-feedback`.
- `test(human-validation)` — `lib/tracking-quality/human-validation.ts` is only on `feat/overnight-wave18-stress-hardening` / `feat/451-tracking-stress-hardening`.
- `test(subject-identity)` — `lib/tracking-quality/subject-identity.ts` is only on `feat/overnight-wave18-stress-hardening` / `feat/445-tracking-resilience-ar-overlay`.

## Notes

- No production code changes. No new dependencies.
- Mocks use existing globals from `tests/setup.ts` (Supabase auth, AsyncStorage). Adds per-test scoped mocks for `social-service`, `supabase` realtime channels, and `@/lib/logger.warnWithTs`.
- `occlusion` pack description mentioned "callback dedup" but the current `OcclusionHoldManager` class takes no callback — tests cover its actual hold/decay surface instead.

## Test plan

- [x] `bunx jest lib/tracking-quality/cue-hysteresis.test.ts` — 19 pass
- [x] `bunx jest tests/unit/contexts/SocialContext.test.tsx` — 13 pass
- [x] `bunx jest tests/unit/contexts/UnitsContext.test.tsx` — 14 pass
- [x] `bunx jest lib/tracking-quality/occlusion.test.ts` — 16 pass
- [x] `bunx jest lib/tracking-quality/visibility.test.ts` — 27 pass
- [x] `bunx jest` (full suite) — 77 of 79 suites pass, 658 tests pass, 10 pre-existing skips, 0 regressions
- [x] `bun run lint` — 0 errors (2 pre-existing warnings in `app/(modals)/template-builder.tsx`)
- [x] `bun run check:types` — clean