### PR TITLE
fix(notify): harden edge function validation and token-only rate limiting

### DIFF
--- a/supabase/functions/notify/index.ts
+++ b/supabase/functions/notify/index.ts
@@ -2,6 +2,8 @@
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.45.4?target=deno';
 
+import { checkNotifyRateLimit, sanitizeNotificationData } from './validation';
+
 interface PushRequest {
   userIds?: string[];
   tokens?: string[];
@@ -21,6 +23,7 @@ type ExpoPushMessage = {
 const EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send';
 const MAX_BATCH = 90;
 const MAX_IDS = 1000;
+const notifyRateLimits = new Map<string, { count: number; windowStart: number }>();
 
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL');
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
@@ -157,9 +160,31 @@ serve(async (req: Request) => {
     const payload = (await req.json()) as PushRequest;
     const title = payload.title?.trim();
     const body = payload.body?.trim();
+    const sanitizedData = sanitizeNotificationData(payload.data ?? {});
+    const rateLimitUserIds = Array.isArray(payload.userIds)
+      ? Array.from(new Set(payload.userIds.filter((userId) => typeof userId === 'string' && userId.length > 0)))
+      : [];
+
+    if (rateLimitUserIds.length === 0 && typeof sanitizedData.userId === 'string') {
+      rateLimitUserIds.push(sanitizedData.userId);
+    }
 
     if (!title || !body) {
       return jsonResponse({ error: 'title and body are required' }, 400);
+    }
+
+    for (const userId of rateLimitUserIds) {
+      const rateLimit = checkNotifyRateLimit(userId, notifyRateLimits);
+
+      if (!rateLimit.allowed) {
+        return jsonResponse(
+          {
+            error: 'Rate limit exceeded',
+            retryAfter: rateLimit.retryAfter,
+          },
+          429,
+        );
+      }
     }
 
     const tokenList: string[] = [];
@@ -182,7 +207,7 @@ serve(async (req: Request) => {
       sound: 'default',
       title: title.slice(0, 64),
       body: body.slice(0, 180),
-      data: payload.data ?? {},
+      data: sanitizedData,
     }));
 
     const result = await sendExpoMessages(messages);

--- a/supabase/functions/notify/index.ts
+++ b/supabase/functions/notify/index.ts
@@ -2,7 +2,11 @@
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.45.4?target=deno';
 
-import { checkNotifyRateLimit, sanitizeNotificationData } from './validation';
+import {
+  checkNotifyRateLimit,
+  deriveNotifyRateLimitKeys,
+  sanitizeNotificationData,
+} from './validation';
 
 interface PushRequest {
   userIds?: string[];
@@ -161,20 +165,18 @@ serve(async (req: Request) => {
     const title = payload.title?.trim();
     const body = payload.body?.trim();
     const sanitizedData = sanitizeNotificationData(payload.data ?? {});
-    const rateLimitUserIds = Array.isArray(payload.userIds)
-      ? Array.from(new Set(payload.userIds.filter((userId) => typeof userId === 'string' && userId.length > 0)))
-      : [];
-
-    if (rateLimitUserIds.length === 0 && typeof sanitizedData.userId === 'string') {
-      rateLimitUserIds.push(sanitizedData.userId);
-    }
+    const rateLimitKeys = deriveNotifyRateLimitKeys({
+      userIds: payload.userIds,
+      sanitizedData,
+      tokens: payload.tokens,
+    });
 
     if (!title || !body) {
       return jsonResponse({ error: 'title and body are required' }, 400);
     }
 
-    for (const userId of rateLimitUserIds) {
-      const rateLimit = checkNotifyRateLimit(userId, notifyRateLimits);
+    for (const rateLimitKey of rateLimitKeys) {
+      const rateLimit = checkNotifyRateLimit(rateLimitKey, notifyRateLimits);
 
       if (!rateLimit.allowed) {
         return jsonResponse(

--- a/supabase/functions/notify/validation.ts
+++ b/supabase/functions/notify/validation.ts
@@ -10,6 +10,7 @@ export const ALLOWED_NOTIFICATION_DATA_KEYS = [
 export const MAX_NOTIFICATION_DATA_LENGTH = 255;
 export const NOTIFY_RATE_LIMIT_MAX_REQUESTS = 50;
 export const NOTIFY_RATE_LIMIT_WINDOW_MS = 60_000;
+export const TOKEN_ONLY_NOTIFY_RATE_LIMIT_KEY = '__token_only_request__';
 
 export type NotifyRateLimitEntry = {
   count: number;
@@ -19,6 +20,12 @@ export type NotifyRateLimitEntry = {
 type NotifyRateLimitMap = Map<string, NotifyRateLimitEntry>;
 
 const allowedNotificationDataKeySet = new Set<string>(ALLOWED_NOTIFICATION_DATA_KEYS);
+
+type NotifyRateLimitKeyInput = {
+  userIds?: unknown;
+  sanitizedData?: Record<string, string>;
+  tokens?: unknown;
+};
 
 export function sanitizeNotificationData(
   data: Record<string, unknown> = {},
@@ -34,6 +41,29 @@ export function sanitizeNotificationData(
   }
 
   return sanitized;
+}
+
+export function deriveNotifyRateLimitKeys({
+  userIds,
+  sanitizedData = {},
+  tokens,
+}: NotifyRateLimitKeyInput): string[] {
+  const validUserIds = Array.isArray(userIds)
+    ? Array.from(new Set(userIds.filter((userId): userId is string => typeof userId === 'string' && userId.length > 0)))
+    : [];
+
+  if (validUserIds.length > 0) {
+    return validUserIds;
+  }
+
+  if (typeof sanitizedData.userId === 'string' && sanitizedData.userId.length > 0) {
+    return [sanitizedData.userId];
+  }
+
+  const hasRawTokens = Array.isArray(tokens)
+    && tokens.some((token): token is string => typeof token === 'string' && token.length > 0);
+
+  return hasRawTokens ? [TOKEN_ONLY_NOTIFY_RATE_LIMIT_KEY] : [];
 }
 
 export function checkNotifyRateLimit(

--- a/supabase/functions/notify/validation.ts
+++ b/supabase/functions/notify/validation.ts
@@ -1,0 +1,65 @@
+export const ALLOWED_NOTIFICATION_DATA_KEYS = [
+  'type',
+  'postId',
+  'userId',
+  'workoutId',
+  'exerciseId',
+  'screen',
+] as const;
+
+export const MAX_NOTIFICATION_DATA_LENGTH = 255;
+export const NOTIFY_RATE_LIMIT_MAX_REQUESTS = 50;
+export const NOTIFY_RATE_LIMIT_WINDOW_MS = 60_000;
+
+export type NotifyRateLimitEntry = {
+  count: number;
+  windowStart: number;
+};
+
+type NotifyRateLimitMap = Map<string, NotifyRateLimitEntry>;
+
+const allowedNotificationDataKeySet = new Set<string>(ALLOWED_NOTIFICATION_DATA_KEYS);
+
+export function sanitizeNotificationData(
+  data: Record<string, unknown> = {},
+): Record<string, string> {
+  const sanitized: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(data)) {
+    if (!allowedNotificationDataKeySet.has(key) || typeof value !== 'string') {
+      continue;
+    }
+
+    sanitized[key] = value.slice(0, MAX_NOTIFICATION_DATA_LENGTH);
+  }
+
+  return sanitized;
+}
+
+export function checkNotifyRateLimit(
+  userId: string,
+  limits: NotifyRateLimitMap,
+  now = Date.now(),
+): { allowed: boolean; retryAfter?: number } {
+  const existingLimit = limits.get(userId);
+
+  if (!existingLimit || now - existingLimit.windowStart >= NOTIFY_RATE_LIMIT_WINDOW_MS) {
+    limits.set(userId, { count: 1, windowStart: now });
+    return { allowed: true };
+  }
+
+  if (existingLimit.count >= NOTIFY_RATE_LIMIT_MAX_REQUESTS) {
+    const retryAfterMs = existingLimit.windowStart + NOTIFY_RATE_LIMIT_WINDOW_MS - now;
+    return {
+      allowed: false,
+      retryAfter: Math.max(1, Math.ceil(retryAfterMs / 1000)),
+    };
+  }
+
+  limits.set(userId, {
+    count: existingLimit.count + 1,
+    windowStart: existingLimit.windowStart,
+  });
+
+  return { allowed: true };
+}

--- a/tests/unit/services/notify-validation.test.ts
+++ b/tests/unit/services/notify-validation.test.ts
@@ -1,0 +1,84 @@
+import {
+  checkNotifyRateLimit,
+  MAX_NOTIFICATION_DATA_LENGTH,
+  NOTIFY_RATE_LIMIT_MAX_REQUESTS,
+  sanitizeNotificationData,
+} from '@/supabase/functions/notify/validation';
+
+describe('sanitizeNotificationData', () => {
+  it('keeps only whitelisted string keys', () => {
+    expect(
+      sanitizeNotificationData({
+        type: 'rest_timer',
+        userId: 'user-123',
+        unknown: 'drop-me',
+        workoutId: 'workout-456',
+      }),
+    ).toEqual({
+      type: 'rest_timer',
+      userId: 'user-123',
+      workoutId: 'workout-456',
+    });
+  });
+
+  it('strips non-string values', () => {
+    expect(
+      sanitizeNotificationData({
+        type: 'comment',
+        postId: 123,
+        exerciseId: false,
+        screen: null,
+      }),
+    ).toEqual({ type: 'comment' });
+  });
+
+  it('truncates long string values to the maximum length', () => {
+    const longValue = 'x'.repeat(MAX_NOTIFICATION_DATA_LENGTH + 10);
+
+    expect(sanitizeNotificationData({ screen: longValue })).toEqual({
+      screen: 'x'.repeat(MAX_NOTIFICATION_DATA_LENGTH),
+    });
+  });
+
+  it('returns an empty object for empty input', () => {
+    expect(sanitizeNotificationData({})).toEqual({});
+  });
+});
+
+describe('checkNotifyRateLimit', () => {
+  it('allows the first fifty requests in a minute', () => {
+    const limits = new Map();
+    const now = 1_000;
+
+    for (let attempt = 1; attempt <= NOTIFY_RATE_LIMIT_MAX_REQUESTS; attempt += 1) {
+      expect(checkNotifyRateLimit('user-123', limits, now)).toEqual({ allowed: true });
+    }
+  });
+
+  it('blocks the fifty-first request and returns retryAfter', () => {
+    const limits = new Map();
+    const windowStart = 10_000;
+
+    for (let attempt = 1; attempt <= NOTIFY_RATE_LIMIT_MAX_REQUESTS; attempt += 1) {
+      checkNotifyRateLimit('user-123', limits, windowStart);
+    }
+
+    expect(checkNotifyRateLimit('user-123', limits, windowStart + 5_000)).toEqual({
+      allowed: false,
+      retryAfter: 55,
+    });
+  });
+
+  it('resets the window after one minute', () => {
+    const limits = new Map();
+    const windowStart = 20_000;
+
+    for (let attempt = 1; attempt <= NOTIFY_RATE_LIMIT_MAX_REQUESTS; attempt += 1) {
+      checkNotifyRateLimit('user-123', limits, windowStart);
+    }
+
+    expect(checkNotifyRateLimit('user-123', limits, windowStart + 60_000)).toEqual({
+      allowed: true,
+    });
+  });
+});

--- a/tests/unit/services/notify-validation.test.ts
+++ b/tests/unit/services/notify-validation.test.ts
@@ -1,8 +1,10 @@
 import {
   checkNotifyRateLimit,
+  deriveNotifyRateLimitKeys,
   MAX_NOTIFICATION_DATA_LENGTH,
   NOTIFY_RATE_LIMIT_MAX_REQUESTS,
   sanitizeNotificationData,
+  TOKEN_ONLY_NOTIFY_RATE_LIMIT_KEY,
 } from '@/supabase/functions/notify/validation';
 
 describe('sanitizeNotificationData', () => {
@@ -80,5 +82,36 @@ describe('checkNotifyRateLimit', () => {
     expect(checkNotifyRateLimit('user-123', limits, windowStart + 60_000)).toEqual({
       allowed: true,
     });
+  });
+});
+
+describe('deriveNotifyRateLimitKeys', () => {
+  it('prefers deduped explicit userIds', () => {
+    expect(
+      deriveNotifyRateLimitKeys({
+        userIds: ['user-123', '', 'user-123', 'user-456'],
+        sanitizedData: { userId: 'fallback-user' },
+        tokens: ['ExponentPushToken[token-1]'],
+      }),
+    ).toEqual(['user-123', 'user-456']);
+  });
+
+  it('falls back to sanitized data userId when userIds are absent', () => {
+    expect(
+      deriveNotifyRateLimitKeys({
+        sanitizedData: { userId: 'user-789' },
+        tokens: ['ExponentPushToken[token-1]'],
+      }),
+    ).toEqual(['user-789']);
+  });
+
+  it('returns a token-only fallback key when only raw tokens are present', () => {
+    expect(
+      deriveNotifyRateLimitKeys({
+        userIds: [],
+        sanitizedData: {},
+        tokens: ['', 'ExponentPushToken[token-1]'],
+      }),
+    ).toEqual([TOKEN_ONLY_NOTIFY_RATE_LIMIT_KEY]);
   });
 });


### PR DESCRIPTION
## Summary
- harden the notify edge function with strict payload validation helpers local to the edge handler
- add stable rate limiting for token-only notification sends without broadening the bundle into client notification code
- cover the notify validation path with focused unit tests for Bundle C delivery

Closes #301
Closes #302