### PR TITLE
feat(notifications): add deep linking, categories, and token refresh

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,7 @@
 import './global.css';
 import { Slot, usePathname, useRouter, useSegments } from 'expo-router';
 import * as Linking from 'expo-linking';
+import * as Notifications from 'expo-notifications';
 import React, { Component, useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, Pressable, View, Text as RNText, StyleSheet, Platform } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -21,6 +22,7 @@ import { VoiceControlProvider } from '../contexts/VoiceControlContext';
 import { isVoiceControlPipelineEnabled } from '@/lib/services/voice-pipeline-flag';
 import { logWithTs, warnWithTs } from '@/lib/logger';
 import { isOnboardingCompleted } from '@/lib/services/onboarding';
+import { handleNotificationResponse } from '@/lib/services/notifications';
 import { hasSeenWelcome } from '@/app/(onboarding)/welcome';
 import { MilestoneToastBridge } from '@/components/MilestoneToastBridge';
 import { SessionTelemetryBinder } from '@/components/telemetry/SessionTelemetryBinder';
@@ -202,6 +204,18 @@ function InitialLayout() {
     return () => {
       cancelled = true;
       sub.remove();
+    };
+  }, [router]);
+
+  useEffect(() => {
+    const subscription = Notifications.addNotificationResponseReceivedListener((response) => {
+      handleNotificationResponse(response, (route) => {
+        router.push(route as never);
+      });
+    });
+
+    return () => {
+      subscription.remove();
     };
   }, [router]);
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -22,7 +22,10 @@ import { VoiceControlProvider } from '../contexts/VoiceControlContext';
 import { isVoiceControlPipelineEnabled } from '@/lib/services/voice-pipeline-flag';
 import { logWithTs, warnWithTs } from '@/lib/logger';
 import { isOnboardingCompleted } from '@/lib/services/onboarding';
-import { handleNotificationResponse } from '@/lib/services/notifications';
+import {
+  handleNotificationResponse,
+  syncPushTokenRefreshListener,
+} from '@/lib/services/notifications';
 import { hasSeenWelcome } from '@/app/(onboarding)/welcome';
 import { MilestoneToastBridge } from '@/components/MilestoneToastBridge';
 import { SessionTelemetryBinder } from '@/components/telemetry/SessionTelemetryBinder';
@@ -218,6 +221,8 @@ function InitialLayout() {
       subscription.remove();
     };
   }, [router]);
