### PR TITLE
feat(wave35): a11y + haptic + input-validation polish — 9 atomic commits

### DIFF
--- a/app/(modals)/add-food.tsx
+++ b/app/(modals)/add-food.tsx
@@ -238,6 +238,9 @@ export default function AddFoodScreen() {
               returnKeyType="next"
               onSubmitEditing={() => caloriesRef.current?.focus()}
               blurOnSubmit={false}
+              textContentType="none"
+              autoComplete="off"
+              autoCorrect={false}
             />
             {errors.name ? <Text style={styles.errorText}>{errors.name}</Text> : null}
           </View>

--- a/app/(modals)/add-food.tsx
+++ b/app/(modals)/add-food.tsx
@@ -56,6 +56,9 @@ export default function AddFoodScreen() {
   const fatRef = React.useRef<TextInput>(null);
   const accessoryID = 'decimalAccessory';
   const shouldSkipDiscardWarningRef = useRef(false);
+  // Track per-field "touched" state so we only flash live-validation errors
+  // after the user has interacted with (and blurred away from) a field.
+  const nameTouchedRef = useRef(false);
 
   const isDirty = useMemo(
     () => Boolean(name.trim() || calories.trim() || protein.trim() || carbs.trim() || fat.trim()),
@@ -226,11 +229,17 @@ export default function AddFoodScreen() {
               value={name}
               onChangeText={(value: string) => {
                 setName(value);
-                if (errors.name) {
+                // Once the user has blurred at least once, validate live on
+                // every keystroke so helper text / red border reflect current
+                // state instead of waiting for the next blur.
+                if (nameTouchedRef.current) {
                   validateName(value);
                 }
               }}
-              onBlur={() => validateName(name)}
+              onBlur={() => {
+                nameTouchedRef.current = true;
+                validateName(name);
+              }}
               placeholder="e.g., Chicken Breast, Apple, Pasta"
               placeholderTextColor="#8CA5C6"
               editable={!saving}

--- a/app/(modals)/followers.tsx
+++ b/app/(modals)/followers.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
+import * as Haptics from 'expo-haptics';
 import { useSafeBack } from '@/hooks/use-safe-back';
 import { useToast } from '@/contexts/ToastContext';
 import { useAuth } from '@/contexts/AuthContext';
@@ -142,7 +143,15 @@ export default function FollowersModal() {
         keyboardVerticalOffset={Platform.OS === 'ios' ? 88 : 0}
       >
         <View style={styles.header}>
-          <TouchableOpacity onPress={safeBack} style={styles.iconButton}>
+          <TouchableOpacity
+            onPress={() => {
+              void Haptics.selectionAsync();
+              safeBack();
+            }}
+            style={styles.iconButton}
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+          >
             <Ionicons name="chevron-back" size={20} color="#9AACD1" />
           </TouchableOpacity>
           <Text style={styles.headerTitle}>Connections</Text>

--- a/app/(modals)/user-profile.tsx
+++ b/app/(modals)/user-profile.tsx
@@ -225,10 +225,13 @@ export default function UserProfileModal() {
             text: 'Unfollow',
             style: 'destructive',
             onPress: () => {
+              // Fire destructive haptic synchronously on tap so the user gets
+              // iOS-native feedback at the moment of destructive confirmation,
+              // not after the async unfollow network round-trip completes.
+              void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
               void (async () => {
                 try {
                   setLoadingFollowAction(true);
-                  await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
                   await social.unfollowUser(targetUserId);
 
                   const [nextStatus, nextCounts] = await Promise.all([

--- a/app/(modals)/video-comments.tsx
+++ b/app/(modals)/video-comments.tsx
@@ -407,8 +407,19 @@ export default function VideoCommentsModal() {
                 onChangeText={setCommentInput}
                 multiline
               />
-              <TouchableOpacity style={styles.sendButton} onPress={handleSend} disabled={sending}>
-                <Text style={styles.sendButtonText}>{sending ? '...' : 'Send'}</Text>
+              <TouchableOpacity
+                style={styles.sendButton}
+                onPress={handleSend}
+                disabled={sending}
+                accessibilityRole="button"
+                accessibilityLabel={sending ? 'Sending comment' : 'Send comment'}
+                accessibilityState={{ disabled: sending, busy: sending }}
+              >
+                {sending ? (
+                  <ActivityIndicator color="#FFFFFF" />
+                ) : (
+                  <Text style={styles.sendButtonText}>Send</Text>
+                )}
               </TouchableOpacity>
             </View>
 

--- a/app/(tabs)/coach.tsx
+++ b/app/(tabs)/coach.tsx
@@ -348,6 +348,7 @@ export default function CoachScreen() {
               onPress={() => handleCoachSend(prompt)}
               accessibilityRole="button"
               accessibilityLabel={`Quick prompt: ${prompt}`}
+              accessibilityHint="Sends this suggested message to the coach"
             >
               <Text style={styles.quickPromptText}>{prompt}</Text>
             </TouchableOpacity>

--- a/app/(tabs)/coach.tsx
+++ b/app/(tabs)/coach.tsx
@@ -356,18 +356,34 @@ export default function CoachScreen() {
         </View>
 
         {coachError && (
-          <View style={styles.coachError} testID="coach-error-banner">
+          <TouchableOpacity
+            style={styles.coachError}
+            testID="coach-error-banner"
+            onPress={() => {
+              const lastUserMessage = [...coachMessages].reverse().find(msg => msg.role === 'user');
+              if (lastUserMessage?.content) {
+                void handleCoachSend(lastUserMessage.content);
+              }
+            }}
+            accessibilityRole="button"
+            accessibilityLabel={
+              coachErrorCode === 'COACH_RATE_LIMITED'
+                ? 'Coach is busy. Tap to retry.'
+                : 'Coach unavailable. Tap to retry.'
+            }
+            accessibilityHint="Retries the last message you sent"
+          >
             <Text style={styles.coachErrorTitle}>
               {coachErrorCode === 'COACH_RATE_LIMITED'
-                ? 'Coach is rate-limited'
+                ? 'Coach is busy — try again in a few minutes. Tap to retry.'
                 : coachErrorDomain === 'network'
-                  ? 'Connection error'
+                  ? 'Connection error. Tap to retry.'
                   : coachErrorDomain === 'unknown' || coachErrorDomain == null
-                    ? 'Coach is busy'
-                    : 'Service unavailable'}
+                    ? 'Coach is busy. Tap to retry.'
+                    : 'Service unavailable. Tap to retry.'}
             </Text>
             <Text style={styles.coachErrorText}>{coachError}</Text>
-          </View>
+          </TouchableOpacity>
         )}
 
         {sessionLoading ? (

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -258,6 +258,7 @@ const FeedVideoPlayer = ({ uri, thumbnailUrl, overlaySummary, overlayTime }: Fee
               onPress={toggleMuted}
               accessibilityLabel={isMuted ? 'Unmute' : 'Mute'}
               accessibilityRole="button"
+              hitSlop={{ top: 14, bottom: 14, left: 14, right: 14 }}
             >
               <Ionicons name={isMuted ? 'volume-mute' : 'volume-high'} size={14} color="#DDE6FF" />
             </TouchableOpacity>
@@ -266,6 +267,7 @@ const FeedVideoPlayer = ({ uri, thumbnailUrl, overlaySummary, overlayTime }: Fee
               onPress={enterFullscreen}
               accessibilityLabel="Enter fullscreen"
               accessibilityRole="button"
+              hitSlop={{ top: 14, bottom: 14, left: 14, right: 14 }}
             >
               <Ionicons name="scan-outline" size={14} color="#DDE6FF" />
             </TouchableOpacity>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1124,9 +1124,14 @@ Generated: ${new Date().toISOString()}
             </View>
             <View style={styles.modalActions}>
               <TouchableOpacity
-                style={[styles.modalButton, styles.modalButtonSecondary]}
+                style={[
+                  styles.modalButton,
+                  styles.modalButtonSecondary,
+                  isSavingName && { opacity: 0.5 },
+                ]}
                 onPress={() => setIsEditProfileVisible(false)}
                 disabled={isSavingName}
+                accessibilityState={{ disabled: isSavingName }}
               >
                 <Text style={[styles.modalButtonText, styles.modalButtonTextSecondary]}>Cancel</Text>
               </TouchableOpacity>


### PR DESCRIPTION
## Summary

Wave-35 pack D — app-wide a11y + haptic + input-validation polish. Nine atomic commits, each one bullet from #594. No `Co-Authored-By`; no AI attribution; no migrations / native / env touched.

Closes #594.

## Commits

| # | Commit | File |
|---|--------|------|
| 1 | `feat(coach): a11y hint on quick-prompt buttons` | `app/(tabs)/coach.tsx` |
| 2 | `feat(coach): actionable copy on rate-limit banner` | `app/(tabs)/coach.tsx` |
| 3 | `fix(video-player): meet 44x44 hit target for mute + fullscreen` | `app/(tabs)/index.tsx` |
| 4 | `fix(follow): fire destructive haptic on unfollow tap, not after network` | `app/(modals)/user-profile.tsx` |
| 5 | `fix(profile-edit): dim cancel button while saving` | `app/(tabs)/profile.tsx` |
| 6 | `feat(add-food): textContentType + autoComplete hints on food name` | `app/(modals)/add-food.tsx` |
| 7 | `feat(followers): selection haptic on back nav` | `app/(modals)/followers.tsx` |
| 8 | `feat(video-comments): in-button spinner when sending` | `app/(modals)/video-comments.tsx` |
| 9 | `feat(add-food): live validation feedback on name input after first blur` | `app/(modals)/add-food.tsx` |

## Notes / scope deviations

- **#2 (coach rate-limit copy)** — The existing UI is an inline banner, not a toast, so the "keep toast duration 4-5s" guidance doesn't apply verbatim. Converted the banner `View` to a `TouchableOpacity` that retries the last user message on tap; added actionable copy ("try again in a few minutes — tap to retry"). The upstream `AppError` for `COACH_RATE_LIMITED` does not carry a structured retry-after field, so no dynamic timing hint is surfaced.
- **#5 (profile close button)** — The issue's line range (1100-1110) points at the TextInput, not a close button. Actual close pathways are the Cancel button (lines ~1125-1144) and the backdrop (line ~1094). Both were already gated on `isSavingName`; this commit adds the visual `opacity: 0.5` dim + `accessibilityState.disabled`. Swipe-back is n/a — this is an inline `<Modal>`, not a stack screen.
- **#6 (add-food suggestions)** — Per the bullet's fallback ("If not, just set the content-type hints and move on."), the inline top-5-prior-meals suggestion row was **skipped**. `FoodContext` exposes `foods` but has no suggestion helper, and adding a new UI row would expand scope beyond this polish pack. Followed up by filing no new issue — leaving for a future pack.

## Verification

- [x] `bun run lint`
- [x] `bun run check:types`
- [x] Husky `pre-commit` (`bun run ci:local`) ran green on each commit
- [x] No touched file has existing co-located tests; no test regressions expected

## Test plan

- [ ] VoiceOver — coach screen: quick-prompt buttons announce the new hint
- [ ] iOS — video feed: mute / fullscreen controls tap area ≥ 44×44
- [ ] iOS — user profile: Warning haptic fires the moment "Unfollow" is confirmed
- [ ] iOS — profile edit: Cancel button visibly dims while Save is in flight
- [ ] iOS — add-food: keyboard shows no Name/Address QuickType suggestions
- [ ] iOS — followers: selection haptic on back tap
- [ ] iOS — video comments: send button shows spinner while sending
- [ ] iOS — add-food: red border + helper text update live after first blur of the Food Name field