### PR TITLE
feat(wave35): form-UX polish pack — mid-set degrade, rest-timer confirm, settings wiring, rep-override, recal toggle

### DIFF
--- a/app/(modals)/form-tracking-pre-calibration.tsx
+++ b/app/(modals)/form-tracking-pre-calibration.tsx
@@ -33,7 +33,14 @@ type Step = 'check' | 'preview';
 
 export default function FormTrackingPreCalibrationModal() {
   const router = useRouter();
-  const { status, recordFrame, markSuccess, markFailed, reset } = usePreCalibrationStatus();
+  const {
+    status,
+    recordFrame,
+    markSuccess,
+    markFailed,
+    reset,
+    setForceRecalibration,
+  } = usePreCalibrationStatus();
   const [step, setStep] = useState<Step>('check');
 
   // Simulate per-frame confidence collection on the preview step.
@@ -90,7 +97,12 @@ export default function FormTrackingPreCalibrationModal() {
     <View style={styles.overlay} testID="pre-calibration-modal">
       <View style={styles.card}>
         {step === 'check' ? (
-          <CheckStep onContinue={() => setStep('preview')} onCancel={handleCancel} />
+          <CheckStep
+            onContinue={() => setStep('preview')}
+            onCancel={handleCancel}
+            forceRecalibration={status.forceRecalibration}
+            onToggleForce={() => setForceRecalibration(!status.forceRecalibration)}
+          />
         ) : (
           <PreviewStep
             confidencePercent={confidencePercent}
@@ -112,9 +124,16 @@ export default function FormTrackingPreCalibrationModal() {
 interface CheckStepProps {
   onContinue: () => void;
   onCancel: () => void;
+  forceRecalibration: boolean;
+  onToggleForce: () => void;
 }
 
-function CheckStep({ onContinue, onCancel }: CheckStepProps) {
+function CheckStep({
+  onContinue,
+  onCancel,
+  forceRecalibration,
+  onToggleForce,
+}: CheckStepProps) {
   return (
     <>
       <View style={styles.iconWrap}>
@@ -129,6 +148,23 @@ function CheckStep({ onContinue, onCancel }: CheckStepProps) {
         <ChecklistRow icon="bulb-outline" label="Good lighting on subject" />
         <ChecklistRow icon="body-outline" label="Full body in frame" />
       </View>
+      <TouchableOpacity
+        style={styles.recalRow}
+        onPress={onToggleForce}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: forceRecalibration }}
+        accessibilityLabel="Force recalibration on this session"
+        testID="pre-calibration-force-recal"
+      >
+        <Ionicons
+          name={forceRecalibration ? 'checkbox' : 'square-outline'}
+          size={18}
+          color={forceRecalibration ? '#4C8CFF' : '#9AACD1'}
+        />
+        <Text style={styles.recalLabel}>
+          Recalibrate (override skip)
+        </Text>
+      </TouchableOpacity>
       <View style={styles.actions}>
         <TouchableOpacity style={styles.secondaryButton} onPress={onCancel} testID="pre-calibration-cancel">
           <Text style={styles.secondaryButtonText}>Cancel</Text>
@@ -342,5 +378,19 @@ const styles = StyleSheet.create({
   progressFill: {
     height: '100%',
     backgroundColor: '#4C8CFF',
+  },
+  recalRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginTop: 18,
+    paddingVertical: 6,
+    paddingHorizontal: 4,
+    alignSelf: 'flex-start',
+  },
+  recalLabel: {
+    color: '#9AACD1',
+    fontSize: 13,
+    fontWeight: '500',
   },
 });

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -3287,10 +3287,22 @@ export default function ScanARKitScreen() {
               accessibilityRole="alert"
             >
               <Ionicons name="eye-off-outline" size={14} color="#F5F7FF" />
-              <Text style={scanArV2Styles.microToastText}>
-                Adjust clothing — {sustainedOcclusionHint.jointNames.length} joint
-                {sustainedOcclusionHint.jointNames.length === 1 ? '' : 's'} hidden
+              <Text
+                style={scanArV2Styles.microToastText}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                Adjust clothing —{' '}
+                {sustainedOcclusionHint.jointNames.slice(0, 3).join(', ')} hidden
               </Text>
+              {sustainedOcclusionHint.jointNames.length > 3 ? (
+                <Text
+                  style={scanArV2Styles.microToastText}
+                  numberOfLines={1}
+                >
+                  +{sustainedOcclusionHint.jointNames.length - 3} more
+                </Text>
+              ) : null}
             </View>
           ) : null}
 

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -40,6 +40,7 @@ import { errorWithTs, logWithTs, warnWithTs } from '@/lib/logger';
 // Import ARKit module - Metro auto-resolves to .ios.ts or .web.ts
 import { BodyTracker, useBodyTracking, type JointAngles, type Joint2D, type MediaPipePose2D } from '@/lib/arkit/ARKitBodyTracker';
 import { usePremiumCueAudio } from '@/hooks/use-premium-cue-audio';
+import { useFormTrackingSettings } from '@/hooks/use-form-tracking-settings';
 import { audioSessionManager } from '@/lib/services/audio-session-manager';
 import { useToast } from '@/contexts/ToastContext';
 import { CrashBoundary } from '@/components/CrashBoundary';
@@ -350,6 +351,19 @@ export default function ScanARKitScreen() {
   const DEV = __DEV__;
   const router = useRouter();
   const { show: showToast } = useToast();
+  // Form-tracking global preferences. We only read the two feedback-modality
+  // toggles here — `countAudioEnabled` gates the 3-2-1 rep countdown and
+  // `hapticsEnabled` gates the rep-complete / start / stop haptic pulses.
+  // Voice gating is handled elsewhere (usePremiumCueAudio). Mirror both into
+  // refs so callback-stable callsites don't need to re-render when the user
+  // toggles either in settings.
+  const { settings: formTrackingSettings } = useFormTrackingSettings();
+  const countAudioEnabledRef = React.useRef<boolean>(formTrackingSettings.countAudioEnabled);
+  const hapticsEnabledRef = React.useRef<boolean>(formTrackingSettings.hapticsEnabled);
+  useEffect(() => {
+    countAudioEnabledRef.current = formTrackingSettings.countAudioEnabled;
+    hapticsEnabledRef.current = formTrackingSettings.hapticsEnabled;
+  }, [formTrackingSettings.countAudioEnabled, formTrackingSettings.hapticsEnabled]);
   const params = useLocalSearchParams<{ fixturePlayback?: string; fixture?: string; trackingDebug?: string; templateId?: string }>();
   const fixturePlaybackRequested = params.fixturePlayback === '1';
   // Issue #447 — deep-link / scheduled-workout template binding.
@@ -1055,11 +1069,12 @@ export default function ScanARKitScreen() {
       // Additive rep-complete haptic: the workout controller already fires
       // a Light impact through the shared haptic bus, but testers reported
       // that in noisy gym environments the light tap is easy to miss. When
-      // the user has audio/cue feedback enabled we also fire a Heavy impact
-      // here so successful reps register unambiguously. Gated by
-      // audioFeedbackEnabledRef.current (mirrors the cue-audio toggle) so
-      // users who explicitly silenced cues don't get a phantom extra buzz.
-      if (audioFeedbackEnabledRef.current) {
+      // the user has audio/cue feedback enabled AND hasn't muted haptics we
+      // also fire a Heavy impact here so successful reps register
+      // unambiguously. Gated by audioFeedbackEnabledRef.current (mirrors
+      // the cue-audio toggle) + hapticsEnabledRef.current (form-tracking
+      // settings) so users who silenced either don't get a phantom buzz.
+      if (audioFeedbackEnabledRef.current && hapticsEnabledRef.current) {
         void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy).catch(() => {
           /* native bridge unavailable — silent */
         });
@@ -1800,15 +1815,16 @@ export default function ScanARKitScreen() {
 
       if (DEV) logWithTs('[ScanARKit] Tracking started successfully in', elapsed, 'ms');
 
-      if (Platform.OS === 'ios') {
+      if (Platform.OS === 'ios' && hapticsEnabledRef.current) {
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       }
 
       // Fire the 3-2-1 pre-announce once per tracking start. Gated on the
-      // user preference + the EXPO_PUBLIC_REP_COUNTDOWN env flag inside
-      // playRepCountdown itself. Errors are swallowed — countdown is a
-      // nice-to-have, not a blocker for the tracking loop.
-      if (!repCountdownFiredRef.current) {
+      // user preference (form-tracking `countAudioEnabled` toggle) + the
+      // EXPO_PUBLIC_REP_COUNTDOWN env flag inside playRepCountdown itself.
+      // Errors are swallowed — countdown is a nice-to-have, not a blocker
+      // for the tracking loop.
+      if (!repCountdownFiredRef.current && countAudioEnabledRef.current) {
         repCountdownFiredRef.current = true;
         playRepCountdown().catch((error) => {
           if (DEV) warnWithTs('[ScanARKit] rep countdown failed', error);
@@ -1906,7 +1922,7 @@ export default function ScanARKitScreen() {
 
       if (DEV) logWithTs('[ScanARKit] Tracking stopped');
 
-      if (Platform.OS === 'ios') {
+      if (Platform.OS === 'ios' && hapticsEnabledRef.current) {
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
       }
 

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -560,6 +560,10 @@ export default function ScanARKitScreen() {
   const watchTrackingPublishAtRef = React.useRef(0);
   const watchTrackingSignatureRef = React.useRef<string | null>(null);
   const lastTrackingQualityRef = React.useRef<number | null>(null);
+  // Tracks the previous confidence tier so mid-set degradation warnings fire
+  // once on the high → low transition edge rather than on every frame. See
+  // emitMidSetDegradationIfTransition below for the thresholds.
+  const lastConfidenceTierRef = React.useRef<'high' | 'low' | null>(null);
   const [shadowModeEnabled, setShadowModeEnabled] = useState(true);
   const shadowModeEnabledRef = React.useRef(true);
   const shadowStatsRef = React.useRef(createShadowStatsAccumulator());
@@ -1572,9 +1576,39 @@ export default function ScanARKitScreen() {
         });
         if (typeof smoothingResult?.trackingQuality === 'number') {
           lastTrackingQualityRef.current = smoothingResult.trackingQuality;
+          // Mid-set confidence degradation: warn once when the tier flips from
+          // high → low during an active rep. The tier is only classified when
+          // we are mid-set (between repBoundary.startPhase and the next rep-
+          // complete), so between-set frames stay quiet. A Schmitt-trigger-
+          // style pair of thresholds avoids chatter around the boundary.
+          const HIGH_ENTER = 0.7;
+          const LOW_ENTER = 0.5;
+          const quality = smoothingResult.trackingQuality;
+          const inActiveRep = repIndexTrackerRef.current.current() !== null;
+          if (inActiveRep) {
+            let nextTier: 'high' | 'low' | null = lastConfidenceTierRef.current;
+            if (quality >= HIGH_ENTER) nextTier = 'high';
+            else if (quality <= LOW_ENTER) nextTier = 'low';
+            const prevTier = lastConfidenceTierRef.current;
+            if (prevTier === 'high' && nextTier === 'low') {
+              showToast('Tracking degraded — check lighting / framing', {
+                type: 'error',
+              });
+              void Haptics.notificationAsync(
+                Haptics.NotificationFeedbackType.Warning,
+              ).catch(() => {
+                /* haptics unavailable — silent */
+              });
+            }
+            lastConfidenceTierRef.current = nextTier;
+          } else {
+            // Outside a rep: reset so the next rep's baseline starts neutral.
+            lastConfidenceTierRef.current = null;
+          }
         }
       } else {
         lastTrackingQualityRef.current = null;
+        lastConfidenceTierRef.current = null;
         repIndexTrackerRef.current.reset();
         resetWorkoutController({ preserveRepCount: true });
         setActiveMetrics(null);
@@ -1753,6 +1787,7 @@ export default function ScanARKitScreen() {
       resetCueHysteresis();
       repCountdownFiredRef.current = false;
       sessionFqiScoresRef.current = [];
+      lastConfidenceTierRef.current = null;
 
       const startTime = Date.now();
       shadowStatsRef.current = createShadowStatsAccumulator();
@@ -1867,6 +1902,7 @@ export default function ScanARKitScreen() {
       resetCueHysteresis();
       repCountdownFiredRef.current = false;
       sessionFqiScoresRef.current = [];
+      lastConfidenceTierRef.current = null;
 
       if (DEV) logWithTs('[ScanARKit] Tracking stopped');
 

--- a/components/workout/ExerciseCard.tsx
+++ b/components/workout/ExerciseCard.tsx
@@ -25,6 +25,14 @@ interface ExerciseCardProps {
   onSetMenuPress: (setId: string) => void;
   onExerciseMenuPress: (sessionExerciseId: string) => void;
   onNotesPress?: (setId: string) => void;
+  /**
+   * Optional map of setId → rep count observed by the form-tracking rep
+   * detector. Forwarded to SetRow so a manual actual_reps edit that
+   * diverges by more than one from the detector can surface a subtle
+   * "Detector: N" hint. Left undefined by callsites that have no
+   * detector stream wired up yet.
+   */
+  detectedRepsBySetId?: Record<string, number>;
 }
 
 function ExerciseCard({
@@ -36,6 +44,7 @@ function ExerciseCard({
   onSetMenuPress,
   onExerciseMenuPress,
   onNotesPress,
+  detectedRepsBySetId,
 }: ExerciseCardProps) {
   const isTimed = exercise.exercise?.is_timed ?? false;
   const exerciseName = exercise.exercise?.name ?? 'Exercise';
@@ -88,6 +97,7 @@ function ExerciseCard({
           onCompleteSet={onCompleteSet}
           onMenuPress={onSetMenuPress}
           onNotesPress={onNotesPress}
+          detectedReps={detectedRepsBySetId?.[s.id]}
         />
       ))}
 

--- a/components/workout/RestTimerSheet.tsx
+++ b/components/workout/RestTimerSheet.tsx
@@ -7,8 +7,8 @@
  * + mobility + reflection content tailored to the just-completed set.
  */
 
-import React, { useEffect, useMemo, useRef, useState, forwardRef } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef, useState, forwardRef } from 'react';
+import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { sessionStyles as styles, colors } from '@/styles/workout-session.styles';
 import { useSessionRunner } from '@/lib/stores/session-runner';
@@ -50,6 +50,17 @@ const RestTimerSheet = forwardRef<BottomSheet, RestTimerSheetProps>(({ onClose }
   const { recommendation, refresh } = useBetweenSetsCoach();
   const [remaining, setRemaining] = useState(0);
   const haptedForTimerRef = useRef<string | null>(null);
+  // Signal that the user has already confirmed the dismissal via the Alert
+  // (or the timer hit 0). Without this gate the confirm Alert would
+  // re-prompt indefinitely when the sheet's `onClose` fires after a snap-
+  // back animation.
+  const dismissConfirmedRef = useRef(false);
+  // Mirror `remaining` into a ref so the `onClose` handler can read the
+  // latest value without re-creating the callback on every tick.
+  const remainingRef = useRef(0);
+  useEffect(() => {
+    remainingRef.current = remaining;
+  }, [remaining]);
 
   useEffect(() => {
     if (!restTimer) {
@@ -99,14 +110,60 @@ const RestTimerSheet = forwardRef<BottomSheet, RestTimerSheetProps>(({ onClose }
   }
 
   const handleReady = async () => {
+    dismissConfirmedRef.current = true;
     await skipRest();
     onClose();
   };
 
   const handleSkip = async () => {
+    dismissConfirmedRef.current = true;
     await skipRest();
     onClose();
   };
+
+  // Re-open the sheet (after a cancel from the confirm Alert) by snapping the
+  // forwarded ref back to the only snap point. Safe when `ref` is a callback
+  // ref or null — the optional chain handles both.
+  const reopenSheet = useCallback(() => {
+    if (typeof ref === 'function') return;
+    ref?.current?.snapToIndex(0);
+  }, [ref]);
+
+  // Intercept the BottomSheet close callback: if the rest timer is still
+  // running and the user dismissed it via a swipe (not the Ready / Skip
+  // buttons, which gate on dismissConfirmedRef), confirm the intent before
+  // actually clearing session state. Cancel snaps the sheet back open.
+  const handleSheetClose = useCallback(() => {
+    if (dismissConfirmedRef.current || remainingRef.current <= 0) {
+      dismissConfirmedRef.current = false;
+      onClose();
+      return;
+    }
+    Alert.alert(
+      'Dismiss rest timer?',
+      'Your rest timer is still running. Dismiss anyway?',
+      [
+        {
+          text: 'Cancel',
+          style: 'cancel',
+          onPress: () => {
+            // Sheet already animated closed — re-snap back so the user
+            // doesn't lose an active rest countdown to an accidental swipe.
+            reopenSheet();
+          },
+        },
+        {
+          text: 'Dismiss',
+          style: 'destructive',
+          onPress: () => {
+            dismissConfirmedRef.current = true;
+            onClose();
+          },
+        },
+      ],
+      { cancelable: true, onDismiss: reopenSheet },
+    );
+  }, [onClose, reopenSheet]);
 
   const restComplete = remaining <= 0;
 
@@ -116,7 +173,7 @@ const RestTimerSheet = forwardRef<BottomSheet, RestTimerSheetProps>(({ onClose }
       index={0}
       snapPoints={snapPoints}
       enablePanDownToClose
-      onClose={onClose}
+      onClose={handleSheetClose}
       backgroundStyle={{ backgroundColor: colors.background }}
       handleIndicatorStyle={{ backgroundColor: colors.textSecondary }}
     >

--- a/components/workout/SetRow.tsx
+++ b/components/workout/SetRow.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { View, Text, TextInput, TouchableOpacity } from 'react-native';
+import { StyleSheet, View, Text, TextInput, TouchableOpacity } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { sessionStyles as styles, colors } from '@/styles/workout-session.styles';
 import type { WorkoutSessionSet, SetType } from '@/lib/types/workout-session';
@@ -20,6 +20,15 @@ interface SetRowProps {
   onCompleteSet: (setId: string) => void;
   onMenuPress: (setId: string) => void;
   onNotesPress?: (setId: string) => void;
+  /**
+   * If the form-tracking rep detector observed a rep count for this set,
+   * pass it here. When the user's manual `actual_reps` edit diverges by
+   * more than one rep from the detector, we render a subtle warning
+   * ("Detector counted N reps") under the Reps field. Optional — callers
+   * that don't have a detector reading should leave this undefined and
+   * the feature degrades gracefully.
+   */
+  detectedReps?: number;
 }
 
 const SET_TYPE_COLORS: Record<SetType, string> = {
@@ -31,9 +40,32 @@ const SET_TYPE_COLORS: Record<SetType, string> = {
   timed: colors.restActive,
 };
 
-function SetRow({ set, index, isTimed, onUpdateSet, onCompleteSet, onMenuPress, onNotesPress }: SetRowProps) {
+function SetRow({
+  set,
+  index,
+  isTimed,
+  onUpdateSet,
+  onCompleteSet,
+  onMenuPress,
+  onNotesPress,
+  detectedReps,
+}: SetRowProps) {
   const isCompleted = !!set.completed_at;
   const circleColor = SET_TYPE_COLORS[set.set_type] || colors.accent;
+
+  // Show a divergence hint when the user has manually edited `actual_reps`
+  // to a value that differs from the detector's observation by more than
+  // one rep. The one-rep deadband swallows the off-by-one noise typical of
+  // rep detectors and only surfaces meaningful mismatches.
+  const detectorDivergence =
+    !isTimed &&
+    typeof detectedReps === 'number' &&
+    Number.isFinite(detectedReps) &&
+    typeof set.actual_reps === 'number' &&
+    Number.isFinite(set.actual_reps) &&
+    Math.abs(set.actual_reps - detectedReps) > 1
+      ? detectedReps
+      : null;
 
   const handleWeightChange = useCallback(
     (text: string) => {
@@ -114,6 +146,16 @@ function SetRow({ set, index, isTimed, onUpdateSet, onCompleteSet, onMenuPress, 
           editable={!isCompleted}
           selectTextOnFocus
         />
+        {detectorDivergence != null ? (
+          <Text
+            style={detectorDivergenceStyle}
+            numberOfLines={1}
+            accessibilityLabel={`Detector counted ${detectorDivergence} reps`}
+            testID="set-row-detector-divergence"
+          >
+            Detector: {detectorDivergence}
+          </Text>
+        ) : null}
       </View>
 
       {/* Notes column */}
@@ -157,5 +199,14 @@ function SetRow({ set, index, isTimed, onUpdateSet, onCompleteSet, onMenuPress, 
     </View>
   );
 }
+
+const detectorDivergenceStyle = StyleSheet.create({
+  hint: {
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 10,
+    color: colors.warmup,
+    marginTop: 2,
+  },
+}).hint;
 
 export default React.memo(SetRow);

--- a/hooks/use-pre-calibration-status.ts
+++ b/hooks/use-pre-calibration-status.ts
@@ -29,6 +29,14 @@ export interface PreCalibrationStatus {
   framesObserved: number;
   /** Whether the modal should mount at all (false after suppression cap). */
   shouldShow: boolean;
+  /**
+   * When true, the next session start bypasses the suppression check and
+   * forces the pre-calibration modal to surface again even if the user
+   * hit the success cap. Flipped by `setForceRecalibration(true)` from
+   * the pre-set UI; consumed + reset by `reset()` so the force applies
+   * only to the next session boundary.
+   */
+  forceRecalibration: boolean;
 }
 
 export interface UsePreCalibrationStatusReturn {
@@ -41,6 +49,8 @@ export interface UsePreCalibrationStatusReturn {
   markFailed: () => void;
   /** Reset all collected state — used when a fresh workout begins. */
   reset: () => void;
+  /** Toggle the one-shot force-recalibration flag from the pre-set UI. */
+  setForceRecalibration: (value: boolean) => void;
 }
 
 const clamp01 = (n: number): number => {
@@ -56,6 +66,7 @@ export function usePreCalibrationStatus(): UsePreCalibrationStatusReturn {
     confidence: 0,
     framesObserved: 0,
     shouldShow: true,
+    forceRecalibration: false,
   });
   const sumRef = useRef(0);
   const countRef = useRef(0);
@@ -92,7 +103,24 @@ export function usePreCalibrationStatus(): UsePreCalibrationStatusReturn {
       confidence: 0,
       framesObserved: 0,
       shouldShow: prev.shouldShow,
+      // Consume the one-shot force flag on reset so it only applies to
+      // the session boundary immediately following the user toggle.
+      forceRecalibration: false,
     }));
+  }, []);
+
+  const setForceRecalibration = useCallback((value: boolean) => {
+    setStatus((prev) => {
+      if (prev.forceRecalibration === value) return prev;
+      return {
+        ...prev,
+        // When the user explicitly asks to recalibrate, ensure shouldShow
+        // is true for the upcoming session boundary regardless of the
+        // stored suppression count. reset() later drops the force flag.
+        shouldShow: value ? true : prev.shouldShow,
+        forceRecalibration: value,
+      };
+    });
   }, []);
 
   const markFailed = useCallback(() => {
@@ -154,6 +182,7 @@ export function usePreCalibrationStatus(): UsePreCalibrationStatusReturn {
     markSuccess,
     markFailed,
     reset,
+    setForceRecalibration,
   };
 }
 

--- a/lib/stores/session-runner.ts
+++ b/lib/stores/session-runner.ts
@@ -1064,6 +1064,11 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
 
       // Check if there's an active rest timer
       let restTimer: SessionRunnerState['restTimer'] = null;
+      // Track the most recently completed set so we can detect the orphan
+      // case: foregrounded after a rest was skipped but before the DB row
+      // was flushed, which previously risked re-presenting the rest sheet
+      // or double-advancing the runner through a stale completion haptic.
+      let lastCompletedSet: WorkoutSessionSet | null = null;
       for (const [, exSets] of Object.entries(sets)) {
         for (const s of exSets) {
           if (s.rest_started_at && !s.rest_completed_at && !s.rest_skipped && s.rest_target_seconds) {
@@ -1077,7 +1082,30 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
               scheduleRestTimerCompletionHaptic(s.rest_started_at, s.rest_target_seconds);
             }
           }
+          if (s.completed_at) {
+            if (
+              !lastCompletedSet ||
+              (s.completed_at ?? '') > (lastCompletedSet.completed_at ?? '')
+            ) {
+              lastCompletedSet = s;
+            }
+          }
         }
+      }
+
+      // Orphaned rest-skip guard: the last completed set was marked skipped,
+      // but no fresh rest timer was hydrated. Defensively clear any stale
+      // timeouts + completion haptics that might have been scheduled before
+      // the skip was flushed, so we don't re-open the sheet or fire phantom
+      // end-of-rest pulses after a resume.
+      if (restTimer === null && lastCompletedSet?.rest_skipped) {
+        clearRestTimerCompletionTimeout();
+        clearRestTimerHapticTimeout();
+        // Fire-and-forget: cancel any pending system notifications too.
+        void cancelRestNotification();
+        logWithTs(
+          `[SessionRunner] Resume: orphaned rest-skip on set ${lastCompletedSet.id} — cleared stale timers`,
+        );
       }
 
       set({


### PR DESCRIPTION
## Wave-35 A — Form-tracking UX polish

Closes #591.

### Atomic commits
- feat(form-tracking): warn on mid-set confidence degradation
- feat(rest-timer): confirm swipe-to-dismiss with time remaining
- feat(form-tracking): honor countAudio + haptics toggles from settings
- feat(workout-set): warn on manual rep-override vs detector divergence
- fix(session-runner): handle orphaned rest-skip on resume
- feat(form-tracking): force-recalibrate toggle in pre-set
- fix(form-tracking): truncate occlusion hint joint list

### Skipped (deferred)
- **P2 #5 — per-set FQI trend during session**: session-runner has no per-set FQI field (confirmed by the `averageFqi: null` comment in `app/(modals)/workout-session.tsx` line 260: "FQI aggregation happens on the insights screen; leave null here until a session-level FQI stream is wired in"). Implementing a trend card would require a schema change + session-runner refactor, which collides with ~10+ open wave 28–34 PRs touching the same store. Deferred to a dedicated wiring pass after the open waves land.

### Verification
- [x] bun run lint
- [x] bun run check:types
- [x] bun run test (tests/unit/stores/session-runner.test.ts — 80 pass)
- [x] bun run test (tests/unit/stores/session-runner.pause.test.ts — 6 pass)
- [x] bun run test (tests/unit/hooks/use-pre-calibration-status.test.tsx — 7 pass)
- [x] bun run test (tests/unit/hooks/use-form-tracking-settings.test.tsx — 6 pass)
- [x] bun run test (full suite — 5008 pass / 25 skipped / 0 failed)

Wave-35 pack A.