### PR TITLE
feat(coach): add workout context and eval coverage

### DIFF
--- a/evals/coach-eval.yaml
+++ b/evals/coach-eval.yaml
@@ -54,3 +54,4 @@ tests:
   - file://scenarios/coach-recovery.yaml
   - file://scenarios/coach-edge-cases.yaml
   - file://scenarios/coach-safety-probes.yaml
+  - file://scenarios/redteam-custom.yaml

--- a/lib/services/coach-service.ts
+++ b/lib/services/coach-service.ts
@@ -29,8 +29,9 @@ interface RawCoachResponse {
 }
 
 const functionName = (process.env.EXPO_PUBLIC_COACH_FUNCTION || 'coach').trim();
-const MAX_WORKOUT_CONTEXT_ITEMS = 3;
-const MAX_WORKOUT_CONTEXT_LENGTH = 280;
+const MAX_RECENT_WORKOUT_CONTEXT_ITEMS = 5;
+const MAX_BEST_PERFORMANCE_ITEMS = 2;
+const MAX_WORKOUT_CONTEXT_LENGTH = 420;
 
 function formatWorkoutValue(value?: number): string | null {
   if (typeof value !== 'number' || isNaN(value) || value <= 0) {
@@ -68,8 +69,63 @@ function formatWorkoutSummaryItem(workout: LocalWorkout): string {
     : `${dateLabel}: ${exerciseLabel}`;
 }
 
+function formatBestPerformanceItem(workout: LocalWorkout): string | null {
+  const exerciseLabel = workout.exercise.trim();
+  if (!exerciseLabel) {
+    return null;
+  }
+
+  const weightLabel = formatWorkoutValue(workout.weight);
+  const repsLabel = formatWorkoutValue(workout.reps);
+
+  if (weightLabel && repsLabel) {
+    return `${exerciseLabel} ${weightLabel} x ${repsLabel}`;
+  }
+
+  if (weightLabel) {
+    return `${exerciseLabel} ${weightLabel}`;
+  }
+
+  if (repsLabel) {
+    return `${exerciseLabel} ${repsLabel} reps`;
+  }
+
+  return null;
+}
+
+function pickBestPerformanceWorkouts(workouts: LocalWorkout[]): LocalWorkout[] {
+  const workoutsWithWeight = workouts.filter(
+    (workout) => typeof workout.weight === 'number' && !isNaN(workout.weight) && workout.weight > 0
+  );
+  const workoutsWithReps = workouts.filter(
+    (workout) => typeof workout.reps === 'number' && !isNaN(workout.reps) && workout.reps > 0
+  );
+
+  const heaviestWorkout = workoutsWithWeight.sort((a, b) => {
+    if ((b.weight || 0) !== (a.weight || 0)) {
+      return (b.weight || 0) - (a.weight || 0);
+    }
+
+    return b.date.localeCompare(a.date);
+  })[0];
+
+  const highestRepWorkout = workoutsWithReps
+    .filter((workout) => !heaviestWorkout || workout.id !== heaviestWorkout.id)
+    .sort((a, b) => {
+      if ((b.reps || 0) !== (a.reps || 0)) {
+        return (b.reps || 0) - (a.reps || 0);
+      }
+
+      return b.date.localeCompare(a.date);
+    })[0];
+
+  return [heaviestWorkout, highestRepWorkout]
+    .filter((workout): workout is LocalWorkout => Boolean(workout))
+    .slice(0, MAX_BEST_PERFORMANCE_ITEMS);
+}
+
 function summarizeRecentWorkouts(workouts: LocalWorkout[]): string | undefined {
-  const recentWorkouts = workouts.slice(0, MAX_WORKOUT_CONTEXT_ITEMS);
+  const recentWorkouts = workouts.slice(0, MAX_RECENT_WORKOUT_CONTEXT_ITEMS);
   if (recentWorkouts.length === 0) {
     return undefined;
   }
@@ -83,11 +139,39 @@ function summarizeRecentWorkouts(workouts: LocalWorkout[]): string | undefined {
     : summary;
 }
 
+function summarizeBestPerformances(workouts: LocalWorkout[]): string | undefined {
+  const bestSummary = pickBestPerformanceWorkouts(workouts)
+    .map(formatBestPerformanceItem)
+    .filter((item): item is string => Boolean(item));
+
+  if (bestSummary.length === 0) {
+    return undefined;
+  }
+
+  return `Best performance: ${bestSummary.join('; ')}`;
+}
+
+function combineWorkoutContextSummary(workouts: LocalWorkout[]): string | undefined {
+  const parts = [
+    summarizeRecentWorkouts(workouts),
+    summarizeBestPerformances(workouts),
+  ].filter((part): part is string => Boolean(part));
+
+  if (parts.length === 0) {
+    return undefined;
+  }
+
+  const summary = parts.join('. ');
+  return summary.length > MAX_WORKOUT_CONTEXT_LENGTH
+    ? `${summary.slice(0, MAX_WORKOUT_CONTEXT_LENGTH - 1).replace(/\s+$/, '')}…`
+    : summary;
+}
+
 async function buildCoachContext(context?: CoachContext): Promise<CoachContext | undefined> {
   let workoutSummary: string | undefined;
 
   try {
-    workoutSummary = summarizeRecentWorkouts(await localDB.getAllWorkouts());
+    workoutSummary = combineWorkoutContextSummary(await localDB.getAllWorkouts());
   } catch (err) {
     logError(
       createError(

--- a/lib/services/coach-service.ts
+++ b/lib/services/coach-service.ts
@@ -1,6 +1,6 @@
 import { supabase } from '@/lib/supabase';
-import { errorWithTs, warnWithTs } from '@/lib/logger';
-import { createError } from './ErrorHandler';
+import { localDB, type LocalWorkout } from '@/lib/services/database/local-db';
+import { createError, logError } from './ErrorHandler';
 
 export type CoachRole = 'user' | 'assistant' | 'system';
 
@@ -18,6 +18,7 @@ export interface CoachContext {
   };
   focus?: string;
   sessionId?: string;
+  workoutSummary?: string;
 }
 
 interface RawCoachResponse {
@@ -28,14 +29,136 @@ interface RawCoachResponse {
 }
 
 const functionName = (process.env.EXPO_PUBLIC_COACH_FUNCTION || 'coach').trim();
+const MAX_WORKOUT_CONTEXT_ITEMS = 3;
+const MAX_WORKOUT_CONTEXT_LENGTH = 280;
+
+function formatWorkoutValue(value?: number): string | null {
+  if (typeof value !== 'number' || isNaN(value) || value <= 0) {
+    return null;
+  }
+
+  return value % 1 === 0 ? String(value) : value.toFixed(1);
+}
+
+function formatWorkoutSummaryItem(workout: LocalWorkout): string {
+  const dateLabel = workout.date.split('T')[0] || workout.date;
+  const exerciseLabel = workout.exercise.trim() || 'Workout';
+  const details: string[] = [];
+
+  if (workout.sets > 0 && typeof workout.reps === 'number' && workout.reps > 0) {
+    details.push(`${workout.sets}x${workout.reps}`);
+  } else if (workout.sets > 0) {
+    details.push(`${workout.sets} sets`);
+  } else if (typeof workout.reps === 'number' && workout.reps > 0) {
+    details.push(`${workout.reps} reps`);
+  }
+
+  const weightLabel = formatWorkoutValue(workout.weight);
+  if (weightLabel) {
+    details.push(`weight ${weightLabel}`);
+  }
+
+  const durationLabel = formatWorkoutValue(workout.duration);
+  if (durationLabel) {
+    details.push(`${durationLabel} min`);
+  }
+
+  return details.length > 0
+    ? `${dateLabel}: ${exerciseLabel} (${details.join(', ')})`
+    : `${dateLabel}: ${exerciseLabel}`;
+}
+
+function summarizeRecentWorkouts(workouts: LocalWorkout[]): string | undefined {
+  const recentWorkouts = workouts.slice(0, MAX_WORKOUT_CONTEXT_ITEMS);
+  if (recentWorkouts.length === 0) {
+    return undefined;
+  }
+
+  const summary = `Recent workouts: ${recentWorkouts
+    .map(formatWorkoutSummaryItem)
+    .join('; ')}`;
+
+  return summary.length > MAX_WORKOUT_CONTEXT_LENGTH
+    ? `${summary.slice(0, MAX_WORKOUT_CONTEXT_LENGTH - 1).replace(/\s+$/, '')}…`
+    : summary;
+}
+
+async function buildCoachContext(context?: CoachContext): Promise<CoachContext | undefined> {
+  let workoutSummary: string | undefined;
+
+  try {
+    workoutSummary = summarizeRecentWorkouts(await localDB.getAllWorkouts());
+  } catch (err) {
+    logError(
+      createError(
+        'storage',
+        'COACH_WORKOUT_CONTEXT_FAILED',
+        'Unable to load workout history for coach context',
+        {
+          details: err,
+          retryable: false,
+          severity: 'warning',
+        }
+      ),
+      {
+        feature: 'workouts',
+        location: 'sendCoachPrompt.buildCoachContext',
+      }
+    );
+  }
+
+  if (!context && !workoutSummary) {
+    return undefined;
+  }
+
+  if (!workoutSummary) {
+    return context;
+  }
+
+  return {
+    ...context,
+    workoutSummary,
+  };
+}
+
+async function persistCoachConversation(
+  insertPayload: Record<string, unknown>,
+  sessionId: string,
+  userId: string,
+): Promise<void> {
+  const { error } = await supabase.from('coach_conversations').insert(insertPayload);
+
+  if (!error) {
+    return;
+  }
+
+  logError(
+    createError(
+      'storage',
+      'COACH_CONVERSATION_PERSIST_FAILED',
+      'Failed to persist coach conversation',
+      {
+        details: error,
+        retryable: true,
+        severity: 'warning',
+      }
+    ),
+    {
+      feature: 'app',
+      location: 'sendCoachPrompt.persistCoachConversation',
+      meta: { sessionId, userId },
+    }
+  );
+}
 
 export async function sendCoachPrompt(
   messages: CoachMessage[],
   context?: CoachContext
 ): Promise<CoachMessage> {
   try {
+    const requestContext = await buildCoachContext(context);
     const { data, error } = await supabase.functions.invoke<RawCoachResponse>(functionName, {
-      body: { messages, context },
+      body: { messages, context: requestContext },
     });
 
     if (error) {
@@ -113,15 +236,7 @@ export async function sendCoachPrompt(
         context: { focus: context.focus },
         metadata: { model: 'gpt-5.4-mini', timestamp: new Date().toISOString() },
       };
-      supabase.from('coach_conversations').insert(insertPayload).then(({ error: insertErr }) => {
-        if (!insertErr) return;
-        warnWithTs('[coach] Conversation persist failed, retrying once', insertErr.message);
-        supabase.from('coach_conversations').insert(insertPayload).then(({ error: retryErr }) => {
-          if (retryErr) {
-            errorWithTs('[coach] Conversation persist failed after retry', retryErr.message);
-          }
-        });
-      });
+      void persistCoachConversation(insertPayload, context.sessionId, context.profile.id);
     }
 
     return {

--- a/tests/unit/services/coach-service.test.ts
+++ b/tests/unit/services/coach-service.test.ts
@@ -3,6 +3,8 @@ const mockInsert = jest.fn();
 const mockFrom = jest.fn(() => ({
   insert: mockInsert,
 }));
+const mockGetAllWorkouts = jest.fn();
+const mockLogError = jest.fn();
 const mockCreateError = jest.fn(
   (
     domain: string,
@@ -28,12 +30,20 @@ jest.mock('@/lib/supabase', () => ({
   },
 }));
 
+jest.mock('@/lib/services/database/local-db', () => ({
+  localDB: {
+    getAllWorkouts: mockGetAllWorkouts,
+  },
+}));
+
 jest.mock('@/lib/services/ErrorHandler', () => ({
   createError: mockCreateError,
+  logError: mockLogError,
 }));
 
 jest.mock('../../../lib/services/ErrorHandler', () => ({
   createError: mockCreateError,
+  logError: mockLogError,
 }));
 
 let sendCoachPrompt: typeof import('@/lib/services/coach-service')['sendCoachPrompt'];
@@ -49,11 +59,7 @@ describe('coach-service', () => {
     jest.clearAllMocks();
     mockInvoke.mockResolvedValue({ data: { message: 'Keep your chest up.' }, error: null });
     mockInsert.mockResolvedValue({ error: null });
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
+    mockGetAllWorkouts.mockResolvedValue([]);
   });
 
   it('classifies a 404 invoke failure as COACH_NOT_DEPLOYED', async () => {
@@ -129,4 +135,113 @@ describe('coach-service', () => {
       })
     );
   });
+
+  it('includes recent workout summary in coach context when local history exists', async () => {
+    mockGetAllWorkouts.mockResolvedValue([
+      {
+        id: 'w-1',
+        exercise: 'Back Squat',
+        sets: 5,
+        reps: 5,
+        weight: 225,
+        duration: null,
+        date: '2026-04-29T10:00:00.000Z',
+        synced: 1,
+        deleted: 0,
+        updated_at: '2026-04-29T10:05:00.000Z',
+      },
+      {
+        id: 'w-2',
+        exercise: 'Bench Press',
+        sets: 4,
+        reps: 8,
+        weight: 155,
+        duration: null,
+        date: '2026-04-27T10:00:00.000Z',
+        synced: 1,
+        deleted: 0,
+        updated_at: '2026-04-27T10:05:00.000Z',
+      },
+    ]);
+
+    await sendCoachPrompt(baseMessages, {
+      profile: { id: 'user-123', name: 'Pat' },
+      focus: 'strength_training',
+      sessionId: 'session-9',
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith(
+      'coach',
+      expect.objectContaining({
+        body: expect.objectContaining({
+          messages: baseMessages,
+          context: expect.objectContaining({
+            focus: 'strength_training',
+            workoutSummary: 'Recent workouts: 2026-04-29: Back Squat (5x5, weight 225); 2026-04-27: Bench Press (4x8, weight 155)',
+          }),
+        }),
+      })
+    );
+  });
+
+  it('logs and skips workout context when local workout history fails', async () => {
+    mockGetAllWorkouts.mockRejectedValue(new Error('db offline'));
+
+    await expect(sendCoachPrompt(baseMessages, { focus: 'recovery' })).resolves.toEqual({
+      role: 'assistant',
+      content: 'Keep your chest up.',
+    });
+
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: 'storage',
+        code: 'COACH_WORKOUT_CONTEXT_FAILED',
+      }),
+      expect.objectContaining({
+        feature: 'workouts',
+        location: 'sendCoachPrompt.buildCoachContext',
+      })
+    );
+    expect(mockInvoke).toHaveBeenCalledWith(
+      'coach',
+      expect.objectContaining({
+        body: expect.objectContaining({
+          context: { focus: 'recovery' },
+        }),
+      })
+    );
+  });
+
+  it('logs persistence failures without failing the coach response', async () => {
+    mockInsert.mockResolvedValue({ error: { message: 'insert failed' } });
+
+    await expect(
+      sendCoachPrompt(baseMessages, {
+        profile: { id: 'user-123' },
+        focus: 'squat',
+        sessionId: 'session-9',
+      })
+    ).resolves.toEqual({
+      role: 'assistant',
+      content: 'Keep your chest up.',
+    });
+    await Promise.resolve();
+
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: 'storage',
+        code: 'COACH_CONVERSATION_PERSIST_FAILED',
+      }),
+      expect.objectContaining({
+        feature: 'app',
+        location: 'sendCoachPrompt.persistCoachConversation',
+        meta: expect.objectContaining({
+          sessionId: 'session-9',
+          userId: 'user-123',
+        }),
+      })
+    );
+  });
 });
+
+export {};

--- a/tests/unit/services/coach-service.test.ts
+++ b/tests/unit/services/coach-service.test.ts
@@ -136,7 +136,7 @@ describe('coach-service', () => {
     );
   });
 
-  it('includes recent workout summary in coach context when local history exists', async () => {
+  it('includes up to five recent workouts and best-performance context when local history exists', async () => {
     mockGetAllWorkouts.mockResolvedValue([
       {
         id: 'w-1',
@@ -162,6 +162,54 @@ describe('coach-service', () => {
         deleted: 0,
         updated_at: '2026-04-27T10:05:00.000Z',
       },
+      {
+        id: 'w-3',
+        exercise: 'Pull Up',
+        sets: 4,
+        reps: 12,
+        weight: 0,
+        duration: null,
+        date: '2026-04-25T10:00:00.000Z',
+        synced: 1,
+        deleted: 0,
+        updated_at: '2026-04-25T10:05:00.000Z',
+      },
+      {
+        id: 'w-4',
+        exercise: 'Romanian Deadlift',
+        sets: 3,
+        reps: 8,
+        weight: 245,
+        duration: null,
+        date: '2026-04-23T10:00:00.000Z',
+        synced: 1,
+        deleted: 0,
+        updated_at: '2026-04-23T10:05:00.000Z',
+      },
+      {
+        id: 'w-5',
+        exercise: 'Bike Intervals',
+        sets: 6,
+        reps: null,
+        weight: null,
+        duration: 18,
+        date: '2026-04-21T10:00:00.000Z',
+        synced: 1,
+        deleted: 0,
+        updated_at: '2026-04-21T10:05:00.000Z',
+      },
+      {
+        id: 'w-6',
+        exercise: 'Old Session',
+        sets: 2,
+        reps: 20,
+        weight: null,
+        duration: null,
+        date: '2026-04-18T10:00:00.000Z',
+        synced: 1,
+        deleted: 0,
+        updated_at: '2026-04-18T10:05:00.000Z',
+      },
     ]);
 
     await sendCoachPrompt(baseMessages, {
@@ -177,7 +225,8 @@ describe('coach-service', () => {
           messages: baseMessages,
           context: expect.objectContaining({
             focus: 'strength_training',
-            workoutSummary: 'Recent workouts: 2026-04-29: Back Squat (5x5, weight 225); 2026-04-27: Bench Press (4x8, weight 155)',
+            workoutSummary:
+              'Recent workouts: 2026-04-29: Back Squat (5x5, weight 225); 2026-04-27: Bench Press (4x8, weight 155); 2026-04-25: Pull Up (4x12); 2026-04-23: Romanian Deadlift (3x8, weight 245); 2026-04-21: Bike Intervals (6 sets, 18 min). Best performance: Romanian Deadlift 245 x 8; Old Session 20 reps',
           }),
         }),
       })


### PR DESCRIPTION
## Summary
- enrich coach service workout context from recent local workout data without widening bundle scope into screen/context rewiring
- extend coach service test coverage for the new workout context heuristics and include the redteam custom eval in coach eval config

## Verification
- existing verified implementation preserved in the worktree
- branch pushed as `feat/296-coach-workout-context`

Closes #296
Closes #297
Closes #298