### PR TITLE
feat(wave36): form-UX journey polish pack — rep a11y, debrief resilience, calibration fallback, AutoDebrief UX, progression-plan copy, settings nav, session-compare first-time, CueCard empty guard

### DIFF
--- a/app/(modals)/calibration-failure-recovery.tsx
+++ b/app/(modals)/calibration-failure-recovery.tsx
@@ -96,6 +96,14 @@ export default function CalibrationFailureRecoveryModal(): React.ReactElement {
     } as never);
   }, [router, suggestedExercise]);
 
+  // Fallback when the analyzer did not surface a specific suggestion: send
+  // the user to the workouts tab so they can pick any exercise manually.
+  // No dedicated exercise-picker route exists yet in the app; the workouts
+  // tab is the closest canonical entry point for browsing exercises.
+  const handleChooseDifferent = useCallback(() => {
+    router.replace('/(tabs)/workouts' as never);
+  }, [router]);
+
   const handleClose = useCallback(() => {
     router.back();
   }, [router]);
@@ -185,7 +193,7 @@ export default function CalibrationFailureRecoveryModal(): React.ReactElement {
           <Text style={styles.ctaSecondaryText}>Open camera guide</Text>
         </TouchableOpacity>
 
-        {suggestedExercise && (
+        {suggestedExercise ? (
           <TouchableOpacity
             style={[styles.ctaButton, styles.ctaTertiary]}
             onPress={handleTryOther}
@@ -196,6 +204,17 @@ export default function CalibrationFailureRecoveryModal(): React.ReactElement {
             <Text style={styles.ctaTertiaryText}>
               Try {formatExerciseLabel(suggestedExercise)} instead
             </Text>
+          </TouchableOpacity>
+        ) : (
+          <TouchableOpacity
+            style={[styles.ctaButton, styles.ctaTertiary]}
+            onPress={handleChooseDifferent}
+            accessibilityRole="button"
+            accessibilityLabel="Choose a different exercise"
+            testID="calibration-failure-choose-different"
+          >
+            <Ionicons name="swap-horizontal-outline" size={18} color="#8693A8" />
+            <Text style={styles.ctaTertiaryText}>Choose a different exercise</Text>
           </TouchableOpacity>
         )}
 

--- a/app/(modals)/form-tracking-debrief.tsx
+++ b/app/(modals)/form-tracking-debrief.tsx
@@ -313,9 +313,9 @@ export default function FormTrackingDebriefScreen() {
           ) : (
             <View style={styles.emptyState} testID="form-tracking-debrief-empty">
               <Ionicons name="information-circle-outline" size={28} color="#9AACD1" />
-              <Text style={styles.emptyTitle}>No reps recorded yet</Text>
+              <Text style={styles.emptyTitle}>This session had no counted reps</Text>
               <Text style={styles.emptyBody}>
-                Start a live tracking set to see your breakdown.
+                Check framing or lighting and try again.
               </Text>
             </View>
           )}

--- a/app/(modals)/form-tracking-debrief.tsx
+++ b/app/(modals)/form-tracking-debrief.tsx
@@ -32,6 +32,8 @@ import { useAutoDebrief } from '@/hooks/use-auto-debrief';
 import { useSessionComparisonQuery } from '@/hooks/use-session-comparison';
 import { supabase } from '@/lib/supabase';
 import { isCoachPipelineV2Enabled } from '@/lib/services/coach-pipeline-v2-flag';
+import { createError, logError } from '@/lib/services/ErrorHandler';
+import { useToast } from '@/contexts/ToastContext';
 
 function safeParseReps(raw: string | undefined): RepSummary[] {
   if (!raw) return [];
@@ -92,6 +94,7 @@ function pickBestAndWorst(reps: RepSummary[]): {
 
 export default function FormTrackingDebriefScreen() {
   const router = useRouter();
+  const { show: showToast } = useToast();
   const [userId, setUserId] = useState<string | null>(null);
   useEffect(() => {
     // Resolve the current user lazily via supabase.auth.getSession() rather
@@ -158,8 +161,25 @@ export default function FormTrackingDebriefScreen() {
       exerciseId: comparisonExerciseId,
       priorSessionId: comparison.priorSessionId,
     }).toString();
-    router.push(`/(modals)/form-comparison?${qs}` as `/${string}`);
-  }, [router, comparison?.priorSessionId, comparisonExerciseId, routeSessionId]);
+    try {
+      router.push(`/(modals)/form-comparison?${qs}` as `/${string}`);
+    } catch (err) {
+      // Router.push is synchronous today but future expo-router versions may
+      // surface native-side nav errors (deep-link conflict, unregistered
+      // route, etc.). Log + show a toast so the user gets feedback; the
+      // compare card itself stays tappable so retry is one-more-tap away.
+      logError(
+        createError(
+          'form-tracking',
+          'DEBRIEF_COMPARE_NAV_FAILED',
+          'Could not open session comparison',
+          { details: err, retryable: true },
+        ),
+        { feature: 'form-tracking', location: 'form-tracking-debrief' },
+      );
+      showToast("Couldn't open comparison — tap to retry", { type: 'error' });
+    }
+  }, [router, showToast, comparison?.priorSessionId, comparisonExerciseId, routeSessionId]);
 
   // Pipeline v2: synthesize a stable sessionId from the recap payload so the
   // auto-debrief hook can dedupe via AsyncStorage. We derive from exercise

--- a/app/(modals)/form-tracking-debrief.tsx
+++ b/app/(modals)/form-tracking-debrief.tsx
@@ -202,6 +202,20 @@ export default function FormTrackingDebriefScreen() {
     sessionId: pipelineV2 ? sessionId : null,
   });
 
+  // Local dismiss latch for the auto-debrief error card. The hook does not
+  // expose a `clearError` method; when the user dismisses we simply hide the
+  // error locally until the next retry (which clears dismissed via effect).
+  const [autoDebriefErrorDismissed, setAutoDebriefErrorDismissed] = useState(false);
+  useEffect(() => {
+    if (autoDebrief.loading || autoDebrief.data) {
+      setAutoDebriefErrorDismissed(false);
+    }
+  }, [autoDebrief.loading, autoDebrief.data]);
+  const handleDismissAutoDebriefError = useCallback(() => {
+    setAutoDebriefErrorDismissed(true);
+  }, []);
+  const visibleAutoDebriefError = autoDebriefErrorDismissed ? null : autoDebrief.error;
+
   const handleClose = useCallback(() => {
     router.back();
   }, [router]);
@@ -312,9 +326,10 @@ export default function FormTrackingDebriefScreen() {
             <Text style={styles.sectionTitle}>Coach debrief</Text>
             <AutoDebriefCard
               loading={autoDebrief.loading}
-              error={autoDebrief.error}
+              error={visibleAutoDebriefError}
               data={autoDebrief.data}
               onRetry={autoDebrief.retry}
+              onDismissError={handleDismissAutoDebriefError}
               // Reps in the URL params indicate the user just finished a
               // session (recap route), so we want the friendly "preparing
               // your feedback…" copy in the empty grace window — NOT the

--- a/app/(modals)/form-tracking-debrief.tsx
+++ b/app/(modals)/form-tracking-debrief.tsx
@@ -35,6 +35,20 @@ import { isCoachPipelineV2Enabled } from '@/lib/services/coach-pipeline-v2-flag'
 import { createError, logError } from '@/lib/services/ErrorHandler';
 import { useToast } from '@/contexts/ToastContext';
 
+/**
+ * Thin wrapper around `useToast` that degrades gracefully to a no-op when
+ * the component is rendered outside a ToastProvider (e.g. older unit tests
+ * that didn't wrap the tree). Ensures navigation-error toasts don't crash
+ * existing test renderings that don't mount the app's provider stack.
+ */
+function useOptionalToast(): { show: (msg: string, opts?: { type?: 'info' | 'success' | 'error' }) => void } {
+  try {
+    return useToast();
+  } catch {
+    return { show: () => undefined };
+  }
+}
+
 function safeParseReps(raw: string | undefined): RepSummary[] {
   if (!raw) return [];
   try {
@@ -94,7 +108,7 @@ function pickBestAndWorst(reps: RepSummary[]): {
 
 export default function FormTrackingDebriefScreen() {
   const router = useRouter();
-  const { show: showToast } = useToast();
+  const { show: showToast } = useOptionalToast();
   const [userId, setUserId] = useState<string | null>(null);
   useEffect(() => {
     // Resolve the current user lazily via supabase.auth.getSession() rather
@@ -307,7 +321,7 @@ export default function FormTrackingDebriefScreen() {
           )}
         </View>
 
-        {comparisonLoading || comparisonError || comparison?.priorSessionId ? (
+        {comparisonLoading || comparisonError || comparison ? (
           <View style={styles.sectionGap} testID="form-tracking-debrief-compare-section">
             <Text style={styles.sectionTitle}>Progress</Text>
             <SessionCompareToLastCard
@@ -316,6 +330,7 @@ export default function FormTrackingDebriefScreen() {
               error={comparisonError}
               onRetry={reloadComparison}
               onPress={comparison?.priorSessionId ? handleOpenComparison : undefined}
+              exerciseName={exerciseName}
               testID="form-tracking-debrief-compare-card"
             />
           </View>

--- a/app/(modals)/form-tracking-settings.tsx
+++ b/app/(modals)/form-tracking-settings.tsx
@@ -9,6 +9,7 @@ import {
   View,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
 
 import { useSafeBack } from '@/hooks/use-safe-back';
 import {
@@ -156,12 +157,20 @@ const ToggleRow = ({ testID, icon, title, subtitle, value, onChange, disabled }:
 
 export default function FormTrackingSettingsModal() {
   const safeBack = useSafeBack(['/(tabs)/profile', '/profile'], { alwaysReplace: true });
+  const router = useRouter();
   const {
     settings,
     loading,
     update,
     reset,
   }: UseFormTrackingSettingsResult = useFormTrackingSettings();
+
+  const openOverridesOnScan = React.useCallback(() => {
+    router.push({
+      pathname: '/(tabs)/scan-arkit',
+      params: { openOverrides: '1' },
+    } as never);
+  }, [router]);
 
   React.useEffect(() => {
     const handler = () => {
@@ -291,6 +300,15 @@ export default function FormTrackingSettingsModal() {
               <Text style={styles.settingSubtitle}>
                 Customize per-exercise from the scan screen long-press menu.
               </Text>
+              <TouchableOpacity
+                testID="ft-settings-open-overrides"
+                style={styles.overrideNavButton}
+                onPress={openOverridesOnScan}
+                accessibilityRole="button"
+                accessibilityLabel="Open scan to edit overrides"
+              >
+                <Text style={styles.overrideNavLabel}>Open scan to edit overrides</Text>
+              </TouchableOpacity>
             </View>
           </View>
         </View>
@@ -429,4 +447,18 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(255, 68, 68, 0.08)',
   },
   resetLabel: { color: '#FF6B6B', fontSize: 14, fontWeight: '600' },
+  // Secondary button for navigating into the scan screen with overrides
+  // pre-opened. Mirrors the resetButton geometry but in the accent/link
+  // colour family so it reads as affordance rather than destructive.
+  overrideNavButton: {
+    alignSelf: 'flex-start',
+    marginTop: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: 'rgba(76, 140, 255, 0.35)',
+    backgroundColor: 'rgba(76, 140, 255, 0.08)',
+  },
+  overrideNavLabel: { color: '#4C8CFF', fontSize: 13, fontWeight: '600' },
 });

--- a/app/(modals)/progression-plan.tsx
+++ b/app/(modals)/progression-plan.tsx
@@ -184,9 +184,17 @@ export default function ProgressionPlanModal() {
         >
           <Ionicons name="construct" size={40} color={TEXT_SECONDARY} />
           <Text style={styles.loadingText}>
-            Progression planner is turned off. Enable it with
-            EXPO_PUBLIC_PROGRESSION_PLAN=on to preview.
+            Progression planner is coming soon. We&apos;ll let you know when it&apos;s ready.
           </Text>
+          <TouchableOpacity
+            style={styles.primaryButton}
+            onPress={() => router.back()}
+            accessibilityLabel="Close"
+            accessibilityRole="button"
+            testID="progression-plan-disabled-close"
+          >
+            <Text style={styles.primaryButtonText}>Close</Text>
+          </TouchableOpacity>
         </View>
       ) : loading ? (
         <View

--- a/app/(tabs)/scan-arkit.tsx
+++ b/app/(tabs)/scan-arkit.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { createCueRotator } from '@/lib/services/cue-rotator';
 import { CUE_ROTATION_VARIANTS } from '@/lib/services/cue-rotator-variants';
 import {
+  AccessibilityInfo,
   ActivityIndicator,
   Alert,
   Modal,
@@ -865,6 +866,11 @@ export default function ScanARKitScreen() {
   // do not re-announce on mode swaps / transient phase re-entries. Reset
   // to false inside startTracking + stopTracking.
   const repCountdownFiredRef = React.useRef(false);
+  // Throttles VoiceOver/TalkBack rep-completion announcements so burst
+  // sets (e.g. 10 reps in 5s) don't flood the screen-reader queue. At
+  // most one announcement every 400ms; the SVG rep counter itself is
+  // not announceable so this is the primary a11y affordance for reps.
+  const lastRepAnnounceAtMsRef = React.useRef(0);
 
   const { speak: speakCue, stop: stopSpeech } = usePremiumCueAudio({
     enabled: audioFeedbackEnabled && isScreenFocused,
@@ -1059,6 +1065,22 @@ export default function ScanARKitScreen() {
         void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy).catch(() => {
           /* native bridge unavailable — silent */
         });
+      }
+      // VoiceOver/TalkBack announcement. The rep-counter overlay is an
+      // SVG <Text>, which RN does not expose to screen readers, so we
+      // rely on announceForAccessibility. Throttled to 400ms to avoid
+      // queue pile-up during fast sets (RN queues announcements rather
+      // than coalescing them). No-op on web.
+      if (Platform.OS !== 'web') {
+        const nowMs = Date.now();
+        if (nowMs - lastRepAnnounceAtMsRef.current >= 400) {
+          lastRepAnnounceAtMsRef.current = nowMs;
+          try {
+            AccessibilityInfo.announceForAccessibility(`Rep ${repNumber}`);
+          } catch {
+            /* a11y bridge unavailable — silent */
+          }
+        }
       }
     },
     onPullupScoring: (

--- a/components/form-tracking/AutoDebriefCard.tsx
+++ b/components/form-tracking/AutoDebriefCard.tsx
@@ -15,7 +15,20 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { Animated, Easing, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import type { AutoDebriefResult, CoachProvider } from '@/lib/services/coach-auto-debrief';
+
+/**
+ * Upper bound on raw error strings that reach the user-visible card. Error
+ * copy from the coach pipeline can be verbose (stack traces, provider
+ * payloads); we truncate to keep the card compact and avoid layout blowups.
+ */
+export const AUTO_DEBRIEF_ERROR_MAX_CHARS = 120;
+
+function truncateError(raw: string, max: number = AUTO_DEBRIEF_ERROR_MAX_CHARS): string {
+  if (raw.length <= max) return raw;
+  return `${raw.slice(0, Math.max(0, max - 1))}…`;
+}
 
 /**
  * Grace window for the "Coach is preparing your feedback…" empty copy.
@@ -35,6 +48,12 @@ export interface AutoDebriefCardProps {
   error: string | null;
   data: AutoDebriefResult | null;
   onRetry?: () => void;
+  /**
+   * Optional dismiss handler for the error state. When provided, the error
+   * card renders an X button in the top-right that calls this callback.
+   * Absent → no dismiss affordance (hosting screen opts in explicitly).
+   */
+  onDismissError?: () => void;
   /**
    * True when the parent considers the user "fresh off a session" — e.g.
    * the debrief screen was opened right after session end. Signals the card
@@ -72,6 +91,7 @@ export default function AutoDebriefCard({
   error,
   data,
   onRetry,
+  onDismissError,
   awaitingResult = false,
   testIDPrefix = 'auto-debrief',
 }: AutoDebriefCardProps) {
@@ -109,15 +129,30 @@ export default function AutoDebriefCard({
   }
 
   if (error) {
+    const displayedError = truncateError(error);
     return (
       <View
         testID={`${testIDPrefix}-error`}
         accessibilityRole="alert"
-        accessibilityLabel={`Failed to load debrief: ${error}`}
+        accessibilityLabel={`Failed to load debrief: ${displayedError}`}
         style={[styles.card, styles.errorCard]}
       >
-        <Text style={styles.title}>Session debrief</Text>
-        <Text style={styles.errorMessage}>Couldn’t load your debrief. {error}</Text>
+        <View style={styles.header}>
+          <Text style={styles.title}>Session debrief</Text>
+          {onDismissError ? (
+            <TouchableOpacity
+              testID={`${testIDPrefix}-dismiss-error`}
+              accessibilityRole="button"
+              accessibilityLabel="Dismiss debrief error"
+              onPress={onDismissError}
+              style={styles.dismissButton}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
+              <Ionicons name="close" size={16} color="#FCA5A5" />
+            </TouchableOpacity>
+          ) : null}
+        </View>
+        <Text style={styles.errorMessage}>Couldn’t load your debrief. {displayedError}</Text>
         {onRetry ? (
           <TouchableOpacity
             testID={`${testIDPrefix}-retry`}
@@ -288,5 +323,13 @@ const styles = StyleSheet.create({
     height: 8,
     borderRadius: 4,
     backgroundColor: '#60A5FA',
+  },
+  dismissButton: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(252, 165, 165, 0.12)',
   },
 });

--- a/components/form-tracking/CueCard.tsx
+++ b/components/form-tracking/CueCard.tsx
@@ -17,10 +17,12 @@
  * message into a typed `CueEntry` with priority + fault type.
  */
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { View, Text, StyleSheet, type ViewStyle, type StyleProp } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { MotiView } from 'moti';
+
+import { createError, logError } from '@/lib/services/ErrorHandler';
 
 export type CuePriority = 'critical' | 'warning' | 'advisory';
 
@@ -121,7 +123,29 @@ export default function CueCard({ cue, style, testID }: CueCardProps) {
   // Re-mount on message change so the fade-in replays.
   const motiKey = useMemo(() => cue?.message ?? 'empty', [cue?.message]);
 
-  if (!cue || !palette || !icon) {
+  // Defensive guard: the cue-engine contract requires `message` to be
+  // non-empty (rules define `message: string` as required, with variant
+  // fallback on empty). A silent/empty cue is worse UX than no cue, so we
+  // bail out and log it so regressions surface in telemetry.
+  const isEmptyMessage = !!cue && cue.message.trim() === '';
+  useEffect(() => {
+    if (isEmptyMessage && cue) {
+      logError(
+        createError(
+          'form-tracking',
+          'CUE_EMPTY_MESSAGE',
+          'CueCard received a cue with an empty message string',
+          {
+            details: { priority: cue.priority, faultType: cue.faultType },
+            severity: 'warning',
+          },
+        ),
+        { feature: 'form-tracking', location: 'CueCard' },
+      );
+    }
+  }, [isEmptyMessage, cue]);
+
+  if (!cue || !palette || !icon || isEmptyMessage) {
     return null;
   }
 

--- a/components/form-tracking/SessionCompareToLastCard.tsx
+++ b/components/form-tracking/SessionCompareToLastCard.tsx
@@ -55,6 +55,11 @@ export interface SessionCompareToLastCardProps {
    * "Retry" button.
    */
   onRetry?: () => void;
+  /**
+   * Optional display name for the exercise, surfaced in the "first session"
+   * placeholder copy. When absent we fall back to a generic string.
+   */
+  exerciseName?: string;
   testID?: string;
 }
 
@@ -105,6 +110,7 @@ export function SessionCompareToLastCard({
   loading = false,
   error = null,
   onRetry,
+  exerciseName,
   testID = 'session-compare-to-last-card',
 }: SessionCompareToLastCardProps) {
   // Error state wins over loading so a retry is always reachable.
@@ -158,7 +164,35 @@ export function SessionCompareToLastCard({
     );
   }
 
-  if (!comparison || !comparison.priorSessionId) return null;
+  // No comparison payload at all → genuine "no data" (exercise unsupported,
+  // aggregator skipped, etc.). Stay silent to avoid adding empty real estate.
+  if (!comparison) return null;
+
+  // Comparison exists but there is no prior session to diff against → this
+  // is the user's first logged session for this exercise. Render a
+  // low-emphasis placeholder so the debrief doesn't leave a blank gap where
+  // the progress section lives.
+  if (!comparison.priorSessionId) {
+    const titleExercise = exerciseName?.trim() ? exerciseName : 'this exercise';
+    return (
+      <View
+        style={[styles.card, styles.placeholderCard]}
+        testID={`${testID}-first-session`}
+        accessibilityRole="summary"
+        accessibilityLabel={`First session for ${titleExercise}. No comparison yet — we'll chart progress once you log another.`}
+      >
+        <View style={styles.header}>
+          <Ionicons name="sparkles-outline" size={16} color="#6F80A0" />
+          <Text style={styles.placeholderTitle}>
+            First session for {titleExercise}
+          </Text>
+        </View>
+        <Text style={styles.placeholderBody}>
+          No comparison yet — we&apos;ll chart progress once you log another.
+        </Text>
+      </View>
+    );
+  }
 
   const deltas: DeltaSpec[] = [
     {
@@ -348,6 +382,23 @@ const styles = StyleSheet.create({
     fontFamily: 'Lexend_500Medium',
     fontSize: 13,
     fontWeight: '600',
+  },
+  placeholderCard: {
+    backgroundColor: 'rgba(255, 255, 255, 0.03)',
+    gap: 6,
+  },
+  placeholderTitle: {
+    color: '#C9D7F4',
+    fontFamily: 'Lexend_500Medium',
+    fontSize: 13,
+    fontWeight: '600',
+    flex: 1,
+  },
+  placeholderBody: {
+    color: '#6F80A0',
+    fontFamily: 'Lexend_400Regular',
+    fontSize: 12,
+    lineHeight: 18,
   },
 });
 

--- a/tests/unit/components/form-tracking/SessionCompareToLastCard.test.tsx
+++ b/tests/unit/components/form-tracking/SessionCompareToLastCard.test.tsx
@@ -41,17 +41,29 @@ function buildComparison(overrides: Partial<SessionComparison> = {}): SessionCom
 }
 
 describe('SessionCompareToLastCard', () => {
-  it('renders null when there is no prior session', () => {
-    const { queryByTestId } = render(
+  it('renders the first-session placeholder when there is no prior session', () => {
+    const { queryByTestId, getByTestId } = render(
       <SessionCompareToLastCard
         comparison={buildComparison({
           priorSessionId: null,
           priorSummary: null,
           overallTrend: 'baseline',
         })}
+        exerciseName="Squat"
       />,
     );
+    // The full compare card should not render — only the low-emphasis
+    // placeholder card keyed by `-first-session`.
     expect(queryByTestId('session-compare-to-last-card')).toBeNull();
+    expect(
+      getByTestId('session-compare-to-last-card-first-session'),
+    ).toBeTruthy();
+  });
+
+  it('renders null when comparison payload is entirely missing', () => {
+    const { queryByTestId } = render(<SessionCompareToLastCard />);
+    expect(queryByTestId('session-compare-to-last-card')).toBeNull();
+    expect(queryByTestId('session-compare-to-last-card-first-session')).toBeNull();
   });
 
   it('renders all three delta cells with signed values', () => {
@@ -206,8 +218,8 @@ describe('SessionCompareToLastCard', () => {
     });
   });
 
-  it('settles to null when not loading, no error, no prior session', () => {
-    const { queryByTestId } = render(
+  it('settles to the first-session placeholder when not loading, no error, no prior session', () => {
+    const { queryByTestId, getByTestId } = render(
       <SessionCompareToLastCard
         comparison={buildComparison({
           priorSessionId: null,
@@ -216,8 +228,11 @@ describe('SessionCompareToLastCard', () => {
         })}
       />,
     );
+    // Neither the full card nor the loading/error variants render; only the
+    // low-emphasis first-session placeholder is visible.
     expect(queryByTestId('session-compare-to-last-card')).toBeNull();
     expect(queryByTestId('session-compare-to-last-card-loading')).toBeNull();
     expect(queryByTestId('session-compare-to-last-card-error')).toBeNull();
+    expect(getByTestId('session-compare-to-last-card-first-session')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
Wave-36 Pack A — 9 atomic commits addressing form-tracking journey gaps.

- Rep counter announces to VoiceOver (scan-arkit)
- Debrief compare-to-last handles nav failures
- Calibration-failure modal has exercise-swap fallback
- AutoDebriefCard error is bounded + dismissible
- Progression-plan disabled copy is user-friendly
- Form-tracking-settings has per-exercise override affordance
- SessionCompareToLastCard shows first-session placeholder
- CueCard guards against empty messages
- Debrief zero-reps copy is clearer

## Verification
- [x] \`bun run lint\` clean
- [x] \`bun run check:types\` clean
- [x] No file overlap with #596 / #597 / #598 / wave-36 Pack B #602 / Pack C #600 / Pack D #599

Closes #601