### PR TITLE
feat(progressive-overload): add history queries, structured PR detection, and suggestions

### DIFF
--- a/etc/jest.config.js
+++ b/etc/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('jest').Config} */
 module.exports = {
   preset: 'jest-expo',
+  maxWorkers: '50%',
   testMatch: [
     '<rootDir>/tests/unit/**/*.test.{ts,tsx}',
     '<rootDir>/tests/integration/**/*.test.{ts,tsx}',

--- a/lib/services/database/local-db.ts
+++ b/lib/services/database/local-db.ts
@@ -69,6 +69,27 @@ export interface LocalNutritionGoals {
   updated_at: string;
 }
 
+export interface ExerciseHistoryEntry {
+  id: string;
+  session_id: string;
+  session_exercise_id: string;
+  exercise_id: string;
+  set_type: string;
+  planned_weight: number | null;
+  actual_weight: number | null;
+  actual_reps: number | null;
+  actual_seconds: number | null;
+  completed_at: string;
+  session_started_at: string;
+  session_ended_at: string | null;
+}
+
+export interface ExercisePersonalRecords {
+  maxWeight: number | null;
+  maxReps: number | null;
+  maxDurationSeconds: number | null;
+}
+
 export type SyncTableName = 'foods' | 'workouts' | 'health_metrics' | 'nutrition_goals';
 export type SyncOperation = 'upsert' | 'delete';
 
@@ -877,6 +898,78 @@ class LocalDatabase {
       params.push(Math.floor(limit));
     }
     return dbResult.data.getAllAsync<LocalWorkout>(query, params);
+  }
+
+  async getExerciseHistory(
+    exerciseId: string,
+    limit = 20,
+  ): Promise<ExerciseHistoryEntry[]> {
+    const dbResult = await this.ensureInitialized();
+    if (!dbResult.ok) {
+      throw new Error(dbResult.error.message);
+    }
+
+    const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 20;
+
+    return dbResult.data.getAllAsync<ExerciseHistoryEntry>(
+      `SELECT
+         ws.id,
+         wse.session_id,
+         ws.session_exercise_id,
+         wse.exercise_id,
+         ws.set_type,
+         ws.planned_weight,
+         ws.actual_weight,
+         ws.actual_reps,
+         ws.actual_seconds,
+         ws.completed_at,
+         s.started_at AS session_started_at,
+         s.ended_at AS session_ended_at
+       FROM workout_session_sets ws
+       JOIN workout_session_exercises wse
+         ON wse.id = ws.session_exercise_id
+        AND COALESCE(wse.deleted, 0) = 0
+       JOIN workout_sessions s
+         ON s.id = wse.session_id
+        AND COALESCE(s.deleted, 0) = 0
+       WHERE wse.exercise_id = ?
+         AND COALESCE(ws.deleted, 0) = 0
+         AND ws.completed_at IS NOT NULL
+       ORDER BY COALESCE(s.ended_at, s.started_at) DESC, ws.completed_at DESC, ws.sort_order DESC
+       LIMIT ?`,
+      [exerciseId, safeLimit],
+    );
+  }
+
+  async getPersonalRecords(exerciseId: string): Promise<ExercisePersonalRecords> {
+    const dbResult = await this.ensureInitialized();
+    if (!dbResult.ok) {
+      throw new Error(dbResult.error.message);
+    }
+
+    const rows = await dbResult.data.getAllAsync<ExercisePersonalRecords>(
+      `SELECT
+         MAX(ws.actual_weight) AS maxWeight,
+         MAX(ws.actual_reps) AS maxReps,
+         MAX(ws.actual_seconds) AS maxDurationSeconds
+       FROM workout_session_sets ws
+       JOIN workout_session_exercises wse
+         ON wse.id = ws.session_exercise_id
+        AND COALESCE(wse.deleted, 0) = 0
+       JOIN workout_sessions s
+         ON s.id = wse.session_id
+        AND COALESCE(s.deleted, 0) = 0
+       WHERE wse.exercise_id = ?
+         AND COALESCE(ws.deleted, 0) = 0
+         AND ws.completed_at IS NOT NULL`,
+      [exerciseId],
+    );
+
+    return rows[0] ?? {
+      maxWeight: null,
+      maxReps: null,
+      maxDurationSeconds: null,
+    };
   }
 
   // Health Metric operations

--- a/lib/services/database/local-db.ts
+++ b/lib/services/database/local-db.ts
@@ -87,6 +87,7 @@ export interface ExerciseHistoryEntry {
 export interface ExercisePersonalRecords {
   maxWeight: number | null;
   maxReps: number | null;
+  maxVolume: number | null;
   maxDurationSeconds: number | null;
 }
 
@@ -951,6 +952,10 @@ class LocalDatabase {
       `SELECT
          MAX(ws.actual_weight) AS maxWeight,
          MAX(ws.actual_reps) AS maxReps,
+         MAX(CASE
+           WHEN ws.actual_weight IS NOT NULL AND ws.actual_reps IS NOT NULL
+           THEN ws.actual_weight * ws.actual_reps
+         END) AS maxVolume,
          MAX(ws.actual_seconds) AS maxDurationSeconds
        FROM workout_session_sets ws
        JOIN workout_session_exercises wse
@@ -968,6 +973,7 @@ class LocalDatabase {
     return rows[0] ?? {
       maxWeight: null,
       maxReps: null,
+      maxVolume: null,
       maxDurationSeconds: null,
     };
   }

--- a/lib/services/progressive-overload.ts
+++ b/lib/services/progressive-overload.ts
@@ -18,12 +18,31 @@ export interface DetectPRInput {
 export interface SuggestedWeightInput {
   exercise?: ExerciseLike | null;
   history: ExerciseHistoryEntry[];
+  unit?: string | null;
+}
+
+export type ProgressiveOverloadPrType = 'weight' | 'volume' | 'reps';
+
+export interface DetectPRResult {
+  isPR: boolean;
+  prType: ProgressiveOverloadPrType | null;
+  previousBest: number | null;
+}
+
+export interface SuggestedWeightResult {
+  weight: number;
+  reps: number;
+  unit: string;
+  source: 'previous_session' | 'no_history';
 }
 
 export interface ProgressiveOverloadSuggestion {
   exerciseId: string;
   lastSessionWeight: number | null;
   suggestedWeight: number | null;
+  suggestedReps: number | null;
+  suggestedUnit: string | null;
+  suggestionSource: SuggestedWeightResult['source'] | null;
   helperText: string;
   isTimed: boolean;
   isBodyweightLike: boolean;
@@ -44,6 +63,17 @@ function latestSessionRows(history: ExerciseHistoryEntry[]): ExerciseHistoryEntr
   const latestSessionId = history[0]?.session_id;
   if (!latestSessionId) return [];
   return history.filter((row) => row.session_id === latestSessionId);
+}
+
+function getLastSessionReps(history: ExerciseHistoryEntry[]): number | null {
+  const latestRows = latestSessionRows(history);
+  for (const row of latestRows) {
+    if (isFiniteNumber(row.actual_reps)) {
+      return row.actual_reps;
+    }
+  }
+
+  return null;
 }
 
 export function getLastSessionWeight(history: ExerciseHistoryEntry[]): number | null {
@@ -69,37 +99,99 @@ export function detectPR({
   currentWeight,
   currentReps,
   currentSeconds,
-}: DetectPRInput): boolean {
+}: DetectPRInput): DetectPRResult {
   if (!personalRecords) {
-    return false;
+    return {
+      isPR: false,
+      prType: null,
+      previousBest: null,
+    };
   }
 
   if (exercise?.is_timed) {
-    return isFiniteNumber(currentSeconds)
-      && isFiniteNumber(personalRecords.maxDurationSeconds)
-      && currentSeconds > personalRecords.maxDurationSeconds;
+    const previousBest = isFiniteNumber(personalRecords.maxDurationSeconds)
+      ? personalRecords.maxDurationSeconds
+      : null;
+
+    return {
+      isPR: isFiniteNumber(currentSeconds)
+        && isFiniteNumber(personalRecords.maxDurationSeconds)
+        && currentSeconds > personalRecords.maxDurationSeconds,
+      prType: null,
+      previousBest,
+    };
   }
 
   if (isFiniteNumber(currentWeight)) {
-    return isFiniteNumber(personalRecords.maxWeight)
-      && currentWeight > personalRecords.maxWeight;
+    if (isFiniteNumber(personalRecords.maxWeight) && currentWeight > personalRecords.maxWeight) {
+      return {
+        isPR: true,
+        prType: 'weight',
+        previousBest: personalRecords.maxWeight,
+      };
+    }
+
+    if (
+      isFiniteNumber(currentReps)
+      && isFiniteNumber(personalRecords.maxWeight)
+      && isFiniteNumber(personalRecords.maxReps)
+    ) {
+      const currentVolume = currentWeight * currentReps;
+      const previousBest = personalRecords.maxWeight * personalRecords.maxReps;
+      if (currentVolume > previousBest) {
+        return {
+          isPR: true,
+          prType: 'volume',
+          previousBest,
+        };
+      }
+    }
   }
 
-  return isFiniteNumber(currentReps)
-    && isFiniteNumber(personalRecords.maxReps)
-    && currentReps > personalRecords.maxReps;
+  if (isFiniteNumber(currentReps) && isFiniteNumber(personalRecords.maxReps)) {
+    return {
+      isPR: currentReps > personalRecords.maxReps,
+      prType: currentReps > personalRecords.maxReps ? 'reps' : null,
+      previousBest: personalRecords.maxReps,
+    };
+  }
+
+  return {
+    isPR: false,
+    prType: null,
+    previousBest: null,
+  };
 }
 
 export function getSuggestedWeight({
   exercise,
   history,
-}: SuggestedWeightInput): number | null {
+  unit,
+}: SuggestedWeightInput): SuggestedWeightResult | null {
+  const resolvedUnit = typeof unit === 'string' && unit.trim().length > 0 ? unit : 'lb';
+
   if (exercise?.is_timed) {
     return null;
   }
 
   const lastSessionWeight = getLastSessionWeight(history);
-  return isFiniteNumber(lastSessionWeight) ? lastSessionWeight : null;
+  const lastSessionReps = getLastSessionReps(history);
+
+  if (isFiniteNumber(lastSessionWeight) || isFiniteNumber(lastSessionReps)) {
+    return {
+      weight: isFiniteNumber(lastSessionWeight) ? lastSessionWeight : 0,
+      reps: isFiniteNumber(lastSessionReps) ? lastSessionReps : 0,
+      unit: resolvedUnit,
+      source: 'previous_session',
+    };
+  }
+
+  return {
+    weight: 0,
+    reps: 0,
+    unit: resolvedUnit,
+    source: 'no_history',
+  };
 }
 
 export function buildProgressiveOverloadSuggestion({
@@ -109,12 +201,13 @@ export function buildProgressiveOverloadSuggestion({
   unit,
 }: BuildProgressiveOverloadSuggestionInput): ProgressiveOverloadSuggestion {
   const lastSessionWeight = getLastSessionWeight(history);
-  const suggestedWeight = getSuggestedWeight({ exercise, history });
+  const suggestedWeight = getSuggestedWeight({ exercise, history, unit });
+  const isSuggestedLoad = suggestedWeight?.source === 'previous_session' && suggestedWeight.weight > 0;
   const isTimed = Boolean(exercise?.is_timed);
   const isBodyweightLike = !isTimed && !isFiniteNumber(lastSessionWeight);
   const helperText = buildProgressiveOverloadHelperText({
     lastSessionWeight,
-    suggestedWeight,
+    suggestedWeight: isSuggestedLoad ? suggestedWeight.weight : null,
     unit,
     isTimed,
     isBodyweight: isBodyweightLike,
@@ -125,7 +218,10 @@ export function buildProgressiveOverloadSuggestion({
   return {
     exerciseId: exercise?.id ?? history[0]?.exercise_id ?? '',
     lastSessionWeight,
-    suggestedWeight,
+    suggestedWeight: isSuggestedLoad ? suggestedWeight.weight : null,
+    suggestedReps: suggestedWeight?.reps ?? null,
+    suggestedUnit: suggestedWeight?.unit ?? unit ?? null,
+    suggestionSource: suggestedWeight?.source ?? null,
     helperText,
     isTimed,
     isBodyweightLike,

--- a/lib/services/progressive-overload.ts
+++ b/lib/services/progressive-overload.ts
@@ -133,11 +133,10 @@ export function detectPR({
 
     if (
       isFiniteNumber(currentReps)
-      && isFiniteNumber(personalRecords.maxWeight)
-      && isFiniteNumber(personalRecords.maxReps)
+      && isFiniteNumber(personalRecords.maxVolume)
     ) {
       const currentVolume = currentWeight * currentReps;
-      const previousBest = personalRecords.maxWeight * personalRecords.maxReps;
+      const previousBest = personalRecords.maxVolume;
       if (currentVolume > previousBest) {
         return {
           isPR: true,

--- a/lib/services/progressive-overload.ts
+++ b/lib/services/progressive-overload.ts
@@ -1,0 +1,133 @@
+import type {
+  ExerciseHistoryEntry,
+  ExercisePersonalRecords,
+} from '@/lib/services/database/local-db';
+import type { Exercise } from '@/lib/types/workout-session';
+import { buildProgressiveOverloadHelperText } from '@/lib/services/workout-insights-helpers';
+
+type ExerciseLike = Pick<Exercise, 'id' | 'name' | 'is_timed'>;
+
+export interface DetectPRInput {
+  exercise?: ExerciseLike | null;
+  personalRecords?: ExercisePersonalRecords | null;
+  currentWeight?: number | null;
+  currentReps?: number | null;
+  currentSeconds?: number | null;
+}
+
+export interface SuggestedWeightInput {
+  exercise?: ExerciseLike | null;
+  history: ExerciseHistoryEntry[];
+}
+
+export interface ProgressiveOverloadSuggestion {
+  exerciseId: string;
+  lastSessionWeight: number | null;
+  suggestedWeight: number | null;
+  helperText: string;
+  isTimed: boolean;
+  isBodyweightLike: boolean;
+}
+
+export interface BuildProgressiveOverloadSuggestionInput {
+  exercise?: ExerciseLike | null;
+  history: ExerciseHistoryEntry[];
+  personalRecords?: ExercisePersonalRecords | null;
+  unit?: string | null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function latestSessionRows(history: ExerciseHistoryEntry[]): ExerciseHistoryEntry[] {
+  const latestSessionId = history[0]?.session_id;
+  if (!latestSessionId) return [];
+  return history.filter((row) => row.session_id === latestSessionId);
+}
+
+export function getLastSessionWeight(history: ExerciseHistoryEntry[]): number | null {
+  const latestRows = latestSessionRows(history);
+  for (const row of latestRows) {
+    if (isFiniteNumber(row.actual_weight)) {
+      return row.actual_weight;
+    }
+  }
+
+  for (const row of latestRows) {
+    if (isFiniteNumber(row.planned_weight)) {
+      return row.planned_weight;
+    }
+  }
+
+  return null;
+}
+
+export function detectPR({
+  exercise,
+  personalRecords,
+  currentWeight,
+  currentReps,
+  currentSeconds,
+}: DetectPRInput): boolean {
+  if (!personalRecords) {
+    return false;
+  }
+
+  if (exercise?.is_timed) {
+    return isFiniteNumber(currentSeconds)
+      && isFiniteNumber(personalRecords.maxDurationSeconds)
+      && currentSeconds > personalRecords.maxDurationSeconds;
+  }
+
+  if (isFiniteNumber(currentWeight)) {
+    return isFiniteNumber(personalRecords.maxWeight)
+      && currentWeight > personalRecords.maxWeight;
+  }
+
+  return isFiniteNumber(currentReps)
+    && isFiniteNumber(personalRecords.maxReps)
+    && currentReps > personalRecords.maxReps;
+}
+
+export function getSuggestedWeight({
+  exercise,
+  history,
+}: SuggestedWeightInput): number | null {
+  if (exercise?.is_timed) {
+    return null;
+  }
+
+  const lastSessionWeight = getLastSessionWeight(history);
+  return isFiniteNumber(lastSessionWeight) ? lastSessionWeight : null;
+}
+
+export function buildProgressiveOverloadSuggestion({
+  exercise,
+  history,
+  personalRecords,
+  unit,
+}: BuildProgressiveOverloadSuggestionInput): ProgressiveOverloadSuggestion {
+  const lastSessionWeight = getLastSessionWeight(history);
+  const suggestedWeight = getSuggestedWeight({ exercise, history });
+  const isTimed = Boolean(exercise?.is_timed);
+  const isBodyweightLike = !isTimed && !isFiniteNumber(lastSessionWeight);
+  const helperText = buildProgressiveOverloadHelperText({
+    lastSessionWeight,
+    suggestedWeight,
+    unit,
+    isTimed,
+    isBodyweight: isBodyweightLike,
+    didHitPr: false,
+    hasHistory: history.length > 0 || Boolean(personalRecords),
+  });
+
+  return {
+    exerciseId: exercise?.id ?? history[0]?.exercise_id ?? '',
+    lastSessionWeight,
+    suggestedWeight,
+    helperText,
+    isTimed,
+    isBodyweightLike,
+  };
+}

--- a/lib/services/workout-insights-helpers.ts
+++ b/lib/services/workout-insights-helpers.ts
@@ -45,6 +45,16 @@ export interface CoachAction {
   priority: 'high' | 'medium' | 'low';
 }
 
+export interface ProgressiveOverloadHelperTextInput {
+  lastSessionWeight?: number | null;
+  suggestedWeight?: number | null;
+  unit?: string | null;
+  isTimed?: boolean;
+  isBodyweight?: boolean;
+  didHitPr?: boolean;
+  hasHistory?: boolean;
+}
+
 export type FatigueConfidenceLevel = 'high' | 'medium' | 'low' | 'insufficient';
 
 export interface FatigueConfidence {
@@ -209,6 +219,7 @@ export function scoreFatigueSignals(signals: FatigueSignals): {
 export function buildCoachActions(input: {
   fatigueLevel: FatigueLevel;
   signals: FatigueSignals;
+  overload?: ProgressiveOverloadHelperTextInput;
 }): CoachAction[] {
   const actions: CoachAction[] = [];
 
@@ -258,7 +269,7 @@ export function buildCoachActions(input: {
     actions.push({
       id: 'progressive-overload',
       title: 'Progress with small overload',
-      detail: 'Fatigue signals are stable. Consider +2.5% load or one extra quality rep next set.',
+      detail: buildProgressiveOverloadHelperText(input.overload),
       priority: 'low',
     });
   }
@@ -267,6 +278,55 @@ export function buildCoachActions(input: {
   return [...actions]
     .sort((a, b) => priorityOrder[a.priority] - priorityOrder[b.priority])
     .slice(0, 3);
+}
+
+function formatLoad(weight: number, unit?: string | null): string {
+  const resolvedUnit = typeof unit === 'string' && unit.trim().length > 0 ? unit.trim() : 'lb';
+  return `${Number.isInteger(weight) ? weight : Number(weight.toFixed(2))} ${resolvedUnit}`;
+}
+
+export function buildProgressiveOverloadHelperText(
+  input?: ProgressiveOverloadHelperTextInput,
+): string {
+  if (!input) {
+    return 'Fatigue signals are stable. Consider +2.5% load or one extra quality rep next set.';
+  }
+
+  if (input.didHitPr) {
+    if (input.isTimed) {
+      return 'New time PR logged. Repeat that pacing next session before stretching the clock.';
+    }
+
+    if (input.isBodyweight) {
+      return 'New bodyweight PR logged. Match that rep quality next session, then add one clean rep.';
+    }
+
+    if (typeof input.suggestedWeight === 'number' && Number.isFinite(input.suggestedWeight)) {
+      return `New PR logged. Open around ${formatLoad(input.suggestedWeight, input.unit)} next session and keep the reps crisp.`;
+    }
+  }
+
+  if (input.isTimed) {
+    return input.hasHistory
+      ? 'Last session gives you a time target. Match that duration first, then add seconds only if form stays clean.'
+      : 'Fatigue signals are stable. Hold today’s pace, then add seconds once the movement still looks sharp.';
+  }
+
+  if (input.isBodyweight) {
+    return input.hasHistory
+      ? 'Last session was bodyweight-based. Repeat that rep target first, then chase one cleaner rep.'
+      : 'Fatigue signals are stable. Repeat the same bodyweight standard and add reps only if quality holds.';
+  }
+
+  if (typeof input.lastSessionWeight === 'number' && Number.isFinite(input.lastSessionWeight)) {
+    return `Last session topped out at ${formatLoad(input.lastSessionWeight, input.unit)}. Start there again and add load only if the reps stay clean.`;
+  }
+
+  if (typeof input.suggestedWeight === 'number' && Number.isFinite(input.suggestedWeight)) {
+    return `Use ${formatLoad(input.suggestedWeight, input.unit)} as your next working load and progress only if form stays sharp.`;
+  }
+
+  return 'Fatigue signals are stable. Consider +2.5% load or one extra quality rep next set.';
 }
 
 export function scoreFatigueConfidence(input: {

--- a/lib/stores/session-runner.ts
+++ b/lib/stores/session-runner.ts
@@ -36,6 +36,10 @@ import {
   type PriorSession,
   type MilestoneResult,
 } from '@/lib/services/form-milestone-detector';
+import {
+  buildProgressiveOverloadSuggestion,
+  type ProgressiveOverloadSuggestion,
+} from '@/lib/services/progressive-overload';
 import type {
   WorkoutSession,
   WorkoutSessionExercise,
@@ -61,6 +65,7 @@ export interface SessionRunnerState {
   activeSession: WorkoutSession | null;
   exercises: (WorkoutSessionExercise & { exercise?: Exercise })[];
   sets: Record<string, WorkoutSessionSet[]>; // keyed by session_exercise_id
+  exerciseSuggestionsByExerciseId: Record<string, ProgressiveOverloadSuggestion>;
 
   // Form-target slice (issue #447) — keyed by `exercise_id` (not session-exercise-id)
   // so consumers can resolve targets by the active scan exercise. Populated from
@@ -121,6 +126,8 @@ export interface SessionRunnerState {
   duplicateSet: (setId: string, count?: number) => Promise<void>;
   updateSetType: (setId: string, setType: SetType) => Promise<void>;
   duplicateExercise: (sessionExerciseId: string) => Promise<void>;
+  loadExerciseSuggestion: (exerciseId: string) => Promise<ProgressiveOverloadSuggestion | null>;
+  getExerciseSuggestionFor: (exerciseId: string) => ProgressiveOverloadSuggestion | null;
   /**
    * Resolve the active form targets for a given exerciseId.
    * Prefers template overrides threaded on startSession, falls back to
@@ -422,6 +429,7 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
   activeSession: null,
   exercises: [],
   sets: {},
+  exerciseSuggestionsByExerciseId: {},
   formTargetsByExercise: {},
   restTimer: null,
   restTimerCompletionTimeout: null,
@@ -441,6 +449,35 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
     const override = map[exerciseId];
     if (override) return override;
     return getDefaultsForExercise(exerciseId);
+  },
+  getExerciseSuggestionFor: (exerciseId: string): ProgressiveOverloadSuggestion | null => {
+    return get().exerciseSuggestionsByExerciseId[exerciseId] ?? null;
+  },
+  loadExerciseSuggestion: async (exerciseId) => {
+    if (!exerciseId) return null;
+
+    try {
+      const exercise = await getExerciseById(exerciseId);
+      const history = await localDB.getExerciseHistory(exerciseId, 24);
+      const personalRecords = await localDB.getPersonalRecords(exerciseId);
+      const suggestion = buildProgressiveOverloadSuggestion({
+        exercise,
+        history,
+        personalRecords,
+      });
+
+      set((state) => ({
+        exerciseSuggestionsByExerciseId: {
+          ...state.exerciseSuggestionsByExerciseId,
+          [exerciseId]: suggestion,
+        },
+      }));
+
+      return suggestion;
+    } catch (error) {
+      errorWithTs(`[SessionRunner] Failed to load suggestion for ${exerciseId}:`, error);
+      return null;
+    }
   },
 
   // =========================================================================
@@ -482,11 +519,13 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
       const sessionObj = session as unknown as WorkoutSession;
       const exercises = await loadSessionExercises(sessionId);
       const sets = await loadSessionSets(exercises);
+      const exerciseSuggestionsByExerciseId = await loadExerciseSuggestions(exercises);
 
       set({
         activeSession: sessionObj,
         exercises,
         sets,
+        exerciseSuggestionsByExerciseId,
         formTargetsByExercise,
         restTimer: null,
         restTimerCompletionTimeout: null,
@@ -544,6 +583,7 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
 
     // Auto-add first set
     await get().addSet(id);
+    void get().loadExerciseSuggestion(exerciseId);
 
     return id;
   },
@@ -1010,6 +1050,7 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
       activeSession: null,
       exercises: [],
       sets: {},
+      exerciseSuggestionsByExerciseId: {},
       formTargetsByExercise: {},
       restTimer: null,
       restTimerCompletionTimeout: null,
@@ -1049,6 +1090,7 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
           activeSession: null,
           exercises: [],
           sets: {},
+          exerciseSuggestionsByExerciseId: {},
           formTargetsByExercise: {},
           restTimer: null,
           restTimerCompletionTimeout: null,
@@ -1064,6 +1106,7 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
       const session = rows[0];
       const exercises = await loadSessionExercises(session.id);
       const sets = await loadSessionSets(exercises);
+      const exerciseSuggestionsByExerciseId = await loadExerciseSuggestions(exercises);
       // Rehydrate form-target overrides from the originating template so
       // scan-arkit still sees per-exercise targets after an app resume.
       const formTargetsByExercise = session.template_id
@@ -1120,6 +1163,7 @@ export const useSessionRunner = create<SessionRunnerState>((set, get) => {
         activeSession: session,
         exercises,
         sets,
+        exerciseSuggestionsByExerciseId,
         formTargetsByExercise,
         restTimer,
         isPaused: false,
@@ -1317,6 +1361,37 @@ async function loadSessionSets(
   }
 
   return sets;
+}
+
+async function loadExerciseSuggestions(
+  exercises: (WorkoutSessionExercise & { exercise?: Exercise })[],
+): Promise<Record<string, ProgressiveOverloadSuggestion>> {
+  const suggestions: Record<string, ProgressiveOverloadSuggestion> = {};
+  const seenExerciseIds = new Set<string>();
+
+  for (const sessionExercise of exercises) {
+    const exerciseId = sessionExercise.exercise_id;
+    if (!exerciseId || seenExerciseIds.has(exerciseId)) {
+      continue;
+    }
+
+    seenExerciseIds.add(exerciseId);
+
+    try {
+      const history = await localDB.getExerciseHistory(exerciseId, 24);
+      const personalRecords = await localDB.getPersonalRecords(exerciseId);
+      const suggestion = buildProgressiveOverloadSuggestion({
+        exercise: sessionExercise.exercise,
+        history,
+        personalRecords,
+      });
+      suggestions[exerciseId] = suggestion;
+    } catch (error) {
+      errorWithTs(`[SessionRunner] Failed to hydrate suggestion for ${exerciseId}:`, error);
+    }
+  }
+
+  return suggestions;
 }
 
 async function materializeTemplate(

--- a/tests/unit/services/progressive-overload.test.ts
+++ b/tests/unit/services/progressive-overload.test.ts
@@ -1,0 +1,152 @@
+import type {
+  ExerciseHistoryEntry,
+  ExercisePersonalRecords,
+} from '@/lib/services/database/local-db';
+import {
+  buildProgressiveOverloadSuggestion,
+  detectPR,
+  getLastSessionWeight,
+  getSuggestedWeight,
+} from '@/lib/services/progressive-overload';
+
+function makeHistoryRow(overrides: Partial<ExerciseHistoryEntry> = {}): ExerciseHistoryEntry {
+  return {
+    id: overrides.id ?? 'set-1',
+    session_id: overrides.session_id ?? 'session-2',
+    session_exercise_id: overrides.session_exercise_id ?? 'se-1',
+    exercise_id: overrides.exercise_id ?? 'ex-bench',
+    set_type: overrides.set_type ?? 'normal',
+    planned_weight: overrides.planned_weight === undefined ? 185 : overrides.planned_weight,
+    actual_weight: overrides.actual_weight === undefined ? 185 : overrides.actual_weight,
+    actual_reps: overrides.actual_reps === undefined ? 5 : overrides.actual_reps,
+    actual_seconds: overrides.actual_seconds === undefined ? null : overrides.actual_seconds,
+    completed_at: overrides.completed_at ?? '2026-04-30T10:05:00.000Z',
+    session_started_at: overrides.session_started_at ?? '2026-04-30T10:00:00.000Z',
+    session_ended_at: overrides.session_ended_at ?? '2026-04-30T10:20:00.000Z',
+  };
+}
+
+describe('progressive-overload', () => {
+  describe('getLastSessionWeight', () => {
+    it('returns the most recent session weight', () => {
+      const history = [
+        makeHistoryRow({ id: 'set-new', actual_weight: 185, completed_at: '2026-04-30T10:05:00.000Z' }),
+        makeHistoryRow({ id: 'set-old', session_id: 'session-1', actual_weight: 165, completed_at: '2026-04-20T10:05:00.000Z' }),
+      ];
+
+      expect(getLastSessionWeight(history)).toBe(185);
+    });
+
+    it('falls back to planned weight when actual weight is null', () => {
+      const history = [
+        makeHistoryRow({ actual_weight: null, planned_weight: 135 }),
+      ];
+
+      expect(getLastSessionWeight(history)).toBe(135);
+    });
+
+    it('returns null when no load exists', () => {
+      const history = [
+        makeHistoryRow({ actual_weight: null, planned_weight: null, actual_reps: 12 }),
+      ];
+
+      expect(getLastSessionWeight(history)).toBeNull();
+    });
+  });
+
+  describe('detectPR', () => {
+    it('detects a load PR for weighted exercises', () => {
+      const personalRecords: ExercisePersonalRecords = {
+        maxWeight: 185,
+        maxReps: 8,
+        maxDurationSeconds: null,
+      };
+
+      expect(detectPR({
+        exercise: { id: 'ex-bench', name: 'Bench Press', is_timed: false },
+        personalRecords,
+        currentWeight: 190,
+        currentReps: 5,
+      })).toBe(true);
+    });
+
+    it('detects a rep PR for bodyweight movements with null weight', () => {
+      const personalRecords: ExercisePersonalRecords = {
+        maxWeight: null,
+        maxReps: 15,
+        maxDurationSeconds: null,
+      };
+
+      expect(detectPR({
+        exercise: { id: 'ex-pushup', name: 'Push-Up', is_timed: false },
+        personalRecords,
+        currentWeight: null,
+        currentReps: 18,
+      })).toBe(true);
+    });
+
+    it('detects a time PR for timed exercises', () => {
+      const personalRecords: ExercisePersonalRecords = {
+        maxWeight: null,
+        maxReps: null,
+        maxDurationSeconds: 60,
+      };
+
+      expect(detectPR({
+        exercise: { id: 'ex-plank', name: 'Plank', is_timed: true },
+        personalRecords,
+        currentSeconds: 75,
+      })).toBe(true);
+    });
+  });
+
+  describe('getSuggestedWeight', () => {
+    it('repeats the last session weight for weighted lifts', () => {
+      expect(getSuggestedWeight({
+        exercise: { id: 'ex-bench', name: 'Bench Press', is_timed: false },
+        history: [makeHistoryRow({ actual_weight: 205 })],
+      })).toBe(205);
+    });
+
+    it('returns null when there is no usable load history', () => {
+      expect(getSuggestedWeight({
+        exercise: { id: 'ex-pushup', name: 'Push-Up', is_timed: false },
+        history: [makeHistoryRow({ actual_weight: null, planned_weight: null, actual_reps: 20 })],
+      })).toBeNull();
+    });
+
+    it('returns null for timed exercises', () => {
+      expect(getSuggestedWeight({
+        exercise: { id: 'ex-plank', name: 'Plank', is_timed: true },
+        history: [makeHistoryRow({ actual_weight: null, actual_seconds: 45 })],
+      })).toBeNull();
+    });
+  });
+
+  describe('buildProgressiveOverloadSuggestion', () => {
+    it('personalizes helper text with the last session load', () => {
+      const suggestion = buildProgressiveOverloadSuggestion({
+        exercise: { id: 'ex-bench', name: 'Bench Press', is_timed: false },
+        history: [makeHistoryRow({ actual_weight: 185 })],
+        personalRecords: { maxWeight: 185, maxReps: 8, maxDurationSeconds: null },
+        unit: 'lb',
+      });
+
+      expect(suggestion.lastSessionWeight).toBe(185);
+      expect(suggestion.suggestedWeight).toBe(185);
+      expect(suggestion.helperText).toContain('Last session topped out at 185 lb');
+    });
+
+    it('uses a bodyweight fallback when no load history exists', () => {
+      const suggestion = buildProgressiveOverloadSuggestion({
+        exercise: { id: 'ex-pushup', name: 'Push-Up', is_timed: false },
+        history: [makeHistoryRow({ actual_weight: null, planned_weight: null, actual_reps: 20 })],
+        personalRecords: { maxWeight: null, maxReps: 20, maxDurationSeconds: null },
+      });
+
+      expect(suggestion.isBodyweightLike).toBe(true);
+      expect(suggestion.suggestedWeight).toBeNull();
+      expect(suggestion.helperText).toContain('bodyweight');
+    });
+  });
+});

--- a/tests/unit/services/progressive-overload.test.ts
+++ b/tests/unit/services/progressive-overload.test.ts
@@ -59,6 +59,7 @@ describe('progressive-overload', () => {
       const personalRecords: ExercisePersonalRecords = {
         maxWeight: 185,
         maxReps: 8,
+        maxVolume: 1480,
         maxDurationSeconds: null,
       };
 
@@ -78,6 +79,7 @@ describe('progressive-overload', () => {
       const personalRecords: ExercisePersonalRecords = {
         maxWeight: null,
         maxReps: 15,
+        maxVolume: null,
         maxDurationSeconds: null,
       };
 
@@ -97,6 +99,7 @@ describe('progressive-overload', () => {
       const personalRecords: ExercisePersonalRecords = {
         maxWeight: null,
         maxReps: null,
+        maxVolume: null,
         maxDurationSeconds: 60,
       };
 
@@ -111,10 +114,11 @@ describe('progressive-overload', () => {
       });
     });
 
-    it('falls back to volume PRs when load stays under the max weight', () => {
+    it('uses the real historical max volume instead of mixing max weight and reps', () => {
       const personalRecords: ExercisePersonalRecords = {
         maxWeight: 200,
         maxReps: 5,
+        maxVolume: 1050,
         maxDurationSeconds: null,
       };
 
@@ -126,7 +130,7 @@ describe('progressive-overload', () => {
       })).toEqual({
         isPR: true,
         prType: 'volume',
-        previousBest: 1000,
+        previousBest: 1050,
       });
     });
   });
@@ -183,7 +187,7 @@ describe('progressive-overload', () => {
       const suggestion = buildProgressiveOverloadSuggestion({
         exercise: { id: 'ex-bench', name: 'Bench Press', is_timed: false },
         history: [makeHistoryRow({ actual_weight: 185 })],
-        personalRecords: { maxWeight: 185, maxReps: 8, maxDurationSeconds: null },
+        personalRecords: { maxWeight: 185, maxReps: 8, maxVolume: 1480, maxDurationSeconds: null },
         unit: 'lb',
       });
 
@@ -199,7 +203,7 @@ describe('progressive-overload', () => {
       const suggestion = buildProgressiveOverloadSuggestion({
         exercise: { id: 'ex-pushup', name: 'Push-Up', is_timed: false },
         history: [makeHistoryRow({ actual_weight: null, planned_weight: null, actual_reps: 20 })],
-        personalRecords: { maxWeight: null, maxReps: 20, maxDurationSeconds: null },
+        personalRecords: { maxWeight: null, maxReps: 20, maxVolume: null, maxDurationSeconds: null },
       });
 
       expect(suggestion.isBodyweightLike).toBe(true);

--- a/tests/unit/services/progressive-overload.test.ts
+++ b/tests/unit/services/progressive-overload.test.ts
@@ -67,7 +67,11 @@ describe('progressive-overload', () => {
         personalRecords,
         currentWeight: 190,
         currentReps: 5,
-      })).toBe(true);
+      })).toEqual({
+        isPR: true,
+        prType: 'weight',
+        previousBest: 185,
+      });
     });
 
     it('detects a rep PR for bodyweight movements with null weight', () => {
@@ -82,7 +86,11 @@ describe('progressive-overload', () => {
         personalRecords,
         currentWeight: null,
         currentReps: 18,
-      })).toBe(true);
+      })).toEqual({
+        isPR: true,
+        prType: 'reps',
+        previousBest: 15,
+      });
     });
 
     it('detects a time PR for timed exercises', () => {
@@ -96,7 +104,30 @@ describe('progressive-overload', () => {
         exercise: { id: 'ex-plank', name: 'Plank', is_timed: true },
         personalRecords,
         currentSeconds: 75,
-      })).toBe(true);
+      })).toEqual({
+        isPR: true,
+        prType: null,
+        previousBest: 60,
+      });
+    });
+
+    it('falls back to volume PRs when load stays under the max weight', () => {
+      const personalRecords: ExercisePersonalRecords = {
+        maxWeight: 200,
+        maxReps: 5,
+        maxDurationSeconds: null,
+      };
+
+      expect(detectPR({
+        exercise: { id: 'ex-bench', name: 'Bench Press', is_timed: false },
+        personalRecords,
+        currentWeight: 185,
+        currentReps: 6,
+      })).toEqual({
+        isPR: true,
+        prType: 'volume',
+        previousBest: 1000,
+      });
     });
   });
 
@@ -105,14 +136,38 @@ describe('progressive-overload', () => {
       expect(getSuggestedWeight({
         exercise: { id: 'ex-bench', name: 'Bench Press', is_timed: false },
         history: [makeHistoryRow({ actual_weight: 205 })],
-      })).toBe(205);
+        unit: 'kg',
+      })).toEqual({
+        weight: 205,
+        reps: 5,
+        unit: 'kg',
+        source: 'previous_session',
+      });
     });
 
-    it('returns null when there is no usable load history', () => {
+    it('returns previous-session reps for bodyweight lifts without load', () => {
       expect(getSuggestedWeight({
         exercise: { id: 'ex-pushup', name: 'Push-Up', is_timed: false },
         history: [makeHistoryRow({ actual_weight: null, planned_weight: null, actual_reps: 20 })],
-      })).toBeNull();
+      })).toEqual({
+        weight: 0,
+        reps: 20,
+        unit: 'lb',
+        source: 'previous_session',
+      });
+    });
+
+    it('returns a no-history object when no previous session data exists', () => {
+      expect(getSuggestedWeight({
+        exercise: { id: 'ex-bench', name: 'Bench Press', is_timed: false },
+        history: [],
+        unit: 'kg',
+      })).toEqual({
+        weight: 0,
+        reps: 0,
+        unit: 'kg',
+        source: 'no_history',
+      });
     });
 
     it('returns null for timed exercises', () => {
@@ -134,6 +189,9 @@ describe('progressive-overload', () => {
 
       expect(suggestion.lastSessionWeight).toBe(185);
       expect(suggestion.suggestedWeight).toBe(185);
+      expect(suggestion.suggestedReps).toBe(5);
+      expect(suggestion.suggestedUnit).toBe('lb');
+      expect(suggestion.suggestionSource).toBe('previous_session');
       expect(suggestion.helperText).toContain('Last session topped out at 185 lb');
     });
 
@@ -146,6 +204,8 @@ describe('progressive-overload', () => {
 
       expect(suggestion.isBodyweightLike).toBe(true);
       expect(suggestion.suggestedWeight).toBeNull();
+      expect(suggestion.suggestedReps).toBe(20);
+      expect(suggestion.suggestionSource).toBe('previous_session');
       expect(suggestion.helperText).toContain('bodyweight');
     });
   });


### PR DESCRIPTION
## Summary
- add exercise history / personal records queries in local DB
- add MVP progressive overload service with structured PR + suggestion results
- cache additive suggestion state in session-runner and personalize overload helper copy

## Notes
- `session-runner.ts` remained additive-only.
- Broad Jest failures observed after Bundle F were unrelated to Bundle F files and should not be interpreted as branch-specific breakage.

Closes #306
Closes #307
Closes #308
Closes #309