### PR TITLE
feat(notifications): add workout preference types and retryable settings state

### DIFF
--- a/app/(modals)/notifications.tsx
+++ b/app/(modals)/notifications.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { BackHandler, View, Text, StyleSheet, TouchableOpacity, Switch, ActivityIndicator } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '@/contexts/AuthContext';
@@ -16,17 +16,58 @@ import {
 import { openExternalUrl, openSystemSettings as openSystemSettingsHelper } from '@/lib/utils/open-external';
 
 type PermissionState = 'granted' | 'undetermined' | 'denied';
-type ToggleKey = 'comments' | 'likes' | 'reminders';
+type ToggleKey =
+  | 'comments'
+  | 'likes'
+  | 'reminders'
+  | 'pr_celebrations'
+  | 'streak_alerts'
+  | 'rest_day_suggestions';
+type PreferencesState = 'loading' | 'ready' | 'signed_out' | 'error';
 
 export default function NotificationSettingsModal() {
   const { user } = useAuth();
   const toast = useToast();
   const safeBack = useSafeBack(['/(tabs)/profile', '/profile'], { alwaysReplace: true });
   const [permission, setPermission] = useState<PermissionState>('undetermined');
-  const [loading, setLoading] = useState(true);
+  const [preferencesState, setPreferencesState] = useState<PreferencesState>('loading');
   const [registering, setRegistering] = useState(false);
   const [savingKey, setSavingKey] = useState<ToggleKey | null>(null);
   const [prefs, setPrefs] = useState<{ [key in ToggleKey]: boolean } | null>(null);
+
+  const applyPreferences = useCallback((existing: Awaited<ReturnType<typeof loadNotificationPreferences>>) => {
+    setPrefs({
+      comments: existing.comments,
+      likes: existing.likes,
+      reminders: existing.reminders,
+      pr_celebrations: existing.pr_celebrations,
+      streak_alerts: existing.streak_alerts,
+      rest_day_suggestions: existing.rest_day_suggestions,
+    });
+  }, []);
+
+  const loadSettings = useCallback(async () => {
+    setPreferencesState('loading');
+    try {
+      const status = await getNotificationPermissions();
+      setPermission(status);
+
+      if (!user?.id) {
+        setPrefs(null);
+        setPreferencesState('signed_out');
+        return;
+      }
+
+      const existing = await loadNotificationPreferences(user.id);
+      applyPreferences(existing);
+      setPreferencesState('ready');
+    } catch (err) {
+      setPrefs(null);
+      setPreferencesState('error');
+      warnWithTs('[notifications] Failed to load settings', err);
+      toast.show('Unable to load notification settings', { type: 'error' });
+    }
+  }, [applyPreferences, toast, user?.id]);
 
   const statusLabel = useMemo(() => {
     if (permission === 'granted') return 'Enabled';
@@ -35,29 +76,8 @@ export default function NotificationSettingsModal() {
   }, [permission]);
 
   useEffect(() => {
-    const bootstrap = async () => {
-      try {
-        const status = await getNotificationPermissions();
-        setPermission(status);
-
-        if (user?.id) {
-          const existing = await loadNotificationPreferences(user.id);
-          setPrefs({
-            comments: existing.comments,
-            likes: existing.likes,
-            reminders: existing.reminders,
-          });
-        }
-      } catch (err) {
-        warnWithTs('[notifications] Failed to load settings', err);
-        toast.show('Unable to load notification settings', { type: 'error' });
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    bootstrap();
-  }, [toast, user?.id]);
+    void loadSettings();
+  }, [loadSettings]);
 
   useEffect(() => {
     if (!isAndroid()) return;
@@ -104,11 +124,14 @@ export default function NotificationSettingsModal() {
 
     try {
       const updated = await updateNotificationPreferences(user.id, { [key]: nextPrefs[key] });
-      setPrefs({
-        comments: updated.comments,
-        likes: updated.likes,
-        reminders: updated.reminders,
-      });
+        setPrefs({
+          comments: updated.comments,
+          likes: updated.likes,
+          reminders: updated.reminders,
+          pr_celebrations: updated.pr_celebrations,
+          streak_alerts: updated.streak_alerts,
+          rest_day_suggestions: updated.rest_day_suggestions,
+        });
     } catch (err) {
       warnWithTs('[notifications] Failed to update preferences', err);
       setPrefs(prefs);
@@ -180,9 +203,9 @@ export default function NotificationSettingsModal() {
 
       <View style={styles.card}>
         <Text style={styles.cardTitle}>Preferences</Text>
-        {loading ? (
+        {preferencesState === 'loading' ? (
           <ActivityIndicator color="#4C8CFF" style={{ marginTop: 12 }} />
-        ) : prefs ? (
+        ) : preferencesState === 'ready' && prefs ? (
           <>
             <SettingRow
               label="Comments on my videos"
@@ -208,7 +231,38 @@ export default function NotificationSettingsModal() {
               accessibilityLabel="Workout reminder notifications"
               accessibilityHint="Toggle daily reminders to complete your workout"
             />
+            <SettingRow
+              label="PR celebrations"
+              value={prefs.pr_celebrations}
+              onValueChange={() => handleToggle('pr_celebrations')}
+              disabled={savingKey === 'pr_celebrations'}
+              accessibilityLabel="PR celebration notifications"
+              accessibilityHint="Toggle alerts when you hit a personal record"
+            />
+            <SettingRow
+              label="Workout streak alerts"
+              value={prefs.streak_alerts}
+              onValueChange={() => handleToggle('streak_alerts')}
+              disabled={savingKey === 'streak_alerts'}
+              accessibilityLabel="Workout streak notifications"
+              accessibilityHint="Toggle alerts that celebrate your workout streak"
+            />
+            <SettingRow
+              label="Rest day suggestions"
+              value={prefs.rest_day_suggestions}
+              onValueChange={() => handleToggle('rest_day_suggestions')}
+              disabled={savingKey === 'rest_day_suggestions'}
+              accessibilityLabel="Rest day suggestion notifications"
+              accessibilityHint="Toggle suggestions to take a recovery day"
+            />
           </>
+        ) : preferencesState === 'error' ? (
+          <View style={styles.inlineState}>
+            <Text style={styles.cardSubtitle}>We could not load your notification settings.</Text>
+            <TouchableOpacity style={styles.retryButton} onPress={() => void loadSettings()}>
+              <Text style={styles.retryText}>Retry</Text>
+            </TouchableOpacity>
+          </View>
         ) : (
           <Text style={styles.cardSubtitle}>Sign in to adjust your notification settings.</Text>
         )}
@@ -347,6 +401,23 @@ const styles = StyleSheet.create({
   secondaryText: {
     color: '#9AACD1',
     fontWeight: '600',
+  },
+  inlineState: {
+    marginTop: 12,
+    gap: 10,
+  },
+  retryButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 10,
+    backgroundColor: 'rgba(76, 140, 255, 0.16)',
+    borderWidth: 1,
+    borderColor: '#4C8CFF',
+  },
+  retryText: {
+    color: '#E9EFFF',
+    fontWeight: '700',
   },
   settingRow: {
     flexDirection: 'row',

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -242,20 +242,36 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   // Refresh push token when a real user signs in
   useEffect(() => {
-    const syncPushToken = async () => {
-      if (!user || isMockUser) return;
+    const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-      try {
-        const result = await registerDevicePushToken(user.id, { requestPermission: false });
-        if (result.error) {
-          console.warn('[Auth] Push token registration warning:', result.error);
+    const registerPushTokenWithRetry = async (userId: string) => {
+      const delaysMs = [0, 1000, 2000];
+
+      for (let attempt = 0; attempt < delaysMs.length; attempt++) {
+        if (delaysMs[attempt] > 0) {
+          await wait(delaysMs[attempt]);
         }
-      } catch (err) {
-        console.warn('[Auth] Failed to register push token:', err);
+
+        try {
+          const result = await registerDevicePushToken(userId, { requestPermission: false });
+          if (!result.error) {
+            return;
+          }
+
+          console.warn('[Auth] Push token registration warning:', result.error, { attempt: attempt + 1 });
+        } catch (err) {
+          console.warn('[Auth] Failed to register push token:', err, { attempt: attempt + 1 });
+        }
       }
     };
 
-    syncPushToken();
+    const syncPushToken = async () => {
+      if (!user || isMockUser) return;
+
+      await registerPushTokenWithRetry(user.id);
+    };
+
+    void syncPushToken();
   }, [user?.id, isMockUser]);
 
   const handleAuthCallback = useCallback(async (url: string): Promise<void> => {

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -245,12 +245,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
     const registerPushTokenWithRetry = async (userId: string) => {
-      const delaysMs = [0, 1000, 2000];
+      const delaysMs = [1000, 2000, 4000];
 
       for (let attempt = 0; attempt < delaysMs.length; attempt++) {
-        if (delaysMs[attempt] > 0) {
-          await wait(delaysMs[attempt]);
-        }
+        await wait(delaysMs[attempt]);
 
         try {
           const result = await registerDevicePushToken(userId, { requestPermission: false });

--- a/lib/services/notifications.ts
+++ b/lib/services/notifications.ts
@@ -22,6 +22,9 @@ export type NotificationPreferences = {
   comments: boolean;
   likes: boolean;
   reminders: boolean;
+  pr_celebrations: boolean;
+  streak_alerts: boolean;
+  rest_day_suggestions: boolean;
   timezone: string | null;
   quiet_hours: string | null;
   created_at?: string;
@@ -192,7 +195,7 @@ export async function registerDevicePushToken(
   return { status: permissionStatus, token };
 }
 
-let pushTokenSubscription: Notifications.Subscription | null = null;
+let pushTokenSubscription: ReturnType<typeof Notifications.addPushTokenListener> | null = null;
 
 export function startPushTokenRefreshListener(userId: string) {
   stopPushTokenRefreshListener();
@@ -243,9 +246,23 @@ const DEFAULT_PREFERENCES: Omit<NotificationPreferences, 'user_id'> = {
   comments: true,
   likes: true,
   reminders: true,
+  pr_celebrations: true,
+  streak_alerts: true,
+  rest_day_suggestions: true,
   timezone: null,
   quiet_hours: null,
 };
+
+function normalizeNotificationPreferences(
+  userId: string,
+  prefs?: Partial<NotificationPreferences> | null,
+): NotificationPreferences {
+  return {
+    user_id: prefs?.user_id ?? userId,
+    ...DEFAULT_PREFERENCES,
+    ...prefs,
+  };
+}
 
 export async function loadNotificationPreferences(userId: string): Promise<NotificationPreferences> {
   const { data, error, status } = await supabase
@@ -257,10 +274,10 @@ export async function loadNotificationPreferences(userId: string): Promise<Notif
   if (error) {
     if (status !== 406) {
       warnWithTs('[notifications] Failed to load preferences, using defaults', { status, error: error.message });
-      return { user_id: userId, ...DEFAULT_PREFERENCES };
+      return normalizeNotificationPreferences(userId);
     }
   } else if (data) {
-    return data as NotificationPreferences;
+    return normalizeNotificationPreferences(userId, data as Partial<NotificationPreferences>);
   }
 
   const { data: created, error: createError } = await supabase
@@ -274,10 +291,24 @@ export async function loadNotificationPreferences(userId: string): Promise<Notif
 
   if (createError) {
     warnWithTs('[notifications] Failed to create default preferences, using in-memory defaults', createError);
-    return { user_id: userId, ...DEFAULT_PREFERENCES };
+    return normalizeNotificationPreferences(userId);
   }
 
-  return created as NotificationPreferences;
+  return normalizeNotificationPreferences(userId, created as Partial<NotificationPreferences>);
+}
+
+export async function sendCoachTipNotification(userId: string, tip: string) {
+  return supabase.functions.invoke('notify', {
+    body: {
+      userIds: [userId],
+      title: 'Coach tip',
+      body: tip,
+      data: {
+        type: 'coach_tip',
+        tip,
+      },
+    },
+  });
 }
 
 /**
@@ -353,5 +384,5 @@ export async function updateNotificationPreferences(
     throw error;
   }
 
-  return data as NotificationPreferences;
+  return normalizeNotificationPreferences(userId, data as Partial<NotificationPreferences>);
 }

--- a/tests/unit/contexts/auth-context.test.tsx
+++ b/tests/unit/contexts/auth-context.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import type * as AuthContextModule from '@/contexts/AuthContext';
 import type { Session, User } from '@supabase/supabase-js';
+import { registerDevicePushToken } from '@/lib/services/notifications';
+import { PermissionStatus } from 'expo-modules-core';
 
 // Mock user and session data
 const mockUser: User = {
@@ -135,6 +137,11 @@ describe('AuthContext', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     authStateChangeCallback = null;
+
+    (registerDevicePushToken as jest.MockedFunction<typeof registerDevicePushToken>).mockResolvedValue({
+      status: PermissionStatus.GRANTED,
+      error: undefined,
+    });
     
     // Default mock implementations
     mockSessionManager.getStoredSession.mockResolvedValue(null);
@@ -152,6 +159,10 @@ describe('AuthContext', () => {
     
     mockLocalDB.clearAllData.mockResolvedValue(undefined);
     mockSyncService.cleanupRealtimeSync.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   describe('useAuth hook', () => {
@@ -684,6 +695,56 @@ describe('AuthContext', () => {
       unmount();
 
       expect(mockUnsubscribe).toHaveBeenCalled();
+    });
+
+    it('attempts push token registration three times with 0ms, 1000ms, and 2000ms semantics when registration keeps failing', async () => {
+      jest.useFakeTimers();
+
+      const mockRegisterDevicePushToken = registerDevicePushToken as jest.MockedFunction<typeof registerDevicePushToken>;
+      mockRegisterDevicePushToken.mockRejectedValue(new Error('push registration failed'));
+
+      renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(authStateChangeCallback).not.toBeNull();
+      });
+
+      await act(async () => {
+        authStateChangeCallback!('SIGNED_IN', mockSession);
+      });
+
+      await waitFor(() => {
+        expect(mockRegisterDevicePushToken).toHaveBeenCalledTimes(1);
+      });
+      expect(mockRegisterDevicePushToken).toHaveBeenNthCalledWith(1, mockUser.id, { requestPermission: false });
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(999);
+      });
+      expect(mockRegisterDevicePushToken).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1);
+      });
+
+      await waitFor(() => {
+        expect(mockRegisterDevicePushToken).toHaveBeenCalledTimes(2);
+      });
+      expect(mockRegisterDevicePushToken).toHaveBeenNthCalledWith(2, mockUser.id, { requestPermission: false });
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1999);
+      });
+      expect(mockRegisterDevicePushToken).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1);
+      });
+
+      await waitFor(() => {
+        expect(mockRegisterDevicePushToken).toHaveBeenCalledTimes(3);
+      });
+      expect(mockRegisterDevicePushToken).toHaveBeenNthCalledWith(3, mockUser.id, { requestPermission: false });
     });
   });
 

--- a/tests/unit/contexts/auth-context.test.tsx
+++ b/tests/unit/contexts/auth-context.test.tsx
@@ -697,7 +697,7 @@ describe('AuthContext', () => {
       expect(mockUnsubscribe).toHaveBeenCalled();
     });
 
-    it('attempts push token registration three times with 0ms, 1000ms, and 2000ms semantics when registration keeps failing', async () => {
+    it('attempts push token registration three times with 1000ms, 2000ms, and 4000ms exponential backoff when registration keeps failing', async () => {
       jest.useFakeTimers();
 
       const mockRegisterDevicePushToken = registerDevicePushToken as jest.MockedFunction<typeof registerDevicePushToken>;
@@ -713,13 +713,22 @@ describe('AuthContext', () => {
         authStateChangeCallback!('SIGNED_IN', mockSession);
       });
 
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(999);
+      });
+      expect(mockRegisterDevicePushToken).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1);
+      });
+
       await waitFor(() => {
         expect(mockRegisterDevicePushToken).toHaveBeenCalledTimes(1);
       });
       expect(mockRegisterDevicePushToken).toHaveBeenNthCalledWith(1, mockUser.id, { requestPermission: false });
 
       await act(async () => {
-        await jest.advanceTimersByTimeAsync(999);
+        await jest.advanceTimersByTimeAsync(1999);
       });
       expect(mockRegisterDevicePushToken).toHaveBeenCalledTimes(1);
 
@@ -733,7 +742,7 @@ describe('AuthContext', () => {
       expect(mockRegisterDevicePushToken).toHaveBeenNthCalledWith(2, mockUser.id, { requestPermission: false });
 
       await act(async () => {
-        await jest.advanceTimersByTimeAsync(1999);
+        await jest.advanceTimersByTimeAsync(3999);
       });
       expect(mockRegisterDevicePushToken).toHaveBeenCalledTimes(2);
 

--- a/tests/unit/screens/notifications-modal.test.tsx
+++ b/tests/unit/screens/notifications-modal.test.tsx
@@ -1,0 +1,93 @@
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { PermissionStatus } from 'expo-modules-core';
+
+import NotificationSettingsModal from '../../../app/(modals)/notifications';
+import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/contexts/ToastContext';
+import {
+  getNotificationPermissions,
+  loadNotificationPreferences,
+} from '@/lib/services/notifications';
+
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/contexts/ToastContext', () => ({
+  useToast: jest.fn(),
+}));
+
+jest.mock('@/hooks/use-safe-back', () => ({
+  useSafeBack: () => jest.fn(),
+}));
+
+jest.mock('@/lib/platform-utils', () => ({
+  isAndroid: () => false,
+  isIOS: () => true,
+}));
+
+jest.mock('@/lib/logger', () => ({
+  warnWithTs: jest.fn(),
+}));
+
+jest.mock('@/lib/utils/open-external', () => ({
+  openExternalUrl: jest.fn(),
+  openSystemSettings: jest.fn(),
+}));
+
+jest.mock('@/lib/services/notifications', () => ({
+  getNotificationPermissions: jest.fn(),
+  loadNotificationPreferences: jest.fn(),
+  registerDevicePushToken: jest.fn(),
+  requestNotificationPermissions: jest.fn(),
+  updateNotificationPreferences: jest.fn(),
+}));
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockUseToast = useToast as jest.MockedFunction<typeof useToast>;
+const mockGetNotificationPermissions = getNotificationPermissions as jest.MockedFunction<typeof getNotificationPermissions>;
+const mockLoadNotificationPreferences = loadNotificationPreferences as jest.MockedFunction<typeof loadNotificationPreferences>;
+
+describe('NotificationSettingsModal', () => {
+  const toast = { show: jest.fn() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseToast.mockReturnValue(toast as ReturnType<typeof useToast>);
+    mockGetNotificationPermissions.mockResolvedValue(PermissionStatus.GRANTED);
+  });
+
+  it('renders load-error state with Retry for a signed-in user when preferences fail to load', async () => {
+    mockUseAuth.mockReturnValue({ user: { id: 'user-123' } } as ReturnType<typeof useAuth>);
+    mockLoadNotificationPreferences.mockRejectedValue(new Error('load failed'));
+
+    const { getByText } = render(<NotificationSettingsModal />);
+
+    await waitFor(() => {
+      expect(getByText('We could not load your notification settings.')).toBeTruthy();
+    });
+
+    expect(getByText('Retry')).toBeTruthy();
+    expect(toast.show).toHaveBeenCalledWith('Unable to load notification settings', { type: 'error' });
+
+    fireEvent.press(getByText('Retry'));
+
+    await waitFor(() => {
+      expect(mockLoadNotificationPreferences).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('renders the signed-out message instead of load-error copy when no user is signed in', async () => {
+    mockUseAuth.mockReturnValue({ user: null } as ReturnType<typeof useAuth>);
+
+    const { getByText, queryByText } = render(<NotificationSettingsModal />);
+
+    await waitFor(() => {
+      expect(getByText('Sign in to adjust your notification settings.')).toBeTruthy();
+    });
+
+    expect(queryByText('We could not load your notification settings.')).toBeNull();
+    expect(queryByText('Retry')).toBeNull();
+    expect(mockLoadNotificationPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/notifications.test.ts
+++ b/tests/unit/services/notifications.test.ts
@@ -63,8 +63,12 @@ jest.mock('@/lib/logger', () => ({
 
 // Supabase — we build chains per-test, so the factory just provides `from`
 const mockFrom = jest.fn();
+const mockInvoke = jest.fn();
 jest.mock('@/lib/supabase', () => ({
-  supabase: { from: (...args: any[]) => mockFrom(...args) },
+  supabase: {
+    from: (...args: any[]) => mockFrom(...args),
+    functions: { invoke: (...args: any[]) => mockInvoke(...args) },
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -93,6 +97,7 @@ import {
   registerDevicePushToken,
   unregisterDevicePushToken,
   loadNotificationPreferences,
+  sendCoachTipNotification,
   updateNotificationPreferences,
 } from '@/lib/services/notifications';
 
@@ -114,27 +119,6 @@ function fakeBytes(len: number): Uint8Array {
   const arr = new Uint8Array(len);
   for (let i = 0; i < len; i++) arr[i] = i;
   return arr;
-}
-
-/**
- * Build a Supabase-style chainable query mock.
- * Every chaining method returns the same object so the chain resolves
- * to `{ data, error, status }` regardless of call order.
- */
-function createChain(data: any, error: any = null, status = 200) {
-  const resolved = { data, error, status };
-  const chain: Record<string, jest.Mock> = {};
-  const methods = ['select', 'eq', 'match', 'single', 'upsert', 'delete'];
-  methods.forEach((m) => {
-    chain[m] = jest.fn().mockReturnValue(chain);
-  });
-  // Make the chain thenable so `await supabase.from(...).select(...)` works
-  Object.defineProperty(chain, 'then', {
-    value: (onFulfilled: any, onRejected?: any) =>
-      Promise.resolve(resolved).then(onFulfilled, onRejected),
-    configurable: true,
-  });
-  return chain;
 }
 
 // ---------------------------------------------------------------------------
@@ -308,7 +292,6 @@ describe('registerDevicePushToken', () => {
     mockGetPermissionsAsync.mockResolvedValue({ status: 'undetermined' });
     mockRequestPermissionsAsync.mockResolvedValue({ status: 'granted' });
 
-    const chain = createChain(null, null);
     mockFrom.mockReturnValue({ upsert: jest.fn().mockResolvedValue({ error: null }) });
 
     await registerDevicePushToken('user-123');
@@ -576,6 +559,9 @@ describe('loadNotificationPreferences', () => {
     comments: true,
     likes: true,
     reminders: true,
+    pr_celebrations: true,
+    streak_alerts: true,
+    rest_day_suggestions: true,
     timezone: null,
     quiet_hours: null,
   };
@@ -586,6 +572,9 @@ describe('loadNotificationPreferences', () => {
       comments: false,
       likes: true,
       reminders: false,
+      pr_celebrations: false,
+      streak_alerts: true,
+      rest_day_suggestions: false,
       timezone: 'America/New_York',
       quiet_hours: '22:00-07:00',
     };
@@ -631,8 +620,43 @@ describe('loadNotificationPreferences', () => {
         comments: true,
         likes: true,
         reminders: true,
+        pr_celebrations: true,
+        streak_alerts: true,
+        rest_day_suggestions: true,
       }),
     );
+  });
+
+  it('fills in new workout preference types for legacy rows', async () => {
+    const mockSingle = jest.fn().mockResolvedValue({
+      data: {
+        user_id: userId,
+        comments: false,
+        likes: true,
+        reminders: false,
+        timezone: null,
+        quiet_hours: null,
+      },
+      error: null,
+      status: 200,
+    });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+
+    const result = await loadNotificationPreferences(userId);
+
+    expect(result).toEqual({
+      user_id: userId,
+      comments: false,
+      likes: true,
+      reminders: false,
+      pr_celebrations: true,
+      streak_alerts: true,
+      rest_day_suggestions: true,
+      timezone: null,
+      quiet_hours: null,
+    });
   });
 
   it('returns in-memory defaults when auto-create fails after 406', async () => {
@@ -692,6 +716,9 @@ describe('updateNotificationPreferences', () => {
       comments: false,
       likes: true,
       reminders: true,
+      pr_celebrations: true,
+      streak_alerts: false,
+      rest_day_suggestions: true,
       timezone: null,
       quiet_hours: null,
     };
@@ -730,6 +757,9 @@ describe('updateNotificationPreferences', () => {
         comments: true,
         likes: false,
         reminders: true,
+        pr_celebrations: true,
+        streak_alerts: true,
+        rest_day_suggestions: true,
         timezone: 'US/Pacific',
         quiet_hours: null,
       },
@@ -748,6 +778,66 @@ describe('updateNotificationPreferences', () => {
       { user_id: userId, likes: false, timezone: 'US/Pacific' },
       { onConflict: 'user_id' },
     );
+  });
+
+  it('normalizes new workout preference types in update responses', async () => {
+    const mockSingle = jest.fn().mockResolvedValue({
+      data: {
+        user_id: userId,
+        comments: true,
+        likes: true,
+        reminders: true,
+        timezone: null,
+        quiet_hours: null,
+      },
+      error: null,
+    });
+    const mockSelect = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockUpsert = jest.fn().mockReturnValue({ select: mockSelect });
+    mockFrom.mockReturnValue({ upsert: mockUpsert });
+
+    const result = await updateNotificationPreferences(userId, { streak_alerts: false });
+
+    expect(result).toEqual({
+      user_id: userId,
+      comments: true,
+      likes: true,
+      reminders: true,
+      pr_celebrations: true,
+      streak_alerts: true,
+      rest_day_suggestions: true,
+      timezone: null,
+      quiet_hours: null,
+    });
+    expect(mockUpsert).toHaveBeenCalledWith(
+      { user_id: userId, streak_alerts: false },
+      { onConflict: 'user_id' },
+    );
+  });
+});
+
+// ===========================================================================
+// sendCoachTipNotification
+// ===========================================================================
+
+describe('sendCoachTipNotification', () => {
+  it('invokes notify edge function with coach tip payload', async () => {
+    mockInvoke.mockResolvedValue({ data: { delivered: 1 }, error: null });
+
+    const result = await sendCoachTipNotification('user-999', 'Take a lighter recovery day tomorrow.');
+
+    expect(mockInvoke).toHaveBeenCalledWith('notify', {
+      body: {
+        userIds: ['user-999'],
+        title: 'Coach tip',
+        body: 'Take a lighter recovery day tomorrow.',
+        data: {
+          type: 'coach_tip',
+          tip: 'Take a lighter recovery day tomorrow.',
+        },
+      },
+    });
+    expect(result).toEqual({ data: { delivered: 1 }, error: null });
   });
 });
 


### PR DESCRIPTION
## Summary
- add normalized workout-specific notification preference keys
- distinguish signed-in load errors from signed-out state in the modal
- retry push token registration in AuthContext and add coach-tip notification stub

## Verification
- scoped Jest tests pass; exact `bun test` remains a known Bun/React-Native parser mismatch

Closes #303
Closes #305