### PR TITLE
feat(wave36): Gemma dispatch + PII + retry UX — strip email, taskKind propagation, Retry-After parsing, focus/taskKind docs, coach returnKeyType

### DIFF
--- a/app/(tabs)/coach.tsx
+++ b/app/(tabs)/coach.tsx
@@ -75,12 +75,11 @@ export default function CoachScreen() {
         name:
           (userMetadata && typeof userMetadata.full_name === 'string' ? userMetadata.full_name : null) ??
           (userMetadata && typeof userMetadata.name === 'string' ? userMetadata.name : null),
-        email: user?.email ?? null,
       },
       focus: 'fitness_coach',
       sessionId: coachSessionId,
     }),
-    [coachSessionId, user?.email, user?.id, userMetadata]
+    [coachSessionId, user?.id, userMetadata]
   );
 
   const handleCoachSend = async (preset?: string) => {

--- a/app/(tabs)/coach.tsx
+++ b/app/(tabs)/coach.tsx
@@ -447,6 +447,13 @@ export default function CoachScreen() {
             value={coachInput}
             onChangeText={setCoachInput}
             multiline
+            returnKeyType="send"
+            blurOnSubmit={false}
+            onSubmitEditing={() => {
+              if (!coachSending && coachInput.trim()) {
+                handleCoachSend();
+              }
+            }}
           />
 
           {voiceEnabled && !coachSending && (

--- a/app/(tabs)/coach.tsx
+++ b/app/(tabs)/coach.tsx
@@ -48,6 +48,7 @@ export default function CoachScreen() {
   const [coachError, setCoachError] = useState<string | null>(null);
   const [coachErrorDomain, setCoachErrorDomain] = useState<AppError['domain'] | null>(null);
   const [coachErrorCode, setCoachErrorCode] = useState<string | null>(null);
+  const [coachRetryAfterMs, setCoachRetryAfterMs] = useState<number | null>(null);
   const [coachSending, setCoachSending] = useState(false);
   const [showCoachWelcome, setShowCoachWelcome] = useState(false);
   const [sessionLoading, setSessionLoading] = useState(false);
@@ -99,6 +100,7 @@ export default function CoachScreen() {
     setCoachError(null);
     setCoachErrorDomain(null);
     setCoachErrorCode(null);
+    setCoachRetryAfterMs(null);
     setCoachSending(true);
 
     try {
@@ -118,6 +120,15 @@ export default function CoachScreen() {
       setCoachError(hasDomain ? mapToUserMessage(appErr as AppError) : fallback);
       setCoachErrorDomain(hasDomain ? (appErr as AppError).domain : null);
       setCoachErrorCode(hasDomain ? (appErr as AppError).code : null);
+      // Extract retry-after (parsed from the upstream Retry-After header) from
+      // the error details so we can show a concrete countdown rather than a
+      // generic "try again in a moment".
+      const details = hasDomain ? (appErr as AppError).details : undefined;
+      const retryAfterMs =
+        details && typeof details === 'object' && 'retryAfterMs' in details
+          ? Number((details as { retryAfterMs?: unknown }).retryAfterMs)
+          : NaN;
+      setCoachRetryAfterMs(Number.isFinite(retryAfterMs) ? retryAfterMs : null);
     } finally {
       setCoachSending(false);
     }
@@ -245,6 +256,7 @@ export default function CoachScreen() {
     setCoachError(null);
     setCoachErrorDomain(null);
     setCoachErrorCode(null);
+    setCoachRetryAfterMs(null);
   }, []);
 
   const handleVoiceStart = useCallback(async () => {
@@ -356,7 +368,8 @@ export default function CoachScreen() {
         {coachError && (
           <View style={styles.coachError} testID="coach-error-banner">
             <Text style={styles.coachErrorTitle}>
-              {coachErrorCode === 'COACH_RATE_LIMITED'
+              {coachErrorCode === 'COACH_RATE_LIMITED' ||
+              coachErrorCode === 'COACH_GEMMA_RATE_LIMITED'
                 ? 'Coach is rate-limited'
                 : coachErrorDomain === 'network'
                   ? 'Connection error'
@@ -364,7 +377,13 @@ export default function CoachScreen() {
                     ? 'Coach is busy'
                     : 'Service unavailable'}
             </Text>
-            <Text style={styles.coachErrorText}>{coachError}</Text>
+            <Text style={styles.coachErrorText}>
+              {coachRetryAfterMs !== null &&
+              (coachErrorCode === 'COACH_RATE_LIMITED' ||
+                coachErrorCode === 'COACH_GEMMA_RATE_LIMITED')
+                ? `Try again in ${Math.max(1, Math.ceil(coachRetryAfterMs / 1000))}s.`
+                : coachError}
+            </Text>
           </View>
         )}
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -410,7 +410,6 @@ export default function HomeScreen() {
         profile: {
           id: user?.id,
           name: fullName,
-          email: user?.email ?? null,
         },
         focus: 'fitness_coach',
         sessionId: homeCoachSessionId,

--- a/lib/services/coach-gemma-service.ts
+++ b/lib/services/coach-gemma-service.ts
@@ -1,6 +1,6 @@
 import { supabase } from '@/lib/supabase';
 import { createError } from './ErrorHandler';
-import type { CoachContext, CoachMessage } from './coach-service';
+import { parseRetryAfterMs, type CoachContext, type CoachMessage } from './coach-service';
 import type { CoachProvider } from './coach-provider-types';
 
 interface RawCoachGemmaResponse {
@@ -15,6 +15,31 @@ const DEFAULT_FUNCTION_NAME = 'coach-gemma';
 
 function functionName(): string {
   return (process.env.EXPO_PUBLIC_COACH_GEMMA_FUNCTION || DEFAULT_FUNCTION_NAME).trim();
+}
+
+/**
+ * Extract a `Retry-After` delay (ms) from a Supabase Functions failure tuple.
+ * Checks the raw `Response` first (present when the SDK surfaces a
+ * `FunctionsHttpError`) and falls back to `error.context.headers` when the
+ * Response is only reachable through the error wrapper.
+ */
+function readRetryAfterMs(
+  response: Response | undefined,
+  error: unknown,
+): number | undefined {
+  const fromResponse = response?.headers?.get?.('Retry-After');
+  if (fromResponse) {
+    const parsed = parseRetryAfterMs(fromResponse);
+    if (parsed !== undefined) return parsed;
+  }
+  const ctx = (error as { context?: unknown } | null | undefined)?.context;
+  if (ctx && typeof ctx === 'object' && 'headers' in ctx) {
+    const headers = (ctx as { headers?: { get?: (k: string) => string | null } }).headers;
+    const raw = headers?.get?.('Retry-After') ?? null;
+    const parsed = parseRetryAfterMs(raw);
+    if (parsed !== undefined) return parsed;
+  }
+  return undefined;
 }
 
 /**
@@ -35,7 +60,7 @@ export async function sendCoachGemmaPrompt(
     const body: Record<string, unknown> = { messages, context };
     if (opts?.model) body.model = opts.model;
 
-    const { data, error } = await supabase.functions.invoke<RawCoachGemmaResponse>(
+    const { data, error, response } = await supabase.functions.invoke<RawCoachGemmaResponse>(
       functionName(),
       { body },
     );
@@ -48,9 +73,13 @@ export async function sendCoachGemmaPrompt(
         errorMessage.includes('missing');
       const hasStatus =
         typeof error === 'object' && error !== null && 'status' in error;
-      const isNotFound =
-        (hasStatus && (error as { status: unknown }).status === 404) ||
-        errorMessage.includes('404');
+      const status = hasStatus ? (error as { status: unknown }).status : undefined;
+      const isNotFound = status === 404 || errorMessage.includes('404');
+      const isRateLimited =
+        status === 429 ||
+        /\b429\b/.test(errorMessage) ||
+        /rate.?limit/i.test(errorMessage) ||
+        /too many requests/i.test(errorMessage);
 
       if (isNotFound) {
         throw createError(
@@ -67,6 +96,19 @@ export async function sendCoachGemmaPrompt(
           'COACH_GEMMA_NOT_CONFIGURED',
           'Gemma coach is not configured. Please contact support.',
           { details: error, retryable: false },
+        );
+      }
+
+      if (isRateLimited) {
+        const retryAfterMs = readRetryAfterMs(response, error);
+        throw createError(
+          'network',
+          'COACH_GEMMA_RATE_LIMITED',
+          'Gemma coach is rate-limited — try again in a moment.',
+          {
+            details: retryAfterMs !== undefined ? { error, retryAfterMs } : error,
+            retryable: true,
+          },
         );
       }
 

--- a/lib/services/coach-model-dispatch.ts
+++ b/lib/services/coach-model-dispatch.ts
@@ -43,6 +43,7 @@ export type CoachTaskKind =
   | 'rest_calc'
   | 'encouragement'
   | 'fault_explainer'
+  | 'voice_intent'
   | 'form_vision_check'
   | 'program_design'
   | 'nutrition_balance'
@@ -88,6 +89,9 @@ const TACTICAL_TASKS: ReadonlySet<CoachTaskKind> = new Set<CoachTaskKind>([
   'rest_calc',
   'encouragement',
   'fault_explainer',
+  // voice_intent: short classification tasks for hands-free voice control.
+  // Routes to the cheapest Gemma tier — same cost bucket as form_cue_lookup.
+  'voice_intent',
 ]);
 
 const COMPLEX_TASKS: ReadonlySet<CoachTaskKind> = new Set<CoachTaskKind>([

--- a/lib/services/coach-model-dispatch.ts
+++ b/lib/services/coach-model-dispatch.ts
@@ -111,6 +111,9 @@ function complexCloudForTier(tier: CoachUserTier): CoachModelId {
   return tier === 'premium' ? 'gpt-5.4' : 'gpt-5.4-mini';
 }
 
+// Routing is driven by taskKind. If you're tempted to branch on
+// `CoachContext.focus`, add a new taskKind instead — focus is a cosmetic
+// prompt label and does not reach the dispatcher.
 export function decideCoachModel(
   taskKind: CoachTaskKind,
   signals: CoachSignals,

--- a/lib/services/coach-service.ts
+++ b/lib/services/coach-service.ts
@@ -136,6 +136,55 @@ const DEFAULT_MODEL_ID = 'gpt-5.4-mini';
 const functionName = (process.env.EXPO_PUBLIC_COACH_FUNCTION || 'coach').trim();
 
 /**
+ * Parse a `Retry-After` header value per RFC 7231. The header carries either
+ * an integer number of seconds OR an HTTP-date. Returns the delay in
+ * milliseconds, or undefined if the value can't be parsed.
+ *
+ * Exported for reuse by `coach-gemma-service.ts` — the two services share the
+ * same 429 handling contract.
+ */
+export function parseRetryAfterMs(raw: string | null | undefined): number | undefined {
+  if (!raw) return undefined;
+  const asInt = Number.parseInt(raw, 10);
+  if (Number.isFinite(asInt) && asInt >= 0 && /^\d+$/.test(raw.trim())) {
+    return asInt * 1000;
+  }
+  const asDate = Date.parse(raw);
+  if (Number.isFinite(asDate)) {
+    return Math.max(0, asDate - Date.now());
+  }
+  return undefined;
+}
+
+/**
+ * Extract a `Retry-After` delay (ms) from a Supabase Edge Functions failure
+ * tuple. Handles both shapes the SDK returns on 429:
+ *   - `response.headers.get('Retry-After')` — the raw Response from a
+ *     FunctionsHttpError.
+ *   - `error.context.headers.get('Retry-After')` — the same Response, but
+ *     surfaced via the error wrapper.
+ * Returns undefined when neither path yields a header.
+ */
+function extractRetryAfterMs(
+  response: Response | undefined,
+  error: unknown,
+): number | undefined {
+  const fromResponse = response?.headers?.get?.('Retry-After');
+  if (fromResponse) {
+    const parsed = parseRetryAfterMs(fromResponse);
+    if (parsed !== undefined) return parsed;
+  }
+  const ctx = (error as { context?: unknown } | null | undefined)?.context;
+  if (ctx && typeof ctx === 'object' && 'headers' in ctx) {
+    const headers = (ctx as { headers?: { get?: (k: string) => string | null } }).headers;
+    const raw = headers?.get?.('Retry-After') ?? null;
+    const parsed = parseRetryAfterMs(raw);
+    if (parsed !== undefined) return parsed;
+  }
+  return undefined;
+}
+
+/**
  * Feature-flag gate for prepending cross-session memory to coach prompts.
  * Defaults to ON (value 'true' or unset). Any other value disables the
  * memory clause so the coach behaves as before.
@@ -321,7 +370,7 @@ async function sendCoachPromptInner(
         ? { ...(context ?? {}), memoryClause }
         : context;
 
-    const { data, error } = await supabase.functions.invoke<RawCoachResponse>(functionName, {
+    const { data, error, response } = await supabase.functions.invoke<RawCoachResponse>(functionName, {
       body: { messages: outgoingMessages, context: outgoingContext },
     });
 
@@ -359,11 +408,15 @@ async function sendCoachPromptInner(
       }
 
       if (isRateLimited) {
+        const retryAfterMs = extractRetryAfterMs(response, error);
         throw createError(
           'network',
           'COACH_RATE_LIMITED',
           'Coach is rate-limited — try again in a moment.',
-          { details: error, retryable: true }
+          {
+            details: retryAfterMs !== undefined ? { error, retryAfterMs } : error,
+            retryable: true,
+          }
         );
       }
 
@@ -388,11 +441,18 @@ async function sendCoachPromptInner(
         /too many requests/i.test(data.error);
 
       if (isRateLimitedPayload) {
+        const retryAfterMs = extractRetryAfterMs(response, error);
         throw createError(
           'network',
           'COACH_RATE_LIMITED',
           'Coach is rate-limited — try again in a moment.',
-          { details: data.error, retryable: true }
+          {
+            details:
+              retryAfterMs !== undefined
+                ? { error: data.error, retryAfterMs }
+                : data.error,
+            retryable: true,
+          }
         );
       }
 

--- a/lib/services/coach-service.ts
+++ b/lib/services/coach-service.ts
@@ -56,6 +56,13 @@ export interface CoachContext {
     id?: string;
     name?: string | null;
   };
+  /**
+   * User-context label for prompt composition ONLY (e.g. 'fitness_coach',
+   * 'pre-set-stance-preview'). Does NOT influence cost-aware routing — use
+   * `CoachSendOptions.taskKind` to control which provider/model serves the
+   * request. Callers that rely on `focus` for routing will silently hit the
+   * default dispatch path.
+   */
   focus?: string;
   sessionId?: string;
   /**
@@ -111,6 +118,10 @@ export interface CoachSendOptions {
    * `EXPO_PUBLIC_COACH_DISPATCH=on`, the task kind is fed to
    * `decideCoachModel()` to pick a provider (tactical → Gemma, complex → GPT)
    * before the legacy provider hint runs. Omitted means "general_chat".
+   *
+   * NOTE: `taskKind` is the ONLY routing signal. `CoachContext.focus` is a
+   * cosmetic prompt label and does not affect model selection — always set
+   * `taskKind` for new surfaces that should be cost-aware routed.
    */
   taskKind?: CoachTaskKind;
   /** Pipeline-v2 user tier for cost-aware model routing. Defaults to 'free'. */

--- a/lib/services/coach-service.ts
+++ b/lib/services/coach-service.ts
@@ -45,10 +45,16 @@ export interface CoachMessage {
 }
 
 export interface CoachContext {
+  /**
+   * Identifier and display name only. NEVER include email, phone, or other
+   * PII — prompts flow to third-party LLMs (OpenAI, Google Gemma cloud) and
+   * may be logged at the edge. Keep this field minimal. Downstream edge
+   * functions still accept an optional `email` in their input schema for
+   * backward compatibility, but the client MUST NOT populate it.
+   */
   profile?: {
     id?: string;
     name?: string | null;
-    email?: string | null;
   };
   focus?: string;
   sessionId?: string;

--- a/lib/services/pre-set-preview.ts
+++ b/lib/services/pre-set-preview.ts
@@ -86,6 +86,9 @@ async function callGemma(prompt: string): Promise<string> {
   // Direct call to the canonical Gemma service — routes through the
   // coach-gemma edge function rather than the generic `coach` function so
   // model-specific parameters and provider annotations flow through cleanly.
+  // The dispatcher is intentionally NOT consulted here (this path is already
+  // Gemma-pinned); taskKind would be informational only and the service does
+  // not forward it. Equivalent dispatch behavior lives on `callOpenAI`.
   const messages: CoachMessage[] = [{ role: 'user', content: prompt }];
   const reply = await sendCoachGemmaPrompt(messages, {
     focus: 'pre-set-stance-preview-gemma',
@@ -95,9 +98,19 @@ async function callGemma(prompt: string): Promise<string> {
 
 async function callOpenAI(prompt: string): Promise<string> {
   const messages: CoachMessage[] = [{ role: 'user', content: prompt }];
-  const reply = await sendCoachPrompt(messages, {
-    focus: 'pre-set-stance-preview',
-  });
+  const reply = await sendCoachPrompt(
+    messages,
+    {
+      focus: 'pre-set-stance-preview',
+    },
+    {
+      // Declare the task kind so the dispatcher routes this through the
+      // form-vision bucket. Without taskKind the call falls through to the
+      // general_chat default, which may escalate a short stance check onto
+      // a larger cloud model unnecessarily.
+      taskKind: 'form_vision_check',
+    },
+  );
   return reply.content;
 }
 

--- a/lib/services/voice-gemma-nlu-fallback.ts
+++ b/lib/services/voice-gemma-nlu-fallback.ts
@@ -115,6 +115,10 @@ export async function classifyViaGemma(
   try {
     const reply = await sendPrompt(buildGemmaNluPrompt(normalized), undefined, {
       provider: 'gemma',
+      // Route the classification to the cheapest Gemma tier via the coach
+      // dispatcher. Without `taskKind` the call falls through to the
+      // `general_chat` default, which may escalate to GPT unnecessarily.
+      taskKind: 'voice_intent',
     });
     const intent = parseGemmaNluResponse(reply.content ?? '');
     if (intent === 'none') {

--- a/tests/unit/services/coach-gemma-service.test.ts
+++ b/tests/unit/services/coach-gemma-service.test.ts
@@ -256,13 +256,12 @@ describe('coach-gemma-service', () => {
     });
 
     const promise = sendCoachGemmaPrompt(baseMessages);
-    // The current invoke-error path classifies everything-non-404/-config as
-    // INVOKE_FAILED with retryable=true; assert exactly that shape so future
-    // refinements (e.g. a dedicated COACH_GEMMA_RATE_LIMITED code) can tighten
-    // this test without regressing.
+    // 429 now maps to a dedicated COACH_GEMMA_RATE_LIMITED code so the UI
+    // can render a tailored rate-limit banner (wave-36). retryable stays
+    // true — callers should still back off and retry.
     await expect(promise).rejects.toMatchObject({
       domain: 'network',
-      code: 'COACH_GEMMA_INVOKE_FAILED',
+      code: 'COACH_GEMMA_RATE_LIMITED',
       retryable: true,
     });
   });

--- a/tests/unit/services/progression-planner.test.ts
+++ b/tests/unit/services/progression-planner.test.ts
@@ -131,7 +131,7 @@ describe('progression-planner', () => {
 
     it('forwards coach context for persistence', async () => {
       const context = {
-        profile: { id: 'u1', name: 'Test', email: null },
+        profile: { id: 'u1', name: 'Test' },
         sessionId: 'sess-1',
         focus: 'overload',
       };


### PR DESCRIPTION
## Summary

Wave-36 Pack B — 6 atomic commits (plus 1 test-alignment follow-on).

- Strip `email` from `CoachContext.profile` — prevents PII leak to Gemma/OpenAI
- `voice-intent-classifier` passes `taskKind` → cheap-tier Gemma routing (new `voice_intent` kind wired into TACTICAL_TASKS)
- `pre-set-preview` passes `taskKind: 'form_vision_check'` for consistent dispatch
- Parse `Retry-After` header on 429 (RFC 7231 — integer seconds OR HTTP-date) → `retryAfterMs` on error `details`; banner renders `"Try again in Ns"`
- JSDoc separates `focus` (cosmetic) from `taskKind` (routing); dispatcher has matching callout
- Coach TextInput `returnKeyType="send"` + `blurOnSubmit={false}` + `onSubmitEditing` for hardware keyboards

Closes #602

## Commits

1. `fix(coach): strip user email from coach context to prevent PII leak to LLMs` — removes `email` from `CoachContext.profile` type + both call sites (`app/(tabs)/coach.tsx`, `app/(tabs)/index.tsx`); JSDoc spells out why; updates test fixture in `progression-planner.test.ts`.
2. `feat(voice-intent): pass taskKind so Gemma dispatcher routes classification to cheap tier` — adds `voice_intent` to `CoachTaskKind` union + `TACTICAL_TASKS` set; `voice-gemma-nlu-fallback` now passes it through `sendCoachPrompt` opts.
3. `feat(pre-set-preview): pass taskKind for consistent dispatch routing` — `callOpenAI` gets `taskKind: 'form_vision_check'`; `callGemma` documents why taskKind is omitted (already Gemma-pinned).
4. `feat(coach): parse Retry-After header and expose retryAfterMs on 429` — shared `parseRetryAfterMs` helper on `coach-service`; both coach + coach-gemma services extract from Response or `error.context.headers`; Gemma path gets a dedicated `COACH_GEMMA_RATE_LIMITED` code; banner reads `retryAfterMs` and renders `Try again in Ns`.
5. `docs(coach): clarify focus is cosmetic, taskKind drives routing` — JSDoc on `CoachContext.focus` + `CoachSendOptions.taskKind`; comment on `decideCoachModel`.
6. `feat(coach): wire returnKeyType=send on coach input for hardware keyboards` — `returnKeyType="send"` + `blurOnSubmit={false}` + guarded `onSubmitEditing`.
7. `test(coach-gemma): tighten 429 assertion to COACH_GEMMA_RATE_LIMITED` — aligns the pre-existing test (whose comment explicitly anticipated this refinement) with the new rate-limit code.

## Verification

- [x] `bun run lint` — clean
- [x] `bun run check:types` — clean
- [x] `bun test tests/unit/services/coach` — 632 pass across 47 suites
- [x] `bun test tests/unit/services/voice` — 195 pass across 9 suites
- [x] `bun test tests/unit/pre-set-preview` — 6 pass
- [x] `bun test tests/unit/services/progression-planner` — pass (test fixture updated to drop email)
- [x] Full `bun run test` — 5008 pass, 25 skipped, 2 suites skipped (one flaky integration test in fault-heatmap-drill-cta — unrelated; passes on re-run)
- [x] No overlap with #598 (streaming provider/model, focus attribution, injection hardening, per-surface budgets, mismatch counter — all different concerns)

## Constraints honored

- No `supabase/migrations/`, `ios/`, `android/`, `.env` changes
- No `supabase/functions/coach*/index.ts` edits (edge-function input schemas keep optional `email` for backward compat; client just never populates it)
- No new dependencies
- No `--no-verify`
- No AI attribution in commits