+
+  useEffect(() => syncPushTokenRefreshListener(user?.id), [user?.id]);
 
   useEffect(() => {
     if (user) {

--- a/lib/services/notifications.ts
+++ b/lib/services/notifications.ts
@@ -7,6 +7,7 @@ import Constants from 'expo-constants';
 import { Platform } from 'react-native';
 import { PermissionStatus } from 'expo-modules-core';
 import { errorWithTs, infoWithTs, warnWithTs } from '@/lib/logger';
+import { parseTemplateIdFromUrl } from '@/lib/services/workout-scheduler';
 import { supabase } from '../supabase';
 
 let Device: typeof ExpoDevice | undefined;
@@ -38,6 +39,10 @@ const LAST_PUSH_TOKEN_KEY = 'ff.notifications.last_token';
 const DEVICE_ID_KEY = 'ff.notifications.device_id';
 const TOKEN_UPSERT_MAX_RETRIES = 2;
 const TOKEN_UPSERT_RETRY_DELAY_MS = 1000;
+const DISMISSED_ACTION_IDENTIFIER = 'expo.notifications.actions.DISMISSED';
+
+type NotificationPayload = Record<string, unknown>;
+type NotificationNavigator = (route: string) => void;
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -58,6 +63,9 @@ async function registerNotificationCategories() {
     await Notifications.setNotificationCategoryAsync('coach', [
       { identifier: 'reply', buttonTitle: 'Reply', options: { opensAppToForeground: true } },
     ]);
+    await Notifications.setNotificationCategoryAsync('rest_timer', [], {
+      customDismissAction: true,
+    });
     // Templated-workout reminder (issue #447). "Start" action opens the app
     // with the deep-link payload so scan-arkit can auto-bind the template.
     await Notifications.setNotificationCategoryAsync('workout_reminder', [
@@ -76,6 +84,114 @@ function getProjectId() {
   const configProjectId = (Constants.expoConfig as { projectId?: string } | undefined)?.projectId;
 
   return process.env.EXPO_PUBLIC_PUSH_PROJECT_ID || easProjectId || configProjectId;
+}
+
+function readNotificationString(payload: NotificationPayload, key: string): string | null {
+  const value = payload[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function buildScanRoute(templateId: string): string {
+  return `/(tabs)/scan-arkit?templateId=${encodeURIComponent(templateId)}`;
+}
+
+async function saveDevicePushToken(userId: string, token: string): Promise<{ error?: string }> {
+  const deviceId = await getDeviceId();
+
+  const tokenPayload = {
+    token,
+    user_id: userId,
+    platform: Platform.OS,
+    app_version: Application.nativeApplicationVersion || 'dev',
+    device_id: deviceId,
+    last_seen_at: new Date().toISOString(),
+  };
+
+  let lastUpsertError: { message: string } | null = null;
+  for (let attempt = 0; attempt <= TOKEN_UPSERT_MAX_RETRIES; attempt++) {
+    const { error: upsertErr } = await supabase.from('notification_tokens').upsert(tokenPayload);
+    if (!upsertErr) {
+      lastUpsertError = null;
+      break;
+    }
+    lastUpsertError = upsertErr;
+    if (attempt < TOKEN_UPSERT_MAX_RETRIES) {
+      await new Promise((r) => setTimeout(r, TOKEN_UPSERT_RETRY_DELAY_MS * (attempt + 1)));
+    }
+  }
+
+  if (lastUpsertError) {
+    errorWithTs('[notifications] Failed to save push token after retries', lastUpsertError);
+    return { error: lastUpsertError.message };
+  }
+
+  await AsyncStorage.setItem(LAST_PUSH_TOKEN_KEY, token);
+  return {};
+}
+
+export function getNotificationRoute(data: NotificationPayload): string | null {
+  const type = readNotificationString(data, 'type');
+  const deepLink = readNotificationString(data, 'deepLink');
+  const templateId = readNotificationString(data, 'templateId');
+
+  if ((type === 'workout_reminder' || !type) && deepLink) {
+    const linkedTemplateId = parseTemplateIdFromUrl(deepLink);
+    if (linkedTemplateId) {
+      return buildScanRoute(linkedTemplateId);
+    }
+  }
+
+  if ((type === 'workout_reminder' || !type) && templateId) {
+    return buildScanRoute(templateId);
+  }
+
+  switch (type) {
+    case 'coach':
+      return '/(tabs)/coach';
+    case 'shared_inbox':
+    case 'share_thread':
+      return '/(modals)/shared-inbox';
+    case 'follow_request':
+      return '/(modals)/follow-requests';
+    case 'followers':
+      return '/(modals)/followers';
+    case 'user_profile':
+      return '/(modals)/user-profile';
+    case 'notifications':
+    case 'social':
+      return '/(modals)/notifications';
+    default:
+      return null;
+  }
+}
+
+export function handleNotificationResponse(
+  response: Notifications.NotificationResponse,
+  navigate: NotificationNavigator,
+): string | null {
+  if (response.actionIdentifier === DISMISSED_ACTION_IDENTIFIER) {
+    return null;
+  }
+
+  const data = response.notification.request.content.data;
+  const route = getNotificationRoute(
+    data && typeof data === 'object' && !Array.isArray(data) ? data : {},
+  );
+
+  if (!route) {
+    return null;
+  }
+
+  infoWithTs('[notifications] Routing notification response', {
+    actionIdentifier: response.actionIdentifier,
+    route,
+    type: readNotificationString(
+      data && typeof data === 'object' && !Array.isArray(data) ? data : {},
+      'type',
+    ),
+  });
+  navigate(route);
+  return route;
 }
 
 async function getDeviceId() {
@@ -158,36 +274,11 @@ export async function registerDevicePushToken(
 
   const tokenResponse = await Notifications.getExpoPushTokenAsync({ projectId });
   const token = tokenResponse.data;
-  const deviceId = await getDeviceId();
+  const result = await saveDevicePushToken(userId, token);
 
-  const tokenPayload = {
-    token,
-    user_id: userId,
-    platform: Platform.OS,
-    app_version: Application.nativeApplicationVersion || 'dev',
-    device_id: deviceId,
-    last_seen_at: new Date().toISOString(),
-  };
-
-  let lastUpsertError: { message: string } | null = null;
-  for (let attempt = 0; attempt <= TOKEN_UPSERT_MAX_RETRIES; attempt++) {
-    const { error: upsertErr } = await supabase.from('notification_tokens').upsert(tokenPayload);
-    if (!upsertErr) {
-      lastUpsertError = null;
-      break;
-    }
-    lastUpsertError = upsertErr;
-    if (attempt < TOKEN_UPSERT_MAX_RETRIES) {
-      await new Promise((r) => setTimeout(r, TOKEN_UPSERT_RETRY_DELAY_MS * (attempt + 1)));
-    }
+  if (result.error) {
+    return { status: permissionStatus, error: result.error, token };
   }
-
-  if (lastUpsertError) {
-    errorWithTs('[notifications] Failed to save push token after retries', lastUpsertError);
-    return { status: permissionStatus, error: lastUpsertError.message, token };
-  }
-
-  await AsyncStorage.setItem(LAST_PUSH_TOKEN_KEY, token);
 
   return { status: permissionStatus, token };
 }
@@ -199,19 +290,9 @@ export function startPushTokenRefreshListener(userId: string) {
   pushTokenSubscription = Notifications.addPushTokenListener(async (tokenData) => {
     const newToken = tokenData.data;
     infoWithTs('[notifications] Push token refreshed, re-registering', { userId });
-    const deviceId = await getDeviceId();
-    const { error } = await supabase.from('notification_tokens').upsert({
-      token: newToken,
-      user_id: userId,
-      platform: Platform.OS,
-      app_version: Application.nativeApplicationVersion || 'dev',
-      device_id: deviceId,
-      last_seen_at: new Date().toISOString(),
-    });
-    if (error) {
-      errorWithTs('[notifications] Failed to save refreshed token', error);
-    } else {
-      await AsyncStorage.setItem(LAST_PUSH_TOKEN_KEY, newToken);
+    const result = await saveDevicePushToken(userId, newToken);
+    if (result.error) {
+      errorWithTs('[notifications] Failed to save refreshed token', result.error);
     }
   });
 }

--- a/lib/services/notifications.ts
+++ b/lib/services/notifications.ts
@@ -40,6 +40,7 @@ const DEVICE_ID_KEY = 'ff.notifications.device_id';
 const TOKEN_UPSERT_MAX_RETRIES = 2;
 const TOKEN_UPSERT_RETRY_DELAY_MS = 1000;
 const DISMISSED_ACTION_IDENTIFIER = 'expo.notifications.actions.DISMISSED';
+const REST_TIMER_DISMISS_ACTION_IDENTIFIER = 'dismiss';
 
 type NotificationPayload = Record<string, unknown>;
 type NotificationNavigator = (route: string) => void;
@@ -63,9 +64,17 @@ async function registerNotificationCategories() {
     await Notifications.setNotificationCategoryAsync('coach', [
       { identifier: 'reply', buttonTitle: 'Reply', options: { opensAppToForeground: true } },
     ]);
-    await Notifications.setNotificationCategoryAsync('rest_timer', [], {
-      customDismissAction: true,
-    });
+    await Notifications.setNotificationCategoryAsync(
+      'rest_timer',
+      [
+        {
+          identifier: REST_TIMER_DISMISS_ACTION_IDENTIFIER,
+          buttonTitle: 'Dismiss',
+          options: { opensAppToForeground: false },
+        },
+      ],
+      { customDismissAction: true },
+    );
     // Templated-workout reminder (issue #447). "Start" action opens the app
     // with the deep-link payload so scan-arkit can auto-bind the template.
     await Notifications.setNotificationCategoryAsync('workout_reminder', [
@@ -169,7 +178,10 @@ export function handleNotificationResponse(
   response: Notifications.NotificationResponse,
   navigate: NotificationNavigator,
 ): string | null {
-  if (response.actionIdentifier === DISMISSED_ACTION_IDENTIFIER) {
+  if (
+    response.actionIdentifier === DISMISSED_ACTION_IDENTIFIER ||
+    response.actionIdentifier === REST_TIMER_DISMISS_ACTION_IDENTIFIER
+  ) {
     return null;
   }
 
@@ -302,6 +314,16 @@ export function stopPushTokenRefreshListener() {
     pushTokenSubscription.remove();
     pushTokenSubscription = null;
   }
+}
+
+export function syncPushTokenRefreshListener(userId?: string | null) {
+  if (!userId) {
+    stopPushTokenRefreshListener();
+    return stopPushTokenRefreshListener;
+  }
+
+  startPushTokenRefreshListener(userId);
+  return stopPushTokenRefreshListener;
 }
 
 export async function unregisterDevicePushToken(userId?: string) {

--- a/lib/services/notifications.ts
+++ b/lib/services/notifications.ts
@@ -100,6 +100,14 @@ function readNotificationString(payload: NotificationPayload, key: string): stri
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
 }
 
+function readNotificationEntityId(data: NotificationPayload): string | null {
+  return (
+    readNotificationString(data, 'videoId') ||
+    readNotificationString(data, 'postId') ||
+    readNotificationString(data, 'targetId')
+  );
+}
+
 function buildScanRoute(templateId: string): string {
   return `/(tabs)/scan-arkit?templateId=${encodeURIComponent(templateId)}`;
 }
@@ -142,6 +150,8 @@ export function getNotificationRoute(data: NotificationPayload): string | null {
   const type = readNotificationString(data, 'type');
   const deepLink = readNotificationString(data, 'deepLink');
   const templateId = readNotificationString(data, 'templateId');
+  const entityId = readNotificationEntityId(data);
+  const userId = readNotificationString(data, 'userId') || readNotificationString(data, 'targetId');
 
   if ((type === 'workout_reminder' || !type) && deepLink) {
     const linkedTemplateId = parseTemplateIdFromUrl(deepLink);
@@ -155,6 +165,19 @@ export function getNotificationRoute(data: NotificationPayload): string | null {
   }
 
   switch (type) {
+    case 'comment':
+    case 'like':
+      return entityId
+        ? `/(modals)/video-comments?videoId=${encodeURIComponent(entityId)}&returnTo=videos`
+        : '/(tabs)/index';
+    case 'follow':
+      return userId
+        ? `/(modals)/user-profile?userId=${encodeURIComponent(userId)}`
+        : '/(modals)/followers';
+    case 'workout':
+      return '/(tabs)/workouts';
+    case 'rest_timer':
+      return null;
     case 'coach':
       return '/(tabs)/coach';
     case 'shared_inbox':

--- a/tests/unit/services/notifications.test.ts
+++ b/tests/unit/services/notifications.test.ts
@@ -773,6 +773,32 @@ describe('updateNotificationPreferences', () => {
 // ===========================================================================
 
 describe('getNotificationRoute', () => {
+  it('routes comment notifications to the video comments modal', () => {
+    expect(getNotificationRoute({ type: 'comment', videoId: 'vid-123' })).toBe(
+      '/(modals)/video-comments?videoId=vid-123&returnTo=videos',
+    );
+  });
+
+  it('routes like notifications using postId fallback', () => {
+    expect(getNotificationRoute({ type: 'like', postId: 'vid-456' })).toBe(
+      '/(modals)/video-comments?videoId=vid-456&returnTo=videos',
+    );
+  });
+
+  it('routes follow notifications to the user-profile modal', () => {
+    expect(getNotificationRoute({ type: 'follow', userId: 'user-123' })).toBe(
+      '/(modals)/user-profile?userId=user-123',
+    );
+  });
+
+  it('routes workout notifications to the workouts tab', () => {
+    expect(getNotificationRoute({ type: 'workout' })).toBe('/(tabs)/workouts');
+  });
+
+  it('does not navigate for rest timer notifications', () => {
+    expect(getNotificationRoute({ type: 'rest_timer' })).toBeNull();
+  });
+
   it('routes coach notifications to the coach tab', () => {
     expect(getNotificationRoute({ type: 'coach' })).toBe('/(tabs)/coach');
   });
@@ -796,6 +822,48 @@ describe('getNotificationRoute', () => {
 });
 
 describe('handleNotificationResponse', () => {
+  it('navigates comment notifications to video comments', () => {
+    const navigate = jest.fn();
+
+    const route = handleNotificationResponse(
+      {
+        actionIdentifier: Notifications.DEFAULT_ACTION_IDENTIFIER,
+        notification: {
+          request: {
+            content: {
+              data: { type: 'comment', videoId: 'vid-123' },
+            },
+          },
+        },
+      } as any,
+      navigate,
+    );
+
+    expect(route).toBe('/(modals)/video-comments?videoId=vid-123&returnTo=videos');
+    expect(navigate).toHaveBeenCalledWith('/(modals)/video-comments?videoId=vid-123&returnTo=videos');
+  });
+
+  it('navigates follow notifications to user-profile', () => {
+    const navigate = jest.fn();
+
+    const route = handleNotificationResponse(
+      {
+        actionIdentifier: Notifications.DEFAULT_ACTION_IDENTIFIER,
+        notification: {
+          request: {
+            content: {
+              data: { type: 'follow', userId: 'user-123' },
+            },
+          },
+        },
+      } as any,
+      navigate,
+    );
+
+    expect(route).toBe('/(modals)/user-profile?userId=user-123');
+    expect(navigate).toHaveBeenCalledWith('/(modals)/user-profile?userId=user-123');
+  });
+
   it('navigates for supported notification payloads', () => {
     const navigate = jest.fn();
 

--- a/tests/unit/services/notifications.test.ts
+++ b/tests/unit/services/notifications.test.ts
@@ -7,12 +7,14 @@ import { Platform } from 'react-native';
 
 jest.mock('expo-notifications', () => ({
   __esModule: true,
+  DEFAULT_ACTION_IDENTIFIER: 'expo.notifications.actions.DEFAULT',
   getPermissionsAsync: jest.fn(),
   requestPermissionsAsync: jest.fn(),
   getExpoPushTokenAsync: jest.fn(),
   setNotificationChannelAsync: jest.fn(),
   setNotificationHandler: jest.fn(),
   setNotificationCategoryAsync: jest.fn(),
+  addNotificationResponseReceivedListener: jest.fn(),
   addPushTokenListener: jest.fn(),
   AndroidImportance: { MAX: 5 },
 }));
@@ -81,7 +83,11 @@ const mockRequestPermissionsAsync = Notifications.requestPermissionsAsync as jes
 const mockGetExpoPushTokenAsync = Notifications.getExpoPushTokenAsync as jest.Mock;
 const mockSetNotificationChannelAsync = Notifications.setNotificationChannelAsync as jest.Mock;
 const mockSetNotificationHandler = Notifications.setNotificationHandler as jest.Mock;
+const mockSetNotificationCategoryAsync = Notifications.setNotificationCategoryAsync as jest.Mock;
+const mockAddNotificationResponseReceivedListener = Notifications.addNotificationResponseReceivedListener as jest.Mock;
+const mockAddPushTokenListener = Notifications.addPushTokenListener as jest.Mock;
 const mockGetRandomBytesAsync = Crypto.getRandomBytesAsync as jest.Mock;
+const dismissedActionIdentifier = 'expo.notifications.actions.DISMISSED';
 
 // ---------------------------------------------------------------------------
 // Import the module under test AFTER all mocks are in place
@@ -89,8 +95,12 @@ const mockGetRandomBytesAsync = Crypto.getRandomBytesAsync as jest.Mock;
 
 import {
   getNotificationPermissions,
+  getNotificationRoute,
+  handleNotificationResponse,
   requestNotificationPermissions,
   registerDevicePushToken,
+  startPushTokenRefreshListener,
+  stopPushTokenRefreshListener,
   unregisterDevicePushToken,
   loadNotificationPreferences,
   updateNotificationPreferences,
@@ -104,6 +114,9 @@ const notificationHandlerArg =
   mockSetNotificationHandler.mock.calls.length > 0
     ? mockSetNotificationHandler.mock.calls[0][0]
     : undefined;
+const initialNotificationCategoryCalls = Promise.resolve()
+  .then(() => Promise.resolve())
+  .then(() => mockSetNotificationCategoryAsync.mock.calls.map((call) => [...call]));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -153,6 +166,9 @@ beforeEach(() => {
   mockGetExpoPushTokenAsync.mockResolvedValue({ data: 'ExponentPushToken[abc123]' });
   mockGetRandomBytesAsync.mockResolvedValue(fakeBytes(16));
   mockSetNotificationChannelAsync.mockResolvedValue(undefined);
+  mockSetNotificationCategoryAsync.mockResolvedValue(undefined);
+  mockAddNotificationResponseReceivedListener.mockReturnValue({ remove: jest.fn() });
+  mockAddPushTokenListener.mockReturnValue({ remove: jest.fn() });
 
   // Reset Platform.OS to ios
   (Platform as any).OS = 'ios';
@@ -752,6 +768,123 @@ describe('updateNotificationPreferences', () => {
 });
 
 // ===========================================================================
+// Notification routing + listeners
+// ===========================================================================
+
+describe('getNotificationRoute', () => {
+  it('routes coach notifications to the coach tab', () => {
+    expect(getNotificationRoute({ type: 'coach' })).toBe('/(tabs)/coach');
+  });
+
+  it('routes workout reminders from deep links', () => {
+    expect(
+      getNotificationRoute({
+        type: 'workout_reminder',
+        deepLink: 'form-factor://scan?templateId=template-123',
+      }),
+    ).toBe('/(tabs)/scan-arkit?templateId=template-123');
+  });
+
+  it('routes social notifications to the notifications modal', () => {
+    expect(getNotificationRoute({ type: 'social' })).toBe('/(modals)/notifications');
+  });
+
+  it('returns null when no supported route exists', () => {
+    expect(getNotificationRoute({ type: 'unknown' })).toBeNull();
+  });
+});
+
+describe('handleNotificationResponse', () => {
+  it('navigates for supported notification payloads', () => {
+    const navigate = jest.fn();
+
+    const route = handleNotificationResponse(
+      {
+        actionIdentifier: Notifications.DEFAULT_ACTION_IDENTIFIER,
+        notification: {
+          request: {
+            content: {
+              data: { type: 'coach' },
+            },
+          },
+        },
+      } as any,
+      navigate,
+    );
+
+    expect(route).toBe('/(tabs)/coach');
+    expect(navigate).toHaveBeenCalledWith('/(tabs)/coach');
+  });
+
+  it('ignores dismissed notification actions', () => {
+    const navigate = jest.fn();
+
+    const route = handleNotificationResponse(
+      {
+        actionIdentifier: dismissedActionIdentifier,
+        notification: {
+          request: {
+            content: {
+              data: { type: 'coach' },
+            },
+          },
+        },
+      } as any,
+      navigate,
+    );
+
+    expect(route).toBeNull();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});
+
+describe('push token refresh listener', () => {
+  it('re-registers refreshed device tokens and updates cache', async () => {
+    const remove = jest.fn();
+    let listener: ((token: { data: string }) => Promise<void>) | undefined;
+    mockAddPushTokenListener.mockImplementation((callback) => {
+      listener = callback;
+      return { remove };
+    });
+    const mockUpsert = jest.fn().mockResolvedValue({ error: null });
+    mockFrom.mockReturnValue({ upsert: mockUpsert });
+
+    startPushTokenRefreshListener('user-123');
+    await listener?.({ data: 'ExponentPushToken[rotated]' });
+
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: 'ExponentPushToken[rotated]',
+        user_id: 'user-123',
+      }),
+    );
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'ff.notifications.last_token',
+      'ExponentPushToken[rotated]',
+    );
+
+    stopPushTokenRefreshListener();
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('replaces any existing token refresh subscription before starting a new one', () => {
+    const firstRemove = jest.fn();
+    const secondRemove = jest.fn();
+    mockAddPushTokenListener
+      .mockReturnValueOnce({ remove: firstRemove })
+      .mockReturnValueOnce({ remove: secondRemove });
+
+    startPushTokenRefreshListener('user-123');
+    startPushTokenRefreshListener('user-123');
+
+    expect(firstRemove).toHaveBeenCalledTimes(1);
+
+    stopPushTokenRefreshListener();
+    expect(secondRemove).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ===========================================================================
 // Module-level side effects
 // ===========================================================================
 
@@ -776,5 +909,18 @@ describe('module initialization', () => {
       shouldShowList: true,
       shouldSetBadge: false,
     });
+  });
+
+  it('registers notification categories including rest timer dismiss handling', async () => {
+    const notificationCategoryCalls = await initialNotificationCategoryCalls;
+
+    expect(notificationCategoryCalls).toEqual(
+      expect.arrayContaining([
+        ['social', expect.any(Array)],
+        ['coach', expect.any(Array)],
+        ['rest_timer', [], { customDismissAction: true }],
+        ['workout_reminder', expect.any(Array)],
+      ]),
+    );
   });
 });

--- a/tests/unit/services/notifications.test.ts
+++ b/tests/unit/services/notifications.test.ts
@@ -101,6 +101,7 @@ import {
   registerDevicePushToken,
   startPushTokenRefreshListener,
   stopPushTokenRefreshListener,
+  syncPushTokenRefreshListener,
   unregisterDevicePushToken,
   loadNotificationPreferences,
   updateNotificationPreferences,
@@ -836,6 +837,27 @@ describe('handleNotificationResponse', () => {
     expect(route).toBeNull();
     expect(navigate).not.toHaveBeenCalled();
   });
+
+  it('ignores the explicit rest timer dismiss action', () => {
+    const navigate = jest.fn();
+
+    const route = handleNotificationResponse(
+      {
+        actionIdentifier: 'dismiss',
+        notification: {
+          request: {
+            content: {
+              data: { type: 'coach' },
+            },
+          },
+        },
+      } as any,
+      navigate,
+    );
+
+    expect(route).toBeNull();
+    expect(navigate).not.toHaveBeenCalled();
+  });
 });
 
 describe('push token refresh listener', () => {
@@ -882,6 +904,29 @@ describe('push token refresh listener', () => {
     stopPushTokenRefreshListener();
     expect(secondRemove).toHaveBeenCalledTimes(1);
   });
+
+  it('sync helper starts the listener for an active user and stops it on cleanup', () => {
+    const remove = jest.fn();
+    mockAddPushTokenListener.mockReturnValue({ remove });
+
+    const cleanup = syncPushTokenRefreshListener('user-123');
+
+    expect(mockAddPushTokenListener).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('sync helper stops any existing listener when no active user remains', () => {
+    const remove = jest.fn();
+    mockAddPushTokenListener.mockReturnValue({ remove });
+
+    syncPushTokenRefreshListener('user-123');
+    syncPushTokenRefreshListener(undefined);
+
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(mockAddPushTokenListener).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ===========================================================================
@@ -918,7 +963,17 @@ describe('module initialization', () => {
       expect.arrayContaining([
         ['social', expect.any(Array)],
         ['coach', expect.any(Array)],
-        ['rest_timer', [], { customDismissAction: true }],
+        [
+          'rest_timer',
+          [
+            {
+              identifier: 'dismiss',
+              buttonTitle: 'Dismiss',
+              options: { opensAppToForeground: false },
+            },
+          ],
+          { customDismissAction: true },
+        ],
         ['workout_reminder', expect.any(Array)],
       ]),
     );


### PR DESCRIPTION
## Summary
- add deep-link routing for notification taps using the existing modal routes for video comments and user profiles
- wire notification categories, token refresh handling, and rest-timer dismiss behavior without introducing new navigation routes
- cover the notification helpers with unit tests for bundle D behavior

Closes #299
Closes #300
Closes #304